### PR TITLE
fix: Extending token JWT default expiration

### DIFF
--- a/src/Endatix.WebHost/appsettings.Development.json
+++ b/src/Endatix.WebHost/appsettings.Development.json
@@ -61,7 +61,7 @@
     },
     "Jwt": {
       "SigningKey": "L2yGC_Vpd3k#L[<9Zb,h?.HT:n'T/5CTDmBpDskU?NAaT$sLfRU",
-      "AccessExpiryInMinutes": 45,
+      "AccessExpiryInMinutes": 90,
       "RefreshExpiryInDays": 7,
       "Issuer": "endatix-api",
       "Audiences": ["endatix-hub", "endatix-client"]

--- a/src/Endatix.WebHost/appsettings.json
+++ b/src/Endatix.WebHost/appsettings.json
@@ -66,7 +66,7 @@
     },
     "Jwt": {
       "SigningKey": "L2yGC_Vpd3k#L[<9Zb,h?.HT:n'T/5CTDmBpDskU?NAaT$sLfRU",
-      "AccessExpiryInMinutes": 15,
+      "AccessExpiryInMinutes": 90,
       "RefreshExpiryInDays": 7,
       "Issuer": "endatix-api",
       "Audiences": ["endatix-hub", "endatix-client"]


### PR DESCRIPTION
# Extending token JWT default expiration to 90 minutes for dev and default

## Description
Adding fix to extend session lifetime to address frequent logouts

## Related Issues
closes #334

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the contribution guidelines of this project