### PR TITLE
fix: Endatix Hub: Adding support for multiple remote hostnames origins 

### DIFF
--- a/apps/endatix-hub/.env.example
+++ b/apps/endatix-hub/.env.example
@@ -1,46 +1,53 @@
-# Required Env Variables
+# Environment
 ############################
-
 # [REQUIRED] The url where the Endatix API is hosted, e.g. https://api.endatix.com.
 # 💡 TIP: Default value during development is https://localhost:5001
 ENDATIX_BASE_URL=https://localhost:5001
 
+# [OPTIONAL] The hostnames of the remote (external) images that will be used to serve & optimize images. Provide multiple hostnames separated by commas.
+REMOTE_IMAGE_HOSTNAMES=images.unsplash.com,images.pexels.com
+
+# Session
+############################
 # [REQUIRED] The secrete secret key that will be used to encrypt the Endatix Hub session cookie. Example: a28110cc8b94c5f3b3c923aa2c9fae4ed50c86ec61debfe6edb3c29947dbb00c
 # 💡 TIP: You can use: `openssl rand -hex 32` to generate one
 SESSION_SECRET=DbLkxcw0C5om6n2MFdn6E4sevnT8RzWqcdhQ1FUzhiQ6eGm
 
+# Data Collection
+############################
 # [REQUIRED] The name of the cookie that will be used to store the form token.
 NEXT_FORMS_COOKIE_NAME=FPSK
-
 # [OPTIONAL] The number of days the form token will be valid for.
 NEXT_FORMS_COOKIE_DURATION_DAYS=7
 
+# Slack
+############################
 # [OPTIONAL] Slack client id. Optional if you don't want to use Slack.
 SLACK_CLIENT_ID=
-
 # [OPTIONAL] Slack client secret. Optional if you don't want to use Slack.
 SLACK_CLIENT_SECRET=
-
 # [OPTIONAL] Slack redirect uri. Optional if you don't want to use Slack.
 SLACK_REDIRECT_URI=
 
+# Storage
+############################
 # [OPTIONAL] Azure storage account name. Optional if you don't want to use Azure Blob Storage.
 AZURE_STORAGE_ACCOUNT_NAME=
-
 # [OPTIONAL] Azure storage account key. Optional if you don't want to use Azure Blob Storage.
 AZURE_STORAGE_ACCOUNT_KEY=
-
 # [OPTIONAL] Storage container name for user uploaded files. Optional if you don't want to use Blob Storage.
 USER_FILES_STORAGE_CONTAINER_NAME=user-files
-
 # [OPTIONAL] Storage container name for content files uploaded by Endatix users, e.g. images, videos, etc. Optional if you don't want to use Blob Storage.
 CONTENT_STORAGE_CONTAINER_NAME=content
 
+# Image Resize
+############################
 # [OPTIONAL] Whether to resize images.
 RESIZE_IMAGES=false
-
 # [OPTIONAL] The width to resize images to.
 RESIZE_IMAGES_WIDTH=800
 
+# Public
+############################
 # [OPTIONAL] SLK.
 NEXT_PUBLIC_SLK=

--- a/apps/endatix-hub/app/(main)/dashboard/page.tsx
+++ b/apps/endatix-hub/app/(main)/dashboard/page.tsx
@@ -26,6 +26,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { StorageService } from "@/features/storage/infrastructure/storage-service";
+import nextConfig from "@/next.config";
 
 const Dashboard = async () => {
   const forms = await getForms();
@@ -37,6 +38,7 @@ const Dashboard = async () => {
   const RESIZE_IMAGES_WIDTH = process.env.RESIZE_IMAGES_WIDTH;
   const NEXT_PUBLIC_NAME = process.env.NEXT_PUBLIC_NAME;
   const azureStorageConfig = StorageService.getAzureStorageConfig();
+
   return (
     <Tabs defaultValue="all">
       <div className="flex items-center">
@@ -118,11 +120,22 @@ const Dashboard = async () => {
             <li>NEXT_PUBLIC_MAX_IMAGE_SIZE: {NEXT_PUBLIC_MAX_IMAGE_SIZE}</li>
             <li>SLACK_CLIENT_ID: {SLACK_CLIENT_ID}</li>
             <li>NEXT_PUBLIC_NAME: {NEXT_PUBLIC_NAME}</li>
-            <li>SLACK_CLIENT_SECRET_length: {SLACK_CLIENT_SECRET?.length?? 0}</li>
+            <li>
+              SLACK_CLIENT_SECRET_length: {SLACK_CLIENT_SECRET?.length ?? 0}
+            </li>
             <li>NEXT_PUBLIC_SLK: {NEXT_PUBLIC_SLK}</li>
-            <li>Is Azure Enabled: {azureStorageConfig.isEnabled} on {azureStorageConfig.hostName}</li>
+            <li>
+              Is Azure Enabled: {azureStorageConfig.isEnabled} on{" "}
+              {azureStorageConfig.hostName}
+            </li>
             <li>RESIZE_IMAGES: {RESIZE_IMAGES}</li>
             <li>RESIZE_IMAGES_WIDTH: {RESIZE_IMAGES_WIDTH}</li>
+            <li>
+              Remote Image Hostnames: {" "}
+              {nextConfig?.images?.remotePatterns
+                ?.map((p) => p.hostname)
+                .join(", ")}
+            </li>
           </ul>
         </div>
       </TabsContent>

--- a/apps/endatix-hub/env.d.ts
+++ b/apps/endatix-hub/env.d.ts
@@ -1,19 +1,20 @@
 declare namespace NodeJS {
   interface ProcessEnv {
     // Environment
-    NODE_ENV: "development" | "production" | "test";
+    NODE_ENV: 'development' | 'production' | 'test';
+    REMOTE_IMAGE_HOSTNAMES?: string;
 
     // Session
     SESSION_SECRET: string;
     
     // Data Collection
     NEXT_FORMS_COOKIE_NAME: string;
-    NEXT_FORMS_COOKIE_DURATION_DAYS: string;
+    NEXT_FORMS_COOKIE_DURATION_DAYS?: string;
 
     // Slack
-    SLACK_CLIENT_ID: string;
-    SLACK_CLIENT_SECRET: string;
-    SLACK_REDIRECT_URI: string;
+    SLACK_CLIENT_ID?: string;
+    SLACK_CLIENT_SECRET?: string; 
+    SLACK_REDIRECT_URI?: string;
 
     // Storage
     AZURE_STORAGE_ACCOUNT_NAME?: string;
@@ -22,15 +23,15 @@ declare namespace NodeJS {
     CONTENT_STORAGE_CONTAINER_NAME?: string;
     
     // Image Resize
-    RESIZE_IMAGES: string;
-    RESIZE_IMAGES_WIDTH: string;
+    RESIZE_IMAGES?: string;
+    RESIZE_IMAGES_WIDTH?: string;
 
     // Public
-    NEXT_PUBLIC_SLK: string;
-    NEXT_PUBLIC_NAME: string;
+    NEXT_PUBLIC_SLK?: string;
+    NEXT_PUBLIC_NAME?: string;
 
     // Telemetry
-    OTEL_LOG_LEVEL: boolean;
-    APPLICATIONINSIGHTS_CONNECTION_STRING: string;
+    OTEL_LOG_LEVEL?: boolean;
+    APPLICATIONINSIGHTS_CONNECTION_STRING?: string;
   }
 }

--- a/apps/endatix-hub/lib/__tests__/hosting/next-config-helper.test.ts
+++ b/apps/endatix-hub/lib/__tests__/hosting/next-config-helper.test.ts
@@ -1,0 +1,86 @@
+import { RemotePattern } from 'next/dist/shared/lib/image-config';
+import { includesRemoteImageHostnames } from '@/lib/hosting/next-config-helper';
+import { describe, expect, it } from 'vitest';
+
+const wildcardRemotePattern: RemotePattern = {
+  protocol: 'https',
+  hostname: '**',
+};
+
+describe('includesRemoteImageHostnames', () => {
+  it('should do nothing if remotePatterns is undefined', () => {
+    const remotePatterns: RemotePattern[] | undefined = undefined;
+
+    includesRemoteImageHostnames(remotePatterns);
+
+    expect(remotePatterns).toBeUndefined();
+  });
+
+  it('should add wildcard hostname if REMOTE_IMAGE_HOSTNAMES is empty', () => {
+    process.env.REMOTE_IMAGE_HOSTNAMES = '';
+    const remotePatterns: RemotePattern[] = [];
+
+    includesRemoteImageHostnames(remotePatterns);
+
+    expect(remotePatterns).toEqual([wildcardRemotePattern]);
+  });
+
+  it('should add wildcard hostname if REMOTE_IMAGE_HOSTNAMES is undefined', () => {
+    delete process.env.REMOTE_IMAGE_HOSTNAMES;
+    const remotePatterns: RemotePattern[] = [];
+
+    includesRemoteImageHostnames(remotePatterns);
+
+    expect(remotePatterns).toEqual([wildcardRemotePattern]);
+  });
+
+  it('should add multiple hostnames from comma-separated REMOTE_IMAGE_HOSTNAMES', () => {
+    process.env.REMOTE_IMAGE_HOSTNAMES = 'images.unsplash.com,images.pexels.com';
+    const remotePatterns: RemotePattern[] = [];
+
+    includesRemoteImageHostnames(remotePatterns);
+
+    expect(remotePatterns).toEqual([
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'images.pexels.com',
+      },
+    ]);
+  });
+
+  it('should handle single hostname in REMOTE_IMAGE_HOSTNAMES', () => {
+    process.env.REMOTE_IMAGE_HOSTNAMES = 'images.unsplash.com';
+    const remotePatterns: RemotePattern[] = [];
+
+    includesRemoteImageHostnames(remotePatterns);
+
+    expect(remotePatterns).toEqual([
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com',
+      },
+    ]);
+  });
+
+  it('should trim empty strings and whitespace from hostnames', () => {
+    process.env.REMOTE_IMAGE_HOSTNAMES = '  images.unsplash.com  ,  ,  images.pexels.com  ';
+    const remotePatterns: RemotePattern[] = [];
+
+    includesRemoteImageHostnames(remotePatterns);
+
+    expect(remotePatterns).toEqual([
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com',
+      },
+      {
+        protocol: 'https',
+        hostname: 'images.pexels.com',
+      },
+    ]);
+  });
+});

--- a/apps/endatix-hub/lib/hosting/next-config-helper.ts
+++ b/apps/endatix-hub/lib/hosting/next-config-helper.ts
@@ -1,0 +1,32 @@
+import { RemotePattern } from "next/dist/shared/lib/image-config";
+
+export function includesRemoteImageHostnames(
+  remotePatterns: RemotePattern[] | undefined
+): void {
+  if (!remotePatterns) {
+    return;
+  }
+
+  const REMOTE_IMAGE_HOSTNAMES =
+    process.env.REMOTE_IMAGE_HOSTNAMES?.trim() ?? "";
+  const hostnames = REMOTE_IMAGE_HOSTNAMES.split(",").map((h: string) => h.trim());
+
+  if (!REMOTE_IMAGE_HOSTNAMES || hostnames.length < 1) {
+    remotePatterns.push({
+      protocol: "https",
+      hostname: "**",
+    });
+    return;
+  }
+
+  hostnames.forEach((hostname: string) => {
+    if (!hostname?.length) {
+      return;
+    }
+
+    remotePatterns.push({
+      protocol: "https",
+      hostname: hostname,
+    });
+  });
+}

--- a/apps/endatix-hub/next.config.ts
+++ b/apps/endatix-hub/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import { includesRemoteImageHostnames } from "./lib/hosting/next-config-helper";
 import { StorageService } from "@/features/storage/infrastructure/storage-service";
 
 const nextConfig: NextConfig = {
@@ -12,13 +13,11 @@ const nextConfig: NextConfig = {
   },
   images: {
     remotePatterns: [
-      {
-        protocol: "https",
-        hostname: process.env.IMAGE_HOSTNAME || "images.unsplash.com",
-      },
     ],
   },
 };
+
+includesRemoteImageHostnames(nextConfig.images?.remotePatterns);
 
 const storageConfig = StorageService.getAzureStorageConfig();
 if (storageConfig.isEnabled) {


### PR DESCRIPTION
# Endatix Hub: Adding support for multiple remote hostnames origins 

## Description
- Adding next-config-helper to allow for better remote image handling
- Fallback logic to all hostnames on missing env variable
- Updating next.config.ts with new remote image handling logic-
- Updating .env.example and env.d.ts with better grouping, organization and documentation
- Add tracing logic for remote image hostnames
- Adding tests for next-config-helper hostnames to verify behavior

## Related Issues
fixes https://github.com/endatix/endatix-private/issues/47

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 
