### PR TITLE
feat: Form Submission Webhook

### DIFF
--- a/src/Endatix.Core/Abstractions/IPluginInitializer.cs
+++ b/src/Endatix.Core/Abstractions/IPluginInitializer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 
 namespace Endatix.Core;
 
@@ -11,5 +10,5 @@ public interface IPluginInitializer
      /// <summary>
      /// Initialization delete to implement the install logic exposing IServiceCollection. Example use (services) => { logic here... };
      /// </summary>
-     abstract static Action<IServiceCollection> InitializationDelegate { get; }
+     static abstract Action<IServiceCollection> InitializationDelegate { get; }
 }

--- a/src/Endatix.Core/Features/WebHooks/ActionName.cs
+++ b/src/Endatix.Core/Features/WebHooks/ActionName.cs
@@ -5,7 +5,7 @@ namespace Endatix.Core.Features.WebHooks;
 /// <summary>
 /// Enum for defining the types of actions that can be performed on an entity.
 /// </summary>
-public enum ActionNames
+public enum ActionName
 {
     /// <summary>
     /// Represents the action of creating an entity.

--- a/src/Endatix.Core/Features/WebHooks/ActionNameExtensions.cs
+++ b/src/Endatix.Core/Features/WebHooks/ActionNameExtensions.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace Endatix.Core.Features.WebHooks;
+
+/// <summary>
+/// Provides extension methods for the ActionNames enum to retrieve their display names.
+/// </summary>
+public static class ActionNameExtensions
+{
+    /// <summary>
+    /// Retrieves the display name of an ActionNames enum value.
+    /// </summary>
+    /// <param name="action">The ActionNames enum value to retrieve the display name for.</param>
+    /// <returns>The display name of the ActionNames enum value, or its string representation if no display name is found.</returns>
+    public static string GetDisplayName(this ActionNames action)
+    {
+        var displayAttribute = action.GetType()
+            .GetMember(action.ToString())
+            .FirstOrDefault()?
+            .GetCustomAttribute<DisplayAttribute>();
+
+        return displayAttribute?.Name ?? action.ToString();
+    }
+}

--- a/src/Endatix.Core/Features/WebHooks/ActionNameExtensions.cs
+++ b/src/Endatix.Core/Features/WebHooks/ActionNameExtensions.cs
@@ -13,7 +13,7 @@ public static class ActionNameExtensions
     /// </summary>
     /// <param name="action">The ActionNames enum value to retrieve the display name for.</param>
     /// <returns>The display name of the ActionNames enum value, or its string representation if no display name is found.</returns>
-    public static string GetDisplayName(this ActionNames action)
+    public static string GetDisplayName(this ActionName action)
     {
         var displayAttribute = action.GetType()
             .GetMember(action.ToString())

--- a/src/Endatix.Core/Features/WebHooks/ActionNames.cs
+++ b/src/Endatix.Core/Features/WebHooks/ActionNames.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Endatix.Core.Features.WebHooks;
+
+/// <summary>
+/// Enum for defining the types of actions that can be performed on an entity.
+/// </summary>
+public enum ActionNames
+{
+    /// <summary>
+    /// Represents the action of creating an entity.
+    /// </summary>
+    [Display(Name = "created")]
+    Created,
+    /// <summary>
+    /// Represents the action of updating an entity.
+    /// </summary>
+    [Display(Name = "updated")]
+    Updated,
+    /// <summary>
+    /// Represents the action of deleting an entity.
+    /// </summary>
+    [Display(Name = "deleted")]
+    Deleted,
+}

--- a/src/Endatix.Core/Features/WebHooks/IWebHookService.cs
+++ b/src/Endatix.Core/Features/WebHooks/IWebHookService.cs
@@ -1,0 +1,5 @@
+namespace Endatix.Core.Features.WebHooks;
+
+public interface IWebHookService<TPayload> {
+    Task EnqueueWebHookAsync(WebHookMessage<TPayload> message, CancellationToken cancellationToken);
+}

--- a/src/Endatix.Core/Features/WebHooks/IWebHookService.cs
+++ b/src/Endatix.Core/Features/WebHooks/IWebHookService.cs
@@ -1,5 +1,16 @@
 namespace Endatix.Core.Features.WebHooks;
 
-public interface IWebHookService<TPayload> {
-    Task EnqueueWebHookAsync(WebHookMessage<TPayload> message, CancellationToken cancellationToken);
+/// <summary>
+/// Defines the interface for a service that manages WebHook messages.
+/// </summary>
+public interface IWebHookService
+{
+    /// <summary>
+    /// Enqueues a WebHook message for processing.
+    /// </summary>
+    /// <typeparam name="TPayload">The type of the payload carried by the message.</typeparam>
+    /// <param name="message">The WebHook message to enqueue.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task EnqueueWebHookAsync<TPayload>(WebHookMessage<TPayload> message, CancellationToken cancellationToken) where TPayload : notnull;
 }

--- a/src/Endatix.Core/Features/WebHooks/WebHookMessage.cs
+++ b/src/Endatix.Core/Features/WebHooks/WebHookMessage.cs
@@ -4,7 +4,7 @@ namespace Endatix.Core.Features.WebHooks;
 /// Represents a message to be sent via a WebHook.
 /// </summary>
 /// <typeparam name="TPayload">The type of the payload carried by the message.</typeparam>
-public record WebHookMessage<TPayload>(long Id, string Operation, TPayload Payload)
+public record WebHookMessage<TPayload>(long Id, WebHookOperation Operation, TPayload Payload)
 {
     /// <summary>
     /// Gets or sets the unique identifier of the message.
@@ -12,9 +12,14 @@ public record WebHookMessage<TPayload>(long Id, string Operation, TPayload Paylo
     public long Id { get; init; } = Id;
 
     /// <summary>
+    /// Gets or sets the display name of the action associated with the message.
+    /// </summary>
+    public string Action { get; set; } = Operation.Action.GetDisplayName();
+
+    /// <summary>
     /// Gets or sets the operation associated with the message.
     /// </summary>
-    public string Operation { get; init; } = Operation;
+    public WebHookOperation Operation { get; init; } = Operation;
 
     /// <summary>
     /// Gets or sets the payload of the message.

--- a/src/Endatix.Core/Features/WebHooks/WebHookMessage.cs
+++ b/src/Endatix.Core/Features/WebHooks/WebHookMessage.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Endatix.Core.Features.WebHooks;
 
 /// <summary>
@@ -12,6 +14,11 @@ public record WebHookMessage<TPayload>(long Id, WebHookOperation Operation, TPay
     public long Id { get; init; } = Id;
 
     /// <summary>
+    /// Gets or sets the name of the event associated with the message.
+    /// </summary>
+    public string EventName { get; set; } = Operation.EventName;
+
+    /// <summary>
     /// Gets or sets the display name of the action associated with the message.
     /// </summary>
     public string Action { get; set; } = Operation.Action.GetDisplayName();
@@ -19,6 +26,7 @@ public record WebHookMessage<TPayload>(long Id, WebHookOperation Operation, TPay
     /// <summary>
     /// Gets or sets the operation associated with the message.
     /// </summary>
+    [JsonIgnore]
     public WebHookOperation Operation { get; init; } = Operation;
 
     /// <summary>

--- a/src/Endatix.Core/Features/WebHooks/WebHookMessage.cs
+++ b/src/Endatix.Core/Features/WebHooks/WebHookMessage.cs
@@ -1,0 +1,23 @@
+namespace Endatix.Core.Features.WebHooks;
+
+/// <summary>
+/// Represents a message to be sent via a WebHook.
+/// </summary>
+/// <typeparam name="TPayload">The type of the payload carried by the message.</typeparam>
+public record WebHookMessage<TPayload>(long Id, string Operation, TPayload Payload)
+{
+    /// <summary>
+    /// Gets or sets the unique identifier of the message.
+    /// </summary>
+    public long Id { get; init; } = Id;
+
+    /// <summary>
+    /// Gets or sets the operation associated with the message.
+    /// </summary>
+    public string Operation { get; init; } = Operation;
+
+    /// <summary>
+    /// Gets or sets the payload of the message.
+    /// </summary>
+    public TPayload Payload { get; init; } = Payload;
+}

--- a/src/Endatix.Core/Features/WebHooks/WebHookOperation.cs
+++ b/src/Endatix.Core/Features/WebHooks/WebHookOperation.cs
@@ -1,0 +1,42 @@
+using Endatix.Core.Entities;
+
+namespace Endatix.Core.Features.WebHooks;
+
+/// <summary>
+/// Represents a WebHook operation that can be performed on an entity.
+/// </summary>
+public record WebHookOperation
+{
+    /// <summary>
+    /// A static instance of WebHookOperation representing a form submission.
+    /// </summary>
+    public static readonly WebHookOperation FormSubmitted = new("form_submitted", nameof(Submission), ActionNames.Created);
+
+    /// <summary>
+    /// Initializes a new instance of the WebHookOperation record.
+    /// </summary>
+    /// <param name="eventName">The name of the WebHook event.</param>
+    /// <param name="entity">The entity on which the WebHook operation is performed.</param>
+    /// <param name="action">The action performed on the entity.</param>
+    private WebHookOperation(string eventName, string entity, ActionNames action)
+    {
+        EventName = eventName;
+        Entity = entity;
+        Action = action;
+    }
+
+    /// <summary>
+    /// Gets the name of the WebHook event.
+    /// </summary>
+    public string EventName { get; init; }
+
+    /// <summary>
+    /// Gets the entity on which the WebHook operation is performed.
+    /// </summary>
+    public string Entity { get; init; }
+
+    /// <summary>
+    /// Gets the action performed on the entity.
+    /// </summary>
+    public ActionNames Action { get; init; }
+}

--- a/src/Endatix.Core/Features/WebHooks/WebHookOperation.cs
+++ b/src/Endatix.Core/Features/WebHooks/WebHookOperation.cs
@@ -10,7 +10,7 @@ public record WebHookOperation
     /// <summary>
     /// A static instance of WebHookOperation representing a form submission.
     /// </summary>
-    public static readonly WebHookOperation FormSubmitted = new("form_submitted", nameof(Submission), ActionNames.Created);
+    public static readonly WebHookOperation FormSubmitted = new("form_submitted", nameof(Submission), ActionName.Created);
 
     /// <summary>
     /// Initializes a new instance of the WebHookOperation record.
@@ -18,7 +18,7 @@ public record WebHookOperation
     /// <param name="eventName">The name of the WebHook event.</param>
     /// <param name="entity">The entity on which the WebHook operation is performed.</param>
     /// <param name="action">The action performed on the entity.</param>
-    private WebHookOperation(string eventName, string entity, ActionNames action)
+    private WebHookOperation(string eventName, string entity, ActionName action)
     {
         EventName = eventName;
         Entity = entity;
@@ -38,5 +38,5 @@ public record WebHookOperation
     /// <summary>
     /// Gets the action performed on the entity.
     /// </summary>
-    public ActionNames Action { get; init; }
+    public ActionName Action { get; init; }
 }

--- a/src/Endatix.Core/Features/WebHooks/WebHookRequestHeaders.cs
+++ b/src/Endatix.Core/Features/WebHooks/WebHookRequestHeaders.cs
@@ -7,15 +7,15 @@ public class WebHookRequestHeaders
 {
 
     /// <summary>
-    /// The event header. E.g. "SubmissionCompletedEvent"
+    /// The event header. E.g. "form_created"
     /// </summary>
     public static string Event => $"{Constants.COMMON_HEADER_PREFIX}-Event";
     /// <summary>
-    /// The entity header, e.g. "Submission"
+    /// The entity header, e.g. "submission"
     /// </summary>
-    public static string Entity => $"{Constants.COMMON_HEADER_PREFIX}-Action";
+    public static string Entity => $"{Constants.COMMON_HEADER_PREFIX}-Entity";
     /// <summary>
-    /// The action header, e.g. "Create".
+    /// The action header, e.g. "created".
     /// </summary>
     public static string Action => $"{Constants.COMMON_HEADER_PREFIX}-Action";
 

--- a/src/Endatix.Core/Features/WebHooks/WebHookRequestHeaders.cs
+++ b/src/Endatix.Core/Features/WebHooks/WebHookRequestHeaders.cs
@@ -1,0 +1,49 @@
+namespace Endatix.Core.Features.WebHooks;
+
+/// <summary>
+/// This class contains the headers sent when a WebHook is fired.
+/// </summary>
+public class WebHookRequestHeaders
+{
+
+    /// <summary>
+    /// The event header. E.g. "SubmissionCompletedEvent"
+    /// </summary>
+    public static string Event => $"{Constants.COMMON_HEADER_PREFIX}-Event";
+    /// <summary>
+    /// The entity header, e.g. "Submission"
+    /// </summary>
+    public static string Entity => $"{Constants.COMMON_HEADER_PREFIX}-Action";
+    /// <summary>
+    /// The action header, e.g. "Create".
+    /// </summary>
+    public static string Action => $"{Constants.COMMON_HEADER_PREFIX}-Action";
+
+    /// <summary>
+    /// The hook id header. Unique Id associated with each Web Hook, so it can be traced and validated. Additionally, it can be used for ensuring indempotency of Web Hook requests.
+    /// </summary>
+    public static string HookId => $"{Constants.COMMON_HEADER_PREFIX}-Hook-Id";
+
+    /// <summary>
+    /// This header is sent if the webhook is configured with a secret. This is the HMAC hex digest of the request body, and is generated using the SHA-256 hash function and the secret as the HMAC key. 
+    /// NOTE - this is not implemented YET
+    /// </summary>
+    public static string Siganture => $"{Constants.COMMON_HEADER_PREFIX}-Signature";
+
+
+    /// <summary>
+    /// The constants used in the headers.
+    /// </summary>
+    public class Constants
+    {
+        /// <summary>
+        /// The common header prefix.
+        /// </summary>
+        public const string COMMON_HEADER_PREFIX = "X-Endatix";
+
+        /// <summary>
+        /// The value of the User Agent header that should be sent with each Web Hook request
+        /// </summary>
+        public const string ENDATIX_USER_AGENT = "Endatix-HookGun";
+    }
+}

--- a/src/Endatix.Core/Handlers/SubmissionCompletedHandler.cs
+++ b/src/Endatix.Core/Handlers/SubmissionCompletedHandler.cs
@@ -1,13 +1,20 @@
 using Microsoft.Extensions.Logging;
 using Endatix.Core.Events;
 using MediatR;
+using Endatix.Core.Features.WebHooks;
+using Endatix.Core.Specifications;
+using Endatix.Core.Entities;
 
 namespace Endatix.Core.Handlers;
 
-internal sealed class SubmissionCompletedHandler(ILogger<SubmissionCompletedHandler> logger) : INotificationHandler<SubmissionCompletedEvent>
+internal sealed class SubmissionCompletedHandler(IWebHookService<string> webHookService, ILogger<SubmissionCompletedHandler> logger) : INotificationHandler<SubmissionCompletedEvent>
 {
     public async Task Handle(SubmissionCompletedEvent domainEvent, CancellationToken cancellationToken)
     {
         logger.LogTrace("Handling Submission Created event for {@submissionId}", domainEvent.Submission);
+
+        var formSubmittedMessage = new WebHookMessage<string>(domainEvent.Submission.Id, "form_submitted", domainEvent.Submission.JsonData);
+
+        await webHookService.EnqueueWebHookAsync(formSubmittedMessage, cancellationToken);
     }
 }

--- a/src/Endatix.Core/Handlers/SubmissionCompletedHandler.cs
+++ b/src/Endatix.Core/Handlers/SubmissionCompletedHandler.cs
@@ -20,7 +20,7 @@ internal sealed class SubmissionCompletedHandler(IWebHookService webHookService,
     {
         logger.LogTrace("Handling Submission Created event for {@submissionId}", domainEvent.Submission);
 
-        var formSubmittedMessage = new WebHookMessage<SubmissionDto>(domainEvent.Submission.Id, "form_submitted", SubmissionDto.FromSubmission(domainEvent.Submission));
+        var formSubmittedMessage = new WebHookMessage<SubmissionDto>(domainEvent.Submission.Id, WebHookOperation.FormSubmitted, SubmissionDto.FromSubmission(domainEvent.Submission));
         await webHookService.EnqueueWebHookAsync(formSubmittedMessage, cancellationToken);
     }
 }

--- a/src/Endatix.Core/Handlers/SubmissionCompletedHandler.cs
+++ b/src/Endatix.Core/Handlers/SubmissionCompletedHandler.cs
@@ -2,17 +2,25 @@ using Microsoft.Extensions.Logging;
 using Endatix.Core.Events;
 using MediatR;
 using Endatix.Core.Features.WebHooks;
+using Endatix.Core.UseCases.Submissions;
 
 namespace Endatix.Core.Handlers;
 
-internal sealed class SubmissionCompletedHandler(IWebHookService<string> webHookService, ILogger<SubmissionCompletedHandler> logger) : INotificationHandler<SubmissionCompletedEvent>
+/// <summary>
+/// Handles the core Endatix logic on form submission completion.
+/// </summary>
+internal sealed class SubmissionCompletedHandler(IWebHookService webHookService, ILogger<SubmissionCompletedHandler> logger) : INotificationHandler<SubmissionCompletedEvent>
 {
+    /// <summary>
+    /// Handles the SubmissionCompletedEvent by sending a WebHook notification.
+    /// </summary>
+    /// <param name="domainEvent">The SubmissionCompletedEvent to handle.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     public async Task Handle(SubmissionCompletedEvent domainEvent, CancellationToken cancellationToken)
     {
         logger.LogTrace("Handling Submission Created event for {@submissionId}", domainEvent.Submission);
 
-        var formSubmittedMessage = new WebHookMessage<string>(domainEvent.Submission.Id, "form_submitted", domainEvent.Submission.JsonData);
-
+        var formSubmittedMessage = new WebHookMessage<SubmissionDto>(domainEvent.Submission.Id, "form_submitted", SubmissionDto.FromSubmission(domainEvent.Submission));
         await webHookService.EnqueueWebHookAsync(formSubmittedMessage, cancellationToken);
     }
 }

--- a/src/Endatix.Core/Handlers/SubmissionCompletedHandler.cs
+++ b/src/Endatix.Core/Handlers/SubmissionCompletedHandler.cs
@@ -2,8 +2,6 @@ using Microsoft.Extensions.Logging;
 using Endatix.Core.Events;
 using MediatR;
 using Endatix.Core.Features.WebHooks;
-using Endatix.Core.Specifications;
-using Endatix.Core.Entities;
 
 namespace Endatix.Core.Handlers;
 

--- a/src/Endatix.Core/UseCases/Submissions/SubmissionDto.cs
+++ b/src/Endatix.Core/UseCases/Submissions/SubmissionDto.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+using Ardalis.GuardClauses;
+using Endatix.Core.Entities;
+
+namespace Endatix.Core.UseCases.Submissions;
+
+/// <summary>
+/// Represents a submission data transfer object.
+/// </summary>
+/// <param name="Id">The unique identifier of the submission.</param>
+/// <param name="IsComplete">Indicates if the submission is complete.</param>
+/// <param name="JsonData">A dictionary containing JSON data related to the submission.</param>
+/// <param name="FormDefinitionId">The unique identifier of the form definition associated with the submission.</param>
+/// <param name="CurrentPage">The current page of the submission, if applicable.</param>
+/// <param name="CompletedAt">The date and time when the submission was completed, if applicable.</param>
+/// <param name="CreatedAt">The date and time when the submission was created.</param>
+public record SubmissionDto(long Id, bool IsComplete, Dictionary<string, object> JsonData, long FormDefinitionId, int? CurrentPage, DateTime? CompletedAt, DateTime CreatedAt)
+{
+    public long Id { get; init; } = Id;
+    public bool IsComplete { get; init; } = IsComplete;
+    public Dictionary<string, object> JsonData { get; init; } = JsonData;
+    public long FormDefinitionId { get; init; } = FormDefinitionId;
+    public int? CurrentPage { get; init; } = CurrentPage;
+    public DateTime? CompletedAt { get; init; } = CompletedAt;
+    public DateTime CreatedAt { get; init; } = CreatedAt;
+
+    public static SubmissionDto FromSubmission(Submission submission)
+    {
+        Guard.Against.Null(submission, nameof(submission));
+
+        try
+        {
+            var jsonData = JsonSerializer.Deserialize<Dictionary<string, object>>(submission.JsonData) ?? [];
+
+            return new SubmissionDto(
+                submission.Id,
+                 submission.IsComplete,
+                 jsonData,
+                 submission.FormDefinitionId,
+                 submission.CurrentPage,
+                 submission.CompletedAt,
+                 submission.CreatedAt
+            );
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidOperationException("Failed to deserialize JSON data", ex);
+        }
+    }
+}

--- a/src/Endatix.Core/UseCases/Submissions/SubmissionDto.cs
+++ b/src/Endatix.Core/UseCases/Submissions/SubmissionDto.cs
@@ -1,3 +1,4 @@
+using System.Reflection.Metadata.Ecma335;
 using System.Text.Json;
 using Ardalis.GuardClauses;
 using Endatix.Core.Entities;
@@ -14,11 +15,13 @@ namespace Endatix.Core.UseCases.Submissions;
 /// <param name="CurrentPage">The current page of the submission, if applicable.</param>
 /// <param name="CompletedAt">The date and time when the submission was completed, if applicable.</param>
 /// <param name="CreatedAt">The date and time when the submission was created.</param>
-public record SubmissionDto(long Id, bool IsComplete, Dictionary<string, object> JsonData, long FormDefinitionId, int? CurrentPage, DateTime? CompletedAt, DateTime CreatedAt)
+public record SubmissionDto(long Id, bool IsComplete, Dictionary<string, object> JsonData, string Metadata, long FormDefinitionId, int? CurrentPage, DateTime? CompletedAt, DateTime CreatedAt)
 {
     public long Id { get; init; } = Id;
     public bool IsComplete { get; init; } = IsComplete;
     public Dictionary<string, object> JsonData { get; init; } = JsonData;
+
+    public string  Metadata { get; init; } = Metadata;
     public long FormDefinitionId { get; init; } = FormDefinitionId;
     public int? CurrentPage { get; init; } = CurrentPage;
     public DateTime? CompletedAt { get; init; } = CompletedAt;
@@ -36,6 +39,7 @@ public record SubmissionDto(long Id, bool IsComplete, Dictionary<string, object>
                 submission.Id,
                  submission.IsComplete,
                  jsonData,
+                 submission.Metadata,
                  submission.FormDefinitionId,
                  submission.CurrentPage,
                  submission.CompletedAt,
@@ -44,7 +48,7 @@ public record SubmissionDto(long Id, bool IsComplete, Dictionary<string, object>
         }
         catch (JsonException ex)
         {
-            throw new InvalidOperationException("Failed to deserialize JSON data", ex);
+            throw new InvalidOperationException("Failed to deserialize Submission'sJSON data", ex);
         }
     }
 }

--- a/src/Endatix.Core/UseCases/Submissions/SubmissionDto.cs
+++ b/src/Endatix.Core/UseCases/Submissions/SubmissionDto.cs
@@ -1,4 +1,3 @@
-using System.Reflection.Metadata.Ecma335;
 using System.Text.Json;
 using Ardalis.GuardClauses;
 using Endatix.Core.Entities;
@@ -15,13 +14,13 @@ namespace Endatix.Core.UseCases.Submissions;
 /// <param name="CurrentPage">The current page of the submission, if applicable.</param>
 /// <param name="CompletedAt">The date and time when the submission was completed, if applicable.</param>
 /// <param name="CreatedAt">The date and time when the submission was created.</param>
-public record SubmissionDto(long Id, bool IsComplete, Dictionary<string, object> JsonData, string Metadata, long FormDefinitionId, int? CurrentPage, DateTime? CompletedAt, DateTime CreatedAt)
+/// <param name="Metadata">Additional metadata related to the submission.</param>
+public record SubmissionDto(long Id, bool IsComplete, Dictionary<string, object> JsonData, long FormDefinitionId, int? CurrentPage, DateTime? CompletedAt, DateTime CreatedAt, string? Metadata)
 {
     public long Id { get; init; } = Id;
     public bool IsComplete { get; init; } = IsComplete;
     public Dictionary<string, object> JsonData { get; init; } = JsonData;
-
-    public string  Metadata { get; init; } = Metadata;
+    public string? Metadata { get; init; } = Metadata;
     public long FormDefinitionId { get; init; } = FormDefinitionId;
     public int? CurrentPage { get; init; } = CurrentPage;
     public DateTime? CompletedAt { get; init; } = CompletedAt;
@@ -36,19 +35,19 @@ public record SubmissionDto(long Id, bool IsComplete, Dictionary<string, object>
             var jsonData = JsonSerializer.Deserialize<Dictionary<string, object>>(submission.JsonData) ?? [];
 
             return new SubmissionDto(
-                submission.Id,
-                 submission.IsComplete,
-                 jsonData,
-                 submission.Metadata,
-                 submission.FormDefinitionId,
-                 submission.CurrentPage,
-                 submission.CompletedAt,
-                 submission.CreatedAt
+                Id: submission.Id,
+                IsComplete: submission.IsComplete,
+                JsonData: jsonData,
+                FormDefinitionId: submission.FormDefinitionId,
+                CurrentPage: submission.CurrentPage,
+                CompletedAt: submission.CompletedAt,
+                CreatedAt: submission.CreatedAt,
+                Metadata: submission.Metadata
             );
         }
         catch (JsonException ex)
         {
-            throw new InvalidOperationException("Failed to deserialize Submission'sJSON data", ex);
+            throw new InvalidOperationException("Failed to deserialize Submission's JSON data", ex);
         }
     }
 }

--- a/src/Endatix.Infrastructure/Endatix.Infrastructure.csproj
+++ b/src/Endatix.Infrastructure/Endatix.Infrastructure.csproj
@@ -16,6 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="8.10.0" />
 		<PackageReference Include="Serilog.AspNetCore" Version="8.0.1" />
 		<PackageReference Include="serilog.sinks.async" Version="2.0.0" />
 		<PackageReference Include="Ardalis.EFCore.Extensions" Version="6.0.0" />

--- a/src/Endatix.Infrastructure/Features/WebHooks/BackgroundTaskWebHookService.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/BackgroundTaskWebHookService.cs
@@ -4,23 +4,22 @@ using Microsoft.Extensions.Options;
 namespace Endatix.Infrastructure.Features.WebHooks;
 
 /// <summary>
-/// Represents a service for handling background tasks related to WebHooks.
+/// Handles the queuing of WebHook messages for asynchronous processing in the background.
 /// </summary>
-/// <typeparam name="TPayload">The type of payload to be sent with the WebHook.</typeparam>
-internal class BackgroundTaskWebHookService<TPayload>(
+internal class BackgroundTaskWebHookService(
     IBackgroundTasksQueue backgroundQueue,
     IOptions<WebHookSettings> webHookOptions,
-    WebHookServer httpServer) : IWebHookService<TPayload>
+    WebHookServer httpServer) : IWebHookService
 {
     private readonly WebHookSettings _webHookSettings = webHookOptions.Value;
 
     /// <summary>
-    /// Enqueues a WebHook message for asynchronous processing.
+    /// Initiates the asynchronous processing of a WebHook message by adding it to the background queue.
     /// </summary>
-    /// <param name="message">The WebHook message to be enqueued.</param>
+    /// <param name="message">The WebHook message to be processed in the background.</param>
     /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    public async Task EnqueueWebHookAsync(WebHookMessage<TPayload> message, CancellationToken cancellationToken)
+    public async Task EnqueueWebHookAsync<TPayload>(WebHookMessage<TPayload> message, CancellationToken cancellationToken) where TPayload : notnull
     {
         var destinationUrls = _webHookSettings.SubmissionCompleted.WebHookUrls;
         if (destinationUrls is null || !destinationUrls.Any())
@@ -32,23 +31,11 @@ internal class BackgroundTaskWebHookService<TPayload>(
         {
             await backgroundQueue.EnqueueAsync(async token =>
              {
-                 WebHookProps webHookProps = new(destinationUrl);
-                 var result = await httpServer.FireWebHookAsync(message, webHookProps, token);
+                 TaskInstructions instructions = new(destinationUrl);
+                 var result = await httpServer.FireWebHookAsync(message, instructions, token);
              });
         }
 
         return;
     }
-}
-
-/// <summary>
-/// Represents properties for a WebHook.
-/// </summary>
-public class WebHookProps
-{
-    public WebHookProps(string uri)
-    {
-        Uri = uri;
-    }
-    public string Uri { get; init; }
 }

--- a/src/Endatix.Infrastructure/Features/WebHooks/BackgroundTaskWebHookService.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/BackgroundTaskWebHookService.cs
@@ -1,0 +1,35 @@
+using System.Text;
+using System.Text.Json;
+using Endatix.Core.Features.WebHooks;
+using Microsoft.Extensions.Logging;
+
+namespace Endatix.Infrastructure.Features.WebHooks;
+
+internal class BackgroundTaskWebHookService<TPayload>(
+    IBackgroundTasksQueue backgroundQueue,
+    WebHookServer httpServer) : IWebHookService<TPayload>
+{
+    public async Task EnqueueWebHookAsync(WebHookMessage<TPayload> message, CancellationToken cancellationToken)
+    {
+        await backgroundQueue.EnqueueAsync(async token =>
+         {
+
+             // https://webhook.site/3cbd0d84-9e49-4518-a18b-aa82f8fc6305
+             // https://66bf-212-5-158-18.ngrok-free.app
+             WebHookProps webHookProps = new("https://webhook.site/3cbd0d84-9e49-4518-a18b-aa82f8fc6305");
+             var result = await httpServer.FireWebHookAsync(message, webHookProps, token);
+         });
+
+        return;
+    }
+
+}
+
+public class WebHookProps
+{
+    public WebHookProps(string uri)
+    {
+        Uri = uri;
+    }
+    public string Uri { get; init; }
+}

--- a/src/Endatix.Infrastructure/Features/WebHooks/BackgroundTaskWebHookService.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/BackgroundTaskWebHookService.cs
@@ -1,23 +1,35 @@
-using System.Text;
-using System.Text.Json;
 using Endatix.Core.Features.WebHooks;
-using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Endatix.Infrastructure.Features.WebHooks;
 
+/// <summary>
+/// Represents a service for handling background tasks related to WebHooks.
+/// </summary>
+/// <typeparam name="TPayload">The type of payload to be sent with the WebHook.</typeparam>
 internal class BackgroundTaskWebHookService<TPayload>(
     IBackgroundTasksQueue backgroundQueue,
+    IOptions<WebHookSettings> webHookOptions,
     WebHookServer httpServer) : IWebHookService<TPayload>
 {
+    private readonly WebHookSettings _webHookSettings = webHookOptions.Value;
+
+    /// <summary>
+    /// Enqueues a WebHook message for asynchronous processing.
+    /// </summary>
+    /// <param name="message">The WebHook message to be enqueued.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
     public async Task EnqueueWebHookAsync(WebHookMessage<TPayload> message, CancellationToken cancellationToken)
     {
         await backgroundQueue.EnqueueAsync(async token =>
          {
-
-             // https://webhook.site/3cbd0d84-9e49-4518-a18b-aa82f8fc6305
-             // https://66bf-212-5-158-18.ngrok-free.app
-             WebHookProps webHookProps = new("https://webhook.site/3cbd0d84-9e49-4518-a18b-aa82f8fc6305");
-             var result = await httpServer.FireWebHookAsync(message, webHookProps, token);
+             var destinationUrl = _webHookSettings.SubmissionCompleted.WebHookUrls?.FirstOrDefault();
+             if (!string.IsNullOrEmpty(destinationUrl))
+             {
+                 WebHookProps webHookProps = new(destinationUrl);
+                 var result = await httpServer.FireWebHookAsync(message, webHookProps, token);
+             }
          });
 
         return;
@@ -25,6 +37,9 @@ internal class BackgroundTaskWebHookService<TPayload>(
 
 }
 
+/// <summary>
+/// Represents properties for a WebHook.
+/// </summary>
 public class WebHookProps
 {
     public WebHookProps(string uri)

--- a/src/Endatix.Infrastructure/Features/WebHooks/BackgroundTasksQueue.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/BackgroundTasksQueue.cs
@@ -1,0 +1,53 @@
+using System.Collections.Concurrent;
+using System.Threading.Channels;
+
+namespace Endatix.Infrastructure.Features.WebHooks;
+
+/// <summary>
+/// <inheritdoc/>
+/// Implements a queue for managing background tasks.
+/// </summary>
+public class BackgroundTasksQueue : IBackgroundTasksQueue
+{
+    private readonly Channel<Func<CancellationToken, ValueTask>> _queue;
+    private readonly SemaphoreSlim _signal;
+
+    public BackgroundTasksQueue(int capacity = 10)
+    {
+        // Capacity should be set based on the expected application load and number of concurrent threads accessing the queue. BoundedChannelFullMode.Wait will cause calls to WriteAsync() to return a task, which completes only when space became available. This leads to backpressure, in case too many publishers/calls start accumulating.
+        var options = new BoundedChannelOptions(capacity)
+        {
+            FullMode = BoundedChannelFullMode.Wait
+        };
+        _queue = Channel.CreateBounded<Func<CancellationToken, ValueTask>>(options);
+
+        _signal = new SemaphoreSlim(0);
+    }
+    /// <summary>
+    /// Adds a new background work item to the queue.
+    /// </summary>
+    /// <param name="workItem">The work item to be executed in the background.</param>
+    public async ValueTask EnqueueAsync(Func<CancellationToken, ValueTask> workItem)
+    {
+        if (workItem == null)
+        {
+            throw new ArgumentNullException(nameof(workItem));
+        }
+
+        await _queue.Writer.WriteAsync(workItem);
+        _signal.Release();
+    }
+
+    /// <summary>
+    /// Retrieves the next available background work item from the queue.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A task that represents the dequeued work item.</returns>
+    public async ValueTask<Func<CancellationToken, ValueTask>> DequeueAsync(CancellationToken cancellationToken)
+    {
+        await _signal.WaitAsync(cancellationToken);
+        var workItem = await _queue.Reader.ReadAsync(cancellationToken);
+        
+        return workItem;
+    }
+}

--- a/src/Endatix.Infrastructure/Features/WebHooks/IBackgroundTasksQueue.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/IBackgroundTasksQueue.cs
@@ -1,0 +1,19 @@
+namespace Endatix.Infrastructure.Features.WebHooks;
+/// <summary>
+/// Interface for managing a queue of long-running background tasks.
+/// </summary>
+public interface IBackgroundTasksQueue
+{
+    /// <summary>
+    /// Adds a new background work item to the queue.
+    /// </summary>
+    /// <param name="workItem">The work item to be executed in the background.</param>
+    ValueTask EnqueueAsync(Func<CancellationToken, ValueTask> workItem);
+
+    /// <summary>
+    /// Retrieves the next available background work item from the queue.
+    /// </summary>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <returns>A ValueTask that represents the dequeued work item.</returns>
+    ValueTask<Func<CancellationToken, ValueTask>> DequeueAsync(CancellationToken cancellationToken);
+}

--- a/src/Endatix.Infrastructure/Features/WebHooks/TaskInstructions.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/TaskInstructions.cs
@@ -1,0 +1,21 @@
+namespace Endatix.Infrastructure.Features.WebHooks;
+
+/// <summary>
+/// Represents a set of task instructions for specific webhook operation.
+/// </summary>
+public class TaskInstructions
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaskInstructions"/> class with the specified URI.
+    /// </summary>
+    /// <param name="uri">The URI associated with the task instruction set.</param>
+    public TaskInstructions(string uri)
+    {
+        Uri = uri;
+    }
+
+    /// <summary>
+    /// Gets the URI associated with the task instruction set.
+    /// </summary>
+    public string Uri { get; init; }
+}

--- a/src/Endatix.Infrastructure/Features/WebHooks/WebHookBackgroundWorker.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/WebHookBackgroundWorker.cs
@@ -1,0 +1,40 @@
+using Endatix.Infrastructure.Features.WebHooks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+// This class represents a background worker service responsible for processing WebHooks asynchronously.
+public class WebHookBackgroundWorker(IBackgroundTasksQueue backgroundTasksQueue, ILogger<WebHookBackgroundWorker> logger) : BackgroundService
+{
+    public IBackgroundTasksQueue TaskQueue => backgroundTasksQueue;
+
+    // This method starts the background service.
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("{service} Service is running.", nameof(WebHookBackgroundWorker));
+
+        await BackgroundProcessing(stoppingToken);
+
+        logger.LogInformation("{service} Service is stopped.", nameof(WebHookBackgroundWorker));
+    }
+
+    private async Task BackgroundProcessing(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var workItem = await backgroundTasksQueue.DequeueAsync(stoppingToken);
+
+            try
+            {
+                await workItem(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex,
+                    "Error occurred executing {WorkItem}.", nameof(workItem));
+            }
+
+            // Optional: Preventing tight loops by giving 200 ms delay
+            await Task.Delay(200, stoppingToken);
+        }
+    }
+}

--- a/src/Endatix.Infrastructure/Features/WebHooks/WebHookServer.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/WebHookServer.cs
@@ -16,10 +16,10 @@ internal class WebHookServer(HttpClient httpClient, ILogger<WebHookServer> logge
     /// </summary>
     /// <typeparam name="T">The type of the payload carried by the WebHook message.</typeparam>
     /// <param name="message">The WebHook message to be sent.</param>
-    /// <param name="instructions">Properties for the WebHook, including the URI.</param>
+    /// <param name="instructions">Properties for the WebHook operation, including the destination URI.</param>
     /// <param name="token">A cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The task result indicates if the WebHook was successfully processed.</returns>
-    internal async Task<bool> FireWebHookAsync<T>(WebHookMessage<T> message, WebHookProps instructions, CancellationToken token)
+    internal async Task<bool> FireWebHookAsync<T>(WebHookMessage<T> message, TaskInstructions instructions, CancellationToken token)
     {
         var isSuccess = false;
         try

--- a/src/Endatix.Infrastructure/Features/WebHooks/WebHookServer.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/WebHookServer.cs
@@ -1,0 +1,55 @@
+using System.Text;
+using System.Text.Json;
+using Endatix.Core.Features.WebHooks;
+using Microsoft.Extensions.Logging;
+
+namespace Endatix.Infrastructure.Features.WebHooks;
+
+/// <summary>
+/// Represents a server for firing WebHooks.
+/// </summary>
+internal class WebHookServer(HttpClient httpClient, ILogger<WebHookServer> logger)
+{
+    /// <summary>
+    /// Fires a WebHook asynchronously.
+    /// </summary>
+    /// <typeparam name="T">The type of the payload carried by the WebHook message.</typeparam>
+    /// <param name="message">The WebHook message to be sent.</param>
+    /// <param name="instructions">Properties for the WebHook, including the URI.</param>
+    /// <param name="token">A cancellation token.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result indicates if the WebHook was successfully processed.</returns>
+    internal async Task<bool> FireWebHookAsync<T>(WebHookMessage<T> message, WebHookProps instructions, CancellationToken token)
+    {
+        var isSuccess = false; // Flag to indicate if the WebHook was successfully processed
+        try
+        {
+            // Serialize the WebHook message to JSON
+            var jsonContent = JsonSerializer.Serialize(message);
+            // Create a StringContent object with the serialized JSON and set the content type to application/json
+            var content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
+            // Post the content to the specified URI
+            var response = await httpClient.PostAsync(instructions.Uri, content, token);
+
+            // Check if the response was successful
+            if (response.IsSuccessStatusCode)
+            {
+                // Log a trace message indicating the WebHook was successfully processed
+                logger.LogTrace($"Successfully processed WebHook for Submission. Status Code: {response.StatusCode}");
+                isSuccess = true; // Set the success flag to true
+            }
+            else
+            {
+                // Log a warning message if the WebHook processing failed
+                logger.LogWarning($"Failed to process WebHook. Status Code: {response.StatusCode}");
+            }
+
+        }
+        catch (Exception ex)
+        {
+            // Log an error message if an exception occurs during WebHook processing
+            logger.LogError(ex, "Error occurred while processing WebHook @{message}.", message);
+        }
+
+        return isSuccess; // Return the success flag
+    }
+}

--- a/src/Endatix.Infrastructure/Features/WebHooks/WebHookServer.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/WebHookServer.cs
@@ -41,12 +41,12 @@ internal class WebHookServer(HttpClient httpClient, ILogger<WebHookServer> logge
 
             if (response.IsSuccessStatusCode)
             {
-                logger.LogTrace($"Successfully processed WebHook for Submission. Status Code: {response.StatusCode}");
+                logger.LogTrace($"Successfully processed WebHook for operation: {message.Operation}. Item id: {message.Id}. Status Code: {response.StatusCode}");
                 isSuccess = true;
             }
             else
             {
-                logger.LogError($"Failed to process WebHook. Status Code: {response.StatusCode}");
+                logger.LogError($"Failed to process WebHookfor operation: {message.Operation}. Item id: {message.Id}. Status Code: {response.StatusCode}");
             }
 
         }

--- a/src/Endatix.Infrastructure/Features/WebHooks/WebHookServer.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/WebHookServer.cs
@@ -50,10 +50,12 @@ internal class WebHookServer(HttpClient httpClient, ILogger<WebHookServer> logge
             }
 
         }
+         // This exception is thrown when a single request times out (configured with WebHookSettings's AttemptTimeoutInSeconds setting)
         catch (TaskCanceledException ex)
         {
-            logger.LogError("Webhook execution was cancelled. Failed operation: {operation}.Item id: {id}. Destination: {url}. Error message: {message}.", message.Operation, message.Id, instructions.Uri, ex.Message);
+            logger.LogError("Webhook execution was cancelled due to timeout. Failed operation: {operation}. Item id: {id}. Destination: {url}. Error message: {message}.", message.Operation, message.Id, instructions.Uri, ex.Message);
         }
+        // This exception is thrown when the resilience pipeline cancels any further execution (max attempts or total timeout reached.)
         catch (TimeoutRejectedException ex)
         {
             logger.LogError("Webhook execution rejected because of timeout. Failed operation: {operation}.Item id: {id}. Destination: {url}. Error message: {message}.", message.Operation, message.Id, instructions.Uri, ex.Message);

--- a/src/Endatix.Infrastructure/Features/WebHooks/WebHookSettings.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/WebHookSettings.cs
@@ -23,33 +23,33 @@ public class WebHookSettings : IEndatixSettings
 
     /// <summary>
     /// Gets or sets the timeout for each attempt in seconds. Allowed range: 1-120.
-    /// </summary>  
+    /// </summary>
     [Range(1, 120)]
     public uint AttemptTimeoutInSeconds { get; set; } = DEFAULT_ATTEMPT_TIMEOUT_IN_SECONDS;
 
     /// <summary>
     /// Gets or sets the number of retry attempts. Allowed range: 1-10.
-    /// </summary>  
+    /// </summary>
     [Range(1, 10)]
     public int RetryAttempts { get; set; } = DEFAULT_RETRY_ATTEMPTS;
 
     /// <summary>
     /// Gets or sets the delay between retries in seconds. Allowed range: 1-60.
-    /// </summary>  
+    /// </summary>
     [Range(1, 60)]
     public int Delay { get; set; } = DEFAULT_DELAY_IN_SECONDS;
 
 
-    /// <summary>       
+    /// <summary>
     /// Gets or sets the maximum number of concurrent requests. Allowed range: 1-100.
-    /// </summary>  
+    /// </summary>
     [Range(1, 100)]
     public int MaxConcurrentRequests { get; set; } = DEFAULT_MAX_CONCURRENT_REQUESTS;
 
 
-    /// <summary>       
+    /// <summary>
     /// Gets or sets the maximum number of requests in the queue. Allowed range: 1-100.
-    /// </summary>  
+    /// </summary>
     [Range(1, 100)]
     public int MaxQueueSize { get; set; } = DEFAULT_MAX_QUEUE_SIZE;
 

--- a/src/Endatix.Infrastructure/Features/WebHooks/WebHookSettings.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/WebHookSettings.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Endatix.Framework.Settings;
+using static Endatix.Infrastructure.Features.WebHooks.WebHooksPlugin;
 
 namespace Endatix.Infrastructure.Features.WebHooks;
 
@@ -8,63 +9,89 @@ namespace Endatix.Infrastructure.Features.WebHooks;
 /// </summary>
 public class WebHookSettings : IEndatixSettings
 {
-    public const uint DEFAULT_PIPELINE_TIMEOUT_IN_SECONDS = 120;
-    public const uint DEFAULT_ATTEMPT_TIMEOUT_IN_SECONDS = 10;
-    public const int DEFAULT_RETRY_ATTEMPTS = 5;
-    public const int DEFAULT_DELAY_IN_SECONDS = 10;
-    public const int DEFAULT_MAX_CONCURRENT_REQUESTS = 5;
-    public const int DEFAULT_MAX_QUEUE_SIZE = 25;
 
     /// <summary>
-    /// Gets or sets the timeout for the webhook pipeline in seconds. Allowed range: 1-600.
+    /// Represents the settings for the HTTP server handling WebHooks.
     /// </summary>
-    [Range(1, 600)]
-    public uint PipelineTimeoutInSeconds { get; set; } = DEFAULT_PIPELINE_TIMEOUT_IN_SECONDS;
+    public HttpServerSettings ServerSettings { get; set; } = new();
 
     /// <summary>
-    /// Gets or sets the timeout for each attempt in seconds. Allowed range: 1-120.
+    /// Represents the collection of WebHook events and their settings.
     /// </summary>
-    [Range(1, 120)]
-    public uint AttemptTimeoutInSeconds { get; set; } = DEFAULT_ATTEMPT_TIMEOUT_IN_SECONDS;
+    public WebHookEvents Events { get; set; } = new();
 
     /// <summary>
-    /// Gets or sets the number of retry attempts. Allowed range: 1-10.
+    /// Represents the settings for the HTTP server handling WebHooks.
     /// </summary>
-    [Range(1, 10)]
-    public int RetryAttempts { get; set; } = DEFAULT_RETRY_ATTEMPTS;
+    public class HttpServerSettings
+    {
+        private const uint DEFAULT_PIPELINE_TIMEOUT_IN_SECONDS = 120;
+        private const uint DEFAULT_ATTEMPT_TIMEOUT_IN_SECONDS = 10;
+        private const int DEFAULT_RETRY_ATTEMPTS = 5;
+        private const int DEFAULT_DELAY_IN_SECONDS = 10;
+        private const int DEFAULT_MAX_CONCURRENT_REQUESTS = 5;
+        private const int DEFAULT_MAX_QUEUE_SIZE = 25;
+
+        /// <summary>
+        /// Gets or sets the timeout for the webhook pipeline in seconds. Allowed range: 1-600.
+        /// </summary>
+        [Range(1, 600)]
+        public uint PipelineTimeoutInSeconds { get; set; } = DEFAULT_PIPELINE_TIMEOUT_IN_SECONDS;
+
+        /// <summary>
+        /// Gets or sets the timeout for each attempt in seconds. Allowed range: 1-120.
+        /// </summary>
+        [Range(1, 120)]
+        public uint AttemptTimeoutInSeconds { get; set; } = DEFAULT_ATTEMPT_TIMEOUT_IN_SECONDS;
+
+        /// <summary>
+        /// Gets or sets the number of retry attempts. Allowed range: 1-10.
+        /// </summary>
+        [Range(1, 10)]
+        public int RetryAttempts { get; set; } = DEFAULT_RETRY_ATTEMPTS;
+
+        /// <summary>
+        /// Gets or sets the delay between retries in seconds. Allowed range: 1-60.
+        /// </summary>
+        [Range(1, 60)]
+        public int Delay { get; set; } = DEFAULT_DELAY_IN_SECONDS;
+
+
+        /// <summary>
+        /// Gets or sets the maximum number of concurrent requests. Allowed range: 1-100.
+        /// </summary>
+        [Range(1, 100)]
+        public int MaxConcurrentRequests { get; set; } = DEFAULT_MAX_CONCURRENT_REQUESTS;
+
+
+        /// <summary>
+        /// Gets or sets the maximum number of requests in the queue. Allowed range: 1-100.
+        /// </summary>
+        [Range(1, 100)]
+        public int MaxQueueSize { get; set; } = DEFAULT_MAX_QUEUE_SIZE;
+    }
 
     /// <summary>
-    /// Gets or sets the delay between retries in seconds. Allowed range: 1-60.
+    /// Represents the collection of WebHook events and their settings.
     /// </summary>
-    [Range(1, 60)]
-    public int Delay { get; set; } = DEFAULT_DELAY_IN_SECONDS;
-
-
-    /// <summary>
-    /// Gets or sets the maximum number of concurrent requests. Allowed range: 1-100.
-    /// </summary>
-    [Range(1, 100)]
-    public int MaxConcurrentRequests { get; set; } = DEFAULT_MAX_CONCURRENT_REQUESTS;
-
-
-    /// <summary>
-    /// Gets or sets the maximum number of requests in the queue. Allowed range: 1-100.
-    /// </summary>
-    [Range(1, 100)]
-    public int MaxQueueSize { get; set; } = DEFAULT_MAX_QUEUE_SIZE;
-
-
-
-    /// <summary>
-    /// Gets or sets the settings for the SubmissionCompleted event.
-    /// </summary>
-    public EventSetting SubmissionCompleted { get; set; } = new() { EventName = WebHooksPlugin.EventNames.FORM_SUBMITTED };
+    public class WebHookEvents
+    {
+        /// <summary>
+        /// Represents the settings for the 'FormSubmitted' event.
+        /// </summary>
+        public EventSetting FormSubmitted { get; set; } = new() { EventName = EventNames.FORM_SUBMITTED };
+    }
 
     /// <summary>
     /// Represents a setting for a specific event.
     /// </summary>
     public class EventSetting
     {
+        /// <summary>
+        /// Indicates whether the event is enabled.
+        /// </summary>
+        public bool IsEnabled { get; init; } = false;
+
         /// <summary>
         /// Gets or sets the name of the event.
         /// </summary>
@@ -76,4 +103,3 @@ public class WebHookSettings : IEndatixSettings
         public IEnumerable<string>? WebHookUrls { get; init; }
     }
 }
-

--- a/src/Endatix.Infrastructure/Features/WebHooks/WebHookSettings.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/WebHookSettings.cs
@@ -1,0 +1,31 @@
+using Endatix.Framework.Settings;
+
+namespace Endatix.Infrastructure.Features.WebHooks;
+
+/// <summary>
+/// Represents the settings for WebHooks in the application.
+/// </summary>
+public class WebHookSettings : IEndatixSettings
+{
+    /// <summary>
+    /// Gets or sets the settings for the SubmissionCompleted event.
+    /// </summary>
+    public EventSetting SubmissionCompleted { get; set; } = new() { EventName = WebHooksPlugin.EventNames.FORM_SUBMITTED };
+
+    /// <summary>
+    /// Represents a setting for a specific event.
+    /// </summary>
+    public class EventSetting
+    {
+        /// <summary>
+        /// Gets or sets the name of the event.
+        /// </summary>
+        public required string EventName { get; init; }
+
+        /// <summary>
+        /// Gets or sets the URLs for the WebHooks associated with this event.
+        /// </summary>
+        public IEnumerable<string>? WebHookUrls { get; init; }
+    }
+}
+

--- a/src/Endatix.Infrastructure/Features/WebHooks/WebHookSettings.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/WebHookSettings.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel.DataAnnotations;
 using Endatix.Framework.Settings;
 
 namespace Endatix.Infrastructure.Features.WebHooks;
@@ -7,6 +8,53 @@ namespace Endatix.Infrastructure.Features.WebHooks;
 /// </summary>
 public class WebHookSettings : IEndatixSettings
 {
+    public const uint DEFAULT_PIPELINE_TIMEOUT_IN_SECONDS = 120;
+    public const uint DEFAULT_ATTEMPT_TIMEOUT_IN_SECONDS = 10;
+    public const int DEFAULT_RETRY_ATTEMPTS = 5;
+    public const int DEFAULT_DELAY_IN_SECONDS = 10;
+    public const int DEFAULT_MAX_CONCURRENT_REQUESTS = 5;
+    public const int DEFAULT_MAX_QUEUE_SIZE = 25;
+
+    /// <summary>
+    /// Gets or sets the timeout for the webhook pipeline in seconds. Allowed range: 1-600.
+    /// </summary>
+    [Range(1, 600)]
+    public uint PipelineTimeoutInSeconds { get; set; } = DEFAULT_PIPELINE_TIMEOUT_IN_SECONDS;
+
+    /// <summary>
+    /// Gets or sets the timeout for each attempt in seconds. Allowed range: 1-120.
+    /// </summary>  
+    [Range(1, 120)]
+    public uint AttemptTimeoutInSeconds { get; set; } = DEFAULT_ATTEMPT_TIMEOUT_IN_SECONDS;
+
+    /// <summary>
+    /// Gets or sets the number of retry attempts. Allowed range: 1-10.
+    /// </summary>  
+    [Range(1, 10)]
+    public int RetryAttempts { get; set; } = DEFAULT_RETRY_ATTEMPTS;
+
+    /// <summary>
+    /// Gets or sets the delay between retries in seconds. Allowed range: 1-60.
+    /// </summary>  
+    [Range(1, 60)]
+    public int Delay { get; set; } = DEFAULT_DELAY_IN_SECONDS;
+
+
+    /// <summary>       
+    /// Gets or sets the maximum number of concurrent requests. Allowed range: 1-100.
+    /// </summary>  
+    [Range(1, 100)]
+    public int MaxConcurrentRequests { get; set; } = DEFAULT_MAX_CONCURRENT_REQUESTS;
+
+
+    /// <summary>       
+    /// Gets or sets the maximum number of requests in the queue. Allowed range: 1-100.
+    /// </summary>  
+    [Range(1, 100)]
+    public int MaxQueueSize { get; set; } = DEFAULT_MAX_QUEUE_SIZE;
+
+
+
     /// <summary>
     /// Gets or sets the settings for the SubmissionCompleted event.
     /// </summary>

--- a/src/Endatix.Infrastructure/Features/WebHooks/WebHooksPlugin.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/WebHooksPlugin.cs
@@ -1,0 +1,14 @@
+using Endatix.Core;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Endatix.Infrastructure.Features.WebHooks;
+
+public class WebHooksPlugin : IPluginInitializer
+{
+    public class EventNames
+    {
+        public const string FORM_SUBMITTED = "form_submitted";
+    }
+
+    public static Action<IServiceCollection> InitializationDelegate => throw new NotImplementedException();
+}

--- a/src/Endatix.Infrastructure/Setup/EndatixAppExtensions.cs
+++ b/src/Endatix.Infrastructure/Setup/EndatixAppExtensions.cs
@@ -60,6 +60,7 @@ public static class EndatixAppExtensions
 
         services.AddScoped(typeof(IRepository<>), typeof(EfRepository<>));
         services.AddEmailSender<SendGridEmailSender, SendGridSettings>();
+        services.AddWebHookProcessing();
 
         if (setupSettings.Security != null)
         {

--- a/src/Endatix.Infrastructure/Setup/ServiceCollectionExtensions.cs
+++ b/src/Endatix.Infrastructure/Setup/ServiceCollectionExtensions.cs
@@ -96,7 +96,7 @@ public static class ServiceCollectionExtensions
                {
                    var webHookSettings = serviceProvider.GetRequiredService<IOptions<WebHookSettings>>().Value;
 
-                   client.Timeout = TimeSpan.FromSeconds(webHookSettings.PipelineTimeoutInSeconds);
+                   client.Timeout = TimeSpan.FromSeconds(webHookSettings.ServerSettings.PipelineTimeoutInSeconds);
                    client.DefaultRequestHeaders.UserAgent.ParseAdd(WebHookRequestHeaders.Constants.ENDATIX_USER_AGENT);
                })
                .AddResilienceHandler("webhook-resilience", static (builder, context) =>
@@ -113,16 +113,16 @@ public static class ServiceCollectionExtensions
                    builder.AddRetry(new HttpRetryStrategyOptions
                    {
                        BackoffType = DelayBackoffType.Exponential,
-                       Delay = TimeSpan.FromSeconds(webHookSettings.Delay),
-                       MaxRetryAttempts = webHookSettings.RetryAttempts,
+                       Delay = TimeSpan.FromSeconds(webHookSettings.ServerSettings.Delay),
+                       MaxRetryAttempts = webHookSettings.ServerSettings.RetryAttempts,
                        UseJitter = true,
                        ShouldHandle = ex => new ValueTask<bool>(exceptionsToHandle.Contains(ex.GetType()) || ex.Outcome.Result?.IsSuccessStatusCode == false)
                    });
-                   builder.AddTimeout(TimeSpan.FromSeconds(webHookSettings.AttemptTimeoutInSeconds));
+                   builder.AddTimeout(TimeSpan.FromSeconds(webHookSettings.ServerSettings.AttemptTimeoutInSeconds));
                    builder.AddConcurrencyLimiter(new ConcurrencyLimiterOptions
                    {
-                       PermitLimit = webHookSettings.MaxConcurrentRequests,
-                       QueueLimit = webHookSettings.MaxQueueSize
+                       PermitLimit = webHookSettings.ServerSettings.MaxConcurrentRequests,
+                       QueueLimit = webHookSettings.ServerSettings.MaxQueueSize
                    });
                });
 

--- a/src/Endatix.Infrastructure/Setup/ServiceCollectionExtensions.cs
+++ b/src/Endatix.Infrastructure/Setup/ServiceCollectionExtensions.cs
@@ -79,6 +79,8 @@ public static class ServiceCollectionExtensions
     /// <returns>The configured <see cref="IServiceCollection"/> instance.</returns>
     public static IServiceCollection AddWebHookProcessing(this IServiceCollection services)
     {
+        services.AddOptions<WebHookSettings>()
+               .BindConfiguration("Endatix:WebHooks");
         services.AddSingleton<IBackgroundTasksQueue, BackgroundTasksQueue>();
         services.AddSingleton(typeof(IWebHookService<>), typeof(BackgroundTaskWebHookService<>));
         services.AddHostedService<WebHookBackgroundWorker>();

--- a/src/Endatix.Infrastructure/Setup/ServiceCollectionExtensions.cs
+++ b/src/Endatix.Infrastructure/Setup/ServiceCollectionExtensions.cs
@@ -88,7 +88,7 @@ public static class ServiceCollectionExtensions
                .BindConfiguration("Endatix:WebHooks")
                .ValidateDataAnnotations();
         services.AddSingleton<IBackgroundTasksQueue, BackgroundTasksQueue>();
-        services.AddSingleton(typeof(IWebHookService<>), typeof(BackgroundTaskWebHookService<>));
+        services.AddSingleton(typeof(IWebHookService), typeof(BackgroundTaskWebHookService));
         services.AddHostedService<WebHookBackgroundWorker>();
         services.AddHttpClient<WebHookServer>((serviceProvider, client) =>
                {

--- a/src/Endatix.Infrastructure/Setup/ServiceCollectionExtensions.cs
+++ b/src/Endatix.Infrastructure/Setup/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using Endatix.Core.Features.Email;
 using Endatix.Infrastructure.Setup;
 using Endatix.Infrastructure.Features.WebHooks;
 using Endatix.Core.Features.WebHooks;
+using Endatix.Core;
 
 namespace Microsoft.Extensions.DependencyInjection;
 

--- a/src/Endatix.WebHost/appsettings.Development.json
+++ b/src/Endatix.WebHost/appsettings.Development.json
@@ -61,9 +61,17 @@
           "AllowedOrigins": ["*"],
           "AllowedMethods": ["*"],
           "AllowedHeaders": ["*"],
-          "AllowCredentials": true
+          "AllowCredentials": false
         }
       ]
+    },
+    "WebHooks" : {
+      "Events": {
+        "FormSubmitted": {
+          "IsEnabled": false,
+          "WebHookUrls": []
+        }
+      }
     }
   }
 }

--- a/tests/Endatix.Core.Tests/Features/WebHooks/ActionNamesTests.cs
+++ b/tests/Endatix.Core.Tests/Features/WebHooks/ActionNamesTests.cs
@@ -1,0 +1,20 @@
+using Endatix.Core.Features.WebHooks;
+
+namespace Endatix.Core.Tests.Features.WebHooks
+{
+    public class ActionNamesTests
+    {
+        [Theory]
+        [InlineData(ActionNames.Created, "created")]
+        [InlineData(ActionNames.Updated, "updated")]
+        [InlineData(ActionNames.Deleted, "deleted")]
+        public void KnownActionNames_ShouldHaveCorrectDisplayNames(ActionNames actionName, string expectedDisplayName)
+        {
+            // Act
+            var displayName = actionName.GetDisplayName();
+
+            // Assert
+            displayName.Should().Be(expectedDisplayName);
+        }
+    }
+}

--- a/tests/Endatix.Core.Tests/Features/WebHooks/ActionNamesTests.cs
+++ b/tests/Endatix.Core.Tests/Features/WebHooks/ActionNamesTests.cs
@@ -5,10 +5,10 @@ namespace Endatix.Core.Tests.Features.WebHooks
     public class ActionNamesTests
     {
         [Theory]
-        [InlineData(ActionNames.Created, "created")]
-        [InlineData(ActionNames.Updated, "updated")]
-        [InlineData(ActionNames.Deleted, "deleted")]
-        public void KnownActionNames_ShouldHaveCorrectDisplayNames(ActionNames actionName, string expectedDisplayName)
+        [InlineData(ActionName.Created, "created")]
+        [InlineData(ActionName.Updated, "updated")]
+        [InlineData(ActionName.Deleted, "deleted")]
+        public void KnownActionNames_ShouldHaveCorrectDisplayNames(ActionName actionName, string expectedDisplayName)
         {
             // Act
             var displayName = actionName.GetDisplayName();

--- a/tests/Endatix.Core.Tests/Features/WebHooks/WebHookMessageTests.cs
+++ b/tests/Endatix.Core.Tests/Features/WebHooks/WebHookMessageTests.cs
@@ -24,7 +24,7 @@ public class WebHookMessageTests
     }
 
     [Fact]
-    public void WebHookMessage_WhenNullPayload_ShouldNotThrow()
+    public void WebHookMessage_WithNullPayload_DoesNotThrow()
     {
         // Arrange
         long expectedId = 1;

--- a/tests/Endatix.Core.Tests/Features/WebHooks/WebHookMessageTests.cs
+++ b/tests/Endatix.Core.Tests/Features/WebHooks/WebHookMessageTests.cs
@@ -1,0 +1,43 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Features.WebHooks;
+
+namespace Endatix.Core.Tests.Features.WebHooks;
+
+public class WebHookMessageTests
+{
+    [Fact]
+    public void WebHookMessage_ShouldInitializePropertiesCorrectly()
+    {
+        // Arrange
+        long expectedId = 1;
+        var formSubmittedOperation = WebHookOperation.FormSubmitted;
+        var expectedPayload = new Submission(expectedId.ToString());
+
+        // Act
+        var webHookMessage = new WebHookMessage<Submission>(expectedId, formSubmittedOperation, expectedPayload);
+
+        // Assert
+        webHookMessage.Id.Should().Be(expectedId);
+        webHookMessage.Operation.Should().Be(formSubmittedOperation);
+        webHookMessage.Payload.Should().Be(expectedPayload);
+        webHookMessage.Action.Should().Be("created");
+    }
+
+    [Fact]
+    public void WebHookMessage_WhenNullPayload_ShouldNotThrow()
+    {
+        // Arrange
+        long expectedId = 1;
+        var expectedOperation = WebHookOperation.FormSubmitted;
+        Submission? nullPayload = null;
+
+        // Act
+        var message = new WebHookMessage<Submission>(expectedId, expectedOperation, nullPayload);
+
+        // Assert
+        message.Id.Should().Be(expectedId);
+        message.Operation.Should().Be(expectedOperation);
+        message.Payload.Should().BeNull();
+        message.Action.Should().Be("created");
+    }
+}

--- a/tests/Endatix.Core.Tests/Features/WebHooks/WebHookOperationTests.cs
+++ b/tests/Endatix.Core.Tests/Features/WebHooks/WebHookOperationTests.cs
@@ -14,7 +14,7 @@ public class WebHookOperationTests
         formSubmitted.Should().NotBeNull();
         formSubmitted.EventName.Should().Be("form_submitted");
         formSubmitted.Entity.Should().Be("Submission");
-        formSubmitted.Action.Should().Be(ActionNames.Created);
+        formSubmitted.Action.Should().Be(ActionName.Created);
         formSubmitted.Action.GetDisplayName().Should().Be("created");
     }
 

--- a/tests/Endatix.Core.Tests/Features/WebHooks/WebHookOperationTests.cs
+++ b/tests/Endatix.Core.Tests/Features/WebHooks/WebHookOperationTests.cs
@@ -1,0 +1,31 @@
+using Endatix.Core.Features.WebHooks;
+
+namespace Endatix.Core.Tests.Features.WebHooks;
+
+public class WebHookOperationTests
+{
+    [Fact]
+    public void FormSubmitted_Operation_ShouldHaveCorrectValues()
+    {
+        // Arrange & Act
+        var formSubmitted = WebHookOperation.FormSubmitted;
+
+        // Assert
+        formSubmitted.Should().NotBeNull();
+        formSubmitted.EventName.Should().Be("form_submitted");
+        formSubmitted.Entity.Should().Be("Submission");
+        formSubmitted.Action.Should().Be(ActionNames.Created);
+        formSubmitted.Action.GetDisplayName().Should().Be("created");
+    }
+
+    [Fact]
+    public void WebHookOperation_Equality_ShouldBeValueBased()
+    {
+        // Arrange
+        var formSubmittedOperation1 = WebHookOperation.FormSubmitted;
+        var formSubmittedOperation2 = WebHookOperation.FormSubmitted;
+
+        // Act & Assert
+        formSubmittedOperation1.Should().Be(formSubmittedOperation2);
+    }
+}


### PR DESCRIPTION
# Adding support for firing webhook on Form Submission

## Description
- Added firing web hooks on Form Submission event handler
- Added support for multiple Urls destination
- All web hooks are fired in background threads not blocking the UI of the operation
- Added resilience strategy via HTTP Resiliance libraries - https://learn.microsoft.com/en-us/dotnet/core/resilience/http-resilience?tabs=dotnet-cli. 
- Added strategy to send headers with information on EventName, Entity & Action
- Added configs to modify RetryAttempts, Timeouts, Concurrency and other options
- Added tests for the Endatix.Core part of the feature (Endatix.

>[!IMPORTANT]
> - Documentation  is out of scope as it's blocked by merging auth PR. Task has been created - https://github.com/endatix/endatix/issues/170
> - Unit Tests in for the WebHooks parts of the code located in Endatix.Infrastructure  is out of scope as it's blocked by merging auth PR. Task has been created - https://github.com/endatix/endatix/issues/171

### How To Test
1. Update `appSettings.Development.config` and make sure to add the "https://webhook.site/91b2292d-a73f-4dd3-8d48-5fe164c4d210" Url to the config part
```
 "WebHooks" : {
      "Events": {
        "FormSubmitted": {
          "IsEnabled": true,
          "WebHookUrls": ["https://webhook.site/91b2292d-a73f-4dd3-8d48-5fe164c4d210"]
        }
      }
    }
```
2. Run the project
3. Open the https://webhook.site/#!/view/91b2292d-a73f-4dd3-8d48-5fe164c4d210 Url to check for WebHooks
4. Send a submission to a form

### Web Hooks signature and behavior was modelled by following best practices showcased and implemented in the GitHub's WebHooks. More info here - https://docs.github.com/en/webhooks/webhook-events-and-payloads. Below is comparison of the payloads for reference:

### Sample Payload GitHub 

```
> X-GitHub-Delivery: 72d3162e-cc78-11e3-81ab-4c9367dc0958
> X-Hub-Signature: sha1=7d38cdd689735b008b3c702edd92eea23791c5f6
> X-Hub-Signature-256: sha256=d57c68ca6f92289e6987922ff26938930f6e66a2d161ef06abdf1859230aa23c
> User-Agent: GitHub-Hookshot/044aadd
> Content-Type: application/json
> Content-Length: 6615
> X-GitHub-Event: issues
> X-GitHub-Hook-ID: 292430182
> X-GitHub-Hook-Installation-Target-ID: 79929171
> X-GitHub-Hook-Installation-Target-Type: repository

> {
>   "action": "opened",
>   "issue": {
>     "url": "https://api.github.com/repos/octocat/Hello-World/issues/1347",
>     "number": 1347,
>     ...
>   },
>   "repository" : {
>     "id": 1296269,
>     "full_name": "octocat/Hello-World",
>     "owner": {
>       "login": "octocat",
>       "id": 1,
>       ...
>     },
>     ...
>   },
>   "sender": {
>     "login": "octocat",
>     "id": 1,
>     ...
>   }
> }
```

### Sample Payload Endatix
```

Headers
--
content-length | 381
content-type | application/json; charset=utf-8
user-agent | Endatix-HookGun
x-endatix-hook-id | 1300804208097755136
x-endatix-action | created
x-endatix-entity | Submission
x-endatix-event | form_submitted

{
  "Id": 1300804208097755136,
  "EventName": "form_submitted",
  "Action": "created",
  "Payload": {
    "Id": 1300804208097755136,
    "IsComplete": true,
    "JsonData": {
      "name": "Имате ли гъби"
    },
    "Metadata": "string",
    "FormDefinitionId": 1266357680839065600,
    "CurrentPage": 0,
    "CompletedAt": "2024-10-29T12:51:30.953062Z",
    "CreatedAt": "2024-10-29T12:51:30.987541Z"
  }
}
```

## Related Issues
#10 

## Type of Change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots
<img width="1374" alt="image" src="https://github.com/user-attachments/assets/f7e1033d-310f-416c-b8bf-e056d28d8e56">

