### PR TITLE
fix: Images are uploaded twice

### DIFF
--- a/apps/endatix-hub/features/public-form/ui/survey-component.tsx
+++ b/apps/endatix-hub/features/public-form/ui/survey-component.tsx
@@ -100,7 +100,10 @@ export default function SurveyComponent({
         const data = await response.json();
 
         if (!response.ok) {
-          throw new Error(data?.error ?? "Failed to upload files. Please refresh your page and try again.");
+          throw new Error(
+            data?.error ??
+              "Failed to upload files. Please refresh your page and try again."
+          );
         }
 
         if (data.submissionId && data.submissionId !== submissionId) {
@@ -126,12 +129,23 @@ export default function SurveyComponent({
     [formId, submissionId]
   );
 
-  model.onComplete.add(submitForm);
-  model.onUploadFiles.add(uploadFiles);
-  model.onValueChanged.add(updatePartial);
-  model.onCurrentPageChanged.add(updatePartial);
-  model.onDynamicPanelItemValueChanged.add(updatePartial);
-  model.onMatrixCellValueChanged.add(updatePartial);
+  useEffect(() => {
+    model.onComplete.add(submitForm);
+    model.onUploadFiles.add(uploadFiles);
+    model.onValueChanged.add(updatePartial);
+    model.onCurrentPageChanged.add(updatePartial);
+    model.onDynamicPanelItemValueChanged.add(updatePartial);
+    model.onMatrixCellValueChanged.add(updatePartial);
+
+    return () => {
+      model.onComplete.remove(submitForm);
+      model.onUploadFiles.remove(uploadFiles);
+      model.onValueChanged.remove(updatePartial);
+      model.onCurrentPageChanged.remove(updatePartial);
+      model.onDynamicPanelItemValueChanged.remove(updatePartial);
+      model.onMatrixCellValueChanged.remove(updatePartial);
+    };
+  }, [model, submitForm, uploadFiles, updatePartial]);
 
   return <Survey model={model} />;
 }

--- a/apps/endatix-hub/features/public-form/ui/survey-js-wrapper.tsx
+++ b/apps/endatix-hub/features/public-form/ui/survey-js-wrapper.tsx
@@ -1,59 +1,30 @@
-'use client'
+"use client";
 
-import { Submission } from '@/types';
-import dynamic from 'next/dynamic'
-import { useEffect, useState } from 'react';
+import { Submission } from "@/types";
+import dynamic from "next/dynamic";
 
-const SurveyComponent = dynamic(() => import('./survey-component'), {
-    ssr: false,
+const SurveyComponent = dynamic(() => import("./survey-component"), {
+  ssr: false,
 });
 
 interface SurveyJsWrapperProps {
-    definition: string;
-    formId: string;
-    submission?: Submission | undefined
+  definition: string;
+  formId: string;
+  submission?: Submission | undefined;
 }
 
-const SurveyJsWrapper = ({ formId, definition, submission }: SurveyJsWrapperProps) => {
-    const [cookiesEnabled, setCookiesEnabled] = useState(true);
-
-    const areCookiesEnabled = (): boolean => {
-        if (!navigator.cookieEnabled) {
-            return false;
-        }
-
-        if (!document.cookie) {
-            document.cookie = "fkst";
-            if (document.cookie.length === 0) {
-                return false;
-            }
-
-            document.cookie = "";
-        }
-
-        return true;
-    }
-
-    useEffect(() => {
-        const cookiesEnabled = areCookiesEnabled();
-        if (!cookiesEnabled) {
-            setCookiesEnabled(false);
-        }
-    }, [cookiesEnabled]);
-
-    return (
-        <>
-            {cookiesEnabled ? (
-                <SurveyComponent
-                    formId={formId}
-                    definition={definition}
-                    submission={submission}
-                />
-            ) : (
-                <div>Cookies are not enabled. You must enable cookies to continue.</div>
-            )}
-        </>
-    );
-}
+const SurveyJsWrapper = ({
+  formId,
+  definition,
+  submission,
+}: SurveyJsWrapperProps) => {
+  return (
+    <SurveyComponent
+      formId={formId}
+      definition={definition}
+      submission={submission}
+    />
+  );
+};
 
 export default SurveyJsWrapper;


### PR DESCRIPTION
# fix: Images are uploaded twice

## Description
- Add survey model event handlers disposal on unmount and key dependency changes
- Remove cookie check from form-wrapper to increase data capture scope

## Related Issues
fixes #368

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 
