### PR TITLE
feat: Add configurable storage hostname

### DIFF
--- a/apps/endatix-hub/.env.example
+++ b/apps/endatix-hub/.env.example
@@ -24,8 +24,11 @@ SLACK_CLIENT_SECRET=
 # [OPTIONAL] Slack redirect uri. Optional if you don't want to use Slack.
 SLACK_REDIRECT_URI=
 
-# [OPTIONAL] Azure storage connection string. Optional if you don't want to use Azure Blob Storage.
-AZURE_STORAGE_CONNECTION_STRING=
+# [OPTIONAL] Azure storage account name. Optional if you don't want to use Azure Blob Storage.
+AZURE_STORAGE_ACCOUNT_NAME=
+
+# [OPTIONAL] Azure storage account key. Optional if you don't want to use Azure Blob Storage.
+AZURE_STORAGE_ACCOUNT_KEY=
 
 # [OPTIONAL] Storage container name for user uploaded files. Optional if you don't want to use Blob Storage.
 USER_FILES_STORAGE_CONTAINER_NAME=user-files

--- a/apps/endatix-hub/app/(main)/dashboard/page.tsx
+++ b/apps/endatix-hub/app/(main)/dashboard/page.tsx
@@ -25,6 +25,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { StorageService } from "@/features/storage/infrastructure/storage-service";
 
 const Dashboard = async () => {
   const forms = await getForms();
@@ -32,11 +33,10 @@ const Dashboard = async () => {
   const SLACK_CLIENT_ID = process.env.SLACK_CLIENT_ID;
   const SLACK_CLIENT_SECRET = process.env.SLACK_CLIENT_SECRET;
   const NEXT_PUBLIC_SLK = process.env.NEXT_PUBLIC_SLK;
-  const AZURE_STORAGE_CONTAINER_NAME = process.env.AZURE_STORAGE_CONTAINER_NAME;
-  const AZURE_STORAGE_CONNECTION_STRING = process.env.AZURE_STORAGE_CONNECTION_STRING;
   const RESIZE_IMAGES = process.env.RESIZE_IMAGES;
   const RESIZE_IMAGES_WIDTH = process.env.RESIZE_IMAGES_WIDTH;
   const NEXT_PUBLIC_NAME = process.env.NEXT_PUBLIC_NAME;
+  const azureStorageConfig = StorageService.getAzureStorageConfig();
   return (
     <Tabs defaultValue="all">
       <div className="flex items-center">
@@ -120,8 +120,7 @@ const Dashboard = async () => {
             <li>NEXT_PUBLIC_NAME: {NEXT_PUBLIC_NAME}</li>
             <li>SLACK_CLIENT_SECRET_length: {SLACK_CLIENT_SECRET?.length?? 0}</li>
             <li>NEXT_PUBLIC_SLK: {NEXT_PUBLIC_SLK}</li>
-            <li>AZURE_STORAGE_CONTAINER_NAME_length: {AZURE_STORAGE_CONTAINER_NAME}</li>
-            <li>AZURE_STORAGE_CONNECTION_STRING: {AZURE_STORAGE_CONNECTION_STRING?.length?? 0}</li>
+            <li>Is Azure Enabled: {azureStorageConfig.isEnabled} on {azureStorageConfig.hostName}</li>
             <li>RESIZE_IMAGES: {RESIZE_IMAGES}</li>
             <li>RESIZE_IMAGES_WIDTH: {RESIZE_IMAGES_WIDTH}</li>
           </ul>

--- a/apps/endatix-hub/app/(main)/page.tsx
+++ b/apps/endatix-hub/app/(main)/page.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
 const Home = () => {
   return (
     <div className="grid h-full grid-rows-[20px_1fr_20px] items-center justify-items-center p-8 gap-16 sm:p-20 font-[family-name:var(--font-geist-sans)]">
-      <div className="absolute top-0 right-0 left-0 bottom-0 bg-[url('/lines-and-stuff.svg')] brightness-[0.6] opacity-[0.4] dark:grayscale"></div>
+      <div className="absolute top-0 right-0 left-0 bottom-0 bg-[url('/assets/lines-and-stuff.svg')] brightness-[0.6] opacity-[0.4] dark:grayscale"></div>
       <div className="z-10 items-start flex flex-col gap-4 row-start-2 items-center sm:items-start">
         <Card className="sm:col-span-4 auto-rows-max bg-background">
           <CardHeader className="pb-3">

--- a/apps/endatix-hub/env.d.ts
+++ b/apps/endatix-hub/env.d.ts
@@ -1,19 +1,35 @@
 declare namespace NodeJS {
   interface ProcessEnv {
+    // Environment
     NODE_ENV: "development" | "production" | "test";
+
+    // Session
+    SESSION_SECRET: string;
+    
+    // Data Collection
     NEXT_FORMS_COOKIE_NAME: string;
     NEXT_FORMS_COOKIE_DURATION_DAYS: string;
-    SESSION_SECRET: string;
+
+    // Slack
     SLACK_CLIENT_ID: string;
     SLACK_CLIENT_SECRET: string;
     SLACK_REDIRECT_URI: string;
-    AZURE_STORAGE_CONNECTION_STRING: string;
+
+    // Storage
+    AZURE_STORAGE_ACCOUNT_NAME: string;
+    AZURE_STORAGE_ACCOUNT_KEY: string;
     USER_FILES_STORAGE_CONTAINER_NAME: string;
     CONTENT_STORAGE_CONTAINER_NAME: string;
+    
+    // Image Resize
     RESIZE_IMAGES: string;
     RESIZE_IMAGES_WIDTH: string;
+
+    // Public
     NEXT_PUBLIC_SLK: string;
     NEXT_PUBLIC_NAME: string;
+
+    // Telemetry
     OTEL_LOG_LEVEL: boolean;
     APPLICATIONINSIGHTS_CONNECTION_STRING: string;
   }

--- a/apps/endatix-hub/env.d.ts
+++ b/apps/endatix-hub/env.d.ts
@@ -16,10 +16,10 @@ declare namespace NodeJS {
     SLACK_REDIRECT_URI: string;
 
     // Storage
-    AZURE_STORAGE_ACCOUNT_NAME: string;
-    AZURE_STORAGE_ACCOUNT_KEY: string;
-    USER_FILES_STORAGE_CONTAINER_NAME: string;
-    CONTENT_STORAGE_CONTAINER_NAME: string;
+    AZURE_STORAGE_ACCOUNT_NAME?: string;
+    AZURE_STORAGE_ACCOUNT_KEY?: string;
+    USER_FILES_STORAGE_CONTAINER_NAME?: string;
+    CONTENT_STORAGE_CONTAINER_NAME?: string;
     
     // Image Resize
     RESIZE_IMAGES: string;

--- a/apps/endatix-hub/features/storage/infrastructure/storage-service.ts
+++ b/apps/endatix-hub/features/storage/infrastructure/storage-service.ts
@@ -109,12 +109,23 @@ export class StorageService {
     return blobClient.url;
   }
 
-  static getAzureStorageConfig() : AzureStorageConfig {
+  static getAzureStorageConfig(): AzureStorageConfig {
+    const { AZURE_STORAGE_ACCOUNT_NAME, AZURE_STORAGE_ACCOUNT_KEY } = process.env;
+    const isEnabled = !!AZURE_STORAGE_ACCOUNT_NAME && !!AZURE_STORAGE_ACCOUNT_KEY;
+    if (!isEnabled) {
+      return { 
+        isEnabled: false,
+        accountName: "",
+        accountKey: "",
+        hostName: "",
+      };
+    }
+
     return {
-      isEnabled: process.env.AZURE_STORAGE_ACCOUNT_NAME !== undefined && process.env.AZURE_STORAGE_ACCOUNT_KEY !== undefined,
-      accountName: process.env.AZURE_STORAGE_ACCOUNT_NAME,
-      accountKey: process.env.AZURE_STORAGE_ACCOUNT_KEY,
-      hostName: `${process.env.AZURE_STORAGE_ACCOUNT_NAME}.blob.core.windows.net`,
+      isEnabled: true,
+      accountName: AZURE_STORAGE_ACCOUNT_NAME,
+      accountKey: AZURE_STORAGE_ACCOUNT_KEY,
+      hostName: `${AZURE_STORAGE_ACCOUNT_NAME}.blob.core.windows.net`,
     };
   }
 }

--- a/apps/endatix-hub/features/storage/infrastructure/storage-service.ts
+++ b/apps/endatix-hub/features/storage/infrastructure/storage-service.ts
@@ -74,9 +74,9 @@ export class StorageService {
 
   async uploadToStorage(
     fileBuffer: Buffer,
-    folderPath: string,
     fileName: string,
-    containerName: string
+    containerName: string,
+    folderPath?: string,
   ): Promise<string> {
     if (!fileBuffer) {
       throw new Error("a file is not provided");
@@ -97,7 +97,7 @@ export class StorageService {
       access: "container",
     });
 
-    const blobName = `${folderPath}/${fileName}`;
+    const blobName = folderPath ? `${folderPath}/${fileName}` : fileName;
     const blobClient = containerClient.getBlockBlobClient(blobName);
     await blobClient.uploadData(fileBuffer);
 

--- a/apps/endatix-hub/features/storage/use-cases/upload-content-file.use-case.ts
+++ b/apps/endatix-hub/features/storage/use-cases/upload-content-file.use-case.ts
@@ -53,9 +53,9 @@ export const uploadContentFileUseCase = async ({
     const fileName = `${uuid}.${fileExtension}`;
     const fileUrl = await storageService.uploadToStorage(
       fileBuffer,
-      folderPath,
       fileName,
-      containerName
+      containerName,
+      folderPath
     );
 
     return Result.success({

--- a/apps/endatix-hub/features/storage/use-cases/upload-user-files.use-case.ts
+++ b/apps/endatix-hub/features/storage/use-cases/upload-user-files.use-case.ts
@@ -64,9 +64,9 @@ export const uploadUserFilesUseCase = async ({
 
       const fileUrl = await storageService.uploadToStorage(
         fileBuffer,
-        folderPath,
         fileName,
-        containerName
+        containerName,
+        folderPath
       );
 
       uploadedFiles.push({ name: name, url: fileUrl });

--- a/apps/endatix-hub/instrumentation.ts
+++ b/apps/endatix-hub/instrumentation.ts
@@ -1,8 +1,6 @@
-import checkNodeVersion from './lib/hosting/check-node-version'
-
 export const register = async () => {
-  checkNodeVersion();
-  if (process.env.NEXT_RUNTIME === "nodejs") {
-    await import("./instrumentation.node");
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import("@/lib/hosting/check-node-version");
+    await import("@/instrumentation.node");
   }
 };

--- a/apps/endatix-hub/lib/__tests__/check-node-version.test.ts
+++ b/apps/endatix-hub/lib/__tests__/check-node-version.test.ts
@@ -1,4 +1,4 @@
-import checkNodeVersion from '../hosting/check-node-version';
+import { checkNodeVersion } from '../hosting/check-node-version';
 import { describe, it, expect, vi, beforeEach, afterEach, MockInstance } from 'vitest';
 import { PackageJson } from '../hosting/check-node-version';
 

--- a/apps/endatix-hub/lib/__tests__/hosting/check-node-version.test.ts
+++ b/apps/endatix-hub/lib/__tests__/hosting/check-node-version.test.ts
@@ -1,6 +1,6 @@
-import { checkNodeVersion } from '../hosting/check-node-version';
+import { checkNodeVersion } from '@/lib/hosting/check-node-version';
 import { describe, it, expect, vi, beforeEach, afterEach, MockInstance } from 'vitest';
-import { PackageJson } from '../hosting/check-node-version';
+import { PackageJson } from '@/lib/hosting/check-node-version';
 
 const mockPackageJson: PackageJson = vi.hoisted(() => {
     return {

--- a/apps/endatix-hub/lib/__tests__/hosting/runtime.test.ts
+++ b/apps/endatix-hub/lib/__tests__/hosting/runtime.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { isNodeRuntime, isEdgeRuntime } from '@/lib/hosting/runtime';
+
+describe('runtime', () => {
+    describe('isNodeRuntime', () => {
+        it('should return true when NEXT_RUNTIME is nodejs', () => {
+            // Arrange
+            process.env.NEXT_RUNTIME = 'nodejs';
+
+            // Act
+            const result = isNodeRuntime();
+
+            // Assert
+            expect(result).toBe(true);
+        });
+
+        it('should return false when NEXT_RUNTIME is not nodejs', () => {
+            // Arrange
+            process.env.NEXT_RUNTIME = 'edge';
+
+            // Act
+            const result = isNodeRuntime();
+
+            // Assert
+            expect(result).toBe(false);
+        });
+    });
+
+    describe('isEdgeRuntime', () => {
+        it('should return true when NEXT_RUNTIME is edge', () => {
+            // Arrange
+            process.env.NEXT_RUNTIME = 'edge';
+
+            // Act
+            const result = isEdgeRuntime();
+
+            // Assert
+            expect(result).toBe(true);
+        });
+
+        it('should return false when NEXT_RUNTIME is not edge', () => {
+            // Arrange
+            process.env.NEXT_RUNTIME = 'nodejs';
+
+            // Act
+            const result = isEdgeRuntime();
+
+            // Assert
+            expect(result).toBe(false);
+        });
+
+        it('should return false when NEXT_RUNTIME is undefined', () => {
+            // Arrange
+            process.env.NEXT_RUNTIME = undefined;
+
+            // Act
+            const result = isEdgeRuntime();
+
+            // Assert
+            expect(result).toBe(false);
+        });
+    });
+});

--- a/apps/endatix-hub/lib/hosting/check-node-version.ts
+++ b/apps/endatix-hub/lib/hosting/check-node-version.ts
@@ -1,5 +1,6 @@
 import packageJson from '@/package.json' assert { type: 'json' }
 import semver from 'semver'
+import { isEdgeRuntime } from './runtime';
 
 export interface PackageJson {
     engines?: {
@@ -7,7 +8,11 @@ export interface PackageJson {
     };
 }
 
-function checkNodeVersion() {
+export function checkNodeVersion() {
+    if (isEdgeRuntime()) {
+        return;
+    }
+
     const nodeRuntimeVersion = process.version;
     const { engines } = packageJson as PackageJson;
 
@@ -34,4 +39,4 @@ const getWarningMessage = (nodeRuntimeVersion: string, engines: string) => {
             🔗 More info at https://github.com/endatix/endatix/tree/main/apps/endatix-hub`;
 }
 
-export default checkNodeVersion;
+checkNodeVersion();

--- a/apps/endatix-hub/lib/hosting/runtime.ts
+++ b/apps/endatix-hub/lib/hosting/runtime.ts
@@ -1,0 +1,33 @@
+/**
+ * Checks if the current runtime environment is Node.js
+ * 
+ * @returns {boolean} True if running in Node.js environment, false if running in other runtimes (e.g. Edge)
+ * 
+ * This is used to conditionally execute code that should only run in Node.js,
+ * such as file system operations or Node-specific APIs.
+ */
+export const isNodeRuntime = () => {
+    // NEXT_RUNTIME is undefined in regular Node.js environment
+    // or explicitly set to 'nodejs' in Next.js Node runtime
+    if (process.env.NEXT_RUNTIME === 'nodejs') {
+        return true
+    } else {
+        return false
+    }
+}
+
+/**
+ * Checks if the current runtime environment is Edge
+ * 
+ * @returns {boolean} True if running in Edge runtime environment, false otherwise
+ * 
+ * This is used to conditionally execute code that should only run in Edge,
+ * such as Edge-specific APIs or optimizations.
+ */
+export function isEdgeRuntime(): boolean {
+    if (typeof process !== 'undefined' && process.env.NEXT_RUNTIME === 'edge') {
+        return true;
+    }
+
+    return false;
+}

--- a/apps/endatix-hub/next.config.ts
+++ b/apps/endatix-hub/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import { StorageService } from "@/features/storage/infrastructure/storage-service";
 
 const nextConfig: NextConfig = {
   /* config options here */
@@ -6,8 +7,8 @@ const nextConfig: NextConfig = {
   reactStrictMode: true,
   experimental: {
     serverActions: {
-      bodySizeLimit: '20mb',
-    }
+      bodySizeLimit: "20mb",
+    },
   },
   images: {
     remotePatterns: [
@@ -15,12 +16,16 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "images.unsplash.com",
       },
-      {
-        protocol: "https",
-        hostname: "endatixstorageqad.blob.core.windows.net",
-      },
     ],
-  }
+  },
 };
+
+const storageConfig = StorageService.getAzureStorageConfig();
+if (storageConfig.isEnabled) {
+  nextConfig?.images?.remotePatterns?.push({
+    protocol: "https",
+    hostname: storageConfig.hostName,
+  });
+}
 
 export default nextConfig;


### PR DESCRIPTION
# feat: Add configurable storage hostname

## Description
This PR adds more flexibility by eliminating the hard-coded hostname in the `next.config.ts` allowing to use Next.js features in multiple environments setup. Additional changes
- adding more flexible Azure config to support both security + hostname detection. This adds two new env variables `AZURE_STORAGE_ACCOUNT_NAME` & `AZURE_STORAGE_ACCOUNT_KEY`
- fixing failing tests in the `storage-service.ts`
- adding static `getAzureStorageConfig()` const to evaluate env variables needed for Azure storage account support
- rearranging env variables for readability
- fixing edge runtime issues with `checkNodeVersion` logic in `instrumentation.ts`
- remove `AZURE_STORAGE_CONNECTION_STRING` env variable as it's redundant
- `runtime.ts` with methods to detect node.js vs edge runtime + tests

## Related Issues
closes #357 

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
