### PR TITLE
ci: Adding Endatix Hub to CI Process

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   dotnet-build:
     name: "Endatix API: Build & Test"
-    if: ${{ contains(github.event.head_commit.modified, 'src/') || contains(github.event.head_commit.modified, 'tests/') }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
     runs-on: ubuntu-latest
@@ -63,7 +62,6 @@ jobs:
 
   node-build:
     name: "Endatix Hub: Build & Test"
-    if: ${{ contains(github.event.head_commit.modified, 'apps/endatix-hub/') }}
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   dotnet-build:
-    name: Endatix API: Build & Test
+    name: "Endatix API: Build & Test"
     if: ${{ contains(github.event.head_commit.modified, 'src/') || contains(github.event.head_commit.modified, 'tests/') }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
@@ -62,7 +62,7 @@ jobs:
           cat .coverage/report/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
 
   node-build:
-    name: Endatix Hub: Build & Test
+    name: "Endatix Hub: Build & Test"
     if: ${{ contains(github.event.head_commit.modified, 'apps/endatix-hub/') }}
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   dotnet-build:
-    name: Endatix API Build & Test
+    name: Endatix API: Build & Test
     if: ${{ contains(github.event.head_commit.modified, 'src/') || contains(github.event.head_commit.modified, 'tests/') }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
@@ -62,7 +62,7 @@ jobs:
           cat .coverage/report/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
 
   node-build:
-    name: Endatix Hub build & test
+    name: Endatix Hub: Build & Test
     if: ${{ contains(github.event.head_commit.modified, 'apps/endatix-hub/') }}
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -104,8 +104,9 @@ jobs:
       - name: 🏗️  Build Next.js app
         run: pnpm build
 
-      - name: 📊 Upload to Coveralls
-        uses: coverallsapp/github-action@v2
+      - name: 📊 Endatix Hub Coverage
+        uses:  davelosert/vitest-coverage-report-action@v2
         with:
-          format: cobertura
-          file: .coverage/endatix-hub/cobertura-coverage.xml
+          name: 'Endatix Hub'
+          json-summary-path: '.coverage/endatix-hub/coverage-summary.json'
+          json-final-path: '.coverage/endatix-hub/coverage-final.json'

--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -4,18 +4,25 @@ on:
   push:
     branches:
       - "**"
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "apps/**"
+      - ".github/workflows/**"
 
 jobs:
-  test:
+  dotnet-build:
+    name: Endatix API Build & Test
+    if: ${{ contains(github.event.head_commit.modified, 'src/') || contains(github.event.head_commit.modified, 'tests/') }}
     env:
       BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
+      - name: 🔍 Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup .NET
+      - name: 📦 Setup .NET
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: "9.x"
@@ -26,30 +33,81 @@ jobs:
       - name: Build
         run: dotnet build --no-restore
 
-      - name: Run .NET tests
+      - name: 🧪 Run .NET tests
         run: dotnet test --no-build --collect:"XPlat Code Coverage;Format=cobertura" --results-directory:".coverage"
 
       - name: Install DotNet Coverage
         run: dotnet tool update --global dotnet-coverage
 
-      - name: Merge Coverage Reports
+      - name: 📊 Merge Coverage Reports
         run: dotnet-coverage merge .coverage/endatix-hub/cobertura-coverage.xml .coverage/**/coverage.cobertura.xml -f cobertura -o .coverage/merged.cobertura.xml
 
-      - name: Install DotNet Report Generator
+      - name: 📊 Install DotNet Report Generator
         run: dotnet tool install --global dotnet-reportgenerator-globaltool
 
-      - name: Add Summary Report
+      - name: 📊Add Summary Report
         run: reportgenerator -reports:".coverage/merged.cobertura.xml" -targetdir:".coverage/report" -reporttypes:"MarkdownSummaryGithub"
 
-      - name: Upload to Coveralls
+      - name: 📊 Upload to Coveralls
         uses: coverallsapp/github-action@v2
         with:
           format: cobertura
           file: .coverage/merged.cobertura.xml
 
-      - name: Output Summary Report
+      - name: 📝 Output Summary Report
         run: |
           echo ">[!NOTE] " >> $GITHUB_STEP_SUMMARY
-          echo ">#### 🧪 Test Coverage Summary" >> $GITHUB_STEP_SUMMARY
+          echo ">#### 🧪 Endatix API: Test Coverage Summary" >> $GITHUB_STEP_SUMMARY
           echo ">[![Coverage Status](https://coveralls.io/repos/github/endatix/endatix/badge.svg?branch=$BRANCH_NAME)](https://coveralls.io/github/endatix/endatix?branch=$BRANCH_NAME)" >> $GITHUB_STEP_SUMMARY
           cat .coverage/report/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
+
+  node-build:
+    name: Endatix Hub build & test
+    if: ${{ contains(github.event.head_commit.modified, 'apps/endatix-hub/') }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/endatix-hub
+
+    steps:
+      - name: 🔍 Checkout code
+        uses: actions/checkout@v4
+
+      - name: 📦 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: 📦 Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9.2
+          run_install: false
+
+      - name: 📦 Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - uses: actions/cache@v4
+        name: 📦 Setup pnpm cache
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: 🥡 Install Dependencies
+        run: pnpm install --frozen-lockfile
+  
+      - name: 🧪 Run tests
+        run: pnpm test:coverage
+
+      - name: 🏗️  Build Next.js app
+        run: pnpm build
+
+      - name: 📊 Upload to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          format: cobertura
+          file: .coverage/endatix-hub/cobertura-coverage.xml

--- a/apps/endatix-hub/README.md
+++ b/apps/endatix-hub/README.md
@@ -16,8 +16,6 @@ bun dev
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result. If you want to run the site in https, run `pnpm run dev-https` command.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Environment Variables

--- a/apps/endatix-hub/package.json
+++ b/apps/endatix-hub/package.json
@@ -54,8 +54,9 @@
     "@types/react": "19.0.1",
     "@types/react-dom": "19.0.1",
     "@vitejs/plugin-react": "^4.3.4",
-    "@vitest/coverage-v8": "2.1.4",
+    "@vitest/coverage-v8": "2.1.8",
     "@vitest/ui": "^2.1.8",
+    "vitest": "^2.1.8",
     "cross-env": "^7.0.3",
     "eslint": "^8.57.1",
     "eslint-config-next": "15.0.4",
@@ -65,8 +66,7 @@
     "sass": "^1.82.0",
     "tailwindcss": "^3.4.16",
     "typescript": "^5.7.2",
-    "vite-tsconfig-paths": "^5.1.4",
-    "vitest": "^2.1.8"
+    "vite-tsconfig-paths": "^5.1.4"
   },
   "overrides": {
     "@types/react": "npm:types-react@19.0.0-rc.1",

--- a/apps/endatix-hub/package.json
+++ b/apps/endatix-hub/package.json
@@ -10,7 +10,7 @@
     "lint": "next lint",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.1",

--- a/apps/endatix-hub/pnpm-lock.yaml
+++ b/apps/endatix-hub/pnpm-lock.yaml
@@ -131,8 +131,8 @@ importers:
         specifier: ^4.3.4
         version: 4.3.4(vite@5.4.11(@types/node@20.17.9)(sass@1.82.0))
       '@vitest/coverage-v8':
-        specifier: 2.1.4
-        version: 2.1.4(vitest@2.1.8(@types/node@20.17.9)(@vitest/ui@2.1.8)(jsdom@25.0.1)(sass@1.82.0))
+        specifier: 2.1.8
+        version: 2.1.8(vitest@2.1.8(@types/node@20.17.9)(@vitest/ui@2.1.8)(jsdom@25.0.1)(sass@1.82.0))
       '@vitest/ui':
         specifier: ^2.1.8
         version: 2.1.8(vitest@2.1.8)
@@ -1484,11 +1484,11 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0
 
-  '@vitest/coverage-v8@2.1.4':
-    resolution: {integrity: sha512-FPKQuJfR6VTfcNMcGpqInmtJuVXFSCd9HQltYncfR01AzXhLucMEtQ5SinPdZxsT5x/5BK7I5qFJ5/ApGCmyTQ==}
+  '@vitest/coverage-v8@2.1.8':
+    resolution: {integrity: sha512-2Y7BPlKH18mAZYAW1tYByudlCYrQyl5RGvnnDYJKW5tCiO5qg3KSAy3XAxcxKz900a0ZXxWtKrMuZLe3lKBpJw==}
     peerDependencies:
-      '@vitest/browser': 2.1.4
-      vitest: 2.1.4
+      '@vitest/browser': 2.1.8
+      vitest: 2.1.8
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
@@ -4732,7 +4732,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@2.1.4(vitest@2.1.8(@types/node@20.17.9)(@vitest/ui@2.1.8)(jsdom@25.0.1)(sass@1.82.0))':
+  '@vitest/coverage-v8@2.1.8(vitest@2.1.8(@types/node@20.17.9)(@vitest/ui@2.1.8)(jsdom@25.0.1)(sass@1.82.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 0.2.3
@@ -5322,8 +5322,8 @@ snapshots:
       '@typescript-eslint/parser': 8.17.0(eslint@8.57.1)(typescript@5.7.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.2(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.1.0(eslint@8.57.1)
@@ -5342,7 +5342,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.0
@@ -5354,22 +5354,22 @@ snapshots:
       is-glob: 4.0.3
       stable-hash: 0.0.4
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.17.0(eslint@8.57.1)(typescript@5.7.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0)(eslint@8.57.1):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -5380,7 +5380,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.17.0(eslint@8.57.1)(typescript@5.7.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3

--- a/apps/endatix-hub/vitest.config.mts
+++ b/apps/endatix-hub/vitest.config.mts
@@ -24,7 +24,7 @@ export default defineConfig({
       ],
       enabled: true,
       provider: 'v8',
-      reporter: process.env.GITHUB_ACTIONS ? ['cobertura'] : ['cobertura', 'html'],
+      reporter: process.env.GITHUB_ACTIONS ? ['cobertura', 'json', 'json-summary'] : ['cobertura', 'html'],
       reportsDirectory: '../../.coverage/endatix-hub',
     },
     reporters: process.env.GITHUB_ACTIONS ? ['dot', 'github-actions'] : ['dot']

--- a/apps/endatix-hub/vitest.config.mts
+++ b/apps/endatix-hub/vitest.config.mts
@@ -24,8 +24,9 @@ export default defineConfig({
       ],
       enabled: true,
       provider: 'v8',
-      reporter: ['text','cobertura', 'html'],
+      reporter: process.env.GITHUB_ACTIONS ? ['cobertura'] : ['cobertura', 'html'],
       reportsDirectory: '../../.coverage/endatix-hub',
     },
+    reporters: process.env.GITHUB_ACTIONS ? ['dot', 'github-actions'] : ['dot']
   },
 })


### PR DESCRIPTION
# Adding Endatix Hub to CI Process

## Description
We needed this to prevent builds which have failing tests or linting issues.

Now there will be two builds running in parallel for the Endatix API and the Endatix Hub:

<img width="404" alt="image" src="https://github.com/user-attachments/assets/3836f527-75d7-4785-8c06-799553b5b2be">

Also, we will calculate test coverage for the Endatix Hub and will NOT upload to Coveralls as we won't do this fo rnow

<img width="997" alt="image" src="https://github.com/user-attachments/assets/3784908a-a7c0-48c7-980d-60bf8d075064">

>[!IMPORTANT]
>There's way to conditionally trigger the jobs only if files in certain folders have changed, but we won't do this now as well

### Related Issues
closes #277 
