### PR TITLE
feat: Add GET PUT and PATCH endpoints for a form

### DIFF
--- a/src/Endatix.Api/Endpoints/Forms/GetById.GetFormDefinitionByIdRequest.cs
+++ b/src/Endatix.Api/Endpoints/Forms/GetById.GetFormDefinitionByIdRequest.cs
@@ -1,0 +1,12 @@
+﻿namespace Endatix.Api.Endpoints.Forms;
+
+/// <summary>
+/// Request model for getting a form by ID.
+/// </summary>
+public class GetFormByIdRequest
+{
+    /// <summary>
+    /// The ID of the form.
+    /// </summary>
+    public long FormId { get; set; }
+}

--- a/src/Endatix.Api/Endpoints/Forms/GetById.GetFormDefinitionByIdValidator.cs
+++ b/src/Endatix.Api/Endpoints/Forms/GetById.GetFormDefinitionByIdValidator.cs
@@ -1,0 +1,19 @@
+﻿using FastEndpoints;
+using FluentValidation;
+
+namespace Endatix.Api.Endpoints.Forms;
+
+/// <summary>
+/// Validation rules for the <c>GetFormByIdRequest</c> class.
+/// </summary>
+public class GetFormByIdValidator : Validator<GetFormByIdRequest>
+{
+    /// <summary>
+    /// Default constructor
+    /// </summary>
+    public GetFormByIdValidator()
+    {
+        RuleFor(x => x.FormId)
+            .GreaterThan(0);
+    }
+}

--- a/src/Endatix.Api/Endpoints/Forms/GetById.cs
+++ b/src/Endatix.Api/Endpoints/Forms/GetById.cs
@@ -1,0 +1,48 @@
+﻿using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Endatix.Api.Infrastructure;
+using Endatix.Core.Entities;
+using Endatix.Core.UseCases.Forms.GetById;
+
+namespace Endatix.Api.Endpoints.Forms;
+
+/// <summary>
+/// Endpoint for getting a form by ID.
+/// </summary>
+public class GetById(IMediator _mediator) : Endpoint<GetFormByIdRequest, Results<Ok<FormModel>, BadRequest, NotFound>>
+{
+    /// <summary>
+    /// Configures the endpoint settings.
+    /// </summary>
+    public override void Configure()
+    {
+        Get("forms/{formId}");
+        Roles("Admin");
+        Summary(s =>
+        {
+            s.Summary = "Get a form by ID";
+            s.Description = "Gets a form by its ID.";
+            s.Responses[200] = "Form retrieved successfully.";
+            s.Responses[400] = "Invalid input data.";
+            s.Responses[404] = "Form not found.";
+        });
+    }
+
+    /// <summary>
+    /// Executes the HTTP request for getting a form by ID.
+    /// </summary>
+    /// <param name="request">The request model containing the form ID.</param>
+    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
+    public override async Task<Results<Ok<FormModel>, BadRequest, NotFound>> ExecuteAsync(GetFormByIdRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _mediator.Send(
+            new GetFormByIdQuery(request.FormId),
+            cancellationToken);
+
+        return result.ToEndpointResponse<
+            Results<Ok<FormModel>, BadRequest, NotFound>,
+            Form,
+            FormModel>(FormMapper.Map<FormModel>);
+    }
+}

--- a/src/Endatix.Api/Endpoints/Forms/PartialUpdate.PartialUpdateFormRequest.cs
+++ b/src/Endatix.Api/Endpoints/Forms/PartialUpdate.PartialUpdateFormRequest.cs
@@ -1,0 +1,27 @@
+﻿namespace Endatix.Api.Endpoints.Forms;
+
+/// <summary>
+/// Request model for partially updating a form.
+/// </summary>
+public class PartialUpdateFormRequest
+{
+    /// <summary>
+    /// The ID of the form.
+    /// </summary>
+    public long FormId { get; set; }
+
+    /// <summary>
+    /// The name of the form.
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// The description of the form.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Indicates if the form is enabled.
+    /// </summary>
+    public bool? IsEnabled { get; set; }
+}

--- a/src/Endatix.Api/Endpoints/Forms/PartialUpdate.PartialUpdateFormResponse.cs
+++ b/src/Endatix.Api/Endpoints/Forms/PartialUpdate.PartialUpdateFormResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace Endatix.Api.Endpoints.Forms;
+
+/// <summary>
+/// Response model for partially updating a form.
+/// </summary>
+public class PartialUpdateFormResponse : FormModel
+{
+}

--- a/src/Endatix.Api/Endpoints/Forms/PartialUpdate.PartialUpdateFormValidator.cs
+++ b/src/Endatix.Api/Endpoints/Forms/PartialUpdate.PartialUpdateFormValidator.cs
@@ -1,0 +1,19 @@
+﻿using FastEndpoints;
+using FluentValidation;
+
+namespace Endatix.Api.Endpoints.Forms;
+
+/// <summary>
+/// Validation rules for the <c>PartialUpdateFormRequest</c> class.
+/// </summary>
+public class PartialUpdateFormValidator : Validator<PartialUpdateFormRequest>
+{
+    /// <summary>
+    /// Default constructor
+    /// </summary>
+    public PartialUpdateFormValidator()
+    {
+        RuleFor(x => x.FormId)
+            .GreaterThan(0);
+    }
+}

--- a/src/Endatix.Api/Endpoints/Forms/PartialUpdate.cs
+++ b/src/Endatix.Api/Endpoints/Forms/PartialUpdate.cs
@@ -1,0 +1,48 @@
+﻿using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Endatix.Api.Infrastructure;
+using Endatix.Core.Entities;
+using Endatix.Core.UseCases.Forms.PartialUpdate;
+
+namespace Endatix.Api.Endpoints.Forms;
+
+/// <summary>
+/// Endpoint for partially updating a form.
+/// </summary>
+public class PartialUpdate(IMediator _mediator) : Endpoint<PartialUpdateFormRequest, Results<Ok<PartialUpdateFormResponse>, BadRequest, NotFound>>
+{
+    /// <summary>
+    /// Configures the endpoint settings.
+    /// </summary>
+    public override void Configure()
+    {
+        Patch("forms/{formId}");
+        Roles("Admin");
+        Summary(s =>
+        {
+            s.Summary = "Partially update a form";
+            s.Description = "Partially updates a form.";
+            s.Responses[200] = "Form updated successfully.";
+            s.Responses[400] = "Invalid input data.";
+            s.Responses[404] = "Form not found.";
+        });
+    }
+
+    /// <summary>
+    /// Executes the HTTP request for partially updating a form.
+    /// </summary>
+    /// <param name="request">The request model containing form details.</param>
+    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
+    public override async Task<Results<Ok<PartialUpdateFormResponse>, BadRequest, NotFound>> ExecuteAsync(PartialUpdateFormRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _mediator.Send(
+            new PartialUpdateFormCommand(request.FormId, request.Name, request.Description, request.IsEnabled),
+            cancellationToken);
+
+        return result.ToEndpointResponse<
+            Results<Ok<PartialUpdateFormResponse>, BadRequest, NotFound>,
+            Form,
+            PartialUpdateFormResponse>(FormMapper.Map<PartialUpdateFormResponse>);
+    }
+}

--- a/src/Endatix.Api/Endpoints/Forms/Update.UpdateFormRequest.cs
+++ b/src/Endatix.Api/Endpoints/Forms/Update.UpdateFormRequest.cs
@@ -1,0 +1,27 @@
+﻿namespace Endatix.Api.Endpoints.Forms;
+
+/// <summary>
+/// Request model for updating a form.
+/// </summary>
+public class UpdateFormRequest
+{
+    /// <summary>
+    /// The ID of the form.
+    /// </summary>
+    public long FormId { get; set; }
+
+    /// <summary>
+    /// The name of the form.
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// The description of the form.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Indicates if the form is enabled.
+    /// </summary>
+    public bool? IsEnabled { get; set; }
+}

--- a/src/Endatix.Api/Endpoints/Forms/Update.UpdateFormResponse.cs
+++ b/src/Endatix.Api/Endpoints/Forms/Update.UpdateFormResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace Endatix.Api.Endpoints.Forms;
+
+/// <summary>
+/// Response model for updating a form.
+/// </summary>
+public class UpdateFormResponse : FormModel
+{
+}

--- a/src/Endatix.Api/Endpoints/Forms/Update.UpdateFormValidator.cs
+++ b/src/Endatix.Api/Endpoints/Forms/Update.UpdateFormValidator.cs
@@ -1,0 +1,25 @@
+﻿using FastEndpoints;
+using FluentValidation;
+using Endatix.Infrastructure.Data.Config;
+
+namespace Endatix.Api.Endpoints.Forms;
+
+/// <summary>
+/// Validation rules for the <c>UpdateFormRequest</c> class.
+/// </summary>
+public class UpdateFormValidator : Validator<UpdateFormRequest>
+{
+    /// <summary>
+    /// Default constructor
+    /// </summary>
+    public UpdateFormValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MinimumLength(DataSchemaConstants.MIN_NAME_LENGTH)
+            .MaximumLength(DataSchemaConstants.MAX_NAME_LENGTH);
+
+        RuleFor(x => x.IsEnabled)
+            .NotEmpty();
+    }
+}

--- a/src/Endatix.Api/Endpoints/Forms/Update.cs
+++ b/src/Endatix.Api/Endpoints/Forms/Update.cs
@@ -1,0 +1,48 @@
+﻿using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Endatix.Api.Infrastructure;
+using Endatix.Core.Entities;
+using Endatix.Core.UseCases.Forms.Update;
+
+namespace Endatix.Api.Endpoints.Forms;
+
+/// <summary>
+/// Endpoint for updating a form.
+/// </summary>
+public class Update(IMediator _mediator) : Endpoint<UpdateFormRequest, Results<Ok<UpdateFormResponse>, BadRequest, NotFound>>
+{
+    /// <summary>
+    /// Configures the endpoint settings.
+    /// </summary>
+    public override void Configure()
+    {
+        Put("forms/{formId}");
+        Roles("Admin");
+        Summary(s =>
+        {
+            s.Summary = "Update a form";
+            s.Description = "Updates a form.";
+            s.Responses[200] = "Form updated successfully.";
+            s.Responses[400] = "Invalid input data.";
+            s.Responses[404] = "Form not found.";
+        });
+    }
+
+    /// <summary>
+    /// Executes the HTTP request for updating a form.
+    /// </summary>
+    /// <param name="request">The request model containing form details.</param>
+    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
+    public override async Task<Results<Ok<UpdateFormResponse>, BadRequest, NotFound>> ExecuteAsync(UpdateFormRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _mediator.Send(
+            new UpdateFormCommand(request.FormId, request.Name!, request.Description, request.IsEnabled!.Value),
+            cancellationToken);
+
+        return result.ToEndpointResponse<
+            Results<Ok<UpdateFormResponse>, BadRequest, NotFound>,
+            Form,
+            UpdateFormResponse>(FormMapper.Map<UpdateFormResponse>);
+    }
+}

--- a/src/Endatix.Core/UseCases/Forms/GetById/GetFormDefinitionByIdHandler.cs
+++ b/src/Endatix.Core/UseCases/Forms/GetById/GetFormDefinitionByIdHandler.cs
@@ -1,0 +1,19 @@
+﻿using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.Forms.GetById;
+
+public class GetFormByIdHandler(IRepository<Form> _repository) : IQueryHandler<GetFormByIdQuery, Result<Form>>
+{
+    public async Task<Result<Form>> Handle(GetFormByIdQuery request, CancellationToken cancellationToken)
+    {
+        var form = await _repository.GetByIdAsync(request.FormId, cancellationToken);
+        if (form == null)
+        {
+            return Result.NotFound("Form not found.");
+        }
+        return Result.Success(form);
+    }
+}

--- a/src/Endatix.Core/UseCases/Forms/GetById/GetFormDefinitionByIdQuery.cs
+++ b/src/Endatix.Core/UseCases/Forms/GetById/GetFormDefinitionByIdQuery.cs
@@ -1,0 +1,21 @@
+﻿using Ardalis.GuardClauses;
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.Forms.GetById;
+
+/// <summary>
+/// Query for getting a form by ID.
+/// </summary>
+public record GetFormByIdQuery : IQuery<Result<Form>>
+{
+    public long FormId { get; init; }
+
+    public GetFormByIdQuery(long formId)
+    {
+        Guard.Against.NegativeOrZero(formId);
+
+        FormId = formId;
+    }
+}

--- a/src/Endatix.Core/UseCases/Forms/PartialUpdate/PartialUpdateFormCommand.cs
+++ b/src/Endatix.Core/UseCases/Forms/PartialUpdate/PartialUpdateFormCommand.cs
@@ -1,0 +1,27 @@
+﻿using Ardalis.GuardClauses;
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.Forms.PartialUpdate;
+
+/// <summary>
+/// Command for partially updating a form.
+/// </summary>
+public record PartialUpdateFormCommand : ICommand<Result<Form>>
+{
+    public long FormId { get; init; }
+    public string? Name { get; init; }
+    public string? Description { get; init; }
+    public bool? IsEnabled { get; init; }
+
+    public PartialUpdateFormCommand(long formId, string? name, string? description, bool? isEnabled)
+    {
+        Guard.Against.NegativeOrZero(formId);
+
+        FormId = formId;
+        Name = name;
+        Description = description;
+        IsEnabled = isEnabled;
+    }
+}

--- a/src/Endatix.Core/UseCases/Forms/PartialUpdate/PartialUpdateFormHandler.cs
+++ b/src/Endatix.Core/UseCases/Forms/PartialUpdate/PartialUpdateFormHandler.cs
@@ -1,0 +1,24 @@
+﻿using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.Forms.PartialUpdate;
+
+public class PartialUpdateFormHandler(IRepository<Form> _repository) : ICommandHandler<PartialUpdateFormCommand, Result<Form>>
+{
+    public async Task<Result<Form>> Handle(PartialUpdateFormCommand request, CancellationToken cancellationToken)
+    {
+        var form = await _repository.GetByIdAsync(request.FormId, cancellationToken);
+        if (form == null)
+        {
+            return Result.NotFound("Form not found.");
+        }
+
+        form.Name = request.Name ?? form.Name;
+        form.Description = request.Description ?? form.Description;
+        form.IsEnabled = request.IsEnabled ?? form.IsEnabled;
+        await _repository.UpdateAsync(form, cancellationToken);
+        return Result.Success(form);
+    }
+}

--- a/src/Endatix.Core/UseCases/Forms/Update/UpdateFormCommand.cs
+++ b/src/Endatix.Core/UseCases/Forms/Update/UpdateFormCommand.cs
@@ -1,0 +1,28 @@
+﻿using Ardalis.GuardClauses;
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.Forms.Update;
+
+/// <summary>
+/// Command for updating a form.
+/// </summary>
+public record UpdateFormCommand : ICommand<Result<Form>>
+{
+    public long FormId { get; init; }
+    public string Name { get; init; }
+    public string? Description { get; init; }
+    public bool IsEnabled { get; init; }
+
+    public UpdateFormCommand(long formId, string name, string? description, bool isEnabled)
+    {
+        Guard.Against.NegativeOrZero(formId);
+        Guard.Against.NullOrWhiteSpace(name);
+
+        FormId = formId;
+        Name = name;
+        Description = description;
+        IsEnabled = isEnabled;
+    }
+}

--- a/src/Endatix.Core/UseCases/Forms/Update/UpdateFormHandler.cs
+++ b/src/Endatix.Core/UseCases/Forms/Update/UpdateFormHandler.cs
@@ -1,0 +1,24 @@
+﻿using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.Forms.Update;
+
+public class UpdateFormHandler(IRepository<Form> _repository) : ICommandHandler<UpdateFormCommand, Result<Form>>
+{
+    public async Task<Result<Form>> Handle(UpdateFormCommand request, CancellationToken cancellationToken)
+    {
+        var form = await _repository.GetByIdAsync(request.FormId, cancellationToken);
+        if (form == null)
+        {
+            return Result.NotFound("Form not found.");
+        }
+
+        form.Name = request.Name;
+        form.Description = request.Description;
+        form.IsEnabled = request.IsEnabled;
+        await _repository.UpdateAsync(form, cancellationToken);
+        return Result.Success(form);
+    }
+}

--- a/tests/Endatix.Core.Tests/SampleData.cs
+++ b/tests/Endatix.Core.Tests/SampleData.cs
@@ -2,6 +2,10 @@ namespace Endatix.Core.Tests;
 
 public static class SampleData
 {
+    public const string FORM_NAME_1 = "Product Form";
+    public const string FORM_NAME_2 = "Insurance Form";
+    public const string FORM_DESCRIPTION_1 = "Product Form Description";
+    public const string FORM_DESCRIPTION_2 = "Insurance Form Description";
     public const string FORM_DEFINITION_JSON_DATA_1 = "{\"type\":\"text\",\"name\":\"firstname\"";
     public const string FORM_DEFINITION_JSON_DATA_2 = "{\"type\":\"text\",\"name\":\"lastname\"";
 }

--- a/tests/Endatix.Core.Tests/UseCases/Forms/GetById/GetFormByIdHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/GetById/GetFormByIdHandlerTests.cs
@@ -1,0 +1,54 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.Forms.GetById;
+
+namespace Endatix.Core.Tests.UseCases.Forms.GetById;
+
+public class GetFormByIdHandlerTests
+{
+    private readonly IRepository<Form> _repository;
+    private readonly GetFormByIdHandler _handler;
+
+    public GetFormByIdHandlerTests()
+    {
+        _repository = Substitute.For<IRepository<Form>>();
+        _handler = new GetFormByIdHandler(_repository);
+    }
+
+    [Fact]
+    public async Task Handle_FormNotFound_ReturnsNotFoundResult()
+    {
+        // Arrange
+        var request = new GetFormByIdQuery(1);
+        _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
+                   .Returns((Form)null);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be(ResultStatus.NotFound);
+        result.Errors.Should().Contain("Form not found.");
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsForm()
+    {
+        // Arrange
+        var form = new Form() { Id = 1 };
+        var request = new GetFormByIdQuery(1);
+        _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
+                   .Returns(form);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().NotBeNull();
+        result.Value.Should().Be(form);
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/Forms/GetById/GetFormByIdQueryTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/GetById/GetFormByIdQueryTests.cs
@@ -1,0 +1,35 @@
+using Endatix.Core.UseCases.Forms.GetById;
+using static Endatix.Core.Tests.ErrorMessages;
+using static Endatix.Core.Tests.ErrorType;
+
+namespace Endatix.Core.Tests.UseCases.Forms.GetById;
+
+public class GetFormByIdQueryTests
+{
+    [Fact]
+    public void Constructor_NegativeOrZeroFormId_ThrowsArgumentException()
+    {
+        // Arrange
+        var formId = -1;
+
+        // Act
+        Action act = () => new GetFormByIdQuery(formId);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage(GetErrorMessage(nameof(formId), ZeroOrNegative));
+    }
+
+    [Fact]
+    public void Constructor_ValidParameter_SetsPropertyCorrectly()
+    {
+        // Arrange
+        var formId = 1;
+
+        // Act
+        var query = new GetFormByIdQuery(formId);
+
+        // Assert
+        query.FormId.Should().Be(formId);
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/Forms/PartialUpdate/PartialUpdateFormCommandTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/PartialUpdate/PartialUpdateFormCommandTests.cs
@@ -1,0 +1,63 @@
+using Endatix.Core.UseCases.Forms.PartialUpdate;
+using static Endatix.Core.Tests.ErrorMessages;
+using static Endatix.Core.Tests.ErrorType;
+
+namespace Endatix.Core.Tests.UseCases.Forms.PartialUpdate;
+
+public class PartialUpdateFormCommandTests
+{
+    [Fact]
+    public void Constructor_NegativeOrZeroFormId_ThrowsArgumentException()
+    {
+        // Arrange
+        var formId = -1;
+        var name = SampleData.FORM_NAME_1;
+        var description = SampleData.FORM_DESCRIPTION_1;
+        var isEnabled = true;
+
+        // Act
+        Action act = () => new PartialUpdateFormCommand(formId, name, description, isEnabled);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage(GetErrorMessage(nameof(formId), ZeroOrNegative));
+    }
+
+    [Fact]
+    public void Constructor_ValidParameters_SetsPropertiesCorrectly()
+    {
+        // Arrange
+        var formId = 1;
+        string? name = SampleData.FORM_NAME_1;
+        string? description = SampleData.FORM_DESCRIPTION_1;
+        bool? isEnabled = true;
+
+        // Act
+        var command = new PartialUpdateFormCommand(formId, name, description, isEnabled);
+
+        // Assert
+        command.FormId.Should().Be(formId);
+        command.Name.Should().Be(name);
+        command.Description.Should().Be(description);
+        command.IsEnabled.Should().Be(isEnabled);
+    }
+
+    [Fact]
+    public void Constructor_NullOptionalParameters_SetsPropertiesCorrectly()
+    {
+        // Arrange
+        var formId = 1;
+        string? name = null;
+        string? description = null;
+        bool? isEnabled = null;
+
+        // Act
+        var command = new PartialUpdateFormCommand(formId, name, description, isEnabled);
+
+        // Assert
+        command.FormId.Should().Be(formId);
+        command.Name.Should().BeNull();
+        command.Description.Should().BeNull();
+        command.IsEnabled.Should().BeNull();
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/Forms/PartialUpdate/PartialUpdateFormHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/PartialUpdate/PartialUpdateFormHandlerTests.cs
@@ -1,0 +1,79 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.Forms.PartialUpdate;
+
+namespace Endatix.Core.Tests.UseCases.Forms.PartialUpdate;
+
+public class PartialUpdateFormHandlerTests
+{
+    private readonly IRepository<Form> _repository;
+    private readonly PartialUpdateFormHandler _handler;
+
+    public PartialUpdateFormHandlerTests()
+    {
+        _repository = Substitute.For<IRepository<Form>>();
+        _handler = new PartialUpdateFormHandler(_repository);
+    }
+
+    [Fact]
+    public async Task Handle_FormNotFound_ReturnsNotFoundResult()
+    {
+        // Arrange
+        var request = new PartialUpdateFormCommand(1, null, null, null);
+        _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
+                   .Returns((Form)null);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be(ResultStatus.NotFound);
+        result.Errors.Should().Contain("Form not found.");
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_UpdatesForm()
+    {
+        // Arrange
+        var form = new Form() { Id = 1, Name = SampleData.FORM_NAME_1, Description = SampleData.FORM_DESCRIPTION_1, IsEnabled = true };
+        var request = new PartialUpdateFormCommand(1, SampleData.FORM_NAME_2, SampleData.FORM_DESCRIPTION_2, false);
+        _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
+                   .Returns(form);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().NotBeNull();
+        result.Value.Name.Should().Be(request.Name);
+        result.Value.Description.Should().Be(request.Description);
+        result.Value.IsEnabled.Should().Be(request.IsEnabled!.Value);
+        await _repository.Received(1).UpdateAsync(form, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_PartialUpdate_UpdatesOnlySpecifiedFields()
+    {
+        // Arrange
+        var form = new Form() { Id = 1, Name = SampleData.FORM_NAME_1, Description = SampleData.FORM_DESCRIPTION_1, IsEnabled = true };
+        var request = new PartialUpdateFormCommand(1, null, SampleData.FORM_DESCRIPTION_2, null);
+        _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
+                   .Returns(form);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().NotBeNull();
+        result.Value.Name.Should().Be(form.Name);
+        result.Value.Description.Should().Be(request.Description);
+        result.Value.IsEnabled.Should().Be(form.IsEnabled);
+        await _repository.Received(1).UpdateAsync(form, Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/Forms/Update/UpdateFormCommandTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/Update/UpdateFormCommandTests.cs
@@ -1,0 +1,61 @@
+using Endatix.Core.UseCases.Forms.Update;
+using static Endatix.Core.Tests.ErrorMessages;
+using static Endatix.Core.Tests.ErrorType;
+
+namespace Endatix.Core.Tests.UseCases.Forms.Update;
+
+public class UpdateFormCommandTests
+{
+    [Fact]
+    public void Constructor_NegativeOrZeroFormId_ThrowsArgumentException()
+    {
+        // Arrange
+        var formId = -1;
+        var name = SampleData.FORM_NAME_1;
+        var description = SampleData.FORM_DESCRIPTION_1;
+        var isEnabled = true;
+
+        // Act
+        Action act = () => new UpdateFormCommand(formId, name, description, isEnabled);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage(GetErrorMessage(nameof(formId), ZeroOrNegative));
+    }
+
+    [Fact]
+    public void Constructor_NullOrWhiteSpaceName_ThrowsArgumentException()
+    {
+        // Arrange
+        var formId = 1;
+        var name = "";
+        var description = SampleData.FORM_DESCRIPTION_1;
+        var isEnabled = true;
+
+        // Act
+        Action act = () => new UpdateFormCommand(formId, name, description, isEnabled);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage(GetErrorMessage(nameof(name), Empty));
+    }
+
+    [Fact]
+    public void Constructor_ValidParameters_SetsPropertiesCorrectly()
+    {
+        // Arrange
+        var formId = 1;
+        var name = SampleData.FORM_NAME_1;
+        var description = SampleData.FORM_DESCRIPTION_1;
+        var isEnabled = true;
+
+        // Act
+        var command = new UpdateFormCommand(formId, name, description, isEnabled);
+
+        // Assert
+        command.FormId.Should().Be(formId);
+        command.Name.Should().Be(name);
+        command.Description.Should().Be(description);
+        command.IsEnabled.Should().Be(isEnabled);
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/Forms/Update/UpdateFormHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/Update/UpdateFormHandlerTests.cs
@@ -1,0 +1,57 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.Forms.Update;
+
+namespace Endatix.Core.Tests.UseCases.Forms.Update;
+
+public class UpdateFormHandlerTests
+{
+    private readonly IRepository<Form> _repository;
+    private readonly UpdateFormHandler _handler;
+
+    public UpdateFormHandlerTests()
+    {
+        _repository = Substitute.For<IRepository<Form>>();
+        _handler = new UpdateFormHandler(_repository);
+    }
+
+    [Fact]
+    public async Task Handle_FormNotFound_ReturnsNotFoundResult()
+    {
+        // Arrange
+        var request = new UpdateFormCommand(1, SampleData.FORM_NAME_1, SampleData.FORM_DESCRIPTION_1, true);
+        _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
+                   .Returns((Form)null);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be(ResultStatus.NotFound);
+        result.Errors.Should().Contain("Form not found.");
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_UpdatesForm()
+    {
+        // Arrange
+        var form = new Form() { Id = 1, Name = SampleData.FORM_NAME_1, Description = SampleData.FORM_DESCRIPTION_1, IsEnabled = true };
+        var request = new UpdateFormCommand(1, SampleData.FORM_NAME_2, SampleData.FORM_DESCRIPTION_2, false);
+        _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
+                   .Returns(form);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().NotBeNull();
+        result.Value.Name.Should().Be(request.Name);
+        result.Value.Description.Should().Be(request.Description);
+        result.Value.IsEnabled.Should().Be(request.IsEnabled);
+        await _repository.Received(1).UpdateAsync(form, Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
# Add GET PUT and PATCH endpoints for a form

## Description
A form needs to have the ability to be edited and displayed. This is achieved by three endpoints:
- `GET forms/{formId}`
- `PUT forms/{formId}`
- `PATCH forms/{formId}`

The three endpoints are added to Endatix API and they strictly follow the way the corresponding endpoints for form definitions are implemented.

**Note:** #99 doesn't include creating GET endpoint but missing such will be a missing functionality in an API that provides endpoints for creating, updating and listing forms so it is also added in this PR.

## Related Issues
closes #99 

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
