### PR TITLE
feat: Design Form saving behavior changes

### DIFF
--- a/apps/endatix-hub/app/(main)/forms/[formId]/ui/form-editor.tsx
+++ b/apps/endatix-hub/app/(main)/forms/[formId]/ui/form-editor.tsx
@@ -125,7 +125,7 @@ const defaultCreatorOptions: ICreatorOptions = {
 
 function FormEditor({ formJson, formId, formName, options }: FormEditorProps) {
   const [creator, setCreator] = useState<SurveyCreator | null>(null);
-  const [isSaving, setIsSaving] = useState(false);
+  const [isSaving] = useState(false);
   const router = useRouter();
   const [isEditingName, setIsEditingName] = useState(false);
   const [name, setName] = useState(formName);

--- a/apps/endatix-hub/app/(main)/forms/[formId]/ui/form-editor.tsx
+++ b/apps/endatix-hub/app/(main)/forms/[formId]/ui/form-editor.tsx
@@ -271,7 +271,7 @@ function FormEditor({ formJson, formId, formName, options }: FormEditorProps) {
         </div>
         <div className="flex items-center gap-2">
           {hasUnsavedChanges && (
-            <span className="text-yellow-600 text-xs border border-yellow-600 px-2 py-0.5 rounded-full whitespace-nowrap">
+            <span className="font-bold text-black text-xs border border-black px-2 py-0.5 rounded-full whitespace-nowrap">
               Unsaved changes
             </span>
           )}

--- a/apps/endatix-hub/app/(main)/forms/[formId]/ui/form-editor.tsx
+++ b/apps/endatix-hub/app/(main)/forms/[formId]/ui/form-editor.tsx
@@ -132,6 +132,7 @@ function FormEditor({ formJson, formId, formName, options }: FormEditorProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [originalName, setOriginalName] = useState(formName);
   const [isPending, startTransition] = useTransition();
+  const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
   const handleNameSave = useCallback(async () => {
     if (name !== originalName) {
@@ -183,22 +184,34 @@ function FormEditor({ formJson, formId, formName, options }: FormEditorProps) {
     };
   }, [isEditingName, handleNameSave]);
 
-  const handleSaveAndGoBack = async () => {
-    try {
-      setIsSaving(true);
+  useEffect(() => {
+    if (creator) {
+      creator.onModified.add(() => {
+        setHasUnsavedChanges(true);
+      });
+    }
+  }, [creator]);
 
-      const updatedFormJson = creator?.JSON;
-
-      const result = await updateFormDefinitionJsonAction(formId, updatedFormJson);
-      if (!result.success) {
-        throw new Error(result.error);
+  useEffect(() => {
+    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+      if (hasUnsavedChanges) {
+        e.preventDefault();
+        e.returnValue = ''; // Required for Chrome
       }
+    };
 
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+  }, [hasUnsavedChanges]);
+
+  const handleSaveAndGoBack = () => {
+    if (hasUnsavedChanges) {
+      const confirm = window.confirm('There are unsaved changes. Are you sure you want to leave?');
+      if (confirm) {
+        router.push('/forms');
+      }
+    } else {
       router.push('/forms');
-    } catch (error) {
-      console.error('Failed to save form', error);
-    } finally {
-      setIsSaving(false);
     }
   };
 
@@ -207,6 +220,7 @@ function FormEditor({ formJson, formId, formName, options }: FormEditorProps) {
       const updatedFormJson = creator?.JSON;
       const result = await updateFormDefinitionJsonAction(formId, updatedFormJson);
       if (result.success) {
+        setHasUnsavedChanges(false);
         toast("Form saved");
       } else {
         throw new Error(result.error);
@@ -255,7 +269,12 @@ function FormEditor({ formJson, formId, formName, options }: FormEditorProps) {
             </span>
           )}
         </div>
-        <div className="flex items-center gap-2" >
+        <div className="flex items-center gap-2">
+          {hasUnsavedChanges && (
+            <span className="text-yellow-600 text-xs border border-yellow-600 px-2 py-0.5 rounded-full whitespace-nowrap">
+              Unsaved changes
+            </span>
+          )}
           <Button
             disabled={isPending}
             onClick={saveForm}


### PR DESCRIPTION
# Design Form saving behavior changes

## Description
Includes the described in #286 changes and additionally on an attempt to close the browser with unsaved changes there is a confirmation dialog.

**Note**
The user still can leave the screen with unsaved changes if they click to some other screen on the side menu bar. Confirmation dialog for this case is not a part of the task. However, I tried to add such logic but it seems changes need to be made on higher level in the whole application to make this possible so I left it as a future enhancement.

## Related Issues
closes #286

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
