### PR TITLE
feat: [POC] Return AssistantResponse in DefineForm endpoint

### DIFF
--- a/src/Endatix.Api/Endpoints/Assistant/DefineForm.DefineFormResponse.cs
+++ b/src/Endatix.Api/Endpoints/Assistant/DefineForm.DefineFormResponse.cs
@@ -6,17 +6,22 @@ namespace Endatix.Api.Endpoints.Assistant;
 public class DefineFormResponse
 {
     /// <summary>
+    /// The human-friendly response from the AI assistant.
+    /// </summary>
+    public string AssistantResponse { get; set; } = string.Empty;
+
+    /// <summary>
     /// The AI-generated or refined form definition.
     /// </summary>
-    public string Definition { get; set; } = string.Empty;
+    public string? Definition { get; set; }
 
     /// <summary>
     /// The assistant ID for continuing the conversation.
     /// </summary>
-    public string? AssistantId { get; set; }
+    public string AssistantId { get; set; } = string.Empty;
 
     /// <summary>
     /// The thread ID for continuing the conversation.
     /// </summary>
-    public string? ThreadId { get; set; }
+    public string ThreadId { get; set; } = string.Empty;
 }

--- a/src/Endatix.Api/Endpoints/Assistant/DefineForm.cs
+++ b/src/Endatix.Api/Endpoints/Assistant/DefineForm.cs
@@ -43,6 +43,7 @@ public class DefineForm(IMediator _mediator) : Endpoint<DefineFormRequest, Resul
             Results<Ok<DefineFormResponse>, BadRequest>,
             AssistedDefinitionDto,
             DefineFormResponse>(assistedDefinition => new DefineFormResponse {
+                AssistantResponse = assistedDefinition.AssistantResponse,
                 Definition = assistedDefinition.Definition,
                 AssistantId = assistedDefinition.AssistantId,
                 ThreadId = assistedDefinition.ThreadId

--- a/src/Endatix.Core/UseCases/Assistant/DefineForm/AssistedDefinitionDto.cs
+++ b/src/Endatix.Core/UseCases/Assistant/DefineForm/AssistedDefinitionDto.cs
@@ -1,3 +1,3 @@
 namespace Endatix.Core.UseCases.Assistant.DefineForm;
 
-public record AssistedDefinitionDto(string Definition, string AssistantId, string ThreadId);
+public record AssistedDefinitionDto(string AssistantResponse, string? Definition, string AssistantId, string ThreadId);


### PR DESCRIPTION
# Return AssistantResponse in DefineForm endpoint

## Description
Added a new field in the response called `AssistantResponse` that returns a human readable response from the AI Assistant. The response's `Definition` field is now optional as not every prompt makes changes to the definition.