### PR TITLE
fix: Set Submission CompletedAt time correctly

### DIFF
--- a/src/Endatix.Core/Entities/Submission.cs
+++ b/src/Endatix.Core/Entities/Submission.cs
@@ -32,7 +32,7 @@ namespace Endatix.Core.Entities;
         CurrentPage = currentPage;
         Metadata = metadata;
 
-        SetCompletionData(isComplete);
+        SetCompletionStatus(isComplete);
     }
 
     public void Update(string jsonData, long formDefinitionId, bool isComplete = true, int currentPage = 1, string metadata = null)
@@ -45,10 +45,10 @@ namespace Endatix.Core.Entities;
         CurrentPage = currentPage;
         Metadata = metadata;
 
-        SetCompletionData(isComplete);
+        SetCompletionStatus(isComplete);
     }
 
-    private void SetCompletionData(bool newIsCompleteValue)
+    private void SetCompletionStatus(bool newIsCompleteValue)
     {
         if (!IsComplete && newIsCompleteValue)
         {

--- a/src/Endatix.Core/Entities/Submission.cs
+++ b/src/Endatix.Core/Entities/Submission.cs
@@ -1,4 +1,3 @@
-using System;
 using Ardalis.GuardClauses;
 using Endatix.Core.Infrastructure.Domain;
 
@@ -29,15 +28,11 @@ namespace Endatix.Core.Entities;
             FormDefinitionId = formDefinitionId.Value;
         }
 
-        IsComplete = isComplete;
         JsonData = jsonData;
         CurrentPage = currentPage;
         Metadata = metadata;
 
-        if (isComplete)
-        {
-            CreatedAt = DateTime.UtcNow;
-        }
+        SetCompletionData(isComplete);
     }
 
     public void Update(string jsonData, long formDefinitionId, bool isComplete = true, int currentPage = 1, string metadata = null)
@@ -50,9 +45,14 @@ namespace Endatix.Core.Entities;
         CurrentPage = currentPage;
         Metadata = metadata;
 
-        if (!IsComplete && isComplete == true)
+        SetCompletionData(isComplete);
+    }
+
+    private void SetCompletionData(bool newIsCompleteValue)
+    {
+        if (!IsComplete && newIsCompleteValue)
         {
-            IsComplete = isComplete;
+            IsComplete = true;
             CompletedAt = DateTime.UtcNow;
         }
     }

--- a/tests/Endatix.Core.Tests/Entities/SubmissionConstructorTests.cs
+++ b/tests/Endatix.Core.Tests/Entities/SubmissionConstructorTests.cs
@@ -1,0 +1,79 @@
+using Endatix.Core.Entities;
+using static Endatix.Core.Tests.ErrorMessages;
+using static Endatix.Core.Tests.ErrorType;
+
+namespace Endatix.Core.Tests.Entities;
+
+public class SubmissionConstructorTests
+{
+    [Fact]
+    public void Constructor_NullJsonData_ThrowsArgumentNullException()
+    {
+        // Act
+        var action = () => new Submission(null);
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>()
+            .WithMessage(GetErrorMessage(nameof(Submission.JsonData), Null));
+    }
+
+    [Fact]
+    public void Constructor_EmptyJsonData_ThrowsArgumentException()
+    {
+        // Act
+        var action = () => new Submission(string.Empty);
+
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithMessage(GetErrorMessage(nameof(Submission.JsonData), Empty));
+    }
+
+    [Fact]
+    public void Constructor_NegativeFormDefinitionId_ThrowsArgumentException()
+    {
+        // Arrange
+        const string jsonData = SampleData.SUBMISSION_JSON_DATA_1;
+        const long invalidFormDefinitionId = -1;
+
+        // Act
+        var action = () => new Submission(jsonData, invalidFormDefinitionId);
+
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithMessage(GetErrorMessage(nameof(Submission.FormDefinitionId), ZeroOrNegative));
+    }
+
+    [Fact]
+    public void Constructor_ValidInput_SetsPropertiesCorrectly()
+    {
+        // Arrange
+        const string jsonData = SampleData.SUBMISSION_JSON_DATA_1;
+        const long formDefinitionId = 123;
+
+        // Act
+        var submission = new Submission(jsonData, formDefinitionId, isComplete: false, currentPage: 2, metadata: "Test");
+
+        // Assert
+        submission.Should().NotBeNull();
+        submission.JsonData.Should().Be(jsonData);
+        submission.FormDefinitionId.Should().Be(formDefinitionId);
+        submission.IsComplete.Should().BeFalse();
+        submission.CurrentPage.Should().Be(2);
+        submission.Metadata.Should().Be("Test");
+    }
+
+    [Fact]
+    public void Constructor_CompleteSubmission_SetsCompletedAt()
+    {
+        // Arrange
+        const string jsonData = SampleData.SUBMISSION_JSON_DATA_1;
+
+        // Act
+        var submission = new Submission(jsonData, isComplete: true);
+
+        // Assert
+        submission.Should().NotBeNull();
+        submission.IsComplete.Should().BeTrue();
+        submission.CompletedAt.Should().NotBeNull();
+    }
+}

--- a/tests/Endatix.Core.Tests/Entities/SubmissionUpdateTests.cs
+++ b/tests/Endatix.Core.Tests/Entities/SubmissionUpdateTests.cs
@@ -1,0 +1,86 @@
+using Endatix.Core.Entities;
+using static Endatix.Core.Tests.ErrorMessages;
+using static Endatix.Core.Tests.ErrorType;
+
+namespace Endatix.Core.Tests.Entities;
+
+public class SubmissionUpdateTests
+{
+    [Fact]
+    public void Update_NullJsonData_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var submission = new Submission(SampleData.SUBMISSION_JSON_DATA_1, formDefinitionId: 123);
+
+        // Act
+        var action = () => submission.Update(null, formDefinitionId: 123);
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>()
+            .WithMessage(GetErrorMessage(nameof(Submission.JsonData), Null));
+    }
+
+    [Fact]
+    public void Update_EmptyJsonData_ThrowsArgumentException()
+    {
+        // Arrange
+        var submission = new Submission(SampleData.SUBMISSION_JSON_DATA_1, formDefinitionId: 123);
+
+        // Act
+        var action = () => submission.Update(string.Empty, formDefinitionId: 123);
+
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithMessage(GetErrorMessage(nameof(Submission.JsonData), Empty));
+    }
+
+    [Fact]
+    public void Update_NegativeFormDefinitionId_ThrowsArgumentException()
+    {
+        // Arrange
+        var submission = new Submission(SampleData.SUBMISSION_JSON_DATA_1);
+        const long invalidFormDefinitionId = -1;
+
+        // Act
+        var action = () => submission.Update(SampleData.SUBMISSION_JSON_DATA_1, invalidFormDefinitionId);
+
+        // Assert
+        action.Should().Throw<ArgumentException>()
+            .WithMessage(GetErrorMessage(nameof(Submission.FormDefinitionId), ZeroOrNegative));
+    }
+
+    [Fact]
+    public void Update_ValidInput_UpdatesPropertiesCorrectly()
+    {
+        // Arrange
+        var submission = new Submission(SampleData.SUBMISSION_JSON_DATA_1, formDefinitionId: 123, isComplete: false);
+        const string updatedJsonData = SampleData.SUBMISSION_JSON_DATA_2;
+        const long updatedFormDefinitionId = 456;
+
+        // Act
+        submission.Update(updatedJsonData, updatedFormDefinitionId, isComplete: false, currentPage: 3, metadata: "Updated");
+
+        // Assert
+        submission.Should().NotBeNull();
+        submission.JsonData.Should().Be(updatedJsonData);
+        submission.FormDefinitionId.Should().Be(updatedFormDefinitionId);
+        submission.CurrentPage.Should().Be(3);
+        submission.Metadata.Should().Be("Updated");
+        submission.IsComplete.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Update_CompleteSubmission_UpdatesCompletedAt()
+    {
+        // Arrange
+        var submission = new Submission(SampleData.SUBMISSION_JSON_DATA_1);
+
+        // Act
+        submission.Update(SampleData.SUBMISSION_JSON_DATA_1, formDefinitionId: 123, isComplete: true);
+
+        // Assert
+        submission.Should().NotBeNull();
+        submission.IsComplete.Should().BeTrue();
+        submission.CompletedAt.Should().NotBeNull();
+    }
+}

--- a/tests/Endatix.Core.Tests/ErrorMessages.cs
+++ b/tests/Endatix.Core.Tests/ErrorMessages.cs
@@ -3,6 +3,7 @@ namespace Endatix.Core.Tests;
 public enum ErrorType
 {
     ZeroOrNegative,
+    Null,
     Empty,
 }
 
@@ -11,6 +12,7 @@ public static class ErrorMessages
     private static readonly Dictionary<ErrorType, string> errorMessageTemplates = new Dictionary<ErrorType, string>
     {
         { ErrorType.ZeroOrNegative, "Required input {0} cannot be zero or negative. (Parameter '{0}')" },
+        { ErrorType.Null, "Value cannot be null. (Parameter '{0}')" },
         { ErrorType.Empty, "Required input {0} was empty. (Parameter '{0}')" }
     };
 

--- a/tests/Endatix.Core.Tests/SampleData.cs
+++ b/tests/Endatix.Core.Tests/SampleData.cs
@@ -4,4 +4,6 @@ public static class SampleData
 {
     public const string FORM_DEFINITION_JSON_DATA_1 = "{\"type\":\"text\",\"name\":\"firstname\"";
     public const string FORM_DEFINITION_JSON_DATA_2 = "{\"type\":\"text\",\"name\":\"lastname\"";
+    public const string SUBMISSION_JSON_DATA_1 = "{\"firstname\":\"mr test\"";
+    public const string SUBMISSION_JSON_DATA_2 = "{\"firstname\":\"mrs test\"";
 }


### PR DESCRIPTION
# Set Submission CompletedAt time correctly

## Description
CompletedAt  has not set on Submission creation. The is fixed, the logic is extracted to follow DRY and tests are added for Submission entity.

## Related Issues
closes #101 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
