### PR TITLE
fix: Bypass EF query filter for internal test forms on the public form sharing page

### DIFF
--- a/src/Endatix.Core/Specifications/ActiveFormDefinitionByFormIdSpec.cs
+++ b/src/Endatix.Core/Specifications/ActiveFormDefinitionByFormIdSpec.cs
@@ -8,6 +8,7 @@ public sealed class ActiveFormDefinitionByFormIdSpec : Specification<Form>, ISin
     public ActiveFormDefinitionByFormIdSpec(long formId)
     {
         Query.Where(f => f.Id == formId)
-             .Include(f => f.ActiveDefinition);
+            .IgnoreQueryFilters()
+            .Include(f => f.ActiveDefinition);
     }
 }


### PR DESCRIPTION
# Bypass EF query filter for internal test forms on the public form sharing page

## Description
The internal test form filter implemented with [PR 372](https://github.com/endatix/endatix/pull/372) is preventing test forms from being displayed on the public page. 

## Type of Change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules