### PR TITLE
fix: Adding fix for current page set to zero as starting index

### DIFF
--- a/src/Endatix.Api/Endpoints/Submissions/PartialUpdateByToken.PartialUpdateSubmissionByTokenValidator.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/PartialUpdateByToken.PartialUpdateSubmissionByTokenValidator.cs
@@ -25,7 +25,7 @@ public class PartialUpdateSubmissionByTokenValidator : Validator<PartialUpdateSu
             .When(x => x.JsonData != null);
 
         RuleFor(x => x.CurrentPage)
-            .GreaterThan(0)
+            .GreaterThanOrEqualTo(0)
             .When(x => x.CurrentPage != null);
     }
-} 
+}

--- a/src/Endatix.Core/UseCases/Submissions/PartialUpdateByToken/PartialUpdateSubmissionByTokenCommand.cs
+++ b/src/Endatix.Core/UseCases/Submissions/PartialUpdateByToken/PartialUpdateSubmissionByTokenCommand.cs
@@ -22,6 +22,11 @@ public record PartialUpdateSubmissionByTokenCommand : ICommand<Result<Submission
         Guard.Against.NullOrEmpty(token);
         Guard.Against.NegativeOrZero(formId);
 
+        if (currentPage.HasValue)
+        {
+            Guard.Against.Negative(currentPage.Value);
+        }
+
         Token = token;
         FormId = formId;
         IsComplete = isComplete;

--- a/tests/Endatix.Core.Tests/ErrorMessages.cs
+++ b/tests/Endatix.Core.Tests/ErrorMessages.cs
@@ -3,6 +3,7 @@ namespace Endatix.Core.Tests;
 public enum ErrorType
 {
     ZeroOrNegative,
+    Negative,
     Null,
     Empty,
     SigningKeyEmpty,
@@ -17,6 +18,7 @@ public static class ErrorMessages
     private static readonly Dictionary<ErrorType, string> errorMessageTemplates = new Dictionary<ErrorType, string>
     {
         { ErrorType.ZeroOrNegative, "Required input {0} cannot be zero or negative. (Parameter '{0}')" },
+        { ErrorType.Negative, "Required input {0} cannot be negative. (Parameter '{0}')" },
         { ErrorType.Null, "Value cannot be null. (Parameter '{0}')" },
         { ErrorType.Empty, "Required input {0} was empty. (Parameter '{0}')" },
         { ErrorType.SigningKeyEmpty, "Signing key cannot be empty. Please check your appSettings. (Parameter '{0}')" },

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/PartialUpdateByToken/PartialUpdateSubmissionByTokenCommandTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/PartialUpdateByToken/PartialUpdateSubmissionByTokenCommandTests.cs
@@ -37,6 +37,48 @@ public class PartialUpdateSubmissionByTokenCommandTests
     }
 
     [Fact]
+    public void Constructor_NegativeCurrentPage_ThrowsArgumentException()
+    {
+        // Arrange
+        var token = "valid-token";
+        var formId = 1L;
+        int? negativeCurrentPage = -1;
+
+        // Act
+        Action act = () => new PartialUpdateSubmissionByTokenCommand(
+            token: token,
+            formId: formId,
+            isComplete: false,
+            currentPage: negativeCurrentPage,
+            jsonData: null,
+            metadata: null
+        );
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage(GetErrorMessage("currentPage.Value", Negative));
+    }
+
+    [Fact]
+    public void Constructor_OmittedCurrentPage_SetsPropertiesCorrectly()
+    {
+        // Arrange
+        var token = "valid-token";
+        var formId = 1L;
+        var isComplete = true;
+        int? currentPage = null;
+        var jsonData = "{}";
+        var metadata = string.Empty;
+
+        // Act
+        var command = new PartialUpdateSubmissionByTokenCommand(token, formId, isComplete, currentPage, jsonData, metadata);
+
+        // Assert
+        command.Should().NotBeNull();
+        command.CurrentPage.Should().Be(currentPage);
+    }
+
+    [Fact]
     public void Constructor_ValidParameters_SetsPropertiesCorrectly()
     {
         // Arrange


### PR DESCRIPTION
# Adding fix for current page set to zero as starting index

## Description
- As part of the #237 task, have encountered a bug in the Partial submission server side validation of the CurrentPage prop. This is a fix to allow for currentPage starting from 0 as default for multi page and single page forms
- Adding couple of tests to cover related fail scenarios

## Related Issues
List any related issues (e.g., fixes #123, addresses #456).

## Type of Change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have followed the accepted guideline

