### PR TITLE
fix: Change DB and API healthcheck config, remove healthz requests from logs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,10 +23,10 @@ services:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/healthz"]
-      interval: 5s
-      retries: 5
-      start_period: 5s
-      timeout: 2s
+      interval: 15s
+      retries: 3
+      start_period: 30s
+      timeout: 3s
 
   endatix-hub:
     container_name: endatix-hub
@@ -57,9 +57,9 @@ services:
     healthcheck:
       test: ["CMD", "opt/mssql-tools18/bin/sqlcmd", "-S", "localhost", "-U", "sa", "-P", "${SQLSERVER_SA_PASSWORD}", "-Q", "SELECT 1", "-C"]
       interval: 5s
-      retries: 5
-      start_period: 5s
-      timeout: 2s
+      retries: 3
+      start_period: 30s
+      timeout: 3s
 
 networks:
   appnetwork:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -20,10 +20,10 @@ services:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/healthz"]
-      interval: 5s
-      retries: 5
-      start_period: 5s
-      timeout: 2s
+      interval: 15s
+      retries: 3
+      start_period: 30s
+      timeout: 3s
 
   endatix-hub:
     container_name: endatix-hub
@@ -50,10 +50,10 @@ services:
       - appnetwork
     healthcheck:
       test: ["CMD", "opt/mssql-tools18/bin/sqlcmd", "-S", "localhost", "-U", "sa", "-P", "${SQLSERVER_SA_PASSWORD}", "-Q", "SELECT 1", "-C"]
-      interval: 5s
-      retries: 5
-      start_period: 5s
-      timeout: 2s
+      interval: 15s
+      retries: 3
+      start_period: 30s
+      timeout: 3s
 
 networks:
   appnetwork:

--- a/src/Endatix.Extensions.Hosting/AppBuilderExtensions.cs
+++ b/src/Endatix.Extensions.Hosting/AppBuilderExtensions.cs
@@ -26,9 +26,14 @@ public static class AppBuilderExtensions
         app.UseSerilogRequestLogging(options =>
         {
             options.GetLevel = (httpContext, elapsed, ex) =>
-                httpContext.Request.Path.StartsWithSegments("/healthz") ?
-                    LogEventLevel.Verbose :
-                    LogEventLevel.Information;
+            {
+                if (httpContext.Request.Path.StartsWithSegments("/healthz"))
+                {
+                    return LogEventLevel.Verbose;
+                }
+
+                return LogEventLevel.Information;
+            };
         });
 
         app.UseHttpsRedirection();

--- a/src/Endatix.Extensions.Hosting/AppBuilderExtensions.cs
+++ b/src/Endatix.Extensions.Hosting/AppBuilderExtensions.cs
@@ -2,6 +2,7 @@ using Endatix.Framework.Hosting;
 using Endatix.Setup;
 using Microsoft.AspNetCore.Builder;
 using Serilog;
+using Serilog.Events;
 
 namespace Endatix.Setup;
 
@@ -22,7 +23,13 @@ public static class AppBuilderExtensions
         app.UseAuthentication()
             .UseAuthorization();
 
-        app.UseSerilogRequestLogging();
+        app.UseSerilogRequestLogging(options =>
+        {
+            options.GetLevel = (httpContext, elapsed, ex) =>
+                httpContext.Request.Path.StartsWithSegments("/healthz") ?
+                    LogEventLevel.Verbose :
+                    LogEventLevel.Information;
+        });
 
         app.UseHttpsRedirection();
 

--- a/src/Endatix.WebHost/appsettings.Development.json
+++ b/src/Endatix.WebHost/appsettings.Development.json
@@ -7,8 +7,8 @@
     "MinimumLevel": {
       "Default": "Debug",
       "Override": {
-        "Microsoft": "Information",
-        "System": "Information"
+        "Microsoft": "Warning",
+        "System": "Warning"
       }
     },
     "WriteTo": [


### PR DESCRIPTION
# Change DB and API healthcheck config and remove /healthz requests from logs

## Description
Logs become large very fast becaus of logging /healthz requests every 5 s. To prevent this and to make the operation of Endatix API smoother, two things are done:
- Extend the healthcheck interval to15 sec (including a few more healthcheck config values changed that are better now)
- Changes in the Serilog setup to skip /healthz requests from logging and also change the logging level of Microsoft/System logging on dev so it doesn't automatically log all the requests (this is already done by Serilog)

## Related Issues
closes #100

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
