### PR TITLE
feat: Internal test forms filtering and Slack message bypass

### DIFF
--- a/src/Endatix.Infrastructure/Integrations/Slack/SlackClient.cs
+++ b/src/Endatix.Infrastructure/Integrations/Slack/SlackClient.cs
@@ -69,7 +69,7 @@ public class SlackClient : INotificationHandler<SubmissionCompletedEvent>, ISlac
 
             // TODO: Remove when per-account settings are implemented
             if(form != null && form.CreatedAt.CompareTo(new DateTime(2021,1,1)) < 0) {
-                _logger.LogWarning($"Functional test form - skip Slack notification.");
+                _logger.LogInformation($"Functional test form - skip Slack notification.");
                 return;
             }
 

--- a/src/Endatix.Infrastructure/Integrations/Slack/SlackClient.cs
+++ b/src/Endatix.Infrastructure/Integrations/Slack/SlackClient.cs
@@ -67,6 +67,12 @@ public class SlackClient : INotificationHandler<SubmissionCompletedEvent>, ISlac
                 form = await repository.GetByIdAsync(notification.Submission.FormId, cancellationToken);
             }
 
+            // TODO: Remove when per-account settings are implemented
+            if(form != null && form.CreatedAt.CompareTo(new DateTime(2021,1,1)) < 0) {
+                _logger.LogWarning($"Functional test form - skip Slack notification.");
+                return;
+            }
+
             if(form != null && !string.IsNullOrEmpty(form.Name)) {
                 formNameOrId = form.Name;
             }

--- a/src/Endatix.Infrastructure/Setup/EndatixAppExtensions.cs
+++ b/src/Endatix.Infrastructure/Setup/EndatixAppExtensions.cs
@@ -61,6 +61,7 @@ public static class EndatixAppExtensions
         services.AddScoped<IUnitOfWork, EfUnitOfWork>();
         services.AddEmailSender<SendGridEmailSender, SendGridSettings>();
         services.AddSlackConfiguration<SlackSettings>();
+        services.AddHttpContextAccessor();
 
         services.AddWebHookProcessing();
 

--- a/src/Endatix.WebHost/Program.cs
+++ b/src/Endatix.WebHost/Program.cs
@@ -3,7 +3,6 @@ using Endatix.Setup;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddHealthChecks();
-builder.Services.AddHttpContextAccessor();
 
 builder.CreateEndatix()
     .AddDefaultSetup()

--- a/src/Endatix.WebHost/Program.cs
+++ b/src/Endatix.WebHost/Program.cs
@@ -3,6 +3,7 @@ using Endatix.Setup;
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddHealthChecks();
+builder.Services.AddHttpContextAccessor();
 
 builder.CreateEndatix()
     .AddDefaultSetup()


### PR DESCRIPTION
# A temporary workaround for filtering internal test forms

## Description

Applies a global query filter for all forms with a CreatedAt date that is earlier than 2021-01-01. This filter is ignored for user accounts with @endatix.com email address.

Slack messages are skipped for all forms with CreatedAt date that is earlier than 2021-01-01.

## Type of Change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules