### PR TITLE
fix: Set MapInboundClaim to false to prevent unintended claims mapping

### DIFF
--- a/src/Endatix.Hosting/Builders/EndatixSecurityBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixSecurityBuilder.cs
@@ -152,7 +152,8 @@ public class EndatixSecurityBuilder
 
         var isDevelopment = appEnvironment?.IsDevelopment() ?? false;
 
-        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+        services
+            .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(options =>
             {
                 // Apply default configuration
@@ -168,6 +169,7 @@ public class EndatixSecurityBuilder
                     ValidateIssuerSigningKey = true,
                     ClockSkew = TimeSpan.FromSeconds(JWT_CLOCK_SKEW_IN_SECONDS)
                 };
+                options.MapInboundClaims = false;
 
                 // Apply custom configuration if provided
                 configure?.Invoke(options);


### PR DESCRIPTION
# fix: Set MapInboundClaim to false to prevent unintended claims mapping

## Description
Fixes the login issue via preventing unintended claims mapping occurred during JWT token validation

## Related Issues
fixes #413

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
