### PR TITLE
fix: Adding auth to the API call to edit submissions to fix auth issue

### DIFF
--- a/apps/endatix-hub/services/api.ts
+++ b/apps/endatix-hub/services/api.ts
@@ -313,11 +313,21 @@ export const updateSubmission = async (
   submissionId: string,
   submissionData: SubmissionData
 ): Promise<Submission> => {
+  const session = await getSession();
+
+  if (!session.isLoggedIn) {
+    redirect('/login');
+  }
+
   if (!formId || !submissionId) {
     throw new Error('FormId or submissionId is required');
   }
 
-  const headers = new HeaderBuilder().acceptJson().provideJson().build();
+  const headers = new HeaderBuilder()
+    .withAuth(session)
+    .acceptJson()
+    .provideJson()
+    .build();
 
   const response = await fetch(
     `${API_BASE_URL}/forms/${formId}/submissions/${submissionId}`,
@@ -329,6 +339,7 @@ export const updateSubmission = async (
   );
 
   if (!response.ok) {
+    console.error(response);
     throw new Error('Failed to update submission');
   }
 


### PR DESCRIPTION
# Adding auth to the API call to edit submissions to fix auth issue

## Description
Fixes error when users update a submission

## Related Issues
fixes https://github.com/endatix/endatix-private/issues/96

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 
