### PR TITLE
fix: Adding `getRewriteRuleFor` method to next-config-helpers for parallel routes

### DIFF
--- a/apps/endatix-hub/lib/__tests__/hosting/next-config-helper.test.ts
+++ b/apps/endatix-hub/lib/__tests__/hosting/next-config-helper.test.ts
@@ -1,5 +1,8 @@
 import { RemotePattern } from "next/dist/shared/lib/image-config";
-import { includesRemoteImageHostnames } from "@/lib/hosting/next-config-helper";
+import {
+  getRewriteRuleFor,
+  includesRemoteImageHostnames,
+} from "@/lib/hosting/next-config-helper";
 import { describe, expect, it } from "vitest";
 
 const wildcardRemotePattern: RemotePattern = {
@@ -84,5 +87,33 @@ describe("includesRemoteImageHostnames", () => {
         hostname: "images.pexels.com",
       },
     ]);
+  });
+});
+
+describe("getRewriteRuleFor", () => {
+  it("should throw an error if the route name is empty", () => {
+    expect(() => getRewriteRuleFor("")).toThrow("Invalid route name value");
+  });
+
+  it("should throw an error if the route name is whitespace", () => {
+    const whitespaceRouteName: string = "   ";
+    expect(() => getRewriteRuleFor(whitespaceRouteName)).toThrow(
+      "Invalid route name value",
+    );
+  });
+
+  it("should throw an error if the route name starts with @", () => {
+    expect(() => getRewriteRuleFor("@test")).toThrow(
+      "Invalid route name value",
+    );
+  });
+
+  it("should return the correct rewrite rule for a valid route name", () => {
+    const validRouteName: string = "breadcrumbs";
+    const rewriteRule = getRewriteRuleFor(validRouteName);
+    expect(rewriteRule).toEqual({
+      source: `/_next/static/chunks/app/:folder*/@breadcrumbs/:path*`,
+      destination: `/_next/static/chunks/app/:folder*/%40breadcrumbs/:path*`,
+    });
   });
 });

--- a/apps/endatix-hub/next.config.ts
+++ b/apps/endatix-hub/next.config.ts
@@ -1,6 +1,10 @@
 import type { NextConfig } from "next";
-import { includesRemoteImageHostnames } from "./lib/hosting/next-config-helper";
+import {
+  getRewriteRuleFor,
+  includesRemoteImageHostnames,
+} from "./lib/hosting/next-config-helper";
 import { StorageService } from "@/features/storage/infrastructure/storage-service";
+import { Rewrite } from "next/dist/lib/load-custom-routes";
 
 const nextConfig: NextConfig = {
   /* config options here */
@@ -13,6 +17,18 @@ const nextConfig: NextConfig = {
   },
   images: {
     remotePatterns: [],
+  },
+  rewrites: async () => {
+    const rules = {
+      beforeFiles: new Array<Rewrite>(),
+      afterFiles: new Array<Rewrite>(),
+      fallback: new Array<Rewrite>(),
+    };
+
+    const headerRouteFix = getRewriteRuleFor("header");
+    rules.beforeFiles.push(headerRouteFix);
+
+    return rules;
   },
 };
 


### PR DESCRIPTION
# Adding `getRewriteRuleFor` method to next-config-helpers for parallel routes

## Description
- Adding setting for the header parallel route
- Adding test
- Adding setting for `@headers` parallel route

## Related Issues
fixes #386

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 
