### PR TITLE
fix: Do not send Slack notifications when they are not active

### DIFF
--- a/src/Endatix.Infrastructure/Integrations/Slack/SlackSettings.cs
+++ b/src/Endatix.Infrastructure/Integrations/Slack/SlackSettings.cs
@@ -10,26 +10,22 @@ public class SlackSettings
     /// <summary>
     /// The token provided by Slack
     /// </summary>
-    [Required]
     public string? Token { get; set; }
 
 
     /// <summary>
     /// The Base Url for the Endatix Hub, e.g. https://admin.endatix.com
     /// </summary>
-    [Required]
     public string? EndatixHubBaseUrl { get; set; }
 
 
     /// <summary>
     /// The id of the channel to which notifications should be posted
     /// </summary>
-    [Required]
     public string? ChannelId { get; set; }
 
     /// <summary>
     /// A toggle for activating the integration
     /// </summary>
-    [Required]
     public bool? Active { get; set; }
 }

--- a/src/Endatix.WebHost/appsettings.Development.json
+++ b/src/Endatix.WebHost/appsettings.Development.json
@@ -44,7 +44,7 @@
   "Integrations": {
     "Slack": {
       "SlackSettings": {
-        "Active": true,
+        "Active": false,
         "EndatixHubBaseUrl": "http://localhost:3000",
         "Token": "",
         "ChannelId": "C083KENJ932"

--- a/src/Endatix.WebHost/appsettings.json
+++ b/src/Endatix.WebHost/appsettings.json
@@ -49,7 +49,7 @@
   "Integrations": {
     "Slack": {
       "SlackSettings": {
-        "Active": true,
+        "Active": false,
         "EndatixHubBaseUrl": "http://localhost:3000",
         "Token": "",
         "ChannelId": "C083KENJ932"


### PR DESCRIPTION
# Do not send Slack notifications when they are not active

## Description
Only check for the other Slack settings if `Active==true` and only send notifications if `Active==true`

## Related Issues
closes https://github.com/endatix/endatix-private/issues/27

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
