### PR TITLE
feat: [WIP] Schema and auth/access changes for multitenancy

### DIFF
--- a/src/Endatix.Core/Abstractions/ITenantContext.cs
+++ b/src/Endatix.Core/Abstractions/ITenantContext.cs
@@ -1,0 +1,12 @@
+namespace Endatix.Core.Abstractions;
+
+/// <summary>
+/// Provides access to the current tenant context within a request scope
+/// </summary>
+public interface ITenantContext
+{
+    /// <summary>
+    /// Gets the current tenant ID
+    /// </summary>
+    long? TenantId { get; }
+}

--- a/src/Endatix.Core/Abstractions/IUserRegistrationService.cs
+++ b/src/Endatix.Core/Abstractions/IUserRegistrationService.cs
@@ -11,9 +11,10 @@ public interface IUserRegistrationService
     /// <summary>
     /// Registers a new user with the provided email and password.
     /// </summary>
+    /// <param name="tenantId">The tenant of the user to be registered. </param>
     /// <param name="email">The email address of the user to be registered.</param>
     /// <param name="password">The password for the new user account.</param>
     /// <param name="cancellationToken">A cancellation token to cancel the operation if needed.</param>
     /// <returns>A a Task with Result of the registered User if successful.</returns>
-    Task<Result<User>> RegisterUserAsync(string email, string password, CancellationToken cancellationToken);
+    Task<Result<User>> RegisterUserAsync(long tenantId, string email, string password, CancellationToken cancellationToken);
 }

--- a/src/Endatix.Core/Entities/Form.cs
+++ b/src/Endatix.Core/Entities/Form.cs
@@ -3,18 +3,25 @@ using Endatix.Core.Infrastructure.Domain;
 
 namespace Endatix.Core.Entities;
 
-public partial class Form : BaseEntity, IAggregateRoot
+public partial class Form : TenantEntity, IAggregateRoot
 {
     private readonly List<FormDefinition> _formDefinitions = [];
 
     private Form() { } // For EF Core
 
-    public Form(string name, string? description = null, bool isEnabled = false)
+    public Form(long tenantId, string name, string? description = null, bool isEnabled = false)
+        : base(tenantId)
     {
         Guard.Against.NullOrEmpty(name, null, "Form name cannot be null.");
         Name = name;
         Description = description;
         IsEnabled = isEnabled;
+    }
+
+    // TEMP until the tests are fixed
+    public Form(string name, string? description = null, bool isEnabled = false)
+        : this(1, name, description, isEnabled)
+    {
     }
 
     public string Name { get; set; }

--- a/src/Endatix.Core/Entities/FormDefinition.cs
+++ b/src/Endatix.Core/Entities/FormDefinition.cs
@@ -3,17 +3,24 @@ using Endatix.Core.Infrastructure.Domain;
 
 namespace Endatix.Core.Entities;
 
-public partial class FormDefinition : BaseEntity, IAggregateRoot
+public partial class FormDefinition : TenantEntity, IAggregateRoot
 {
     private readonly List<Submission> _submissions = [];
 
-    private FormDefinition() { }
+    private FormDefinition() { } // For EF Core
 
-    public FormDefinition(bool isDraft = false, string? jsonData = null)
+    public FormDefinition(long tenantId,bool isDraft = false, string? jsonData = null)
+        : base(tenantId)
     {
         jsonData ??= EndatixConfig.Configuration.DefaultFormDefinitionJson;
         IsDraft = isDraft;
         JsonData = jsonData;
+    }
+
+    // TEMP until the tests are fixed
+    public FormDefinition(bool isDraft = false, string? jsonData = null)
+        : this(1, isDraft, jsonData)
+    {
     }
 
     public IReadOnlyList<Submission> Submissions => _submissions.AsReadOnly();

--- a/src/Endatix.Core/Entities/Identity/User.cs
+++ b/src/Endatix.Core/Entities/Identity/User.cs
@@ -9,14 +9,16 @@ namespace Endatix.Core.Entities.Identity;
 /// It encapsulates the core attributes and behaviors of a user within the application.
 /// Persistence implementation is done via the <see cref="AppUser"/>
 /// </summary>
-public sealed class User : BaseEntity, IAggregateRoot
+public sealed class User : TenantEntity, IAggregateRoot
 {
     public User(
         long id,
+        long tenantId,
         string userName,
         string email,
         bool isVerified
         )
+        : base(tenantId)
     {
         Guard.Against.NegativeOrZero(id);
         Guard.Against.NullOrWhiteSpace(userName);
@@ -26,6 +28,17 @@ public sealed class User : BaseEntity, IAggregateRoot
         UserName = userName;
         Email = email;
         IsVerified = isVerified;
+    }
+
+    // TEMP until the tests are fixed
+    public User(
+        long id,
+        string userName,
+        string email,
+        bool isVerified
+        )
+        : this(id, 1, userName, email, isVerified)
+    {
     }
 
     /// <summary>

--- a/src/Endatix.Core/Entities/Submission.cs
+++ b/src/Endatix.Core/Entities/Submission.cs
@@ -3,11 +3,12 @@ using Endatix.Core.Infrastructure.Domain;
 
 namespace Endatix.Core.Entities;
 
-public partial class Submission : BaseEntity, IAggregateRoot
+public partial class Submission : TenantEntity, IAggregateRoot
 {
-    private Submission() { }
+    private Submission() { } // For EF Core
 
-    public Submission(string jsonData, long formId, long formDefinitionId, bool isComplete = true, int currentPage = 1, string? metadata = null)
+    public Submission(long tenantId, string jsonData, long formId, long formDefinitionId, bool isComplete = true, int currentPage = 1, string? metadata = null)
+        : base(tenantId)
     {
         Guard.Against.NullOrEmpty(jsonData, nameof(jsonData));
         Guard.Against.NegativeOrZero(formId, nameof(formId));
@@ -21,6 +22,12 @@ public partial class Submission : BaseEntity, IAggregateRoot
         Status = SubmissionStatus.New;
 
         SetCompletionStatus(isComplete);
+    }
+
+    // TEMP until the tests are fixed
+    public Submission(string jsonData, long formId, long formDefinitionId, bool isComplete = true, int currentPage = 1, string? metadata = null)
+        : this(1, jsonData, formId, formDefinitionId, isComplete, currentPage, metadata)
+    {
     }
 
     public bool IsComplete { get; private set; }

--- a/src/Endatix.Core/Entities/Tenant.cs
+++ b/src/Endatix.Core/Entities/Tenant.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations.Schema;
+using Ardalis.GuardClauses;
+using Endatix.Core.Entities.Identity;
+using Endatix.Core.Infrastructure.Domain;
+
+namespace Endatix.Core.Entities
+{
+    public class Tenant : BaseEntity, IAggregateRoot
+    {
+        private readonly List<Form> _forms = [];
+        private readonly List<FormDefinition> _formDefinitions = [];
+        private readonly List<Submission> _submissions = [];
+
+        private Tenant() { } // For EF Core
+
+        public Tenant(string name, string? description = null)
+        {
+            Guard.Against.NullOrEmpty(name, nameof(name));
+            
+            Name = name;
+            Description = description;
+        }
+
+        public string Name { get; private set; }
+        public string? Description { get; private set; }
+
+        public IReadOnlyCollection<Form> Forms => _forms.AsReadOnly();
+        public IReadOnlyCollection<FormDefinition> FormDefinitions => _formDefinitions.AsReadOnly();
+        public IReadOnlyCollection<Submission> Submissions => _submissions.AsReadOnly();
+        
+        [NotMapped]
+        public ICollection<User> Users { get; set; } = new List<User>();
+    }
+}

--- a/src/Endatix.Core/Entities/TenantEntity.cs
+++ b/src/Endatix.Core/Entities/TenantEntity.cs
@@ -1,0 +1,17 @@
+using Ardalis.GuardClauses;
+
+namespace Endatix.Core.Entities;
+
+public abstract class TenantEntity : BaseEntity
+{
+    protected TenantEntity(long tenantId)
+    {
+        Guard.Against.NegativeOrZero(tenantId, nameof(tenantId));
+        TenantId = tenantId;
+    }
+
+    protected TenantEntity() { } // For EF Core
+
+    public long TenantId { get; private set; }
+    public Tenant Tenant { get; private set; }
+}

--- a/src/Endatix.Core/UseCases/FormDefinitions/List/ListFormDefinitionsHandler.cs
+++ b/src/Endatix.Core/UseCases/FormDefinitions/List/ListFormDefinitionsHandler.cs
@@ -17,6 +17,11 @@ public class ListFormDefinitionsHandler(IRepository<FormDefinition> _repository)
         var pagingParams = new PagingParameters(request.Page, request.PageSize);
         var spec = new FormDefinitionsByFormIdSpec(request.FormId, pagingParams);
         IEnumerable<FormDefinition> formDefinitions = await _repository.ListAsync(spec, cancellationToken);
-        return Result.Success(formDefinitions);
+        if (formDefinitions.Any())
+        {
+            return Result.Success(formDefinitions);
+        }
+
+        return Result.NotFound("Form not found.");
     }
 }

--- a/src/Endatix.Core/UseCases/FormDefinitions/PartialUpdateActive/PartialUpdateActiveFormDefinitionHandler.cs
+++ b/src/Endatix.Core/UseCases/FormDefinitions/PartialUpdateActive/PartialUpdateActiveFormDefinitionHandler.cs
@@ -20,7 +20,7 @@ public class PartialUpdateActiveFormDefinitionHandler(IFormsRepository formsRepo
         }
 
         if(await ShouldCreateNewFormDefinitionAsync(activeDefinition, request)) {
-            var newFormDefinition = new FormDefinition(request.IsDraft??false, request.JsonData);
+            var newFormDefinition = new FormDefinition(formWithActiveDefinition.TenantId, request.IsDraft??false, request.JsonData);
             formWithActiveDefinition.AddFormDefinition(newFormDefinition);
             
             if (!newFormDefinition.IsDraft) {

--- a/src/Endatix.Core/UseCases/Forms/Create/CreateFormHandler.cs
+++ b/src/Endatix.Core/UseCases/Forms/Create/CreateFormHandler.cs
@@ -1,25 +1,23 @@
-﻿using Endatix.Core.Abstractions.Repositories;
+﻿using Ardalis.GuardClauses;
+using Endatix.Core.Abstractions;
+using Endatix.Core.Abstractions.Repositories;
 using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
 
 namespace Endatix.Core.UseCases.Forms.Create;
 
-public class CreateFormHandler : ICommandHandler<CreateFormCommand, Result<Form>>
+public class CreateFormHandler(IFormsRepository formsRepository, ITenantContext tenantContext) : ICommandHandler<CreateFormCommand, Result<Form>>
 {
-    private readonly IFormsRepository _formsRepository;
-
-    public CreateFormHandler(IFormsRepository formsRepository)
-    {
-        _formsRepository = formsRepository;
-    }
-
     public async Task<Result<Form>> Handle(CreateFormCommand request, CancellationToken cancellationToken)
     {
-        var newForm = new Form(request.Name, request.Description, request.IsEnabled);
-        var newFormDefinition = new FormDefinition(isDraft:true, jsonData: request.FormDefinitionJsonData);
+        Guard.Against.Null(tenantContext.TenantId);
 
-        var form = await _formsRepository.CreateFormWithDefinitionAsync(newForm, newFormDefinition, cancellationToken);
+        var tenantId = tenantContext.TenantId!.Value;
+        var newForm = new Form(tenantId, request.Name, request.Description, request.IsEnabled);
+        var newFormDefinition = new FormDefinition(tenantId, isDraft: true, jsonData: request.FormDefinitionJsonData);
+
+        var form = await formsRepository.CreateFormWithDefinitionAsync(newForm, newFormDefinition, cancellationToken);
 
         return Result<Form>.Created(form);
     }

--- a/src/Endatix.Core/UseCases/Submissions/Create/CreateSubmissionHandler.cs
+++ b/src/Endatix.Core/UseCases/Submissions/Create/CreateSubmissionHandler.cs
@@ -35,6 +35,7 @@ public class CreateSubmissionHandler(
         }
 
         var submission = new Submission(
+            activeDefinition!.TenantId,
             jsonData: request.JsonData,
             formId: request.FormId,
             formDefinitionId: activeDefinition!.Id,

--- a/src/Endatix.Extensions.Hosting/AppBuilderExtensions.cs
+++ b/src/Endatix.Extensions.Hosting/AppBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Endatix.Framework.Hosting;
 using Endatix.Infrastructure.Data;
 using Endatix.Infrastructure.Identity;
 using Endatix.Infrastructure.Identity.Seed;
+using Endatix.Infrastructure.Multitenancy;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
@@ -33,6 +34,7 @@ public static class AppBuilderExtensions
         app.UseHttpsRedirection();
         app.UseAuthentication();
         app.UseAuthorization();
+        app.UseMiddleware<TenantMiddleware>();
 
         app.UseSerilogRequestLogging(options =>
         {

--- a/src/Endatix.Infrastructure/Data/Config/FormConfiguration.cs
+++ b/src/Endatix.Infrastructure/Data/Config/FormConfiguration.cs
@@ -3,13 +3,12 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Endatix.Core.Entities;
 
 namespace Endatix.Infrastructure.Data.Config;
+
 public class FormConfiguration : IEntityTypeConfiguration<Form>
 {
     public void Configure(EntityTypeBuilder<Form> builder)
     {
         builder.ToTable("Forms");
-
-        builder.HasQueryFilter(f => !f.IsDeleted);
 
         builder.Property(f => f.Id)
             .IsRequired();

--- a/src/Endatix.Infrastructure/Data/Config/FormDefinitionConfiguration.cs
+++ b/src/Endatix.Infrastructure/Data/Config/FormDefinitionConfiguration.cs
@@ -2,26 +2,23 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Endatix.Core.Entities;
 
-namespace Endatix.Infrastructure.Data.Config
+namespace Endatix.Infrastructure.Data.Config;
+
+public class FormDefinitionConfiguration : IEntityTypeConfiguration<FormDefinition>
 {
-    public class FormDefinitionConfiguration : IEntityTypeConfiguration<FormDefinition>
+    public void Configure(EntityTypeBuilder<FormDefinition> builder)
     {
-        public void Configure(EntityTypeBuilder<FormDefinition> builder)
-        {
-            builder.ToTable("FormDefinitions");
+        builder.ToTable("FormDefinitions");
 
-            builder.HasQueryFilter(fd => !fd.IsDeleted);
+        builder.Property(fd => fd.Id)
+            .IsRequired();
 
-            builder.Property(fd => fd.Id)
-                .IsRequired();
+        builder.Property(fd => fd.JsonData)
+            .IsRequired();
 
-            builder.Property(fd => fd.JsonData)
-                .IsRequired();
-
-            builder.HasOne<Form>()
-                .WithMany(f => f.FormDefinitions)
-                .IsRequired(false)
-                .HasForeignKey(fd => fd.FormId);
-        }
+        builder.HasOne<Form>()
+            .WithMany(f => f.FormDefinitions)
+            .IsRequired(false)
+            .HasForeignKey(fd => fd.FormId);
     }
 }

--- a/src/Endatix.Infrastructure/Data/Config/SubmissionConfiguration.cs
+++ b/src/Endatix.Infrastructure/Data/Config/SubmissionConfiguration.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Endatix.Core.Entities;
 
 namespace Endatix.ApplicationCore.Infrastructure.Data.Config;
+
 public class SubmissionConfiguration : IEntityTypeConfiguration<Submission>
 {
     private const int TOKEN_VALUE_MAX_LENGTH = 64;
@@ -10,8 +11,6 @@ public class SubmissionConfiguration : IEntityTypeConfiguration<Submission>
     public void Configure(EntityTypeBuilder<Submission> builder)
     {
         builder.ToTable("Submissions");
-
-        builder.HasQueryFilter(s => !s.IsDeleted);
 
         builder.Property(s => s.Id)
             .IsRequired();

--- a/src/Endatix.Infrastructure/Data/Config/TenantConfiguration.cs
+++ b/src/Endatix.Infrastructure/Data/Config/TenantConfiguration.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Endatix.Core.Entities;
+
+namespace Endatix.Infrastructure.Data.Config;
+
+public class TenantConfiguration : IEntityTypeConfiguration<Tenant>
+{
+    public void Configure(EntityTypeBuilder<Tenant> builder)
+    {
+        builder.ToTable("Tenants");
+
+        builder.Property(f => f.Id)
+            .IsRequired();
+
+        builder.Property(t => t.Name)
+            .HasMaxLength(DataSchemaConstants.MAX_NAME_LENGTH)
+            .IsRequired();
+
+        builder.HasMany(t => t.Forms)
+            .WithOne(f => f.Tenant)
+            .HasForeignKey(f => f.TenantId)
+            .IsRequired()
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasMany(t => t.FormDefinitions)
+            .WithOne(fd => fd.Tenant)
+            .HasForeignKey(fd => fd.TenantId)
+            .IsRequired()
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasMany(t => t.Submissions)
+            .WithOne(s => s.Tenant)
+            .HasForeignKey(s => s.TenantId)
+            .IsRequired()
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/src/Endatix.Infrastructure/Identity/AppUser.cs
+++ b/src/Endatix.Infrastructure/Identity/AppUser.cs
@@ -11,6 +11,11 @@ namespace Endatix.Infrastructure.Identity;
 public class AppUser : IdentityUser<long>
 {
     /// <summary>
+    /// The ID of the tenant this user belongs to.
+    /// </summary>
+    public long TenantId { get; set; }
+    
+    /// <summary>
     /// The user's refresh token.
     /// </summary>
     public string? RefreshTokenHash { get; set; }
@@ -27,6 +32,7 @@ public class AppUser : IdentityUser<long>
 
         var user = new User(
             id: Id,
+            tenantId: TenantId,
             userName: UserName,
             email: Email,
             isVerified: EmailConfirmed

--- a/src/Endatix.Infrastructure/Identity/Authentication/JwtTokenService.cs
+++ b/src/Endatix.Infrastructure/Identity/Authentication/JwtTokenService.cs
@@ -54,7 +54,8 @@ internal sealed class JwtTokenService : IUserTokenService
                 new Claim(JwtRegisteredClaimNames.Email, forUser.Email.ToString()),
                 new Claim(ClaimTypes.NameIdentifier, forUser.UserName.ToString()),
                 new Claim(ClaimTypes.Role, RoleNames.ADMIN),
-                new Claim(ClaimNames.Permission, Allow.AllowAll)
+                new Claim(ClaimNames.Permission, Allow.AllowAll),
+                new Claim(ClaimNames.TenantId, forUser.TenantId.ToString())
             ]);
 
         var tokenDescriptor = new SecurityTokenDescriptor

--- a/src/Endatix.Infrastructure/Identity/ClaimNames.cs
+++ b/src/Endatix.Infrastructure/Identity/ClaimNames.cs
@@ -19,4 +19,9 @@ public static class ClaimNames
     /// Represents a claim indicating whether the user's email is verified.
     /// </summary>
     public const string EmailVerified = "email_verified";
+
+    /// <summary>
+    /// Represents a claim for the user's tenant identifier.
+    /// </summary>
+    public const string TenantId = "tenant_id";
 }

--- a/src/Endatix.Infrastructure/Identity/IdentitySetup.cs
+++ b/src/Endatix.Infrastructure/Identity/IdentitySetup.cs
@@ -3,6 +3,7 @@ using Endatix.Core.Abstractions;
 using Endatix.Framework.Hosting;
 using Endatix.Infrastructure.Identity.Authentication;
 using Endatix.Infrastructure.Identity.Users;
+using Endatix.Infrastructure.Multitenancy;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -31,6 +32,7 @@ public static class IdentitySetup
         endatixApp.Services.AddScoped<IAuthService, AuthService>();
         endatixApp.Services.AddScoped<IUserService, AppUserService>();
         endatixApp.Services.AddScoped<IUserRegistrationService, AppUserRegistrationService>();
+        endatixApp.Services.AddScoped<ITenantContext, TenantContext>();
 
         endatixApp.LogSetupInformation("{Component} infrastructure configuration | {Status}", "Security Config", "Finished");
 

--- a/src/Endatix.Infrastructure/Identity/Seed/IdentitySeed.cs
+++ b/src/Endatix.Infrastructure/Identity/Seed/IdentitySeed.cs
@@ -10,6 +10,7 @@ namespace Endatix.Infrastructure.Identity.Seed
     /// </summary>
     public static class IdentitySeed
     {
+        private const long DEFAULT_ADMIN_TENANT_ID = 1;
         private const string DEFAULT_ADMIN_EMAIL = "admin@endatix.com";
         private const string DEFAULT_ADMIN_PASSWORD = "P@ssw0rd";
 
@@ -58,7 +59,7 @@ namespace Endatix.Infrastructure.Identity.Seed
                 password = DEFAULT_ADMIN_PASSWORD;
             }
 
-            await userRegistrationService.RegisterUserAsync(email, password, CancellationToken.None);
+            await userRegistrationService.RegisterUserAsync(DEFAULT_ADMIN_TENANT_ID, email, password, CancellationToken.None);
             logger.LogInformation($"👤 Initial user {email} created successfully! Please use it to authenticate.");
         }
     }

--- a/src/Endatix.Infrastructure/Identity/Users/AppUserRegistrationService.cs
+++ b/src/Endatix.Infrastructure/Identity/Users/AppUserRegistrationService.cs
@@ -11,7 +11,7 @@ namespace Endatix.Infrastructure.Identity.Users;
 public class AppUserRegistrationService(UserManager<AppUser> userManager, IUserStore<AppUser> userStore) : IUserRegistrationService
 {
     /// <inheritdoc />
-    public async Task<Result<User>> RegisterUserAsync(string email, string password, CancellationToken cancellationToken)
+    public async Task<Result<User>> RegisterUserAsync(long tenantId, string email, string password, CancellationToken cancellationToken)
     {
         if (!userManager.SupportsUserEmail)
         {
@@ -20,6 +20,7 @@ public class AppUserRegistrationService(UserManager<AppUser> userManager, IUserS
 
         var newUser = new AppUser
         {
+            TenantId = tenantId,
             EmailConfirmed = true
         };
 

--- a/src/Endatix.Infrastructure/Multitenancy/TenantContext.cs
+++ b/src/Endatix.Infrastructure/Multitenancy/TenantContext.cs
@@ -1,0 +1,23 @@
+using Endatix.Core.Abstractions;
+
+namespace Endatix.Infrastructure.Multitenancy;
+
+/// <summary>
+/// Provides access to the current tenant context within a request scope
+/// </summary>
+public class TenantContext : ITenantContext
+{
+    /// <summary>
+    /// Gets the current tenant ID
+    /// </summary>
+    public long? TenantId { get; private set; }
+
+    /// <summary>
+    /// Sets the current tenant ID
+    /// </summary>
+    /// <param name="tenantId">The tenant ID to set</param>
+    internal void SetTenant(long? tenantId)
+    {
+        TenantId = tenantId;
+    }
+}

--- a/src/Endatix.Infrastructure/Multitenancy/TenantMiddleware.cs
+++ b/src/Endatix.Infrastructure/Multitenancy/TenantMiddleware.cs
@@ -1,0 +1,60 @@
+using Microsoft.AspNetCore.Http;
+using Endatix.Core.Abstractions;
+using Microsoft.Extensions.Logging;
+using Endatix.Infrastructure.Identity;
+
+namespace Endatix.Infrastructure.Multitenancy;
+
+/// <summary>
+/// Middleware that handles tenant context initialization based on user claims.
+/// </summary>
+public class TenantMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<TenantMiddleware> _logger;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TenantMiddleware"/> class.
+    /// </summary>
+    /// <param name="next">The next middleware in the pipeline.</param>
+    /// <param name="logger">The logger instance.</param>
+    public TenantMiddleware(RequestDelegate next, ILogger<TenantMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Processes the request to set the tenant context based on the user's tenant claim.
+    /// </summary>
+    /// <param name="context">The current HTTP context.</param>
+    /// <param name="tenantContext">The tenant context to be initialized.</param>
+    /// <returns>A task representing the asynchronous operation.</returns>
+    public async Task InvokeAsync(HttpContext context, ITenantContext tenantContext)
+    {
+        // Tenant ID is not present for public API endpoints.
+        var tenantClaim = context.User.FindFirst(ClaimNames.TenantId);
+        if (tenantClaim == null)
+        {
+            await _next(context);
+            return;
+        }
+
+        if (!long.TryParse(tenantClaim.Value, out var tenantId))
+        {
+            _logger.LogError("Invalid tenant ID format: {TenantClaimValue}", tenantClaim.Value);
+            await _next(context);
+            return;
+        }
+
+        if (tenantContext is not TenantContext)
+        {
+            _logger.LogError("Expected TenantContext but got {ActualType}", tenantContext.GetType().Name);
+            await _next(context);
+            return;
+        }
+
+        ((TenantContext)tenantContext).SetTenant(tenantId);
+        await _next(context);
+    }
+}

--- a/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250304135430_CreateTenant.Designer.cs
+++ b/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250304135430_CreateTenant.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Endatix.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Endatix.Persistence.PostgreSQL.Migrations.AppEntities
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250304135430_CreateTenant")]
+    partial class CreateTenant
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250304135430_CreateTenant.cs
+++ b/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250304135430_CreateTenant.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Endatix.Persistence.PostgreSQL.Migrations.AppEntities
+{
+    /// <inheritdoc />
+    public partial class CreateTenant : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "TenantId",
+                table: "Submissions",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L);
+
+            migrationBuilder.AddColumn<long>(
+                name: "TenantId",
+                table: "Forms",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L);
+
+            migrationBuilder.AddColumn<long>(
+                name: "TenantId",
+                table: "FormDefinitions",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L);
+
+            migrationBuilder.CreateTable(
+                name: "Tenants",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Tenants", x => x.Id);
+                });
+
+            // Custom SQL for default tenant and data migration
+            migrationBuilder.InsertData(
+                table: "Tenants",
+                columns: ["Id", "Name", "CreatedAt", "IsDeleted"],
+                values: [1L, "Default Tenant", DateTime.UtcNow, false]);
+            migrationBuilder.Sql(@"
+                UPDATE ""Forms"" SET ""TenantId"" = 1 WHERE ""TenantId"" = 0;
+                UPDATE ""FormDefinitions"" SET ""TenantId"" = 1 WHERE ""TenantId"" = 0;
+                UPDATE ""Submissions"" SET ""TenantId"" = 1 WHERE ""TenantId"" = 0;
+            ");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Submissions_TenantId",
+                table: "Submissions",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Forms_TenantId",
+                table: "Forms",
+                column: "TenantId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FormDefinitions_TenantId",
+                table: "FormDefinitions",
+                column: "TenantId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_FormDefinitions_Tenants_TenantId",
+                table: "FormDefinitions",
+                column: "TenantId",
+                principalTable: "Tenants",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Forms_Tenants_TenantId",
+                table: "Forms",
+                column: "TenantId",
+                principalTable: "Tenants",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Submissions_Tenants_TenantId",
+                table: "Submissions",
+                column: "TenantId",
+                principalTable: "Tenants",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_FormDefinitions_Tenants_TenantId",
+                table: "FormDefinitions");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Forms_Tenants_TenantId",
+                table: "Forms");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Submissions_Tenants_TenantId",
+                table: "Submissions");
+
+            migrationBuilder.DropTable(
+                name: "Tenants");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Submissions_TenantId",
+                table: "Submissions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Forms_TenantId",
+                table: "Forms");
+
+            migrationBuilder.DropIndex(
+                name: "IX_FormDefinitions_TenantId",
+                table: "FormDefinitions");
+
+            migrationBuilder.DropColumn(
+                name: "TenantId",
+                table: "Submissions");
+
+            migrationBuilder.DropColumn(
+                name: "TenantId",
+                table: "Forms");
+
+            migrationBuilder.DropColumn(
+                name: "TenantId",
+                table: "FormDefinitions");
+        }
+    }
+}

--- a/src/Endatix.Persistence.PostgreSql/Migrations/AppIdentity/20250305092812_AddTenantToUser.Designer.cs
+++ b/src/Endatix.Persistence.PostgreSql/Migrations/AppIdentity/20250305092812_AddTenantToUser.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Endatix.Infrastructure.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Endatix.Persistence.PostgreSQL.Migrations.AppIdentity
 {
     [DbContext(typeof(AppIdentityDbContext))]
-    partial class AppIdentityDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250305092812_AddTenantToUser")]
+    partial class AddTenantToUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Endatix.Persistence.PostgreSql/Migrations/AppIdentity/20250305092812_AddTenantToUser.cs
+++ b/src/Endatix.Persistence.PostgreSql/Migrations/AppIdentity/20250305092812_AddTenantToUser.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Endatix.Persistence.PostgreSQL.Migrations.AppIdentity
+{
+    /// <inheritdoc />
+    public partial class AddTenantToUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "TenantId",
+                schema: "identity",
+                table: "AspNetUsers",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L);
+
+            // Custom SQL for tenant data migration
+            migrationBuilder.Sql(@"
+                UPDATE identity.""AspNetUsers"" SET ""TenantId"" = 1 WHERE ""TenantId"" = 0;
+            ");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TenantId",
+                schema: "identity",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/FormDefinitions/Create/CreateFormDefinitionHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/FormDefinitions/Create/CreateFormDefinitionHandlerTests.cs
@@ -1,3 +1,4 @@
+using Endatix.Core.Abstractions;
 using Endatix.Core.Abstractions.Repositories;
 using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Result;
@@ -9,12 +10,14 @@ namespace Endatix.Core.Tests.UseCases.FormDefinitions.Create;
 public class CreateFormDefinitionHandlerTests
 {
     private readonly IFormsRepository _formsRepository;
+    private readonly ITenantContext _tenantContext;
     private readonly CreateFormDefinitionHandler _handler;
 
     public CreateFormDefinitionHandlerTests()
     {
         _formsRepository = Substitute.For<IFormsRepository>();
-        _handler = new CreateFormDefinitionHandler(_formsRepository);
+        _tenantContext = Substitute.For<ITenantContext>();
+        _handler = new CreateFormDefinitionHandler(_formsRepository, _tenantContext);
     }
 
     [Fact]

--- a/tests/Endatix.Core.Tests/UseCases/Forms/Create/CreateFormHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/Create/CreateFormHandlerTests.cs
@@ -1,3 +1,4 @@
+using Endatix.Core.Abstractions;
 using Endatix.Core.Abstractions.Repositories;
 using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Result;
@@ -8,12 +9,14 @@ namespace Endatix.Core.Tests.UseCases.Forms.Create;
 public class CreateFormHandlerTests
 {
     private readonly IFormsRepository _repository;
+    private readonly ITenantContext _tenantContext;
     private readonly CreateFormHandler _handler;
 
     public CreateFormHandlerTests()
     {
         _repository = Substitute.For<IFormsRepository>();
-        _handler = new CreateFormHandler(_repository);
+        _tenantContext = Substitute.For<ITenantContext>();
+        _handler = new CreateFormHandler(_repository, _tenantContext);
     }
 
     [Fact]

--- a/tests/Endatix.Infrastructure.Tests/Identity/Seed/IdentitySeedTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Identity/Seed/IdentitySeedTests.cs
@@ -68,7 +68,7 @@ public class IdentitySeedTests
 
         // Assert
         await _userRegistrationService.DidNotReceive()
-            .RegisterUserAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+            .RegisterUserAsync(Arg.Any<long>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -79,6 +79,7 @@ public class IdentitySeedTests
         _userManager.Users.Returns(users);
         DataOptions? nullOptions = null;
 
+        var expectedTenantId = 1;
         var expectedEmail = "admin@endatix.com";
         var expectedPassword = "P@ssw0rd";
 
@@ -87,7 +88,7 @@ public class IdentitySeedTests
 
         // Assert
         await _userRegistrationService.Received(1)
-            .RegisterUserAsync(expectedEmail, expectedPassword, Arg.Any<CancellationToken>());
+            .RegisterUserAsync(expectedTenantId, expectedEmail, expectedPassword, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -97,6 +98,7 @@ public class IdentitySeedTests
         var users = Enumerable.Empty<AppUser>().AsQueryable();
         _userManager.Users.Returns(users);
 
+        var expectedTenantId = 1;
         var expectedEmail = "custom@example.com";
         var expectedPassword = "CustomPass123";
 
@@ -111,6 +113,6 @@ public class IdentitySeedTests
 
         // Assert
         await _userRegistrationService.Received(1)
-            .RegisterUserAsync(expectedEmail, expectedPassword, Arg.Any<CancellationToken>());
+            .RegisterUserAsync(expectedTenantId, expectedEmail, expectedPassword, Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
# Schema and auth/access changes for multitenancy

## Description
Multitenancy support involves changes that include:
- the entities that will be part of a tenant have a TenantId column
- the tenant is determined by the logged in user and is obtained from the JWT token, then kept in a tenant context
- Global Query Filters are used in the app db context to filter entities by the tenant ID from the tenant context.

**Notes:**
The PR is WIP and has missing:
- Migrations for SQL Server
- Unit tests

## Related Issues
closes https://github.com/endatix/endatix-private/issues/78

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] My code follows the style guidelines of this project
