### PR TITLE
feat: Adding support for `submissionId` in user uploaded storage path

### DIFF
--- a/apps/endatix-hub/app/api/public/v0/storage/upload/route.ts
+++ b/apps/endatix-hub/app/api/public/v0/storage/upload/route.ts
@@ -1,14 +1,51 @@
+import {
+  SubmissionData,
+  submitFormAction,
+} from "@/features/public-form/application/actions/submit-form.action";
 import { uploadUserFilesUseCase } from "@/features/storage/use-cases/upload-user-files.use-case";
 import { Result } from "@/lib/result";
 import { headers } from "next/headers";
 
+type UploadUserFilesResult = {
+  success: boolean;
+  submissionId: string;
+  files: {
+    name: string;
+    url: string;
+  }[];
+};
+
 export async function POST(request: Request) {
   const requestHeaders = await headers();
   const formId = requestHeaders.get("edx-form-id") as string;
+  let submissionId = requestHeaders.get("edx-submission-id") as string;
   const formData = await request.formData();
 
   if (!formId) {
-    return Response.json({ error: 'Form ID is required' }, { status: 400 });
+    return Response.json({ error: "Form ID is required" }, { status: 400 });
+  }
+
+  if (!submissionId) {
+    const submissionData: SubmissionData = {
+      isComplete: false,
+      jsonData: JSON.stringify({}),
+      metadata: JSON.stringify({
+        reasonCreated: "Generate submissionId for image upload",
+      }),
+    };
+    const initialSubmissionResult = await submitFormAction(
+      formId,
+      submissionData
+    );
+
+    if (Result.isError(initialSubmissionResult)) {
+      return Response.json(
+        { error: initialSubmissionResult.message },
+        { status: 400 }
+      );
+    }
+
+    submissionId = initialSubmissionResult.value.submissionId;
   }
 
   const files: { name: string; file: File }[] = [];
@@ -27,11 +64,12 @@ export async function POST(request: Request) {
   }
 
   if (files.length === 0) {
-    return Response.json({ error: 'No files provided' }, { status: 400 });
+    return Response.json({ error: "No files provided" }, { status: 400 });
   }
 
   const result = await uploadUserFilesUseCase({
     formId: formId,
+    submissionId: submissionId,
     files: files,
   });
 
@@ -39,5 +77,11 @@ export async function POST(request: Request) {
     return Response.json({ error: result.message }, { status: 400 });
   }
 
-  return Response.json({ success: true, files: result.value });
+  const uploadUserFilesResult: UploadUserFilesResult = {
+    success: true,
+    submissionId: submissionId,
+    files: result.value,
+  };
+
+  return Response.json(uploadUserFilesResult);
 }

--- a/apps/endatix-hub/features/public-form/application/actions/submit-form.action.ts
+++ b/apps/endatix-hub/features/public-form/application/actions/submit-form.action.ts
@@ -13,7 +13,7 @@ export type SubmissionData = {
 }
 
 export type SubmissionOperation = {
-    isSuccess: boolean;
+    submissionId: string;
 }
 
 export type SubmissionOperationResult = Result<SubmissionOperation>;
@@ -52,7 +52,7 @@ async function updateExistingSubmissionViaToken(
         if (updatedSubmission.isComplete) {
             tokenStore.deleteToken(formId);
         }
-        return Result.success({ isSuccess: true });
+        return Result.success({ submissionId: updatedSubmission.id });
     } catch (err) {
         tokenStore.deleteToken(formId);
         return Result.error('Failed to update existing submission. Details: ' + err);
@@ -71,9 +71,8 @@ async function createNewSubmission(
         } else {
             tokenStore.setToken({ formId, token: createSubmissionResponse.token });
         }
-
-        return Result.success({ isSuccess: true });
-    } catch (err) {
+        return Result.success({ submissionId: createSubmissionResponse.id });
+    } catch {
         return Result.error('Failed to create new submission');
     }
 }

--- a/apps/endatix-hub/features/storage/use-cases/upload-content-file.use-case.ts
+++ b/apps/endatix-hub/features/storage/use-cases/upload-content-file.use-case.ts
@@ -28,7 +28,7 @@ export const uploadContentFileUseCase = async ({
     return Result.validationError("File is required");
   }
 
-  const folderPath = `assets/${formId}`;
+  const folderPath = `f/${formId}`;
   const containerName =
     process.env.CONTENT_STORAGE_CONTAINER_NAME ??
     DEFAULT_FORM_CONTENT_FILES_CONTAINER_NAME;

--- a/apps/endatix-hub/features/storage/use-cases/upload-user-files.use-case.ts
+++ b/apps/endatix-hub/features/storage/use-cases/upload-user-files.use-case.ts
@@ -26,14 +26,15 @@ export const uploadUserFilesUseCase = async ({
     return Result.validationError("Form ID is required");
   }
 
+  if (!submissionId) {
+    return Result.validationError("Submission ID is required");
+  }
+
   if (!files || files.length === 0) {
     return Result.validationError("Files are required");
   }
 
-  let folderPath = `usr-files/${formId}`;
-  if (submissionId) {
-    folderPath = `${folderPath}/${submissionId}`;
-  }
+  const folderPath = `s/${formId}/${submissionId}`;
 
   const containerName =
     process.env.USER_FILES_STORAGE_CONTAINER_NAME ??

--- a/apps/endatix-hub/features/storage/use-cases/upload-user-files.use-case.ts
+++ b/apps/endatix-hub/features/storage/use-cases/upload-user-files.use-case.ts
@@ -76,7 +76,7 @@ export const uploadUserFilesUseCase = async ({
     return Result.success(uploadedFiles);
   } catch (err) {
     return Result.error(
-      "Failed to upload file",
+      "Failed to upload file. Please refresh your page and try again.",
       err instanceof Error ? err.message : "Unknown error"
     );
   }


### PR DESCRIPTION
# Adding support for `submissionId` in user uploaded storage path

## Description
- Adding submissionId to storage path
- Changing folder structure for storage using agreed convention
- Refactoring file upload callback flow to async to allow for better response error handling and readability
- Improving error handling for file upload

## Related Issues
closes #354

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 
