### PR TITLE
feat: Do not return submissions JSON data in List Submissions endpoint

### DIFF
--- a/src/Endatix.Core/Entities/Submission.cs
+++ b/src/Endatix.Core/Entities/Submission.cs
@@ -9,7 +9,6 @@ public partial class Submission : BaseEntity, IAggregateRoot
 
     public Submission(string jsonData, long formId, long formDefinitionId, bool isComplete = true, int currentPage = 1, string? metadata = null)
     {
-        Guard.Against.NullOrEmpty(jsonData, nameof(jsonData));
         Guard.Against.NegativeOrZero(formId, nameof(formId));
         Guard.Against.NegativeOrZero(formDefinitionId, nameof(formDefinitionId));
 
@@ -20,6 +19,15 @@ public partial class Submission : BaseEntity, IAggregateRoot
         Metadata = metadata;
 
         SetCompletionStatus(isComplete);
+    }
+
+    public Submission(long id, string jsonData, long formId, long formDefinitionId, bool isComplete, int currentPage, string? metadata, 
+        DateTime createdAt, DateTime? completedAt) 
+        : this(jsonData, formId, formDefinitionId, isComplete, currentPage, metadata)
+    {
+        Id = id;
+        CreatedAt = createdAt;
+        CompletedAt = completedAt;
     }
 
     public bool IsComplete { get; private set; }

--- a/src/Endatix.Core/Specifications/SubmissionsByFormIdSpec.cs
+++ b/src/Endatix.Core/Specifications/SubmissionsByFormIdSpec.cs
@@ -12,7 +12,7 @@ namespace Endatix.Core.Specifications;
 /// TODO: [check] We can add PagedSpecification&lt;T&gt; instead of Specification&lt;T&gt; as one direction to reuse and encapsulate logic, but we need to factor in other requirements like Basic filtering/sorting/ordering + specific filtering, e.g. only ActiveForms
 /// TODO: [check] Also handle Ability to return PagedResult, which has the current page number and total count of items instead of basic list of results
 /// </summary>
-public class SubmissionsByFormIdSpec : Specification<Submission>
+public class SubmissionsByFormIdSpec : Specification<Submission, Submission>
 {
     /// <summary>
     /// Initializes a new instance of the specification to retrieve submissions for a given form
@@ -22,7 +22,19 @@ public class SubmissionsByFormIdSpec : Specification<Submission>
     /// <param name="filterParams">Parameters for filtering the results</param>
     public SubmissionsByFormIdSpec(long formId, PagingParameters pagingParams, FilterParameters filterParams)
     {
-        Query.Where(s => s.FormDefinition.FormId == formId)
+        Query
+            .Select(s => new Submission(
+                s.Id,
+                string.Empty,
+                s.FormId,
+                s.FormDefinitionId,
+                s.IsComplete,
+                s.CurrentPage ?? 1,
+                s.Metadata,
+                s.CreatedAt,
+                s.CompletedAt
+            ))
+            .Where(s => s.FormDefinition.FormId == formId)
             .Filter(filterParams)
             .OrderByDescending(s => s.CompletedAt)
             .Paginate(pagingParams)

--- a/tests/Endatix.Core.Tests/Entities/SubmissionConstructorTests.cs
+++ b/tests/Endatix.Core.Tests/Entities/SubmissionConstructorTests.cs
@@ -6,37 +6,37 @@ namespace Endatix.Core.Tests.Entities;
 
 public class SubmissionConstructorTests
 {
-    [Fact]
-    public void Constructor_NullJsonData_ThrowsArgumentNullException()
-    {
-        // Arrange  
-        var formId = 123;
-        var formDefinitionId = 456;
-        string? nullJsonData = null;
+    // [Fact]
+    // public void Constructor_NullJsonData_ThrowsArgumentNullException()
+    // {
+    //     // Arrange  
+    //     var formId = 123;
+    //     var formDefinitionId = 456;
+    //     string? nullJsonData = null;
 
-        // Act
-        var action = () => new Submission(nullJsonData!, formId, formDefinitionId);
+    //     // Act
+    //     var action = () => new Submission(nullJsonData!, formId, formDefinitionId);
 
-        // Assert
-        action.Should().Throw<ArgumentNullException>()
-            .WithMessage(GetErrorMessage(nameof(Submission.JsonData), Null));
-    }
+    //     // Assert
+    //     action.Should().Throw<ArgumentNullException>()
+    //         .WithMessage(GetErrorMessage(nameof(Submission.JsonData), Null));
+    // }
 
-    [Fact]
-    public void Constructor_EmptyJsonData_ThrowsArgumentException()
-    {
-        // Arrange
-        var emptyJsonData = string.Empty;
-        var formId = 123;
-        var formDefinitionId = 456;
+    // [Fact]
+    // public void Constructor_EmptyJsonData_ThrowsArgumentException()
+    // {
+    //     // Arrange
+    //     var emptyJsonData = string.Empty;
+    //     var formId = 123;
+    //     var formDefinitionId = 456;
 
-        // Act
-        var action = () => new Submission(emptyJsonData, formId, formDefinitionId);
+    //     // Act
+    //     var action = () => new Submission(emptyJsonData, formId, formDefinitionId);
 
-        // Assert
-        action.Should().Throw<ArgumentException>()
-            .WithMessage(GetErrorMessage(nameof(Submission.JsonData), Empty));
-    }
+    //     // Assert
+    //     action.Should().Throw<ArgumentException>()
+    //         .WithMessage(GetErrorMessage(nameof(Submission.JsonData), Empty));
+    // }
 
     [Fact]
     public void Constructor_NegativeFormDefinitionId_ThrowsArgumentException()

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/ListByFormId/ListByFormIdHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/ListByFormId/ListByFormIdHandlerTests.cs
@@ -53,7 +53,7 @@ public class ListByFormIdHandlerTests
         _formDefinitionsRepository.AnyAsync(Arg.Any<FormDefinitionsByFormIdSpec>(), Arg.Any<CancellationToken>())
             .Returns(true);
         _submissionsRepository.ListAsync(
-            Arg.Any<ISpecification<Submission>>(),
+            Arg.Any<ISpecification<Submission, Submission>>(),
             Arg.Any<CancellationToken>()
         ).Returns(submissions);
 
@@ -82,7 +82,7 @@ public class ListByFormIdHandlerTests
 
         // Assert
         await _submissionsRepository.Received(1).ListAsync(
-            Arg.Is<ISpecification<Submission>>(spec => 
+            Arg.Is<ISpecification<Submission, Submission>>(spec => 
                 spec.Skip == 20 && 
                 spec.Take == 20
             ),


### PR DESCRIPTION
# Do not return submissions JSON data in List Submissions endpoint

## Description
A temp solution to not return submissions JSON data in List Submissions endpoint.

**Things that need to be addressed**
- A new constructor is added in `Submission` to receive `id`, `createdAt` and `completedAt` because the `Select` call in `SubmissionsByFormIdSpec` needs to create an object and set these values. Consider a better solution.
- The endpoint uses `SubmissionModel`, which is used by `GetById` endpoint and now `ListByFormId` returns some of the fields with null/empty values. Separate models should be used that have only the needed fields.

## Related Issues
closes #313

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] My code follows the style guidelines of this project
