### PR TITLE
feat: Adding default redirect from root to swagger for Non Prod environments

### DIFF
--- a/src/Endatix.Api/Setup/MiddlewareExtensions.cs
+++ b/src/Endatix.Api/Setup/MiddlewareExtensions.cs
@@ -6,6 +6,8 @@ using Endatix.Infrastructure.Identity;
 using FastEndpoints;
 using FastEndpoints.Swagger;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Rewrite;
+using Microsoft.Extensions.Hosting;
 
 namespace Endatix.Setup;
 
@@ -35,7 +37,15 @@ public static class MiddlewareExtensions
             fastEndpoints.Security.RoleClaimType = ClaimTypes.Role;
             fastEndpoints.Security.PermissionsClaimType = ClaimNames.Permission;
         });
-        app.UseSwaggerGen();
+
+        if (endatixMiddleware.App.Environment.IsDevelopment())
+        {
+            var option = new RewriteOptions();
+            option.AddRedirect("^$", "swagger");
+            app.UseRewriter(option);
+            app.UseSwaggerGen();
+        }
+
         app.UseCors();
 
         return endatixMiddleware;


### PR DESCRIPTION
# Adding default redirect from root to swagger for Non Prod environments

Address the annoying issue with hitting 404 everytime we go to https://localhost:5001. No more... 😎 

## Description
- Now when you go to https://localhost:5001/, you will be redirected to https://localhost:5001/swagger/index.html
- Also Swagger won't generate on Prod as it's typically recommended
- We can generate the API swagger json at build time at later stage

## Related Issues
No issue

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules