### PR TITLE
feat: feature slack notification message integration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,6 +23,24 @@
       }
     },
     {
+      "name": "📎 Sample: CustomEventHandlers",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceFolder}/samples/Endatix.Samples.CustomEventHandlers/bin/Debug/net9.0/Endatix.Samples.CustomEventHandlers.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/samples/Endatix.Samples.CustomEventHandlers",
+      "stopAtEntry": false,
+      "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "\\bNow listening on:\\s+(https?://\\S+)",
+        "uriFormat": "%s/"
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    {
       "name": "📎 Sample: SelfHosted",
       "type": "coreclr",
       "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -23,24 +23,6 @@
       }
     },
     {
-      "name": "📎 Sample: CustomEventHandlers",
-      "type": "coreclr",
-      "request": "launch",
-      "preLaunchTask": "build",
-      "program": "${workspaceFolder}/samples/Endatix.Samples.CustomEventHandlers/bin/Debug/net9.0/Endatix.Samples.CustomEventHandlers.dll",
-      "args": [],
-      "cwd": "${workspaceFolder}/samples/Endatix.Samples.CustomEventHandlers",
-      "stopAtEntry": false,
-      "serverReadyAction": {
-        "action": "openExternally",
-        "pattern": "\\bNow listening on:\\s+(https?://\\S+)",
-        "uriFormat": "%s/"
-      },
-      "env": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
-    {
       "name": "📎 Sample: SelfHosted",
       "type": "coreclr",
       "request": "launch",

--- a/src/Endatix.Core/Integrations/Slack/ISlackClient.cs
+++ b/src/Endatix.Core/Integrations/Slack/ISlackClient.cs
@@ -1,0 +1,12 @@
+namespace Endatix.Core.Integrations.Slack;
+
+public interface SlackCLient {
+    /// <summary>
+    /// Posts a message to a Slack channel through the Endatix Bot Slack app
+    /// </summary>
+    /// <param name="token">The Slack API bearer token</param>
+    /// <param name="channelId">The id of the channel to post the message to</param>
+    /// <param name="message">The body of the message</param>
+    /// <returns>Task</returns>
+    Task PostMessageAsync(string token, string channelId, string message);
+}

--- a/src/Endatix.Core/Integrations/Slack/ISlackClient.cs
+++ b/src/Endatix.Core/Integrations/Slack/ISlackClient.cs
@@ -1,6 +1,6 @@
 namespace Endatix.Core.Integrations.Slack;
 
-public interface SlackCLient {
+public interface ISlackClient {
     /// <summary>
     /// Posts a message to a Slack channel through the Endatix Bot Slack app
     /// </summary>

--- a/src/Endatix.Core/Integrations/Slack/ISlackClient.cs
+++ b/src/Endatix.Core/Integrations/Slack/ISlackClient.cs
@@ -1,10 +1,13 @@
+using Endatix.Core.Events;
+
 namespace Endatix.Core.Integrations.Slack;
 
 public interface ISlackClient {
     /// <summary>
     /// Posts a message to a Slack channel through the Endatix Bot Slack app
     /// </summary>
-    /// <param name="message">The body of the message</param>
+    /// <param name="notification">The notification object passed by the event publisher</param>
+    /// /// <param name="cancellationToken">The event's cancellation token</param>
     /// <returns>Task</returns>
-    private Task PostMessageAsync(string message);
+    public Task Handle(SubmissionCompletedEvent notification, CancellationToken cancellationToken);
 }

--- a/src/Endatix.Core/Integrations/Slack/ISlackClient.cs
+++ b/src/Endatix.Core/Integrations/Slack/ISlackClient.cs
@@ -9,5 +9,5 @@ public interface ISlackClient {
     /// <param name="notification">The notification object passed by the event publisher</param>
     /// /// <param name="cancellationToken">The event's cancellation token</param>
     /// <returns>Task</returns>
-    public Task Handle(SubmissionCompletedEvent notification, CancellationToken cancellationToken);
+    Task Handle(SubmissionCompletedEvent notification, CancellationToken cancellationToken);
 }

--- a/src/Endatix.Core/Integrations/Slack/ISlackClient.cs
+++ b/src/Endatix.Core/Integrations/Slack/ISlackClient.cs
@@ -4,9 +4,7 @@ public interface ISlackClient {
     /// <summary>
     /// Posts a message to a Slack channel through the Endatix Bot Slack app
     /// </summary>
-    /// <param name="token">The Slack API bearer token</param>
-    /// <param name="channelId">The id of the channel to post the message to</param>
     /// <param name="message">The body of the message</param>
     /// <returns>Task</returns>
-    Task PostMessageAsync(string token, string channelId, string message);
+    private Task PostMessageAsync(string message);
 }

--- a/src/Endatix.Core/UseCases/Submissions/Create/CreateSubmissionHandler.cs
+++ b/src/Endatix.Core/UseCases/Submissions/Create/CreateSubmissionHandler.cs
@@ -45,7 +45,10 @@ public class CreateSubmissionHandler(
 
         await submissionRepository.AddAsync(submission, cancellationToken);
         await tokenService.ObtainTokenAsync(submission.Id, cancellationToken);
-        await mediator.Publish(new SubmissionCompletedEvent(submission), cancellationToken);
+        
+        if(submission.IsComplete) {
+            await mediator.Publish(new SubmissionCompletedEvent(submission), cancellationToken);
+        }
 
         return Result<Submission>.Created(submission);
     }

--- a/src/Endatix.Core/UseCases/Submissions/PartialUpdate/PartialUpdateSubmissionHandler.cs
+++ b/src/Endatix.Core/UseCases/Submissions/PartialUpdate/PartialUpdateSubmissionHandler.cs
@@ -1,16 +1,18 @@
 ﻿
 using Endatix.Core.Entities;
+using Endatix.Core.Events;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;
+using MediatR;
 
 namespace Endatix.Core.UseCases.Submissions.PartialUpdate;
 
 /// <summary>
 /// Handler for partially updating a form submission.
 /// </summary>
-public class PartialUpdateSubmissionHandler(IRepository<Submission> repository) : ICommandHandler<PartialUpdateSubmissionCommand, Result<Submission>>
+public class PartialUpdateSubmissionHandler(IRepository<Submission> repository, IMediator mediator) : ICommandHandler<PartialUpdateSubmissionCommand, Result<Submission>>
 {
     private const int DEFAULT_CURRENT_PAGE = 1;
 
@@ -34,6 +36,10 @@ public class PartialUpdateSubmissionHandler(IRepository<Submission> repository) 
         );
 
         await repository.SaveChangesAsync(cancellationToken);
+
+        if(submission.IsComplete) {
+            await mediator.Publish(new SubmissionCompletedEvent(submission), cancellationToken);
+        }
 
         return Result.Success(submission);
     }

--- a/src/Endatix.Core/UseCases/Submissions/PartialUpdate/PartialUpdateSubmissionHandler.cs
+++ b/src/Endatix.Core/UseCases/Submissions/PartialUpdate/PartialUpdateSubmissionHandler.cs
@@ -18,6 +18,7 @@ public class PartialUpdateSubmissionHandler(IRepository<Submission> repository, 
 
     public async Task<Result<Submission>> Handle(PartialUpdateSubmissionCommand request, CancellationToken cancellationToken)
     {
+        var mustPublishEvent = false;
         var submissionSpec = new SubmissionByFormIdAndSubmissionIdSpec(request.FormId, request.SubmissionId);
         var submission = await repository.SingleOrDefaultAsync(submissionSpec, cancellationToken);
         if (submission == null)
@@ -25,6 +26,10 @@ public class PartialUpdateSubmissionHandler(IRepository<Submission> repository, 
             return Result.NotFound("Form submission not found.");
         }
 
+        if(!submission.IsComplete && (request.IsComplete ?? false)) {
+            mustPublishEvent = true;
+        }
+        
         // TODO: add more advanced PATCH-ing where we can not only replace individual properties, but merge, remove and other typical operations. This is valid especially for the JSON based JsonData and Metadata properties, so we can keep payloads and client logic light, e.g. submit one answer at a time and update JsonData
         // TODO: investigate if IsComplete and CurrentPage should be auto calculated as part of processing the submission
         submission.Update(
@@ -37,7 +42,7 @@ public class PartialUpdateSubmissionHandler(IRepository<Submission> repository, 
 
         await repository.SaveChangesAsync(cancellationToken);
 
-        if(submission.IsComplete) {
+        if(mustPublishEvent) {
             await mediator.Publish(new SubmissionCompletedEvent(submission), cancellationToken);
         }
 

--- a/src/Endatix.Infrastructure/AssembyReference.cs
+++ b/src/Endatix.Infrastructure/AssembyReference.cs
@@ -1,0 +1,8 @@
+﻿using System.Reflection;
+
+namespace Endatix.Infrastructure;
+
+public static class AssemblyReference
+{
+    public static readonly Assembly Assembly = typeof(AssemblyReference).Assembly;
+}

--- a/src/Endatix.Infrastructure/Integrations/Slack/SlackClient.cs
+++ b/src/Endatix.Infrastructure/Integrations/Slack/SlackClient.cs
@@ -1,0 +1,34 @@
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Endatix.Core.Integrations.Slack;
+using Microsoft.Extensions.Logging;
+
+namespace Endatix.Infrastructure.Integrations.Slack;
+/// <summary>
+/// A client for communications with the Slack API.
+/// </summary>
+/// <param name="logger"></param>
+public class SlackClient(ILogger<SlackClient> logger) : SlackCLient
+{
+    public async Task PostMessageAsync(string token, string channelId, string message)
+    {
+        using var httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+
+        var payload = new
+        {
+            channel = channelId,
+            text = message
+        };
+
+        var content = new StringContent(
+            System.Text.Json.JsonSerializer.Serialize(payload),
+            Encoding.UTF8,
+            "application/json"
+        );
+
+        var response = await httpClient.PostAsync("https://slack.com/api/chat.postMessage", content);
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/src/Endatix.Infrastructure/Integrations/Slack/SlackClient.cs
+++ b/src/Endatix.Infrastructure/Integrations/Slack/SlackClient.cs
@@ -46,10 +46,10 @@ public class SlackClient : INotificationHandler<SubmissionCompletedEvent>, ISlac
 
     public async Task Handle(SubmissionCompletedEvent notification, CancellationToken cancellationToken)
     {
-        if (notification.Submission.IsComplete && (bool)_slackSettings.Active)
+        if (notification.Submission.IsComplete && (bool)_slackSettings.Active!)
         {
             var formNameOrId = notification.Submission.FormId.ToString();
-            var submissionUrl = string.Format(SLACK_SUBMISSIONS_URL_TEMPLATE, _slackSettings.EndatixHubBaseUrl.TrimEnd('\\', '/'), notification.Submission.FormId, notification.Submission.Id);
+            var submissionUrl = string.Format(SLACK_SUBMISSIONS_URL_TEMPLATE, _slackSettings.EndatixHubBaseUrl!.TrimEnd('\\', '/'), notification.Submission.FormId, notification.Submission.Id);
             Form? form;
 
             using (var scope = _serviceProvider.CreateScope())
@@ -64,10 +64,8 @@ public class SlackClient : INotificationHandler<SubmissionCompletedEvent>, ISlac
             else {
                 _logger.LogWarning($"Form with id {formNameOrId} cannot be loaded by the Slack client");
             }
-            
-            Guard.Against.Null(form, $"Unable to load submission {notification.Submission.Id}'s Form object.");
 
-            var message = string.Format(SLACK_MESSAGE_TEMPLATE, submissionUrl, form.Name);
+            var message = string.Format(SLACK_MESSAGE_TEMPLATE, submissionUrl, formNameOrId);
 
             await PostMessageAsync(message);
         }

--- a/src/Endatix.Infrastructure/Integrations/Slack/SlackClient.cs
+++ b/src/Endatix.Infrastructure/Integrations/Slack/SlackClient.cs
@@ -1,16 +1,44 @@
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Endatix.Core.Entities;
+using Endatix.Core.Events;
+using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Integrations.Slack;
+using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Endatix.Infrastructure.Integrations.Slack;
 /// <summary>
 /// A client for communications with the Slack API.
 /// </summary>
-/// <param name="logger"></param>
-public class SlackClient(ILogger<SlackClient> logger) : SlackCLient
+public class SlackClient : INotificationHandler<SubmissionCompletedEvent>, ISlackClient
 {
+    private readonly ILogger<SlackClient> _logger;
+    private readonly IRepository<Form> _formRepository;
+    private readonly SlackSettings _slackSettings;
+    public SlackClient(ILogger<SlackClient> logger, IRepository<Form> formRepository, IOptions<SlackSettings> options) {
+        _formRepository = formRepository;
+        _logger = logger;
+        _slackSettings = options.Value;
+    }
+
+    public async Task Handle(SubmissionCompletedEvent notification, CancellationToken cancellationToken) {
+        if(notification.Submission.IsComplete && _slackSettings.Active){
+
+            var submissionUrl = $"{_slackSettings.EndatixHubBaseUrl.TrimEnd('\\', '/')}/forms/submissions/{notification.Submission.FormId}";
+            
+            //TODO: Troubleshoot _formRepository being disposed below and uncomment the line in order to reference the form name correctly
+            // var form = await _formRepository.GetByIdAsync(notification.Submission.FormId, cancellationToken) ?? throw new Exception("Form not found by the FormId of the submission");
+
+            var message = $":page_with_curl: <{submissionUrl}|New submission> for form with id {notification.Submission.FormId}";
+
+            await PostMessageAsync(_slackSettings.Token, _slackSettings.ChannelId, message);
+        }
+    }
+
     public async Task PostMessageAsync(string token, string channelId, string message)
     {
         using var httpClient = new HttpClient();
@@ -28,7 +56,13 @@ public class SlackClient(ILogger<SlackClient> logger) : SlackCLient
             "application/json"
         );
 
-        var response = await httpClient.PostAsync("https://slack.com/api/chat.postMessage", content);
-        response.EnsureSuccessStatusCode();
+        try {
+            var response = await httpClient.PostAsync("https://slack.com/api/chat.postMessage", content);
+            response.EnsureSuccessStatusCode();
+            _logger.LogInformation($"Slack notification posted to channel {channelId}: {message}");
+        }
+        catch(Exception ex) {
+            _logger.LogError($"Failed to post a message to Slack. Excption: {ex.Message}");
+        }
     }
 }

--- a/src/Endatix.Infrastructure/Integrations/Slack/SlackClient.cs
+++ b/src/Endatix.Infrastructure/Integrations/Slack/SlackClient.cs
@@ -1,12 +1,14 @@
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Ardalis.GuardClauses;
 using Endatix.Core.Entities;
 using Endatix.Core.Events;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Integrations.Slack;
 using MediatR;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
@@ -19,28 +21,64 @@ public class SlackClient : INotificationHandler<SubmissionCompletedEvent>, ISlac
     private readonly ILogger<SlackClient> _logger;
     private readonly IRepository<Form> _formRepository;
     private readonly SlackSettings _slackSettings;
-    public SlackClient(ILogger<SlackClient> logger, IRepository<Form> formRepository, IOptions<SlackSettings> options) {
+    private readonly IServiceProvider _serviceProvider;
+    //TODO: The Slack message template should be configurable through the Hub's UI
+    // {0} is the submissionURL, {1} is the form name
+    private const string SLACK_MESSAGE_TEMPLATE = ":page_with_curl: <{0}|New submission> for {1}";
+    // Submission URL parameters: {0} is the Hub's base URL, {1} is FormId
+    private const string SLACK_SUBMISSIONS_URL_TEMPLATE = "{0}/forms/submissions/{1}";
+    public SlackClient(ILogger<SlackClient> logger,
+            IRepository<Form> formRepository,
+            IOptions<SlackSettings> options,
+            IServiceProvider serviceProvider)
+    {
         _formRepository = formRepository;
         _logger = logger;
         _slackSettings = options.Value;
+        _serviceProvider = serviceProvider;
     }
 
-    public async Task Handle(SubmissionCompletedEvent notification, CancellationToken cancellationToken) {
-        if(notification.Submission.IsComplete && _slackSettings.Active){
+    public async Task Handle(SubmissionCompletedEvent notification, CancellationToken cancellationToken)
+    {
+        Guard.Against.Null(_slackSettings.Active, nameof(_slackSettings.Active), "Slack settings must specify whether the integration is active.");
+        Guard.Against.NullOrEmpty(_slackSettings.EndatixHubBaseUrl, nameof(_slackSettings.EndatixHubBaseUrl), "EndatixHubBaseUrl must have a value within the Slack settings collection.");
+        Guard.Against.NullOrEmpty(_slackSettings.Token, nameof(_slackSettings.Token), "Token must have a value within the Slack settings collection.");
+        Guard.Against.NullOrEmpty(_slackSettings.ChannelId, nameof(_slackSettings.ChannelId), "ChannelId must have a value within the Slack settings collection.");
 
-            var submissionUrl = $"{_slackSettings.EndatixHubBaseUrl.TrimEnd('\\', '/')}/forms/submissions/{notification.Submission.FormId}";
-            
-            //TODO: Troubleshoot _formRepository being disposed below and uncomment the line in order to reference the form name correctly
-            // var form = await _formRepository.GetByIdAsync(notification.Submission.FormId, cancellationToken) ?? throw new Exception("Form not found by the FormId of the submission");
+        if (notification.Submission.IsComplete && (bool)_slackSettings.Active)
+        {
 
-            var message = $":page_with_curl: <{submissionUrl}|New submission> for form with id {notification.Submission.FormId}";
+            var submissionUrl = string.Format(SLACK_SUBMISSIONS_URL_TEMPLATE, _slackSettings.EndatixHubBaseUrl.TrimEnd('\\', '/'), notification.Submission.FormId);
+            Form? form;
+
+            using (var scope = _serviceProvider.CreateScope())
+            {
+                var repository = scope.ServiceProvider.GetRequiredService<IRepository<Form>>();
+                form = await repository.GetByIdAsync(notification.Submission.FormId, cancellationToken);
+            }
+
+            Guard.Against.Null(form, $"Unable to load submission {notification.Submission.Id}'s Form object.");
+
+            var message = string.Format(SLACK_MESSAGE_TEMPLATE, submissionUrl, form.Name);
 
             await PostMessageAsync(_slackSettings.Token, _slackSettings.ChannelId, message);
+        }
+        else
+        {
+            if (!notification.Submission.IsComplete)
+            {
+                _logger.LogWarning($"SubmissionCompletedEvent raised on an incomplete submission with id {notification.Submission.Id}");
+            }
+
         }
     }
 
     public async Task PostMessageAsync(string token, string channelId, string message)
     {
+        Guard.Against.NullOrEmpty(channelId, nameof(channelId), "EndatixHubBaseUrl must have a value when posting to Slack.");
+        Guard.Against.NullOrEmpty(token, nameof(token), "Token must have a value  when posting to Slack.");
+        Guard.Against.NullOrEmpty(message, nameof(message), "Message must have a value when posting to Slack.");
+
         using var httpClient = new HttpClient();
         httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
 
@@ -56,12 +94,14 @@ public class SlackClient : INotificationHandler<SubmissionCompletedEvent>, ISlac
             "application/json"
         );
 
-        try {
+        try
+        {
             var response = await httpClient.PostAsync("https://slack.com/api/chat.postMessage", content);
             response.EnsureSuccessStatusCode();
             _logger.LogInformation($"Slack notification posted to channel {channelId}: {message}");
         }
-        catch(Exception ex) {
+        catch (Exception ex)
+        {
             _logger.LogError($"Failed to post a message to Slack. Excption: {ex.Message}");
         }
     }

--- a/src/Endatix.Infrastructure/Integrations/Slack/SlackClient.cs
+++ b/src/Endatix.Infrastructure/Integrations/Slack/SlackClient.cs
@@ -25,8 +25,8 @@ public class SlackClient : INotificationHandler<SubmissionCompletedEvent>, ISlac
     //TODO: The Slack message template should be configurable through the Hub's UI
     // {0} is the submissionURL, {1} is the form name
     private const string SLACK_MESSAGE_TEMPLATE = ":page_with_curl: <{0}|New submission> for {1}";
-    // Submission URL parameters: {0} is the Hub's base URL, {1} is FormId
-    private const string SLACK_SUBMISSIONS_URL_TEMPLATE = "{0}/forms/submissions/{1}";
+    // Submission URL parameters: {0} is the Hub's base URL, {1} is FormId, {2} is SubmissionId
+    private const string SLACK_SUBMISSIONS_URL_TEMPLATE = "{0}/forms/{1}/submissions/{2}";
     private const string SLACK_API_POST_URL = "https://slack.com/api/chat.postMessage";
     public SlackClient(ILogger<SlackClient> logger,
             IOptions<SlackSettings> options,
@@ -49,7 +49,7 @@ public class SlackClient : INotificationHandler<SubmissionCompletedEvent>, ISlac
         if (notification.Submission.IsComplete && (bool)_slackSettings.Active)
         {
             var formNameOrId = notification.Submission.FormId.ToString();
-            var submissionUrl = string.Format(SLACK_SUBMISSIONS_URL_TEMPLATE, _slackSettings.EndatixHubBaseUrl.TrimEnd('\\', '/'), notification.Submission.FormId);
+            var submissionUrl = string.Format(SLACK_SUBMISSIONS_URL_TEMPLATE, _slackSettings.EndatixHubBaseUrl.TrimEnd('\\', '/'), notification.Submission.FormId, notification.Submission.Id);
             Form? form;
 
             using (var scope = _serviceProvider.CreateScope())

--- a/src/Endatix.Infrastructure/Integrations/Slack/SlackSettings.cs
+++ b/src/Endatix.Infrastructure/Integrations/Slack/SlackSettings.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Endatix.Infrastructure.Integrations.Slack;
+
+/// <summary>
+/// POCO Class for per environment settings for Slack.
+/// </summary>
+public class SlackSettings
+{
+    /// <summary>
+    /// The token provided by Slack
+    /// </summary>
+    [Required]
+    public string? Token { get; set; }
+
+
+    /// <summary>
+    /// The Base Url for the Endatix Hub, e.g. https://admin.endatix.com
+    /// </summary>
+    [Required]
+    public string? EndatixHubBaseUrl { get; set; }
+
+
+    /// <summary>
+    /// The id of the channel to which notifications should be posted
+    /// </summary>
+    [Required]
+    public string? ChannelId { get; set; }
+
+    /// <summary>
+    /// A toggle for activating the integration
+    /// </summary>
+    [Required]
+    public bool Active { get; set; }
+}

--- a/src/Endatix.Infrastructure/Integrations/Slack/SlackSettings.cs
+++ b/src/Endatix.Infrastructure/Integrations/Slack/SlackSettings.cs
@@ -31,5 +31,5 @@ public class SlackSettings
     /// A toggle for activating the integration
     /// </summary>
     [Required]
-    public bool Active { get; set; }
+    public bool? Active { get; set; }
 }

--- a/src/Endatix.Infrastructure/Setup/EndatixAppExtensions.cs
+++ b/src/Endatix.Infrastructure/Setup/EndatixAppExtensions.cs
@@ -9,6 +9,7 @@ using Endatix.Infrastructure.Data.Abstractions;
 using Endatix.Infrastructure.Email;
 using Endatix.Infrastructure.Features.Submissions;
 using Endatix.Infrastructure.Identity;
+using Endatix.Infrastructure.Integrations.Slack;
 using Endatix.Infrastructure.Repositories;
 using Endatix.Infrastructure.Setup;
 using MediatR;
@@ -59,6 +60,8 @@ public static class EndatixAppExtensions
         services.AddScoped<IFormsRepository, FormsRepository>();
         services.AddScoped<IUnitOfWork, EfUnitOfWork>();
         services.AddEmailSender<SendGridEmailSender, SendGridSettings>();
+        services.AddSlackConfiguration<SlackSettings>();
+
         services.AddWebHookProcessing();
 
         endatixApp.AddDataOptions();
@@ -87,7 +90,8 @@ public static class EndatixAppExtensions
         var services = endatixApp.Services;
         var mediatRAssemblies = new[]
         {
-            Endatix.Core.AssemblyReference.Assembly
+            Endatix.Core.AssemblyReference.Assembly,
+            Endatix.Infrastructure.AssemblyReference.Assembly
         };
 
         if (meditROptions.AdditionalAssemblies.Length != 0)

--- a/src/Endatix.Infrastructure/Setup/ServiceCollectionExtensions.cs
+++ b/src/Endatix.Infrastructure/Setup/ServiceCollectionExtensions.cs
@@ -69,6 +69,23 @@ public static class ServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Register configuration for the Slack section of AppSettings and configure the DI container
+    /// </summary>
+    /// <typeparam name="TSettings">The POCO class that will be used for storing the configuration</typeparam>
+    /// <param name="services"></param>
+    /// <returns>Services ready to follow the AddServices pattern</returns>
+    public static IServiceCollection AddSlackConfiguration<TSettings>(this IServiceCollection services)
+           where TSettings : class
+    {
+        // Configure settings
+        services.AddOptions<TSettings>()
+                .BindConfiguration($"Integrations:Slack:{typeof(TSettings).Name}")
+                .ValidateDataAnnotations();
+
+        return services;
+    }
+
+    /// <summary>
     /// Using this will register centralized MediatR pipeline logic based of the LoggingPipelineBehavior class
     /// </summary>
     /// <param name="options">MediatRConfigOptions options</param>

--- a/src/Endatix.WebHost/appsettings.Development.json
+++ b/src/Endatix.WebHost/appsettings.Development.json
@@ -41,6 +41,16 @@
       "Environment": "Local Development"
     }
   },
+  "Integrations": {
+    "Slack": {
+      "SlackSettings": {
+        "Active": true,
+        "EndatixHubBaseUrl": "http://localhost:3000",
+        "Token": "",
+        "ChannelId": "C083KENJ932"
+      }
+    }
+  },
   "Endatix": {
     "Data": {
       "ApplyMigrations": true,

--- a/src/Endatix.WebHost/appsettings.json
+++ b/src/Endatix.WebHost/appsettings.json
@@ -46,6 +46,16 @@
       "WelcomeEmailTemplateId": "d-111e609ec2d04a8c8347cee3a759638b"
     }
   },
+  "Integrations": {
+    "Slack": {
+      "SlackSettings": {
+        "Active": true,
+        "EndatixHubBaseUrl": "http://localhost:3000",
+        "Token": "",
+        "ChannelId": "C083KENJ932"
+      }
+    }
+  },
   "Endatix": {
     "Data": {
       "ApplyMigrations": true,

--- a/src/Endatix.WebHost/appsettings.json
+++ b/src/Endatix.WebHost/appsettings.json
@@ -58,7 +58,7 @@
   },
   "Endatix": {
     "Data": {
-      "ApplyMigrations": true,
+      "ApplyMigrations": false,
       "InitialUser": {
         "Email": "admin@endatix.com",
         "Password": "P@ssw0rd"

--- a/src/Endatix.WebHost/appsettings.json
+++ b/src/Endatix.WebHost/appsettings.json
@@ -58,7 +58,7 @@
   },
   "Endatix": {
     "Data": {
-      "ApplyMigrations": false,
+      "ApplyMigrations": true,
       "InitialUser": {
         "Email": "admin@endatix.com",
         "Password": "P@ssw0rd"

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/Create/CreateSubmissionHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/Create/CreateSubmissionHandlerTests.cs
@@ -121,14 +121,14 @@ public class CreateSubmissionHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ValidRequest_PublishesSubmissionCreatedEvent()
+    public async Task Handle_ValidRequestAndSubmissionIsCompleted_PublishesSubmissionCreatedEvent()
     {
         // Arrange
         var form = new Form("Test Form") { Id = 1 };
         var formDefinition = new FormDefinition() { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
-        var request = new CreateSubmissionCommand(1, "{ }", null, null, null);
+        var request = new CreateSubmissionCommand(1, "{ }", null, null, true);
         
         _formsRepository.SingleOrDefaultAsync(
             Arg.Any<ActiveFormDefinitionByFormIdSpec>(), 

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/PartialUpdate/PartialUpdateSubmissionHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/PartialUpdate/PartialUpdateSubmissionHandlerTests.cs
@@ -3,6 +3,7 @@ using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;
 using Endatix.Core.UseCases.Submissions.PartialUpdate;
+using MediatR;
 
 namespace Endatix.Core.Tests.UseCases.Submissions.PartialUpdate;
 
@@ -10,11 +11,13 @@ public class PartialUpdateSubmissionHandlerTests
 {
     private readonly IRepository<Submission> _repository;
     private readonly PartialUpdateSubmissionHandler _handler;
+    private readonly IMediator _mediator;
 
     public PartialUpdateSubmissionHandlerTests()
     {
         _repository = Substitute.For<IRepository<Submission>>();
-        _handler = new PartialUpdateSubmissionHandler(_repository);
+        _mediator = Substitute.For<IMediator>();
+        _handler = new PartialUpdateSubmissionHandler(_repository, _mediator);
     }
 
     [Fact]

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/Update/UpdateSubmissionHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/Update/UpdateSubmissionHandlerTests.cs
@@ -4,6 +4,7 @@ using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;
 using Endatix.Core.UseCases.Submissions;
+using MediatR;
 
 namespace Endatix.Core.Tests.UseCases.Submissions.Update;
 
@@ -11,11 +12,13 @@ public class UpdateSubmissionHandlerTests
 {
     private readonly IRepository<Submission> _repository;
     private readonly UpdateSubmissionHandler _handler;
+    private readonly IMediator _mediator;
 
     public UpdateSubmissionHandlerTests()
     {
         _repository = Substitute.For<IRepository<Submission>>();
-        _handler = new UpdateSubmissionHandler(_repository);
+        _handler = new UpdateSubmissionHandler(_repository, _mediator);
+        _mediator = Substitute.For<IMediator>();
     }
 
     [Fact]


### PR DESCRIPTION
# Slack integration

## Description
Created a basic client for the Slack API. Added a handler for the submission complete event. Created settings infrastructure for the Slack integration - configuration is doen through the appsettings.json file.

To test this you will need a Slack bearer token and access to a test Slack channel within the Endatix space.

The Slack message does not refer to the form by Name, due to an issue with DI of the Forms repository. A new issue will be created for it.

TODOs:

- Fix Form repo issue
- Add throttling (Slack limit is 1 message per second per channel)
- Add retry mechanism

## Related Issues
Related to issue #289 

## Type of Change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots
![image](https://github.com/user-attachments/assets/3bab9437-2973-4914-955a-fcf2dc1af5c0)

