### PR TITLE
fix: Fixing build issues detected post merge

### DIFF
--- a/tests/Endatix.Api.Tests/Endpoints/Submissions/GetByTokenTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Submissions/GetByTokenTests.cs
@@ -27,7 +27,7 @@ public class GetByTokenTests
         var submissionToken = "invalid-token";
         var request = new GetByTokenRequest { FormId = formId, SubmissionToken = submissionToken };
         var result = Result.Invalid();
-        
+
         _mediator.Send(Arg.Any<GetByTokenQuery>(), Arg.Any<CancellationToken>())
             .Returns(result);
 
@@ -64,9 +64,11 @@ public class GetByTokenTests
     {
         // Arrange
         var formId = 1L;
+        var formDefinitionId = 2L;
         var submissionToken = "valid-token";
         var request = new GetByTokenRequest { FormId = formId, SubmissionToken = submissionToken };
-        var submission = new Submission { Id = 1, Token = new Token(1) };
+        var submission = new Submission("{}", formId, formDefinitionId) { Id = 1 };
+        submission.UpdateToken(new Token(1));
         var result = Result.Success(submission);
 
         _mediator.Send(Arg.Any<GetByTokenQuery>(), Arg.Any<CancellationToken>())
@@ -93,8 +95,10 @@ public class GetByTokenTests
             FormId = 123,
             SubmissionToken = "token-456"
         };
-        var result = Result.Success(new Submission());
-        
+        var formDefinitionId = 246L;
+
+        var result = Result.Success(new Submission("{}", request.FormId, formDefinitionId));
+
         _mediator.Send(Arg.Any<GetByTokenQuery>(), Arg.Any<CancellationToken>())
             .Returns(result);
 

--- a/tests/Endatix.Api.Tests/Endpoints/Submissions/PartialUpdateByTokenTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Submissions/PartialUpdateByTokenTests.cs
@@ -64,6 +64,7 @@ public class PartialUpdateByTokenTests
     {
         // Arrange
         var formId = 1L;
+        var formDefinitionId = 2L;
         var submissionToken = "valid-token";
         var jsonData = "{ }";
         var request = new PartialUpdateSubmissionByTokenRequest 
@@ -76,7 +77,8 @@ public class PartialUpdateByTokenTests
             Metadata = "test metadata"
         };
         
-        var submission = new Submission(jsonData) { Id = 1, Token = new Token(1) };
+        var submission = new Submission(jsonData, formId, formDefinitionId) { Id = 1 };
+        submission.UpdateToken(new Token(1));
         var result = Result.Success(submission);
 
         _mediator.Send(Arg.Any<PartialUpdateSubmissionByTokenCommand>(), Arg.Any<CancellationToken>())
@@ -107,7 +109,8 @@ public class PartialUpdateByTokenTests
             JsonData = """{ "field": "value" }""",
             Metadata = """{ "key", "value" }"""
         };
-        var result = Result.Success(new Submission());
+        var formDefinitionId = 456;
+        var result = Result.Success(new Submission(request.JsonData, request.FormId, formDefinitionId));
         
         _mediator.Send(Arg.Any<PartialUpdateSubmissionByTokenCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);

--- a/tests/Endatix.Core.Tests/SampleData.cs
+++ b/tests/Endatix.Core.Tests/SampleData.cs
@@ -10,4 +10,29 @@ public static class SampleData
     public const string FORM_DEFINITION_JSON_DATA_2 = "{\"type\":\"text\",\"name\":\"lastname\"";
     public const string SUBMISSION_JSON_DATA_1 = "{\"firstname\":\"mr test\"";
     public const string SUBMISSION_JSON_DATA_2 = "{\"firstname\":\"mrs test\"";
+
+    public class SubmissionJsons
+    {
+
+        public const string MR_TEST = "{\"firstname\":\"mr test\"";
+        public const string MRS_TEST = "{\"firstname\":\"mrs test\"";
+
+        public const string MISSING_FEAT_1 = "{\"missing-feature\":\"robot\"";
+
+        public const string MISSING_FEAT_2 = "{\"missing-feature\":\"rocket\"";
+    }
+
+    public class IDs
+    {
+        public const long ID_121 = 121;
+        public const long ID_122 = 122;
+        public const long ID_123 = 123;
+        public const long ID_124 = 124;
+        public const long ID_125 = 125;
+        public const long ID_126 = 126;
+        public const long ID_127 = 127;
+        public const long ID_128 = 128;
+        public const long ID_129 = 129;
+        public const long ID_130 = 130;
+    }
 }

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/GetByToken/GetByTokenHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/GetByToken/GetByTokenHandlerTests.cs
@@ -49,11 +49,12 @@ public class GetByTokenHandlerTests
     {
         // Arrange
         var formId = 1L;
+        var formDefinitionId = 2L;
         var token = "valid-token";
         var submissionId = 123L;
         var request = new GetByTokenQuery(formId, token);
         var tokenResult = Result.Success(submissionId);
-        var submission = new Submission();
+        var submission = new Submission("{}", formId, formDefinitionId);
         var submissionResult = Result.Success(submission);
 
         _tokenService.ResolveTokenAsync(token, Arg.Any<CancellationToken>())

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/PartialUpdateByToken/PartialUpdateSubmissionByTokenHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/PartialUpdateByToken/PartialUpdateSubmissionByTokenHandlerTests.cs
@@ -1,6 +1,4 @@
-using FluentAssertions;
 using MediatR;
-using NSubstitute;
 using Endatix.Core.Abstractions;
 using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Result;
@@ -50,17 +48,18 @@ public class PartialUpdateSubmissionByTokenHandlerTests
         // Arrange
         var token = "valid-token";
         var formId = 1L;
+        var formDefinitionId = 2L;
         var submissionId = 123L;
         var isComplete = true;
         var currentPage = 2;
         var jsonData = SampleData.SUBMISSION_JSON_DATA_1;
         var metadata = "test metadata";
-        
+
         var request = new PartialUpdateSubmissionByTokenCommand(
             token, formId, isComplete, currentPage, jsonData, metadata);
-        
+
         var tokenResult = Result.Success(submissionId);
-        var submission = new Submission(jsonData) { Id = submissionId };
+        var submission = new Submission(jsonData, formId, formDefinitionId) { Id = submissionId };
         var updateResult = Result.Success(submission);
 
         _tokenService.ResolveTokenAsync(token, Arg.Any<CancellationToken>())
@@ -77,7 +76,7 @@ public class PartialUpdateSubmissionByTokenHandlerTests
         result.Value.Should().Be(submission);
 
         await _tokenService.Received(1).ObtainTokenAsync(submissionId, Arg.Any<CancellationToken>());
-        
+
         await _sender.Received(1).Send(
             Arg.Is<PartialUpdateSubmissionCommand>(cmd =>
                 cmd.SubmissionId == submissionId &&

--- a/tests/Endatix.Infrastructure.Tests/Features/Submissions/SubmissionTokenServiceResolveTokenTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Submissions/SubmissionTokenServiceResolveTokenTests.cs
@@ -77,8 +77,11 @@ public class SubmissionTokenServiceResolveTokenTests
     public async Task ResolveToken_WhenSubmissionIsComplete_ReturnsNotFound()
     {
         // Arrange
+        var formId = 1L;
+        var formDefinitionId = 2L;
         var token = "valid-token";
-        var submission = new Submission("{ }", 123, isComplete: true) { Token = new Token(24) };
+        var submission = new Submission("{ }", formId,formDefinitionId, isComplete: true);
+        submission.UpdateToken(new Token(24));
         _repository.FirstOrDefaultAsync(Arg.Any<SubmissionByTokenSpec>()).Returns(submission);
 
         // Act


### PR DESCRIPTION
Not sure why the build didn't fail locally, but it fail after we have merged into `main`. Fixed several tests and started idea to have more data into the `SampleData`.

Should take us less code to generate mock objects. Maybe a mock factory might help to further develop this concept.