### PR TITLE
feat: Adding fire and forget publishing of MediatR notifications using custom INotificationPublisher

### DIFF
--- a/src/Endatix.Core/Infrastructure/Messaging/MediatRDomainEventDispatcher.cs
+++ b/src/Endatix.Core/Infrastructure/Messaging/MediatRDomainEventDispatcher.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using MediatR;
+﻿using MediatR;
 using Endatix.Core.Infrastructure.Domain;
 
 namespace Endatix.Core.Infrastructure.Messaging;

--- a/src/Endatix.Core/Infrastructure/Messaging/TaskToThreadPoolPublisher.cs
+++ b/src/Endatix.Core/Infrastructure/Messaging/TaskToThreadPoolPublisher.cs
@@ -1,0 +1,22 @@
+using MediatR;
+
+namespace Endatix.Core.Infrastructure.Messaging;
+
+/// <summary>
+/// A "fire and forget" notification publisher that uses the ThreadPool for background execution.
+/// This class is designed to publish notifications to their respective handlers in a non-blocking, asynchronous manner.
+/// It leverages the ThreadPool to execute the handlers in the background, allowing the system to return control as soon as possible.
+/// </summary>
+public class TaskToThreadPoolPublisher : INotificationPublisher
+{
+    /// <inheritdoc/>
+    public Task Publish(IEnumerable<NotificationHandlerExecutor> handlerExecutors, INotification notification, CancellationToken cancellationToken)
+    {
+        foreach (var handler in handlerExecutors)
+        {
+            _ = Task.Run(() => handler.HandlerCallback(notification, cancellationToken), default);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Endatix.Infrastructure/Setup/EndatixAppExtensions.cs
+++ b/src/Endatix.Infrastructure/Setup/EndatixAppExtensions.cs
@@ -115,7 +115,13 @@ public static class EndatixAppExtensions
             mediatRAssemblies = [.. mediatRAssemblies, .. meditROptions.AdditionalAssemblies];
         }
 
-        services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(mediatRAssemblies!));
+        services.AddMediatR(config =>
+        {
+            config.RegisterServicesFromAssemblies(mediatRAssemblies!);
+            config.NotificationPublisher = new TaskToThreadPoolPublisher();
+            config.NotificationPublisherType = typeof(TaskToThreadPoolPublisher);
+
+        });
         services.AddScoped<IDomainEventDispatcher, MediatRDomainEventDispatcher>();
 
         if (meditROptions.IncludeLoggingPipeline)

--- a/tests/Endatix.Core.Tests/Endatix.Core.Tests.csproj
+++ b/tests/Endatix.Core.Tests/Endatix.Core.Tests.csproj
@@ -4,12 +4,12 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />

--- a/tests/Endatix.Core.Tests/Infrastructure/Messaging/TaskToThreadPoolPublisherTests.cs
+++ b/tests/Endatix.Core.Tests/Infrastructure/Messaging/TaskToThreadPoolPublisherTests.cs
@@ -1,0 +1,80 @@
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Endatix.Core.Infrastructure.Messaging;
+using System.Diagnostics;
+
+namespace Endatix.Core.Tests.Infrastructure.Messaging;
+
+public class TaskToThreadPoolPublisherTests
+{
+    private const int ARBITRARY_LOW_DURATION_IN_MS = 50;
+    private readonly IServiceProvider _serviceProvider;
+    public TaskToThreadPoolPublisherTests()
+    {
+        var services = new ServiceCollection();
+        services.AddMediatR(cfg =>
+        {
+            cfg.RegisterServicesFromAssemblyContaining<TestNotification1>();
+            cfg.NotificationPublisher = new TaskToThreadPoolPublisher();
+            cfg.NotificationPublisherType = typeof(TaskToThreadPoolPublisher);
+        });
+
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task WhenTriggered_PublishNotifications_ShouldBeFireAndForget()
+    {
+        // Arrange
+        var mediator = _serviceProvider.GetRequiredService<IMediator>();
+        var timer = new Stopwatch();
+
+        timer.Start();
+
+        // Act
+        await mediator.Publish(new TestNotification1());
+        timer.Stop();
+
+        // Assert
+        var timeElapsed = timer.ElapsedMilliseconds;
+        timeElapsed.Should().BeLessThan(ARBITRARY_LOW_DURATION_IN_MS, because: $"{ARBITRARY_LOW_DURATION_IN_MS} is less than the duration of the NotificationHandlers, which are 200ms each. Passing shows that Publish is fire and forget");
+    }
+
+    [Fact]
+    public async Task WhenNotificationHandlerThrows_ControlFlowShouldNotThrow()
+    {
+        // Arrange
+        var mediator = _serviceProvider.GetRequiredService<IMediator>();
+
+        // Act
+        var action = async () => await mediator.Publish(new TestNotification2());
+
+        // Assert
+        await action.Should().NotThrowAsync<Exception>();
+    }
+
+    public class TestNotification1 : INotification
+    {
+        public class SleepyHandler : INotificationHandler<TestNotification1>
+        {
+            public async Task Handle(TestNotification1 notification, CancellationToken cancellationToken)
+                => await Task.Delay(250, cancellationToken);
+        }
+        public class AnotherSleepyHandler : INotificationHandler<TestNotification1>
+        {
+            public async Task Handle(TestNotification1 notification, CancellationToken cancellationToken)
+                => await Task.Delay(300, cancellationToken);
+        }
+    }
+
+
+
+    public class TestNotification2 : INotification
+    {
+        public class AnotherSleepyHandler : INotificationHandler<TestNotification1>
+        {
+            public Task Handle(TestNotification1 notification, CancellationToken cancellationToken)
+                => throw new Exception("Fatal exception during task execution");
+        }
+    }
+}


### PR DESCRIPTION
# Adding fire and forget publishing of MediatR notifications using custom INotificationPublisher

## Description
* Adding fire and forget publishing of MediatR notifications using custom `INotificationPublisher` -> `TaskToThreadPoolPublisher`. Next level of improvement will be using a queue for decoupled processing of long running background tasks
* Previously NotificatonPublisher was await foreach before returning the control flow making it impractical for our use case of IO tasks like sending emails.
* Now all tasks are sent to the tread pool and control flow is returned back immediately
* Now exceptions in the notifications handlers don't cause exceptions in the main control flow
* Adding tests to validate the desired behavior


## Related Issues
Resolves #129 

## Type of Change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots
These are logs to show how does this behave. Note the thread was released in 4ms to finalize the response and note that 1 handler threw and exception and another one slept for 5 seconds. Still, this did not affect the UI thread in measurable delay,

<img width="988" alt="image" src="https://github.com/user-attachments/assets/329a4e4a-af5a-4ee6-9e84-a8e3b94cdc12">

