### PR TITLE
feat: Configure Swagger and API settings via AppSettings

### DIFF
--- a/src/Endatix.Api/Builders/ApiConfigurationBuilder.cs
+++ b/src/Endatix.Api/Builders/ApiConfigurationBuilder.cs
@@ -64,8 +64,14 @@ public class ApiConfigurationBuilder
     {
         LogSetupInfo("Configuring API endpoints with default settings");
 
-        // Register API options from configuration
-        Services.AddApiOptions();
+        if (_configuration != null)
+        {
+            Services.AddApiOptions(_configuration);
+        }
+        else
+        {
+            LogSetupInfo("No configuration provided. API settings from configuration will not be applied.");
+        }
 
         // Add CORS services
         AddCorsServices();
@@ -268,6 +274,6 @@ public class ApiConfigurationBuilder
 
     protected virtual void LogSetupInfo(string message)
     {
-        _logger?.LogInformation(message);
+        _logger?.LogDebug(message);
     }
 }

--- a/src/Endatix.Api/Builders/ApiConfigurationBuilder.cs
+++ b/src/Endatix.Api/Builders/ApiConfigurationBuilder.cs
@@ -70,7 +70,7 @@ public class ApiConfigurationBuilder
         }
         else
         {
-            LogSetupInfo("No configuration provided. API settings from configuration will not be applied.");
+            LogSetupInfo("No configuration provided. Using default settings.");
         }
 
         // Add CORS services

--- a/src/Endatix.Api/Builders/ApiConfigurationBuilder.cs
+++ b/src/Endatix.Api/Builders/ApiConfigurationBuilder.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Endatix.Api.Infrastructure;
 using Endatix.Api.Infrastructure.Cors;
+using Endatix.Api.Setup;
 using Endatix.Framework.Hosting;
 using Endatix.Framework.Setup;
 using FastEndpoints;
@@ -62,6 +63,9 @@ public class ApiConfigurationBuilder
     public virtual ApiConfigurationBuilder UseDefaults()
     {
         LogSetupInfo("Configuring API endpoints with default settings");
+
+        // Register API options from configuration
+        Services.AddApiOptions();
 
         // Add CORS services
         AddCorsServices();

--- a/src/Endatix.Api/Builders/ApiOptions.cs
+++ b/src/Endatix.Api/Builders/ApiOptions.cs
@@ -13,6 +13,11 @@ namespace Endatix.Api.Builders;
 public class ApiOptions
 {
     /// <summary>
+    /// The configuration section name where these options are stored.
+    /// </summary>
+    public const string SECTION_NAME = "Endatix:Api";
+
+    /// <summary>
     /// Gets or sets a value indicating whether to use exception handling middleware.
     /// </summary>
     public bool UseExceptionHandler { get; set; } = true;

--- a/src/Endatix.Api/Builders/ApiOptions.cs
+++ b/src/Endatix.Api/Builders/ApiOptions.cs
@@ -7,16 +7,12 @@ namespace Endatix.Api.Builders;
 /// Core options for configuring Endatix API features.
 /// </summary>
 /// <remarks>
-/// This class is the definitive source of API configuration options and should be
-/// referenced by other projects rather than duplicating these properties.
+/// This class is the definitive source of API features configuration used throughout the application.
+/// Only a subset of these properties can be configured via appsettings.json through the
+/// <see cref="Configuration.ApiConfigurationOptions"/> class.
 /// </remarks>
 public class ApiOptions
 {
-    /// <summary>
-    /// The configuration section name where these options are stored.
-    /// </summary>
-    public const string SECTION_NAME = "Endatix:Api";
-
     /// <summary>
     /// Gets or sets a value indicating whether to use exception handling middleware.
     /// </summary>
@@ -29,17 +25,13 @@ public class ApiOptions
 
     /// <summary>
     /// Gets or sets a value indicating whether to use Swagger middleware.
+    /// This can be configured via appsettings.json.
     /// </summary>
     public bool UseSwagger { get; set; } = true;
 
     /// <summary>
-    /// Gets or sets a value indicating whether to enable Swagger in production.
-    /// </summary>
-    public bool EnableSwaggerInProduction { get; set; } = false;
-
-    /// <summary>
     /// Gets or sets the custom path for Swagger UI endpoint. Must start with "/".
-    /// Default is "/api-docs".
+    /// Default is "/api-docs". This can be configured via appsettings.json.
     /// </summary>
     public string? SwaggerPath { get; set; } = "/api-docs";
 

--- a/src/Endatix.Api/Configuration/ApiConfigurationOptions.cs
+++ b/src/Endatix.Api/Configuration/ApiConfigurationOptions.cs
@@ -1,0 +1,30 @@
+using System.ComponentModel.DataAnnotations;
+using Endatix.Framework.Configuration;
+
+namespace Endatix.Api.Configuration;
+
+/// <summary>
+/// Configuration options for API features that can be set via appsettings.json.
+/// </summary>
+/// <remarks>
+/// This class provides a focused subset of ApiOptions that can be configured externally.
+/// It acts as a configuration model that maps to the full ApiOptions used throughout the application.
+/// </remarks>
+public class ApiConfigurationOptions : EndatixOptionsBase
+{
+    /// <summary>
+    /// Gets the section path for these options.
+    /// </summary>
+    public override string SectionPath => "Api";
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use Swagger middleware.
+    /// </summary>
+    public bool UseSwagger { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets the custom path for Swagger UI endpoint. Must start with "/".
+    /// </summary>
+    [RegularExpression("^/.*", ErrorMessage = "Swagger path must start with '/'")]
+    public string? SwaggerPath { get; set; } = "/api-docs";
+} 

--- a/src/Endatix.Api/Setup/ApiApplicationBuilderExtensions.cs
+++ b/src/Endatix.Api/Setup/ApiApplicationBuilderExtensions.cs
@@ -30,12 +30,13 @@ public static class ApiApplicationBuilderExtensions
 
         logger?.LogInformation("Configuring Endatix API middleware");
 
-        // Get options from DI to incorporate appsettings values
-        var options = app.ApplicationServices.GetRequiredService<IOptionsSnapshot<ApiOptions>>().Value;
-
-        logger?.LogInformation("Using API options with EnableSwaggerInProduction={EnableSwaggerInProduction}",
-            options.EnableSwaggerInProduction);
-
+        var optionsProvider = app.ApplicationServices.GetService<IOptions<ApiOptions>>();
+        var options = optionsProvider?.Value ?? new ApiOptions();
+        
+        logger?.LogInformation("Using API options with UseSwagger={UseSwagger}, SwaggerPath={SwaggerPath}", 
+            options.UseSwagger,
+            options.SwaggerPath);
+            
         // Set up standard middleware pipeline with options from configuration
         ConfigureApiMiddleware(app, options);
 
@@ -56,11 +57,16 @@ public static class ApiApplicationBuilderExtensions
 
         logger?.LogInformation("Configuring Endatix API middleware with custom options");
 
-        // Create options with defaults
-        var options = new ApiOptions();
-
-        // Apply custom configuration
+        // Get options from DI first - use IOptions not IOptionsSnapshot
+        var optionsProvider = app.ApplicationServices.GetService<IOptions<ApiOptions>>();
+        var options = optionsProvider?.Value ?? new ApiOptions();
+        
+        // Apply custom configuration on top of configuration-provided values
         configure(options);
+        
+        logger?.LogInformation("Using API options with UseSwagger={UseSwagger}, SwaggerPath={SwaggerPath}", 
+            options.UseSwagger,
+            options.SwaggerPath);
 
         // Set up middleware pipeline based on options
         ConfigureApiMiddleware(app, options);
@@ -125,12 +131,14 @@ public static class ApiApplicationBuilderExtensions
 
         logger?.LogInformation("Configuring API endpoints in the application pipeline");
 
-        // Get options from DI
-        var options = app.ApplicationServices.GetRequiredService<IOptionsSnapshot<ApiOptions>>().Value;
-
-        logger?.LogInformation("Using API options with EnableSwaggerInProduction={EnableSwaggerInProduction}",
-            options.EnableSwaggerInProduction);
-
+        // Get options from DI - use IOptions not IOptionsSnapshot
+        var optionsProvider = app.ApplicationServices.GetService<IOptions<ApiOptions>>();
+        var options = optionsProvider?.Value ?? new ApiOptions();
+        
+        logger?.LogInformation("Using API options with UseSwagger={UseSwagger}, SwaggerPath={SwaggerPath}",
+            options.UseSwagger,
+            options.SwaggerPath);
+            
         // Apply middleware based on options from configuration
         ConfigureApiMiddleware(app, options);
 
@@ -151,11 +159,16 @@ public static class ApiApplicationBuilderExtensions
 
         logger?.LogInformation("Configuring API endpoints in the application pipeline with custom options");
 
-        // Create options with defaults
-        var options = new ApiOptions();
-
-        // Apply configuration
+        // Get options from DI first - use IOptions not IOptionsSnapshot
+        var optionsProvider = app.ApplicationServices.GetService<IOptions<ApiOptions>>();
+        var options = optionsProvider?.Value ?? new ApiOptions();
+        
+        // Apply custom configuration on top of configuration-provided values
         configureApi(options);
+        
+        logger?.LogInformation("Using API options with UseSwagger={UseSwagger}, SwaggerPath={SwaggerPath}", 
+            options.UseSwagger,
+            options.SwaggerPath);
 
         // Apply middleware based on options
         ConfigureApiMiddleware(app, options);

--- a/src/Endatix.Api/Setup/ApiApplicationBuilderExtensions.cs
+++ b/src/Endatix.Api/Setup/ApiApplicationBuilderExtensions.cs
@@ -103,11 +103,7 @@ public static class ApiApplicationBuilderExtensions
         // Apply Swagger middleware if enabled
         if (options.UseSwagger)
         {
-            var environment = app.ApplicationServices.GetService<IWebHostEnvironment>();
-            if (environment?.IsDevelopment() == true || options.EnableSwaggerInProduction)
-            {
-                app.UseSwaggerGen();
-            }
+            app.UseSwaggerGen();
         }
 
         // Apply CORS middleware if enabled

--- a/src/Endatix.Api/Setup/ApiServiceCollectionExtensions.cs
+++ b/src/Endatix.Api/Setup/ApiServiceCollectionExtensions.cs
@@ -39,6 +39,20 @@ public static class ApiServiceCollectionExtensions
     }
 
     /// <summary>
+    /// Adds API configuration options from appsettings.json
+    /// </summary>
+    /// <param name="services">The service collection</param>
+    /// <returns>Updated service collection with API options configuration</returns>
+    public static IServiceCollection AddApiOptions(this IServiceCollection services)
+    {
+        services.AddOptions<ApiOptions>()
+                .BindConfiguration(ApiOptions.SECTION_NAME)
+                .ValidateDataAnnotations();
+
+        return services;
+    }
+
+    /// <summary>
     /// Adds API endpoints with default settings.
     /// </summary>
     /// <param name="services">The service collection.</param>

--- a/src/Endatix.Api/Setup/ApiServiceCollectionExtensions.cs
+++ b/src/Endatix.Api/Setup/ApiServiceCollectionExtensions.cs
@@ -12,6 +12,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Routing;
 using Endatix.Framework.Hosting;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Endatix.Api.Configuration;
+using Endatix.Framework.Configuration;
 
 namespace Endatix.Api.Setup;
 
@@ -39,15 +41,25 @@ public static class ApiServiceCollectionExtensions
     }
 
     /// <summary>
-    /// Adds API configuration options from appsettings.json
+    /// Adds API configuration options from appsettings.json and maps them to ApiOptions used throughout the application.
     /// </summary>
     /// <param name="services">The service collection</param>
+    /// <param name="configuration">The application configuration</param>
     /// <returns>Updated service collection with API options configuration</returns>
-    public static IServiceCollection AddApiOptions(this IServiceCollection services)
+    public static IServiceCollection AddApiOptions(this IServiceCollection services, IConfiguration configuration)
     {
-        services.AddOptions<ApiOptions>()
-                .BindConfiguration(ApiOptions.SECTION_NAME)
-                .ValidateDataAnnotations();
+        services.AddEndatixOptions<ApiConfigurationOptions>(configuration);
+
+        services.AddTransient<IConfigureOptions<ApiOptions>>(provider =>
+        {
+            var config = provider.GetRequiredService<IOptions<ApiConfigurationOptions>>().Value;
+            return new ConfigureNamedOptions<ApiOptions>(Options.DefaultName, options =>
+            {
+                // Map properties from ApiConfigurationOptions to ApiOptions
+                options.UseSwagger = config.UseSwagger;
+                options.SwaggerPath = config.SwaggerPath;
+            });
+        });
 
         return services;
     }

--- a/src/Endatix.Hosting/Builders/EndatixApiBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixApiBuilder.cs
@@ -391,6 +391,6 @@ public class EndatixApiBuilder
 
     private void LogSetupInfo(string message)
     {
-        _logger?.LogInformation("[API Setup] {Message}", message);
+        _logger?.LogDebug("[API Setup] {Message}", message);
     }
 }

--- a/src/Endatix.Hosting/Builders/EndatixApiBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixApiBuilder.cs
@@ -366,11 +366,12 @@ public class EndatixApiBuilder
         // Apply Swagger middleware if enabled
         if (_apiOptions.UseSwagger)
         {
-            var environment = app.ApplicationServices.GetService<IWebHostEnvironment>();
-            if (environment?.IsDevelopment() == true || _apiOptions.EnableSwaggerInProduction)
-            {
-                app.UseSwaggerGen();
-            }
+            LogSetupInfo($"Enabling Swagger UI with path: {_apiOptions.SwaggerPath}");
+            app.UseSwaggerGen();
+        }
+        else
+        {
+            LogSetupInfo("Swagger UI disabled through configuration");
         }
 
         // Apply CORS middleware if enabled

--- a/src/Endatix.Hosting/Builders/EndatixMessagingBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixMessagingBuilder.cs
@@ -64,6 +64,6 @@ public class EndatixMessagingBuilder
     
     private void LogSetupInfo(string message)
     {
-        _logger?.LogInformation("[Messaging Setup] {Message}", message);
+        _logger?.LogDebug("[Messaging Setup] {Message}", message);
     }
 } 

--- a/src/Endatix.Hosting/Builders/EndatixMiddlewareBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixMiddlewareBuilder.cs
@@ -128,11 +128,11 @@ public class EndatixMiddlewareBuilder
 
         // Get options from DI to incorporate appsettings values
         var options = App.ApplicationServices.GetRequiredService<IOptionsSnapshot<ApiOptions>>().Value;
-        
-        _logger?.LogInformation("Loaded ApiOptions from configuration: EnableSwaggerInProduction={EnableSwaggerInProduction}, SwaggerPath={SwaggerPath}",
-            options.EnableSwaggerInProduction,
+
+        _logger?.LogInformation("Loaded ApiOptions from configuration: UseSwagger={UseSwagger}, SwaggerPath={SwaggerPath}",
+            options.UseSwagger,
             options.SwaggerPath);
-        
+
         // Apply any additional configuration if provided
         configureApi?.Invoke(options);
 
@@ -150,15 +150,15 @@ public class EndatixMiddlewareBuilder
 
         if (options.UseSwagger)
         {
-            var env = App.ApplicationServices.GetService<IWebHostEnvironment>();
-            if (env != null && (env.IsDevelopment() || options.EnableSwaggerInProduction))
-            {
-                _logger?.LogInformation($"Swagger UI enabled with production setting: {options.EnableSwaggerInProduction}");
-                UseSwagger(
-                    options.SwaggerPath,
-                    options.ConfigureOpenApiDocument,
-                    options.ConfigureSwaggerUi);
-            }
+            _logger?.LogInformation("Swagger UI enabled with path: {SwaggerPath}", options.SwaggerPath);
+            UseSwagger(
+                options.SwaggerPath,
+                options.ConfigureOpenApiDocument,
+                options.ConfigureSwaggerUi);
+        }
+        else
+        {
+            _logger?.LogInformation("Swagger UI disabled through configuration");
         }
 
         if (options.UseCors)

--- a/src/Endatix.Hosting/Builders/EndatixMiddlewareBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixMiddlewareBuilder.cs
@@ -126,13 +126,13 @@ public class EndatixMiddlewareBuilder
             ? "Adding API middleware with default settings"
             : "Adding API middleware with custom settings");
 
-        // Get options from DI to incorporate appsettings values
-        var options = App.ApplicationServices.GetRequiredService<IOptionsSnapshot<ApiOptions>>().Value;
-
+        var optionsProvider = App.ApplicationServices.GetService<IOptions<ApiOptions>>();
+        var options = optionsProvider?.Value ?? new ApiOptions();
+        
         _logger?.LogInformation("Loaded ApiOptions from configuration: UseSwagger={UseSwagger}, SwaggerPath={SwaggerPath}",
             options.UseSwagger,
             options.SwaggerPath);
-
+        
         // Apply any additional configuration if provided
         configureApi?.Invoke(options);
 
@@ -148,6 +148,7 @@ public class EndatixMiddlewareBuilder
             options.ConfigureFastEndpoints?.Invoke(config);
         });
 
+        // Apply Swagger middleware if enabled through configuration
         if (options.UseSwagger)
         {
             _logger?.LogInformation("Swagger UI enabled with path: {SwaggerPath}", options.SwaggerPath);

--- a/src/Endatix.Hosting/Builders/EndatixPersistenceBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixPersistenceBuilder.cs
@@ -269,7 +269,7 @@ public class EndatixPersistenceBuilder
 
     private void LogSetupInfo(string message)
     {
-        _logger?.LogInformation("[Persistence Setup] {Message}", message);
+        _logger?.LogDebug("[Persistence Setup] {Message}", message);
     }
 }
 

--- a/src/Endatix.Hosting/Builders/EndatixSecurityBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixSecurityBuilder.cs
@@ -293,6 +293,6 @@ public class EndatixSecurityBuilder
 
     private void LogSetupInfo(string message)
     {
-        _logger?.LogInformation("{Message}", message);
+        _logger?.LogDebug("[Security Setup] {Message}", message);
     }
 }

--- a/src/Endatix.Hosting/EndatixApplicationBuilderExtensions.cs
+++ b/src/Endatix.Hosting/EndatixApplicationBuilderExtensions.cs
@@ -100,7 +100,6 @@ public static class EndatixApplicationBuilderExtensions
                 apiOptions.UseExceptionHandler = options.ApiOptions.UseExceptionHandler;
                 apiOptions.ExceptionHandlerPath = options.ApiOptions.ExceptionHandlerPath;
                 apiOptions.UseSwagger = options.ApiOptions.UseSwagger;
-                apiOptions.EnableSwaggerInProduction = options.ApiOptions.EnableSwaggerInProduction;
                 apiOptions.SwaggerPath = options.ApiOptions.SwaggerPath;
                 apiOptions.ConfigureOpenApiDocument = options.ApiOptions.ConfigureOpenApiDocument;
                 apiOptions.ConfigureSwaggerUi = options.ApiOptions.ConfigureSwaggerUi;

--- a/src/Endatix.Infrastructure/Builders/InfrastructureDataBuilder.cs
+++ b/src/Endatix.Infrastructure/Builders/InfrastructureDataBuilder.cs
@@ -73,6 +73,6 @@ public class InfrastructureDataBuilder
     /// <param name="message">The message to log.</param>
     private void LogSetupInfo(string message)
     {
-        _logger.LogInformation("[Data Setup] {Message}", message);
+        _logger.LogDebug("[Data Setup] {Message}", message);
     }
 }

--- a/src/Endatix.Infrastructure/Builders/InfrastructureIdentityBuilder.cs
+++ b/src/Endatix.Infrastructure/Builders/InfrastructureIdentityBuilder.cs
@@ -61,6 +61,6 @@ public class InfrastructureIdentityBuilder
 
     private void LogSetupInfo(string message)
     {
-        _logger.LogInformation("[Identity Setup] {Message}", message);
+        _logger.LogDebug("[Identity Setup] {Message}", message);
     }
 }

--- a/src/Endatix.Infrastructure/Builders/InfrastructureIntegrationsBuilder.cs
+++ b/src/Endatix.Infrastructure/Builders/InfrastructureIntegrationsBuilder.cs
@@ -62,6 +62,6 @@ public class InfrastructureIntegrationsBuilder
 
     private void LogSetupInfo(string message)
     {
-        _logger.LogInformation("[Integrations Setup] {Message}", message);
+        _logger.LogDebug("[Integrations Setup] {Message}", message);
     }
 }

--- a/src/Endatix.Infrastructure/Builders/InfrastructureMessagingBuilder.cs
+++ b/src/Endatix.Infrastructure/Builders/InfrastructureMessagingBuilder.cs
@@ -63,6 +63,6 @@ public class InfrastructureMessagingBuilder
 
     private void LogSetupInfo(string message)
     {
-        _logger.LogInformation("[Messaging Setup] {Message}", message);
+        _logger.LogDebug("[Messaging Setup] {Message}", message);
     }
 }

--- a/src/Endatix.Persistence.PostgreSql/Builders/PostgreSqlPersistenceBuilder.cs
+++ b/src/Endatix.Persistence.PostgreSql/Builders/PostgreSqlPersistenceBuilder.cs
@@ -103,6 +103,6 @@ public class PostgreSqlPersistenceBuilder
 
     private void LogSetupInfo(string message)
     {
-        _logger?.LogInformation("[💿 PostgreSQL Setup] {Message}", message);
+        _logger?.LogDebug("[💿 PostgreSQL Setup] {Message}", message);
     }
 }


### PR DESCRIPTION
# Configure Swagger and API settings via AppSettings

## Description
- Adds ability to control swagger and swagger path via AppSettings
- Updates SetupInfo to Debug level to reduce console verbosity on non prod environments
- Removes obsolete `UseSwaggerInProduction` config, since it is now controlled via AppSettings as well => replaced with `UseSwagger` config value

## Related Issues
closes #410

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Examples
- No config -> Swagger is enabled and used in `/api-docs`
- Development
```json
    "Api": {
      "UseSwagger": true,
      "SwaggerPath": ""
    },
```

- Production
```json

    "Api": {
      "UseSwagger": true,
      "SwaggerPath": "/api-docs"
    },
```
