### PR TITLE
feat: Create new forms as draft and do not display drafts on the forms screen

### DIFF
--- a/apps/endatix-hub/app/(main)/forms/[formId]/ui/form-editor.tsx
+++ b/apps/endatix-hub/app/(main)/forms/[formId]/ui/form-editor.tsx
@@ -127,7 +127,7 @@ function FormEditor({ formJson, formId, formName, options }: FormEditorProps) {
   const [creator, setCreator] = useState<SurveyCreator | null>(null);
   const [isSaving] = useState(false);
   const router = useRouter();
-  const [isEditingName, setIsEditingName] = useState(false);
+  const [isEditingName, setIsEditingName] = useState(formName === "New Form");
   const [name, setName] = useState(formName);
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [originalName, setOriginalName] = useState(formName);
@@ -217,8 +217,9 @@ function FormEditor({ formJson, formId, formName, options }: FormEditorProps) {
 
   const saveForm = () => {
     startTransition(async () => {
+      const isDraft = false;
       const updatedFormJson = creator?.JSON;
-      const result = await updateFormDefinitionJsonAction(formId, updatedFormJson);
+      const result = await updateFormDefinitionJsonAction(formId, isDraft, updatedFormJson);
       if (result.success) {
         setHasUnsavedChanges(false);
         toast("Form saved");

--- a/apps/endatix-hub/app/(main)/forms/[formId]/update-form-definition-json.action.ts
+++ b/apps/endatix-hub/app/(main)/forms/[formId]/update-form-definition-json.action.ts
@@ -3,11 +3,11 @@
 import { ensureAuthenticated } from "@/lib/auth-service";
 import { updateFormDefinition } from "@/services/api";
 
-export async function updateFormDefinitionJsonAction(formId: string, formJson: object | null) {
+export async function updateFormDefinitionJsonAction(formId: string, isDraft: boolean, formJson: object | null) {
   await ensureAuthenticated();
 
   try {
-    await updateFormDefinition(formId, JSON.stringify(formJson));
+    await updateFormDefinition(formId, isDraft, JSON.stringify(formJson));
     return { success: true };
   } catch (error) {
     console.error("Failed to update form definition", error);

--- a/apps/endatix-hub/services/api.ts
+++ b/apps/endatix-hub/services/api.ts
@@ -183,6 +183,7 @@ export const getFormDefinition = async (formId: string, definitionId: string): P
 
 export const updateFormDefinition = async (
   formId: string,
+  isDraft: boolean,
   jsonData: string
 ): Promise<void> => {
   const session = await getSession();
@@ -200,7 +201,7 @@ export const updateFormDefinition = async (
   const response = await fetch(`${API_BASE_URL}/forms/${formId}/definition`, {
     method: "PATCH",
     headers: headers,
-    body: JSON.stringify({ jsonData }),
+    body: JSON.stringify({ isDraft, jsonData }),
   });
 
   if (!response.ok) {

--- a/src/Endatix.Core/Specifications/FormsWithSubmissionsCountSpec.cs
+++ b/src/Endatix.Core/Specifications/FormsWithSubmissionsCountSpec.cs
@@ -11,9 +11,10 @@ public sealed class FormsWithSubmissionsCountSpec : Specification<Form, FormDto>
     public FormsWithSubmissionsCountSpec(PagingParameters pagingParams)
     {
         Query
-         .OrderByDescending(x => x.CreatedAt)
-         .Paginate(pagingParams)
-         .AsNoTracking();
+            .Where(f => !f.ActiveDefinition.IsDraft)
+            .OrderByDescending(x => x.CreatedAt)
+            .Paginate(pagingParams)
+            .AsNoTracking();
 
         Query.Select(form =>
             new FormDto()

--- a/src/Endatix.Core/UseCases/Forms/Create/CreateFormHandler.cs
+++ b/src/Endatix.Core/UseCases/Forms/Create/CreateFormHandler.cs
@@ -17,7 +17,7 @@ public class CreateFormHandler : ICommandHandler<CreateFormCommand, Result<Form>
     public async Task<Result<Form>> Handle(CreateFormCommand request, CancellationToken cancellationToken)
     {
         var newForm = new Form(request.Name, request.Description, request.IsEnabled);
-        var newFormDefinition = new FormDefinition(jsonData: request.FormDefinitionJsonData);
+        var newFormDefinition = new FormDefinition(isDraft:true, jsonData: request.FormDefinitionJsonData);
 
         var form = await _formsRepository.CreateFormWithDefinitionAsync(newForm, newFormDefinition, cancellationToken);
 


### PR DESCRIPTION
# Create new forms as draft and do not display drafts on the forms screen

## Description
A new form is created with draft form definition. When it is updated in the Form Designer, the draft is set to false. The Forms screen does not display draft forms. If a form with name "New Form" is opened in the Designer, the form name is set in editing mode.

## Related Issues
closes #318

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project