### PR TITLE
feat: POC AI form creation

### DIFF
--- a/src/Endatix.Api/Endpoints/Assistant/DefineForm.DefineFormRequest.cs
+++ b/src/Endatix.Api/Endpoints/Assistant/DefineForm.DefineFormRequest.cs
@@ -14,4 +14,14 @@ public class DefineFormRequest
     /// Optional existing form definition to refine or modify.
     /// </summary>
     public string? Definition { get; set; }
+
+    /// <summary>
+    /// Optional assistant ID for continuing a conversation.
+    /// </summary>
+    public string? AssistantId { get; set; }
+
+    /// <summary>
+    /// Optional thread ID for continuing a conversation.
+    /// </summary>
+    public string? ThreadId { get; set; }
 }

--- a/src/Endatix.Api/Endpoints/Assistant/DefineForm.DefineFormRequest.cs
+++ b/src/Endatix.Api/Endpoints/Assistant/DefineForm.DefineFormRequest.cs
@@ -1,0 +1,17 @@
+namespace Endatix.Api.Endpoints.Assistant;
+
+/// <summary>
+/// Request model for defining a form using AI assistance.
+/// </summary>
+public class DefineFormRequest
+{
+    /// <summary>
+    /// The prompt to guide the AI in form definition.
+    /// </summary>
+    public string Prompt { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Optional existing form definition to refine or modify.
+    /// </summary>
+    public string? Definition { get; set; }
+}

--- a/src/Endatix.Api/Endpoints/Assistant/DefineForm.DefineFormResponse.cs
+++ b/src/Endatix.Api/Endpoints/Assistant/DefineForm.DefineFormResponse.cs
@@ -9,4 +9,14 @@ public class DefineFormResponse
     /// The AI-generated or refined form definition.
     /// </summary>
     public string Definition { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The assistant ID for continuing the conversation.
+    /// </summary>
+    public string? AssistantId { get; set; }
+
+    /// <summary>
+    /// The thread ID for continuing the conversation.
+    /// </summary>
+    public string? ThreadId { get; set; }
 }

--- a/src/Endatix.Api/Endpoints/Assistant/DefineForm.DefineFormResponse.cs
+++ b/src/Endatix.Api/Endpoints/Assistant/DefineForm.DefineFormResponse.cs
@@ -1,0 +1,12 @@
+namespace Endatix.Api.Endpoints.Assistant;
+
+/// <summary>
+/// Response model for the AI-assisted form definition.
+/// </summary>
+public class DefineFormResponse
+{
+    /// <summary>
+    /// The AI-generated or refined form definition.
+    /// </summary>
+    public string Definition { get; set; } = string.Empty;
+}

--- a/src/Endatix.Api/Endpoints/Assistant/DefineForm.DefineFormValidator.cs
+++ b/src/Endatix.Api/Endpoints/Assistant/DefineForm.DefineFormValidator.cs
@@ -1,0 +1,24 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Endatix.Api.Endpoints.Assistant;
+
+/// <summary>
+/// Validation rules for the <c>DefineFormRequest</c> class.
+/// </summary>
+public class DefineFormValidator : Validator<DefineFormRequest>
+{
+    /// <summary>
+    /// Default constructor
+    /// </summary>
+    public DefineFormValidator()
+    {
+        RuleFor(x => x.Prompt)
+            .NotEmpty()
+            .MaximumLength(1000);
+
+        RuleFor(x => x.Definition)
+            .MaximumLength(10000)
+            .When(x => x.Definition != null);
+    }
+}

--- a/src/Endatix.Api/Endpoints/Assistant/DefineForm.DefineFormValidator.cs
+++ b/src/Endatix.Api/Endpoints/Assistant/DefineForm.DefineFormValidator.cs
@@ -20,5 +20,13 @@ public class DefineFormValidator : Validator<DefineFormRequest>
         RuleFor(x => x.Definition)
             .MaximumLength(10000)
             .When(x => x.Definition != null);
+
+        RuleFor(x => x.AssistantId)
+            .NotEmpty()
+            .When(x => x.AssistantId != null);
+
+        RuleFor(x => x.ThreadId)
+            .NotEmpty()
+            .When(x => x.ThreadId != null);
     }
 }

--- a/src/Endatix.Api/Endpoints/Assistant/DefineForm.cs
+++ b/src/Endatix.Api/Endpoints/Assistant/DefineForm.cs
@@ -36,12 +36,16 @@ public class DefineForm(IMediator _mediator) : Endpoint<DefineFormRequest, Resul
     public override async Task<Results<Ok<DefineFormResponse>, BadRequest>> ExecuteAsync(DefineFormRequest request, CancellationToken cancellationToken)
     {
         var result = await _mediator.Send(
-            new DefineFormCommand(request.Prompt, request.Definition),
+            new DefineFormCommand(request.Prompt, request.Definition, request.AssistantId, request.ThreadId),
             cancellationToken);
 
         return result.ToEndpointResponse<
             Results<Ok<DefineFormResponse>, BadRequest>,
-            string,
-            DefineFormResponse>(definition => new DefineFormResponse { Definition = definition });
+            AssistedDefinitionDto,
+            DefineFormResponse>(assistedDefinition => new DefineFormResponse {
+                Definition = assistedDefinition.Definition,
+                AssistantId = assistedDefinition.AssistantId,
+                ThreadId = assistedDefinition.ThreadId
+            });
     }
 }

--- a/src/Endatix.Api/Endpoints/Assistant/DefineForm.cs
+++ b/src/Endatix.Api/Endpoints/Assistant/DefineForm.cs
@@ -1,0 +1,47 @@
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Endatix.Api.Infrastructure;
+using Endatix.Infrastructure.Identity.Authorization;
+using Endatix.Core.UseCases.Assistant.DefineForm;
+
+namespace Endatix.Api.Endpoints.Assistant;
+
+/// <summary>
+/// Endpoint for defining a form using AI assistance.
+/// </summary>
+public class DefineForm(IMediator _mediator) : Endpoint<DefineFormRequest, Results<Ok<DefineFormResponse>, BadRequest>>
+{
+    /// <summary>
+    /// Configures the endpoint settings.
+    /// </summary>
+    public override void Configure()
+    {
+        Post("assistant/forms/define");
+        Permissions(Allow.AllowAll);
+        Summary(s =>
+        {
+            s.Summary = "Define a form using AI assistance";
+            s.Description = "Uses AI to generate or refine a form definition based on the provided prompt.";
+            s.Responses[200] = "Form definition generated successfully.";
+            s.Responses[400] = "Invalid input data.";
+        });
+    }
+
+    /// <summary>
+    /// Executes the HTTP request for defining a form using AI assistance.
+    /// </summary>
+    /// <param name="request">The request model containing the prompt and optional existing definition.</param>
+    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
+    public override async Task<Results<Ok<DefineFormResponse>, BadRequest>> ExecuteAsync(DefineFormRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _mediator.Send(
+            new DefineFormCommand(request.Prompt, request.Definition),
+            cancellationToken);
+
+        return result.ToEndpointResponse<
+            Results<Ok<DefineFormResponse>, BadRequest>,
+            string,
+            DefineFormResponse>(definition => new DefineFormResponse { Definition = definition });
+    }
+}

--- a/src/Endatix.Core/Abstractions/IAssistantService.cs
+++ b/src/Endatix.Core/Abstractions/IAssistantService.cs
@@ -1,4 +1,5 @@
 using System;
+using Endatix.Core.UseCases.Assistant.DefineForm;
 
 namespace Endatix.Core.Abstractions;
 
@@ -12,6 +13,8 @@ public interface IAssistantService
     /// </summary>
     /// <param name="prompt">The prompt describing the form to be defined.</param>
     /// <param name="definition">An optional existing definition to be refined or expanded.</param>
-    /// <returns>A string containing the form definition.</returns>
-    string DefineForm(string prompt, string? definition = null);
+    /// <param name="assistantId">An optional ID of the assistant to use for adjusting the form definition.</param>
+    /// <param name="threadId">An optional ID of the conversation thread to use for adjusting the form definition.</param>
+    /// <returns>An AssistedDefinitionDto containing the form definition and associated IDs.</returns>
+    Task<AssistedDefinitionDto> DefineFormAsync(string prompt, string? definition = null, string? assistantId = null, string? threadId = null);
 }

--- a/src/Endatix.Core/Abstractions/IAssistantService.cs
+++ b/src/Endatix.Core/Abstractions/IAssistantService.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Endatix.Core.Abstractions;
+
+/// <summary>
+/// Defines operations related to AI assistant functionalities.
+/// </summary>
+public interface IAssistantService
+{
+    /// <summary>
+    /// Defines a form based on the given prompt and optional existing definition.
+    /// </summary>
+    /// <param name="prompt">The prompt describing the form to be defined.</param>
+    /// <param name="definition">An optional existing definition to be refined or expanded.</param>
+    /// <returns>A string containing the form definition.</returns>
+    string DefineForm(string prompt, string? definition = null);
+}

--- a/src/Endatix.Core/UseCases/Assistant/DefineForm/AssistedDefinitionDto.cs
+++ b/src/Endatix.Core/UseCases/Assistant/DefineForm/AssistedDefinitionDto.cs
@@ -1,0 +1,3 @@
+namespace Endatix.Core.UseCases.Assistant.DefineForm;
+
+public record AssistedDefinitionDto(string Definition, string AssistantId, string ThreadId);

--- a/src/Endatix.Core/UseCases/Assistant/DefineForm/DefineFormCommand.cs
+++ b/src/Endatix.Core/UseCases/Assistant/DefineForm/DefineFormCommand.cs
@@ -7,16 +7,20 @@ namespace Endatix.Core.UseCases.Assistant.DefineForm;
 /// <summary>
 /// Command for defining a form using AI assistance.
 /// </summary>
-public record DefineFormCommand : ICommand<Result<string>>
+public record DefineFormCommand : ICommand<Result<AssistedDefinitionDto>>
 {
     public string Prompt { get; init; }
     public string? Definition { get; init; }
+    public string? AssistantId { get; init; }
+    public string? ThreadId { get; init; }
 
-    public DefineFormCommand(string prompt, string? definition = null)
+    public DefineFormCommand(string prompt, string? definition = null, string? assistantId = null, string? threadId = null)
     {
         Guard.Against.NullOrWhiteSpace(prompt);
 
         Prompt = prompt;
         Definition = definition;
+        AssistantId = assistantId;
+        ThreadId = threadId;
     }
 }

--- a/src/Endatix.Core/UseCases/Assistant/DefineForm/DefineFormCommand.cs
+++ b/src/Endatix.Core/UseCases/Assistant/DefineForm/DefineFormCommand.cs
@@ -1,0 +1,22 @@
+using Ardalis.GuardClauses;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.Assistant.DefineForm;
+
+/// <summary>
+/// Command for defining a form using AI assistance.
+/// </summary>
+public record DefineFormCommand : ICommand<Result<string>>
+{
+    public string Prompt { get; init; }
+    public string? Definition { get; init; }
+
+    public DefineFormCommand(string prompt, string? definition = null)
+    {
+        Guard.Against.NullOrWhiteSpace(prompt);
+
+        Prompt = prompt;
+        Definition = definition;
+    }
+}

--- a/src/Endatix.Core/UseCases/Assistant/DefineForm/DefineFormHandler.cs
+++ b/src/Endatix.Core/UseCases/Assistant/DefineForm/DefineFormHandler.cs
@@ -6,7 +6,7 @@ using Endatix.Core.Infrastructure.Result;
 
 namespace Endatix.Core.UseCases.Assistant.DefineForm;
 
-public class DefineFormHandler : ICommandHandler<DefineFormCommand, Result<string>>
+public class DefineFormHandler : ICommandHandler<DefineFormCommand, Result<AssistedDefinitionDto>>
 {
     private readonly IAssistantService assistantService;
 
@@ -15,16 +15,9 @@ public class DefineFormHandler : ICommandHandler<DefineFormCommand, Result<strin
         this.assistantService = assistantService;
     }
 
-    public async Task<Result<string>> Handle(DefineFormCommand request, CancellationToken cancellationToken)
+    public async Task<Result<AssistedDefinitionDto>> Handle(DefineFormCommand request, CancellationToken cancellationToken)
     {
-        try
-        {
-            string formDefinition = assistantService.DefineForm(request.Prompt, request.Definition);
-            return Result.Success(formDefinition);
-        }
-        catch (Exception ex)
-        {
-            return Result.Error($"Failed to define form: {ex.Message}");
-        }
+        var assistedDefinition = await assistantService.DefineFormAsync(request.Prompt, request.Definition, request.AssistantId, request.ThreadId);
+        return Result.Success(assistedDefinition);
     }
 }

--- a/src/Endatix.Core/UseCases/Assistant/DefineForm/DefineFormHandler.cs
+++ b/src/Endatix.Core/UseCases/Assistant/DefineForm/DefineFormHandler.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Endatix.Core.Abstractions;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.Assistant.DefineForm;
+
+public class DefineFormHandler : ICommandHandler<DefineFormCommand, Result<string>>
+{
+    private readonly IAssistantService assistantService;
+
+    public DefineFormHandler(IAssistantService assistantService)
+    {
+        this.assistantService = assistantService;
+    }
+
+    public async Task<Result<string>> Handle(DefineFormCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            string formDefinition = assistantService.DefineForm(request.Prompt, request.Definition);
+            return Result.Success(formDefinition);
+        }
+        catch (Exception ex)
+        {
+            return Result.Error($"Failed to define form: {ex.Message}");
+        }
+    }
+}

--- a/src/Endatix.Infrastructure/Assistant/AssistantOptions.cs
+++ b/src/Endatix.Infrastructure/Assistant/AssistantOptions.cs
@@ -1,0 +1,21 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Endatix.Infrastructure.Assistant;
+
+/// <summary>
+/// Configuration options for AI Assistant
+/// </summary>
+public class AssistantOptions
+{
+    /// <summary>
+    /// The configuration section name where these options are stored.
+    /// </summary>
+    public const string SECTION_NAME = "Endatix:Assistant";
+
+    /// <summary>
+    /// The key used to access the OpenAI API.
+    /// This is required and must be set in the configuration.
+    /// </summary>
+    [Required]
+    public required string OpenAiApiKey { get; set; }
+}

--- a/src/Endatix.Infrastructure/Assistant/AssistantService.cs
+++ b/src/Endatix.Infrastructure/Assistant/AssistantService.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Threading.Tasks;
+using Endatix.Core.Abstractions;
+using OpenAI.Chat;
+
+namespace Endatix.Infrastructure.Assistant;
+
+public class AssistantService : IAssistantService
+{
+    private readonly string apiKey = "";
+    private readonly string model = "gpt-4o";
+    private readonly ChatClient client;
+
+    public AssistantService()
+    {
+        client = new(model: model, apiKey: apiKey);
+    }
+
+    public string DefineForm(string prompt, string? definition = null)
+    {
+        var completionPrompt = "Create a SurveyJS form based on the following prompt:\n" + prompt + "\nReturn only the JSON of the form definition formatted properly and do not return and explanations.";
+
+        ChatCompletion completion = client.CompleteChat(completionPrompt);
+
+        var result = completion.Content[0].Text;
+
+        return result;
+    }
+}

--- a/src/Endatix.Infrastructure/Assistant/AssistantService.cs
+++ b/src/Endatix.Infrastructure/Assistant/AssistantService.cs
@@ -1,19 +1,19 @@
 using System;
 using System.Threading.Tasks;
 using Endatix.Core.Abstractions;
+using Microsoft.Extensions.Options;
 using OpenAI.Chat;
 
 namespace Endatix.Infrastructure.Assistant;
 
 public class AssistantService : IAssistantService
 {
-    private readonly string apiKey = "";
     private readonly string model = "gpt-4o";
     private readonly ChatClient client;
 
-    public AssistantService()
+    public AssistantService(IOptions<AssistantOptions> assistantOptions)
     {
-        client = new(model: model, apiKey: apiKey);
+        client = new(model: model, apiKey: assistantOptions.Value.OpenAiApiKey);
     }
 
     public string DefineForm(string prompt, string? definition = null)

--- a/src/Endatix.Infrastructure/Assistant/AssistantService.cs
+++ b/src/Endatix.Infrastructure/Assistant/AssistantService.cs
@@ -1,29 +1,93 @@
-using System;
-using System.Threading.Tasks;
-using Endatix.Core.Abstractions;
+using System.ClientModel;
 using Microsoft.Extensions.Options;
-using OpenAI.Chat;
+using OpenAI.Assistants;
+using Endatix.Core.Abstractions;
+using Endatix.Core.UseCases.Assistant.DefineForm;
 
 namespace Endatix.Infrastructure.Assistant;
 
 public class AssistantService : IAssistantService
 {
+#pragma warning disable OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
+
+    private const string ASSISTANT_NAME = "SurveyJS form creator";
+    private const string ASSISTANT_INSTRUCTIONS = "You are an assistant that is an expert in SurveyJS and creating forms with it. "
+        + "When asked to generate a SurveyJS form definition, you return the JSON of the form definition.";
+    private const string NEW_DEFINITION_PROMPT_TEMPLATE = "Create a SurveyJS form based on the following prompt:\n{0}";
+    private const string EXISTING_DEFINITION_PROMPT_TEMPLATE = "Following is a SurveyJS form inside triple backticks:\n```{0}```\nAdjust it based on the following prompt:\n{1}";
     private readonly string model = "gpt-4o";
-    private readonly ChatClient client;
+    private readonly AssistantClient client;
 
     public AssistantService(IOptions<AssistantOptions> assistantOptions)
     {
-        client = new(model: model, apiKey: assistantOptions.Value.OpenAiApiKey);
+        client = new(assistantOptions.Value.OpenAiApiKey);
     }
 
-    public string DefineForm(string prompt, string? definition = null)
+    public async Task<AssistedDefinitionDto> DefineFormAsync(string prompt, string? definition = null, string? assistantId = null, string? threadId = null)
     {
-        var completionPrompt = "Create a SurveyJS form based on the following prompt:\n" + prompt + "\nReturn only the JSON of the form definition formatted properly and do not return and explanations.";
+        ThreadRun threadRun;
+        if (string.IsNullOrEmpty(assistantId) || string.IsNullOrEmpty(threadId))
+        {
+            AssistantCreationOptions assistantOptions = new()
+            {
+                Name = ASSISTANT_NAME,
+                Instructions = ASSISTANT_INSTRUCTIONS,
+                ResponseFormat = AssistantResponseFormat.CreateJsonObjectFormat()
+            };
+            OpenAI.Assistants.Assistant assistant = await client.CreateAssistantAsync(model, assistantOptions);
 
-        ChatCompletion completion = client.CompleteChat(completionPrompt);
+            var assistantPrompt = string.IsNullOrEmpty(definition) ?
+                string.Format(NEW_DEFINITION_PROMPT_TEMPLATE, prompt) :
+                string.Format(EXISTING_DEFINITION_PROMPT_TEMPLATE, definition, prompt);
 
-        var result = completion.Content[0].Text;
+            ThreadCreationOptions threadOptions = new()
+            {
+                InitialMessages = { assistantPrompt }
+            };
 
-        return result;
+            threadRun = await client.CreateThreadAndRunAsync(assistant.Id, threadOptions);
+        }
+        else
+        {
+            RunCreationOptions newRunOptions = new()
+            {
+                AdditionalMessages = { prompt }
+            };
+            threadRun = client.CreateRun(threadId, assistantId, newRunOptions);
+        }
+
+        WaitToComplete(threadRun);
+        var newDefinition = await GetLastMessage(threadRun.ThreadId);
+        return new AssistedDefinitionDto(newDefinition, threadRun.AssistantId, threadRun.ThreadId);
     }
+
+    private void WaitToComplete(ThreadRun threadRun)
+    {
+        do
+        {
+            Thread.Sleep(TimeSpan.FromMilliseconds(500));
+            threadRun = client.GetRun(threadRun.ThreadId, threadRun.Id);
+        } while (!threadRun.Status.IsTerminal);
+    }
+
+    private async Task<string> GetLastMessage(string threadId)
+    {
+        AsyncCollectionResult<ThreadMessage> threadMessages =
+            client.GetMessagesAsync(threadId, new MessageCollectionOptions() { Order = MessageCollectionOrder.Ascending });
+
+        var lastMessageContent = string.Empty;
+        await foreach (ThreadMessage message in threadMessages)
+        {
+            foreach (MessageContent contentItem in message.Content)
+            {
+                if (!string.IsNullOrEmpty(contentItem.Text))
+                {
+                    lastMessageContent = contentItem.Text;
+                }
+            }
+        }
+
+        return lastMessageContent;
+    }
+#pragma warning restore OPENAI001 // Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.
 }

--- a/src/Endatix.Infrastructure/Endatix.Infrastructure.csproj
+++ b/src/Endatix.Infrastructure/Endatix.Infrastructure.csproj
@@ -17,6 +17,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.5" />
+		<PackageReference Include="OpenAI" Version="2.0.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
 		<PackageReference Include="serilog.sinks.async" Version="2.0.0" />
 		<PackageReference Include="Ardalis.EFCore.Extensions" Version="6.0.0" />

--- a/src/Endatix.Infrastructure/Setup/EndatixAppExtensions.cs
+++ b/src/Endatix.Infrastructure/Setup/EndatixAppExtensions.cs
@@ -61,6 +61,10 @@ public static class EndatixAppExtensions
         endatixApp.AddDataOptions();
         endatixApp.SetupIdentity(setupSettings);
 
+        endatixApp.Services.AddOptions<AssistantOptions>()
+                .BindConfiguration(AssistantOptions.SECTION_NAME)
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
         endatixApp.Services.AddScoped<IAssistantService, AssistantService>();
 
         return endatixApp;

--- a/src/Endatix.Infrastructure/Setup/EndatixAppExtensions.cs
+++ b/src/Endatix.Infrastructure/Setup/EndatixAppExtensions.cs
@@ -4,6 +4,7 @@ using Endatix.Core.Infrastructure.Logging;
 using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Services;
 using Endatix.Framework.Hosting;
+using Endatix.Infrastructure.Assistant;
 using Endatix.Infrastructure.Data;
 using Endatix.Infrastructure.Email;
 using Endatix.Infrastructure.Identity;
@@ -59,6 +60,8 @@ public static class EndatixAppExtensions
 
         endatixApp.AddDataOptions();
         endatixApp.SetupIdentity(setupSettings);
+
+        endatixApp.Services.AddScoped<IAssistantService, AssistantService>();
 
         return endatixApp;
     }

--- a/src/Endatix.WebHost/appsettings.Development.json
+++ b/src/Endatix.WebHost/appsettings.Development.json
@@ -62,6 +62,9 @@
           "AllowCredentials": true
         }
       ]
+    },
+    "Assistant": {
+      "OpenAiApiKey": ""
     }
   }
 }

--- a/src/Endatix.WebHost/appsettings.json
+++ b/src/Endatix.WebHost/appsettings.json
@@ -74,6 +74,9 @@
           "PreflightMaxAgeInSeconds": 1200
         }
       ]
+    },
+    "Assistant": {
+      "OpenAiApiKey": ""
     }
   },
   "AllowedHosts": "*"


### PR DESCRIPTION
# POC AI form creation

## Description
Added endpoint POST assistant/forms/define according to the description of #140

## Related Issues
closes #140

## Type of Change
- [x] POC (non-breaking change which adds functionality)

## Testing
Example testing of the three scenarios from the issue:
1. Send request with prompt="I need a survey for movie feedback", check the returned definition and keep the assistant and thread IDs. This can be the case when a new form is created from scratch with AI.
2. Send request with prompt="Add a gender question" and the assistant and thread IDs from point 1, check the returned updated definition and keep it. This can be the case to continue an ongoing chat for editing a form with AI, no matter if it's a new or existing form.
3. Send request with prompt="Add three standard questions about Terminator 2" and the returned definition from point 2, check the returned updated definition. This can be the case when an existing form is edited with AI.

For checking the returned definition https://www.toolsoverflow.com/string/unescape-string can be used for escaping characters and then https://surveyjs.io/survey-creator/examples/free-nps-survey-template/reactjs can be used to set the JSON in the tab `JSON Editor` and then see the result in the tab `Preview'