### PR TITLE
fix: Set DateTime kind to UTC in filters

### DIFF
--- a/src/Endatix.Core/Specifications/Common/SpecificationHelper.cs
+++ b/src/Endatix.Core/Specifications/Common/SpecificationHelper.cs
@@ -92,6 +92,14 @@ public static class SpecificationHelper
             return Enum.Parse(targetType, value, true);
         }
 
+        if (targetType == typeof(DateTime) || targetType == typeof(DateTime?))
+        {
+            var dateTime = DateTime.Parse(value);
+            return dateTime.Kind == DateTimeKind.Unspecified 
+                ? DateTime.SpecifyKind(dateTime, DateTimeKind.Utc)
+                : dateTime.ToUniversalTime();
+        }
+
         return TypeDescriptor.GetConverter(targetType).ConvertFromInvariantString(value)
             ?? throw new ArgumentException($"Cannot convert value '{value}' to type {targetType.Name}");
     }


### PR DESCRIPTION
# Set DateTime kind to UTC in filters

## Description
When having time in API filters, the kind should be set in the DateTime objects for Postgres queries to work properly.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project