### PR TITLE
feat: Support form deletion

### DIFF
--- a/apps/endatix-hub/components/ui/alert-dialog.tsx
+++ b/apps/endatix-hub/components/ui/alert-dialog.tsx
@@ -1,0 +1,141 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+const AlertDialog = AlertDialogPrimitive.Root
+
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+
+const AlertDialogPortal = AlertDialogPrimitive.Portal
+
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+    ref={ref}
+  />
+))
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+))
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+
+const AlertDialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-2 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogHeader.displayName = "AlertDialogHeader"
+
+const AlertDialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+AlertDialogFooter.displayName = "AlertDialogFooter"
+
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold", className)}
+    {...props}
+  />
+))
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+AlertDialogDescription.displayName =
+  AlertDialogPrimitive.Description.displayName
+
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action
+    ref={ref}
+    className={cn(buttonVariants(), className)}
+    {...props}
+  />
+))
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(
+      buttonVariants({ variant: "outline" }),
+      "mt-2 sm:mt-0",
+      className
+    )}
+    {...props}
+  />
+))
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/apps/endatix-hub/components/ui/button.tsx
+++ b/apps/endatix-hub/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/apps/endatix-hub/features/forms/application/actions/delete-form.action.ts
+++ b/apps/endatix-hub/features/forms/application/actions/delete-form.action.ts
@@ -1,0 +1,19 @@
+'use server'
+
+import { ensureAuthenticated } from "@/lib/auth-service";
+import { Result } from "@/lib/result";
+import { deleteForm } from "@/services/api";
+
+export type DeleteFormResult = Result<string>;
+
+export async function deleteFormAction(formId: string): Promise<DeleteFormResult> {
+  await ensureAuthenticated();
+
+  try {
+    const deletedFormId = await deleteForm(formId);
+    return Result.success(deletedFormId);
+  } catch (error) {
+    console.error("Failed to delete form", error);
+    return Result.error("Failed to delete form");
+  }
+} 

--- a/apps/endatix-hub/package.json
+++ b/apps/endatix-hub/package.json
@@ -23,6 +23,7 @@
     "@opentelemetry/sdk-trace-node": "^1.30.0",
     "@opentelemetry/semantic-conventions": "^1.28.0",
     "@opentelemetry/tracing": "^0.24.0",
+    "@radix-ui/react-alert-dialog": "^1.1.5",
     "@radix-ui/react-avatar": "^1.1.2",
     "@radix-ui/react-checkbox": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.3",

--- a/apps/endatix-hub/pnpm-lock.yaml
+++ b/apps/endatix-hub/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@opentelemetry/tracing':
         specifier: ^0.24.0
         version: 0.24.0(@opentelemetry/api@1.9.0)
+      '@radix-ui/react-alert-dialog':
+        specifier: ^1.1.5
+        version: 1.1.5(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@radix-ui/react-avatar':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1426,6 +1429,19 @@ packages:
   '@radix-ui/primitive@1.1.1':
     resolution: {integrity: sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==}
 
+  '@radix-ui/react-alert-dialog@1.1.5':
+    resolution: {integrity: sha512-1Y2sI17QzSZP58RjGtrklfSGIf3AF7U/HkD3aAcAnhOUJrm7+7GG1wRDFaUlSe0nW5B/t4mYd/+7RNbP2Wexug==}
+    peerDependencies:
+      '@types/react': 19.0.1
+      '@types/react-dom': 19.0.2
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.1':
     resolution: {integrity: sha512-NaVpZfmv8SKeZbn4ijN2V3jlHA9ngBG16VnIIm22nUR0Yk8KUALyBxT3KYEUnNuch9sTE8UTsS3whzBgKOL30w==}
     peerDependencies:
@@ -1509,6 +1525,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dialog@1.1.5':
+    resolution: {integrity: sha512-LaO3e5h/NOEL4OfXjxD43k9Dx+vn+8n+PCFt6uhX/BADFflllyv3WJG6rgvvSVBxpTch938Qq/LGc2MMxipXPw==}
+    peerDependencies:
+      '@types/react': 19.0.1
+      '@types/react-dom': 19.0.2
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-direction@1.1.0':
     resolution: {integrity: sha512-BUuBvgThEiAXh2DWu93XsT+a3aWrGqolGlqqw5VU1kG7p/ZH2cuDlM1sRLNnY3QcBS69UIz2mcKhMxDsdewhjg==}
     peerDependencies:
@@ -1520,6 +1549,19 @@ packages:
 
   '@radix-ui/react-dismissable-layer@1.1.3':
     resolution: {integrity: sha512-onrWn/72lQoEucDmJnr8uczSNTujT0vJnA/X5+3AkChVPowr8n1yvIKIabhWyMQeMvvmdpsvcyDqx3X1LEXCPg==}
+    peerDependencies:
+      '@types/react': 19.0.1
+      '@types/react-dom': 19.0.2
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.4':
+    resolution: {integrity: sha512-XDUI0IVYVSwjMXxM6P4Dfti7AH+Y4oS/TB+sglZ/EXc7cqLwGAmp1NlMrcUjj7ks6R5WTZuWKv44FBbLpwU3sA==}
     peerDependencies:
       '@types/react': 19.0.1
       '@types/react-dom': 19.0.2
@@ -5912,6 +5954,20 @@ snapshots:
 
   '@radix-ui/primitive@1.1.1': {}
 
+  '@radix-ui/react-alert-dialog@1.1.5(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.1)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.1)(react@19.0.0)
+      '@radix-ui/react-dialog': 1.1.5(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.1.1(@types/react@19.0.1)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.1
+      '@types/react-dom': 19.0.2(@types/react@19.0.1)
+
   '@radix-ui/react-arrow@1.1.1(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -5995,6 +6051,28 @@ snapshots:
       '@types/react': 19.0.1
       '@types/react-dom': 19.0.2(@types/react@19.0.1)
 
+  '@radix-ui/react-dialog@1.1.5(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.1)(react@19.0.0)
+      '@radix-ui/react-context': 1.1.1(@types/react@19.0.1)(react@19.0.0)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-focus-guards': 1.1.1(@types/react@19.0.1)(react@19.0.0)
+      '@radix-ui/react-focus-scope': 1.1.1(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-id': 1.1.0(@types/react@19.0.1)(react@19.0.0)
+      '@radix-ui/react-portal': 1.1.3(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-slot': 1.1.1(@types/react@19.0.1)(react@19.0.0)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@19.0.1)(react@19.0.0)
+      aria-hidden: 1.2.4
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+      react-remove-scroll: 2.6.2(@types/react@19.0.1)(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.1
+      '@types/react-dom': 19.0.2(@types/react@19.0.1)
+
   '@radix-ui/react-direction@1.1.0(@types/react@19.0.1)(react@19.0.0)':
     dependencies:
       react: 19.0.0
@@ -6002,6 +6080,19 @@ snapshots:
       '@types/react': 19.0.1
 
   '@radix-ui/react-dismissable-layer@1.1.3(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.1)(react@19.0.0)
+      '@radix-ui/react-primitive': 2.0.1(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@19.0.1)(react@19.0.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@19.0.1)(react@19.0.0)
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
+    optionalDependencies:
+      '@types/react': 19.0.1
+      '@types/react-dom': 19.0.2(@types/react@19.0.1)
+
+  '@radix-ui/react-dismissable-layer@1.1.4(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@radix-ui/primitive': 1.1.1
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@19.0.1)(react@19.0.0)

--- a/apps/endatix-hub/services/api.ts
+++ b/apps/endatix-hub/services/api.ts
@@ -117,6 +117,29 @@ export const updateForm = async (
   }
 };
 
+export const deleteForm = async (formId: string): Promise<string> => {
+  const session = await getSession();
+  
+  if (!session.isLoggedIn) {
+    redirect("/login");
+  }
+
+  const headers = new HeaderBuilder()
+    .withAuth(session)
+    .build();
+
+  const response = await fetch(`${API_BASE_URL}/forms/${formId}`, {
+    method: "DELETE",
+    headers: headers,
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to delete form");
+  }
+
+  return response.text();
+};
+
 export const getActiveFormDefinition = async (
   formId: string,
   allowAnonymous: boolean = false

--- a/src/Endatix.Api/Endpoints/Forms/Delete.DeleteFormRequest.cs
+++ b/src/Endatix.Api/Endpoints/Forms/Delete.DeleteFormRequest.cs
@@ -1,0 +1,12 @@
+namespace Endatix.Api.Endpoints.Forms;
+
+/// <summary>
+/// Request model for deleting a form.
+/// </summary>
+public class DeleteFormRequest
+{
+    /// <summary>
+    /// The ID of the form to delete.
+    /// </summary>
+    public long FormId { get; init; }
+}

--- a/src/Endatix.Api/Endpoints/Forms/Delete.DeleteFormValidator.cs
+++ b/src/Endatix.Api/Endpoints/Forms/Delete.DeleteFormValidator.cs
@@ -1,0 +1,19 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Endatix.Api.Endpoints.Forms;
+
+/// <summary>
+/// Validation rules for the <c>DeleteFormRequest</c> class.
+/// </summary>
+public class DeleteFormValidator : Validator<DeleteFormRequest>
+{
+    /// <summary>
+    /// Default constructor
+    /// </summary>
+    public DeleteFormValidator()
+    {
+        RuleFor(x => x.FormId)
+            .GreaterThan(0);
+    }
+}

--- a/src/Endatix.Api/Endpoints/Forms/Delete.cs
+++ b/src/Endatix.Api/Endpoints/Forms/Delete.cs
@@ -1,0 +1,43 @@
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Endatix.Api.Infrastructure;
+using Endatix.Core.UseCases.Forms.Delete;
+using Endatix.Infrastructure.Identity.Authorization;
+
+namespace Endatix.Api.Endpoints.Forms;
+
+/// <summary>
+/// Endpoint for deleting a form.
+/// </summary>
+public class Delete(IMediator mediator) : Endpoint<DeleteFormRequest, Results<Ok<string>, BadRequest, NotFound>>
+{
+    /// <summary>
+    /// Configures the endpoint settings.
+    /// </summary>
+    public override void Configure()
+    {
+        Delete("forms/{formId}");
+        Permissions(Allow.AllowAll);
+        Summary(s =>
+        {
+            s.Summary = "Delete a form";
+            s.Description = "Deletes a form and all its definitions and submissions.";
+            s.Responses[204] = "Form deleted successfully.";
+            s.Responses[400] = "Invalid input data.";
+            s.Responses[404] = "Form not found.";
+        });
+    }
+
+    /// <inheritdoc/>
+    public override async Task<Results<Ok<string>, BadRequest, NotFound>> ExecuteAsync(DeleteFormRequest request, CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(
+            new DeleteFormCommand(request.FormId),
+            cancellationToken);
+
+        return TypedResultsBuilder
+            .MapResult(result, form => form.Id.ToString())
+            .SetTypedResults<Ok<string>, BadRequest, NotFound>();
+    }
+}

--- a/src/Endatix.Core/Entities/BaseEntity.cs
+++ b/src/Endatix.Core/Entities/BaseEntity.cs
@@ -4,8 +4,19 @@ namespace Endatix.Core.Entities;
 
 public abstract class BaseEntity
 {
-  [DatabaseGenerated(DatabaseGeneratedOption.None)]
-  public virtual long Id { get; set; }
-  public DateTime CreatedAt { get; protected set; }
-  public DateTime? ModifiedAt { get; protected set; }
+    [DatabaseGenerated(DatabaseGeneratedOption.None)]
+    public virtual long Id { get; set; }
+    public DateTime CreatedAt { get; protected set; }
+    public DateTime? ModifiedAt { get; protected set; }
+    public DateTime? DeletedAt { get; private set; }
+    public bool IsDeleted { get; private set; }
+
+    public virtual void Delete()
+    {
+        if (!IsDeleted)
+        {
+            IsDeleted = true;
+            DeletedAt = DateTime.UtcNow;
+        }
+    }
 }

--- a/src/Endatix.Core/Entities/Form.cs
+++ b/src/Endatix.Core/Entities/Form.cs
@@ -48,4 +48,19 @@ public partial class Form : BaseEntity, IAggregateRoot
             SetActiveFormDefinition(formDefinition);
         }
     }
+
+    public override void Delete()
+    {
+        if (!IsDeleted)
+        {
+            // Delete all related form definitions
+            foreach (var definition in _formDefinitions)
+            {
+                definition.Delete();
+            }
+
+            // Delete the form itself
+            base.Delete();
+        }
+    }
 }

--- a/src/Endatix.Core/Entities/FormDefinition.cs
+++ b/src/Endatix.Core/Entities/FormDefinition.cs
@@ -40,4 +40,19 @@ public partial class FormDefinition : BaseEntity, IAggregateRoot
     {
         IsDraft = isDraft ?? IsDraft;
     }
+
+    public override void Delete()
+    {
+        if (!IsDeleted)
+        {
+            // Delete all related submissions
+            foreach (var submission in _submissions)
+            {
+                submission.Delete();
+            }
+
+            // Delete the form definition itself
+            base.Delete();
+        }
+    }
 }

--- a/src/Endatix.Core/Specifications/FormWithDefinitionsAndSubmissionsSpec.cs
+++ b/src/Endatix.Core/Specifications/FormWithDefinitionsAndSubmissionsSpec.cs
@@ -1,0 +1,15 @@
+using Ardalis.Specification;
+using Endatix.Core.Entities;
+
+namespace Endatix.Core.Specifications;
+
+public sealed class FormWithDefinitionsAndSubmissionsSpec : Specification<Form>, ISingleResultSpecification<Form>
+{
+    public FormWithDefinitionsAndSubmissionsSpec(long formId)
+    {
+        Query
+            .Where(f => f.Id == formId)
+            .Include(f => f.FormDefinitions)
+                .ThenInclude(fd => fd.Submissions);
+    }
+} 

--- a/src/Endatix.Core/UseCases/Forms/Delete/DeleteFormCommand.cs
+++ b/src/Endatix.Core/UseCases/Forms/Delete/DeleteFormCommand.cs
@@ -1,0 +1,20 @@
+using Ardalis.GuardClauses;
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.Forms.Delete;
+
+/// <summary>
+/// Command for deleting a form.
+/// </summary>
+public record DeleteFormCommand : ICommand<Result<Form>>
+{
+    public long FormId { get; init; }
+
+    public DeleteFormCommand(long formId)
+    {
+        Guard.Against.NegativeOrZero(formId);
+        FormId = formId;
+    }
+}

--- a/src/Endatix.Core/UseCases/Forms/Delete/DeleteFormHandler.cs
+++ b/src/Endatix.Core/UseCases/Forms/Delete/DeleteFormHandler.cs
@@ -1,0 +1,25 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
+
+namespace Endatix.Core.UseCases.Forms.Delete;
+
+public class DeleteFormHandler(IRepository<Form> _repository) : ICommandHandler<DeleteFormCommand, Result<Form>>
+{
+    public async Task<Result<Form>> Handle(DeleteFormCommand request, CancellationToken cancellationToken)
+    {
+        var spec = new FormWithDefinitionsAndSubmissionsSpec(request.FormId);
+        var form = await _repository.SingleOrDefaultAsync(spec, cancellationToken);
+        if (form == null)
+        {
+            return Result.NotFound("Form not found.");
+        }
+
+        form.Delete();
+        await _repository.UpdateAsync(form, cancellationToken);
+
+        return Result.Success(form);
+    }
+}

--- a/src/Endatix.Infrastructure/Data/Config/FormConfiguration.cs
+++ b/src/Endatix.Infrastructure/Data/Config/FormConfiguration.cs
@@ -9,6 +9,8 @@ public class FormConfiguration : IEntityTypeConfiguration<Form>
     {
         builder.ToTable("Forms");
 
+        builder.HasQueryFilter(f => !f.IsDeleted);
+
         builder.Property(f => f.Id)
             .IsRequired();
 

--- a/src/Endatix.Infrastructure/Data/Config/FormDefinitionConfiguration.cs
+++ b/src/Endatix.Infrastructure/Data/Config/FormDefinitionConfiguration.cs
@@ -10,6 +10,8 @@ namespace Endatix.Infrastructure.Data.Config
         {
             builder.ToTable("FormDefinitions");
 
+            builder.HasQueryFilter(fd => !fd.IsDeleted);
+
             builder.Property(fd => fd.Id)
                 .IsRequired();
 

--- a/src/Endatix.Infrastructure/Data/Config/SubmissionConfiguration.cs
+++ b/src/Endatix.Infrastructure/Data/Config/SubmissionConfiguration.cs
@@ -11,6 +11,8 @@ public class SubmissionConfiguration : IEntityTypeConfiguration<Submission>
     {
         builder.ToTable("Submissions");
 
+        builder.HasQueryFilter(s => !s.IsDeleted);
+
         builder.Property(s => s.Id)
             .IsRequired();
 

--- a/src/Endatix.Infrastructure/Data/DataSeeder.cs
+++ b/src/Endatix.Infrastructure/Data/DataSeeder.cs
@@ -12,6 +12,18 @@ namespace Endatix.Infrastructure.Data;
 public class DataSeeder(ILogger<DataSeeder> logger, IIdGenerator<long> idGenerator)
 {
     /// <summary>
+    /// Synchronous version of the seeder, existing because EF Core requires both sync and async seeding methods.
+    /// This implementation is safe in the migration/startup context where there's no synchronization context.
+    /// For general seeding, prefer using the async version <see cref="SeedSampleDataAsync"/>.
+    /// </summary>
+    /// <param name="dbContext">The DbContext instance to use for database operations.</param>
+    public void SeedSampleData(DbContext dbContext)
+    {
+        SeedSampleDataAsync(dbContext, CancellationToken.None)
+            .Wait();
+    }
+
+    /// <summary>
     /// This method seeds the database with sample data for demonstration purposes. It leverages the EF Core <see cref="DbContextOptionsBuilder.UseAsyncSeeding(Func{DbContext, CancellationToken, Task})"/> method for asynchronous seeding. For a comprehensive overview, refer to https://learn.microsoft.com/en-us/ef/core/modeling/data-seeding#configuration-options-useseeding-and-useasyncseeding-methods
     /// </summary>
     /// <param name="dbContext">The DbContext instance to use for database operations.</param>

--- a/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250122173850_SupportSoftDelete.Designer.cs
+++ b/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250122173850_SupportSoftDelete.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Endatix.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Endatix.Persistence.PostgreSQL.Migrations.AppEntities
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250122173850_SupportSoftDelete")]
+    partial class SupportSoftDelete
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250122173850_SupportSoftDelete.cs
+++ b/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250122173850_SupportSoftDelete.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Endatix.Persistence.PostgreSQL.Migrations.AppEntities
+{
+    /// <inheritdoc />
+    public partial class SupportSoftDelete : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "Submissions",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Submissions",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "Forms",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "Forms",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "FormDefinitions",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "FormDefinitions",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "Submissions");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Submissions");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "Forms");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "Forms");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "FormDefinitions");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "FormDefinitions");
+        }
+    }
+}

--- a/src/Endatix.Persistence.PostgreSql/Setup/EndatixAppExtensions.cs
+++ b/src/Endatix.Persistence.PostgreSql/Setup/EndatixAppExtensions.cs
@@ -35,6 +35,16 @@ public static class EndatixAppExtensions
         endatixApp.Services.AddDbContext<AppDbContext>((serviceProvider, options) =>
         {
             options.UseNpgsql(connectionString, db => db.MigrationsAssembly(migrationsAssembly));
+
+            options.UseSeeding((context, cancellationToken) =>
+            {
+                if (EndatixConfig.Configuration.SeedSampleData)
+                {
+                    var dataSeeder = serviceProvider.GetRequiredService<DataSeeder>();
+                    dataSeeder.SeedSampleData(context);
+                }
+            });
+
             options.UseAsyncSeeding(async (context, _, cancellationToken) =>
             {
                 if (EndatixConfig.Configuration.SeedSampleData)

--- a/tests/Endatix.Api.Tests/Endpoints/Forms/DeleteTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Forms/DeleteTests.cs
@@ -1,0 +1,102 @@
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Entities;
+using Endatix.Api.Endpoints.Forms;
+using Endatix.Core.UseCases.Forms.Delete;
+
+namespace Endatix.Api.Tests.Endpoints.Forms;
+
+public class DeleteTests
+{
+    private readonly IMediator _mediator;
+    private readonly Delete _endpoint;
+
+    public DeleteTests()
+    {
+        _mediator = Substitute.For<IMediator>();
+        _endpoint = Factory.Create<Delete>(_mediator);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_InvalidRequest_ReturnsBadRequest()
+    {
+        // Arrange
+        var formId = 1L;
+        var request = new DeleteFormRequest { FormId = formId };
+        var result = Result.Invalid();
+        
+        _mediator.Send(Arg.Any<DeleteFormCommand>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, default);
+
+        // Assert
+        var badRequestResult = response.Result as BadRequest;
+        badRequestResult.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FormNotFound_ReturnsNotFound()
+    {
+        // Arrange
+        var formId = 1L;
+        var request = new DeleteFormRequest { FormId = formId };
+        var result = Result.NotFound("Form not found");
+
+        _mediator.Send(Arg.Any<DeleteFormCommand>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, default);
+
+        // Assert
+        var notFoundResult = response.Result as NotFound;
+        notFoundResult.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ValidRequest_ReturnsOkWithDeletedFormId()
+    {
+        // Arrange
+        var formId = 1L;
+        var request = new DeleteFormRequest { FormId = formId };
+        var form = new Form("Test Form") { Id = formId };
+        var result = Result.Success(form);
+
+        _mediator.Send(Arg.Any<DeleteFormCommand>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, default);
+
+        // Assert
+        var okResult = response.Result as Ok<string>;
+        okResult.Should().NotBeNull();
+        okResult!.Value.Should().Be(formId.ToString());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldMapRequestToCommandCorrectly()
+    {
+        // Arrange
+        var request = new DeleteFormRequest { FormId = 123 };
+        var result = Result.Success(new Form("Test Form"));
+        
+        _mediator.Send(Arg.Any<DeleteFormCommand>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+
+        // Act
+        await _endpoint.ExecuteAsync(request, CancellationToken.None);
+
+        // Assert
+        await _mediator.Received(1).Send(
+            Arg.Is<DeleteFormCommand>(cmd =>
+                cmd.FormId == request.FormId
+            ),
+            Arg.Any<CancellationToken>()
+        );
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/Forms/Delete/DeleteFormCommandTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/Delete/DeleteFormCommandTests.cs
@@ -1,0 +1,35 @@
+using Endatix.Core.UseCases.Forms.Delete;
+using static Endatix.Core.Tests.ErrorMessages;
+using static Endatix.Core.Tests.ErrorType;
+
+namespace Endatix.Core.Tests.UseCases.Forms.Delete;
+
+public class DeleteFormCommandTests
+{
+    [Fact]
+    public void Constructor_NegativeOrZeroFormId_ThrowsArgumentException()
+    {
+        // Arrange
+        var formId = -1;
+
+        // Act
+        Action act = () => new DeleteFormCommand(formId);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage(GetErrorMessage(nameof(formId), ZeroOrNegative));
+    }
+
+    [Fact]
+    public void Constructor_ValidParameters_SetsPropertiesCorrectly()
+    {
+        // Arrange
+        var formId = 1;
+
+        // Act
+        var command = new DeleteFormCommand(formId);
+
+        // Assert
+        command.FormId.Should().Be(formId);
+    }
+} 

--- a/tests/Endatix.Core.Tests/UseCases/Forms/Delete/DeleteFormHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/Delete/DeleteFormHandlerTests.cs
@@ -1,0 +1,84 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
+using Endatix.Core.UseCases.Forms.Delete;
+
+namespace Endatix.Core.Tests.UseCases.Forms.Delete;
+
+public class DeleteFormHandlerTests
+{
+    private readonly IRepository<Form> _repository;
+    private readonly DeleteFormHandler _handler;
+
+    public DeleteFormHandlerTests()
+    {
+        _repository = Substitute.For<IRepository<Form>>();
+        _handler = new DeleteFormHandler(_repository);
+    }
+
+    [Fact]
+    public async Task Handle_FormNotFound_ReturnsNotFoundResult()
+    {
+        // Arrange
+        var request = new DeleteFormCommand(1);
+        _repository.SingleOrDefaultAsync(
+            Arg.Any<FormWithDefinitionsAndSubmissionsSpec>(),
+            Arg.Any<CancellationToken>())
+            .Returns((Form?)null);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be(ResultStatus.NotFound);
+        result.Errors.Should().Contain("Form not found.");
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_DeletesForm()
+    {
+        // Arrange
+        var form = new Form("Test Form") { Id = 1 };
+        var request = new DeleteFormCommand(1);
+        
+        _repository.SingleOrDefaultAsync(
+            Arg.Any<FormWithDefinitionsAndSubmissionsSpec>(),
+            Arg.Any<CancellationToken>())
+            .Returns(form);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().NotBeNull();
+        result.Value.Should().Be(form);
+        
+        await _repository.Received(1).UpdateAsync(
+            Arg.Is<Form>(f => f.Id == form.Id),
+            Arg.Any<CancellationToken>()
+        );
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_CallsDeleteOnForm()
+    {
+        // Arrange
+        var form = new Form("Test Form") { Id = 1 };
+        var request = new DeleteFormCommand(1);
+        
+        _repository.SingleOrDefaultAsync(
+            Arg.Any<FormWithDefinitionsAndSubmissionsSpec>(),
+            Arg.Any<CancellationToken>())
+            .Returns(form);
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        form.IsDeleted.Should().BeTrue();
+    }
+} 


### PR DESCRIPTION
# Support form deletion

## Description
DB schema changes, Endatix API and Hub implementation of form deletion support.
Use the Delete menu item in the Form Sheet dots menu. Deleting a from deletes all its definitions and submissions. Deletion is soft deletion setting a new column `IsDeleted` in every entity table.

## Related Issues
closes #362

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] My code follows the style guidelines of this project
