### PR TITLE
fix: Filtering by time results Bad Request

### DIFF
--- a/src/Endatix.Api/Common/FilteredRequestValidator.cs
+++ b/src/Endatix.Api/Common/FilteredRequestValidator.cs
@@ -9,15 +9,7 @@ namespace Endatix.Api.Common;
 public class FilteredRequestValidator : AbstractValidator<IFilteredRequest>
 {
     private static readonly string[] _validOperators = { "!:", ">:", "<:", ":", ">", "<" };
-    private readonly Dictionary<string, Type>? _validFields;
-
-    /// <summary>
-    /// Default constructor
-    /// </summary>
-    public FilteredRequestValidator()
-    {
-        ConfigureRules();
-    }
+    private readonly Dictionary<string, Type> _validFields;
 
     /// <summary>
     /// Constructor that accepts a dictionary of valid field names and their corresponding types
@@ -52,65 +44,48 @@ public class FilteredRequestValidator : AbstractValidator<IFilteredRequest>
             return false;
         }
 
-        // If we have valid fields defined, check if the filter starts with any of them
-        if (_validFields != null)
+        var field = _validFields.Keys
+            .FirstOrDefault(field => 
+                filter.StartsWith(field, StringComparison.OrdinalIgnoreCase) && 
+                filter.Length > field.Length && 
+                !char.IsLetterOrDigit(filter[field.Length]));
+
+        if (field == null)
         {
-            var matchingField = _validFields.Keys
-                .FirstOrDefault(field => 
-                    filter.StartsWith(field, StringComparison.OrdinalIgnoreCase) && 
-                    filter.Length > field.Length && 
-                    !char.IsLetterOrDigit(filter[field.Length]));
+            errorMessage = $"Filter must start with a valid field name. Allowed fields: {string.Join(", ", _validFields.Keys)}";
+            return false;
+        }
 
-            if (matchingField == null)
-            {
-                errorMessage = $"Filter must start with a valid field name. Allowed fields: {string.Join(", ", _validFields.Keys)}";
-                return false;
-            }
+        var remainingFilter = filter[field.Length..];
 
-            // Extract the rest of the filter after the field name
-            var remainingFilter = filter[matchingField.Length..];
+        var @operator = _validOperators.FirstOrDefault(remainingFilter.StartsWith);
+        if (@operator == null)
+        {
+            errorMessage = $"Filter must contain a valid operator after the field name. Allowed operators: {string.Join(", ", _validOperators)}";
+            return false;
+        }
 
-            // Check if the remaining part starts with a valid operator
-            var matchingOperator = _validOperators.FirstOrDefault(op => remainingFilter.StartsWith(op));
-            if (matchingOperator == null)
-            {
-                errorMessage = $"After field name '{matchingField}', filter must contain one of these operators: {string.Join(", ", _validOperators)}";
-                return false;
-            }
+        var value = remainingFilter[@operator.Length..];
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            errorMessage = "Filter must contain a value after the operator.";
+            return false;
+        }
 
-            // Extract the value part
-            var value = remainingFilter[matchingOperator.Length..];
-            if (string.IsNullOrWhiteSpace(value))
+        // For : and !: operators, check each value in the comma-separated list
+        if (@operator is ":" or "!:")
+        {
+            var values = value.Split(',', StringSplitOptions.RemoveEmptyEntries);
+            if (!values.All(v => IsValidType(v.Trim(), _validFields[field])))
             {
-                errorMessage = "Filter must include a value after the operator";
-                return false;
-            }
-
-            // Validate the value type
-            if (matchingOperator is ":" or "!:")
-            {
-                var values = value.Split(',', StringSplitOptions.RemoveEmptyEntries);
-                if (!values.All(v => IsValidType(v.Trim(), _validFields[matchingField])))
-                {
-                    errorMessage = $"One or more values are not valid for type {_validFields[matchingField].Name}";
-                    return false;
-                }
-            }
-            else if (!IsValidType(value, _validFields[matchingField]))
-            {
-                errorMessage = $"Value is not valid for type {_validFields[matchingField].Name}";
+                errorMessage = $"One or more values are not valid for type {_validFields[field].Name}";
                 return false;
             }
         }
-        else
+        else if (!IsValidType(value.Trim(), _validFields[field]))
         {
-            // If no valid fields are defined, just check for operator presence
-            var hasValidOperator = _validOperators.Any(op => filter.Contains(op));
-            if (!hasValidOperator)
-            {
-                errorMessage = $"Filter must contain one of these operators: {string.Join(", ", _validOperators)}";
-                return false;
-            }
+            errorMessage = $"Value is not valid for type {_validFields[field].Name}";
+            return false;
         }
 
         return true;

--- a/src/Endatix.Core/Specifications/Parameters/FilterCriterion.cs
+++ b/src/Endatix.Core/Specifications/Parameters/FilterCriterion.cs
@@ -45,7 +45,6 @@ public class FilterCriterion
     {
         Guard.Against.NullOrWhiteSpace(filterExpression, nameof(filterExpression));
 
-        // Find the field name by taking all alphanumeric characters from the start
         var fieldEndIndex = 0;
         while (fieldEndIndex < filterExpression.Length && char.IsLetterOrDigit(filterExpression[fieldEndIndex]))
         {
@@ -55,20 +54,18 @@ public class FilterCriterion
         Field = Guard.Against.NullOrWhiteSpace(
             filterExpression[..fieldEndIndex],
             nameof(filterExpression),
-            "Filter must have a field");
+            "Filter must have a field name");
 
-        // Find the operator starting at the end of the field name
         var @operator = _operatorMap.Keys
             .FirstOrDefault(op => filterExpression.IndexOf(op, fieldEndIndex) == fieldEndIndex);
 
         Guard.Against.Null(
             @operator,
             nameof(filterExpression),
-            $"Invalid filter operator at position {fieldEndIndex}. Valid operators are: {string.Join(", ", _operatorMap.Keys)}");
+            $"Filter must have a valid operator after the field name. Valid operators are: {string.Join(", ", _operatorMap.Keys)}");
 
         Operator = _operatorMap[@operator];
 
-        // Extract the value part after the operator
         var valueStartIndex = fieldEndIndex + @operator.Length;
         var values = filterExpression[valueStartIndex..]
             .Split(',')
@@ -79,7 +76,7 @@ public class FilterCriterion
             values,
             nameof(filterExpression),
             v => !v.Any(string.IsNullOrWhiteSpace),
-            "Filter values cannot be empty or whitespace");
+            "Filter values cannot be empty");
 
         Values = values.AsReadOnly();
     }

--- a/tests/Endatix.Api.Tests/Common/FilteredRequestValidatorTests.cs
+++ b/tests/Endatix.Api.Tests/Common/FilteredRequestValidatorTests.cs
@@ -5,94 +5,94 @@ namespace Endatix.Api.Tests.Common;
 
 public class FilteredRequestValidatorTests
 {
+    private readonly FilteredRequestValidator _validator;
+
+    public FilteredRequestValidatorTests()
+    {
+        var validFields = new Dictionary<string, Type>
+        {
+            { "name", typeof(string) },
+            { "name1", typeof(string) },
+            { "age", typeof(int) },
+            { "created", typeof(DateTime) },
+        };
+        _validator = new FilteredRequestValidator(validFields);
+    }
+
     [Theory]
     [InlineData("")]
     [InlineData(" ")]
     public void Validate_EmptyFilter_ReturnsError(string filter)
     {
         // Arrange
-        var validator = new FilteredRequestValidator();
         var request = new TestFilteredRequest { Filter = [filter] };
 
         // Act
-        var result = validator.TestValidate(request);
+        var result = _validator.TestValidate(request);
 
         // Assert
         result.ShouldHaveValidationErrorFor(x => x.Filter)
             .WithErrorMessage($"Invalid filter '{filter}': Filter cannot be empty");
     }
 
+    [Theory]
+    [InlineData(":value")]
+    [InlineData("invalid:value")]
+    public void Validate_InvalidFieldName_ReturnsError(string filter)
+    {
+        // Arrange
+        var request = new TestFilteredRequest { Filter = [filter] };
+
+        // Act
+        var result = _validator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Filter)
+            .WithErrorMessage($"Invalid filter '{filter}': Filter must start with a valid field name. Allowed fields: name, name1, age, created");
+    }
+
     [Fact]
     public void Validate_InvalidOperator_ReturnsError()
     {
         // Arrange
-        var validator = new FilteredRequestValidator();
         var invalidFilter = "name==test";
         var request = new TestFilteredRequest { Filter = [invalidFilter] };
 
         // Act
-        var result = validator.TestValidate(request);
+        var result = _validator.TestValidate(request);
 
         // Assert
         result.ShouldHaveValidationErrorFor(x => x.Filter)
-            .WithErrorMessage($"Invalid filter '{invalidFilter}': Filter must contain one of these operators: !:, >:, <:, :, >, <");
-    }
-
-    [Theory]
-    [InlineData(":value")]
-    [InlineData("field:")]
-    [InlineData(":")]
-    public void Validate_InvalidFilterFormat_ReturnsError(string filter)
-    {
-        // Arrange
-        var validator = new FilteredRequestValidator();
-        var request = new TestFilteredRequest { Filter = [filter] };
-
-        // Act
-        var result = validator.TestValidate(request);
-
-        // Assert
-        result.ShouldHaveValidationErrorFor(x => x.Filter)
-            .WithErrorMessage($"Invalid filter '{filter}': Filter must be in format 'field[operator]value'");
+            .WithErrorMessage($"Invalid filter '{invalidFilter}': Filter must contain a valid operator after the field name. Allowed operators: !:, >:, <:, :, >, <");
     }
 
     [Fact]
-    public void Validate_InvalidFieldName_ReturnsError()
+    public void Validate_MissingValue_ReturnsError()
     {
+        var filter = "age:";
         // Arrange
-        var validFields = new Dictionary<string, Type>
-        {
-            { "name", typeof(string) },
-            { "age", typeof(int) }
-        };
-        var validator = new FilteredRequestValidator(validFields);
-        var invalidFilter = "invalid:value";
-        var request = new TestFilteredRequest { Filter = [invalidFilter] };
+        var request = new TestFilteredRequest { Filter = [filter] };
 
         // Act
-        var result = validator.TestValidate(request);
+        var result = _validator.TestValidate(request);
 
         // Assert
         result.ShouldHaveValidationErrorFor(x => x.Filter)
-            .WithErrorMessage($"Invalid filter '{invalidFilter}': Invalid field name 'invalid'. Allowed fields: name, age");
+            .WithErrorMessage($"Invalid filter '{filter}': Filter must contain a value after the operator.");
     }
 
     [Theory]
     [InlineData("age:notanumber", "One or more values are not valid for type Int32")]
+    [InlineData("age:5,twenty", "One or more values are not valid for type Int32")]
     [InlineData("age>:abc", "Value is not valid for type Int32")]
+    [InlineData("created>yesterday", "Value is not valid for type DateTime")]
     public void Validate_InvalidValueType_ReturnsError(string filter, string expectedError)
     {
         // Arrange
-        var validFields = new Dictionary<string, Type>
-        {
-            { "name", typeof(string) },
-            { "age", typeof(int) }
-        };
-        var validator = new FilteredRequestValidator(validFields);
         var request = new TestFilteredRequest { Filter = [filter] };
 
         // Act
-        var result = validator.TestValidate(request);
+        var result = _validator.TestValidate(request);
 
         // Assert
         result.ShouldHaveValidationErrorFor(x => x.Filter)
@@ -101,22 +101,17 @@ public class FilteredRequestValidatorTests
 
     [Theory]
     [InlineData("name:john")]
+    [InlineData("name1:john,jane")]
     [InlineData("age:25")]
     [InlineData("age>:18")]
-    [InlineData("name:john,jane")]
+    [InlineData("created>2025-01-05T15:14:13")]
     public void Validate_ValidFilter_PassesValidation(string filter)
     {
         // Arrange
-        var validFields = new Dictionary<string, Type>
-        {
-            { "name", typeof(string) },
-            { "age", typeof(int) }
-        };
-        var validator = new FilteredRequestValidator(validFields);
         var request = new TestFilteredRequest { Filter = [filter] };
 
         // Act
-        var result = validator.TestValidate(request);
+        var result = _validator.TestValidate(request);
 
         // Assert
         result.ShouldNotHaveAnyValidationErrors();

--- a/tests/Endatix.Core.Tests/ErrorMessages.cs
+++ b/tests/Endatix.Core.Tests/ErrorMessages.cs
@@ -31,8 +31,8 @@ public static class ErrorMessages
         { ErrorType.AccessTokenZeroOrNegative, "Access Token expiration must be positive number representing minutes for access token lifetime (Parameter '{0}')" },
         { ErrorType.RefreshTokenZeroOrNegative, "Refresh Token expiration must be positive number representing days for refresh token lifetime (Parameter '{0}')" },
         { ErrorType.InvalidFilterOperator, "Invalid filter operator. Valid operators are: !:, >:, <:, :, >, < (Parameter '{0}')" },
-        { ErrorType.FilterNoField, "Filter must have a field (Parameter '{0}')" },
-        { ErrorType.FilterEmptyValue, "Filter values cannot be empty or whitespace (Parameter '{0}')" },
+        { ErrorType.FilterNoField, "Filter must have a field name (Parameter '{0}')" },
+        { ErrorType.FilterEmptyValue, "Filter values cannot be empty (Parameter '{0}')" },
         { ErrorType.PropertyNotExist, "Property '{0}' does not exist on type 'TestEntity' (Parameter '{1}')" },
     };
 

--- a/tests/Endatix.Core.Tests/Specifications/Parameters/FilterCriterionTests.cs
+++ b/tests/Endatix.Core.Tests/Specifications/Parameters/FilterCriterionTests.cs
@@ -16,14 +16,30 @@ public class FilterCriterionTests
         // Assert
         act.Should()
            .Throw<ArgumentException>()
-           .WithMessage(ErrorMessages.GetErrorMessage("filterExpression", ErrorType.Empty));
+           .WithParameterName("filterExpression");
+    }
+
+    [Theory]
+    [InlineData(":value")]
+    [InlineData("^&")]
+    public void Constructor_EmptyField_ThrowsArgumentException(string filterExpression)
+    {
+        // Act
+        var act = () => new FilterCriterion(filterExpression);
+
+        // Assert
+        act.Should()
+           .Throw<ArgumentException>()
+           .WithMessage(ErrorMessages.GetErrorMessage("filterExpression", ErrorType.FilterNoField));
     }
 
     [Theory]
     [InlineData("field")]
     [InlineData("field=value")]
-    [InlineData("field^two:value")]
-    [InlineData("@field:value")]
+    [InlineData("field^value")]
+    [InlineData("field$:value")]
+    [InlineData("field@:value")]
+    [InlineData("field-name:value")]
     public void Constructor_InvalidOperator_ThrowsArgumentException(string filterExpression)
     {
         // Act
@@ -32,22 +48,8 @@ public class FilterCriterionTests
         // Assert
         act.Should()
            .Throw<ArgumentException>()
-           .WithMessage(ErrorMessages.GetErrorMessage("filterExpression", ErrorType.InvalidFilterOperator));
-    }
-
-    [Fact]
-    public void Constructor_EmptyField_ThrowsArgumentException()
-    {
-        // Arrange
-        var filterExpression = ":value";
-
-        // Act
-        var act = () => new FilterCriterion(filterExpression);
-
-        // Assert
-        act.Should()
-           .Throw<ArgumentException>()
-           .WithMessage(ErrorMessages.GetErrorMessage("filterExpression", ErrorType.FilterNoField));
+           .WithParameterName("filterExpression")
+           .WithMessage("*Filter must have a valid operator*");
     }
 
     [Theory]
@@ -68,8 +70,10 @@ public class FilterCriterionTests
     [Theory]
     [InlineData("age:18", ExpressionType.Equal, "age", new[] { "18" })]
     [InlineData("status!:active", ExpressionType.NotEqual, "status", new[] { "active" })]
-    [InlineData("price>:100", ExpressionType.GreaterThanOrEqual, "price", new[] { "100" })]
+    [InlineData("price>:100.35", ExpressionType.GreaterThanOrEqual, "price", new[] { "100.35" })]
     [InlineData("date<:2024-01-01", ExpressionType.LessThanOrEqual, "date", new[] { "2024-01-01" })]
+    [InlineData("date<2024-01-01T10:15:25", ExpressionType.LessThan, "date", new[] { "2024-01-01T10:15:25" })]
+    [InlineData("date<:2024-01-01T10:15:25", ExpressionType.LessThanOrEqual, "date", new[] { "2024-01-01T10:15:25" })]
     [InlineData("count>5", ExpressionType.GreaterThan, "count", new[] { "5" })]
     [InlineData("amount<10", ExpressionType.LessThan, "amount", new[] { "10" })]
     [InlineData("tags:draft,published", ExpressionType.Equal, "tags", new[] { "draft", "published" })]


### PR DESCRIPTION
# Filtering by time results Bad Request

## Description
Filters with time like e.g. `created>2025-01-05T15:14:13` led to bad requests because of the way they are parsed - the `:` in the time was confused with the `:` used as equal operator. This is fixed by changing the parsing logic - now it's clearer and more robust.

## Related Issues
closes #346 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
