### PR TITLE
feat: Adds Endatix into the  EmailSender config namespacing

### DIFF
--- a/src/Endatix.Infrastructure/Setup/ServiceCollectionExtensions.cs
+++ b/src/Endatix.Infrastructure/Setup/ServiceCollectionExtensions.cs
@@ -33,7 +33,7 @@ public static class ServiceCollectionExtensions
     {
         // Configure settings
         services.AddOptions<TSettings>()
-                .BindConfiguration($"Email:{typeof(TSettings).Name}")
+                .BindConfiguration($"Endatix:Integrations:Email:{typeof(TSettings).Name}")
                 .ValidateDataAnnotations();
 
         // Register the email sender and invoke the initialization delegate


### PR DESCRIPTION
# Adds Endatix into the  EmailSender config namespacing

## Description
Adding EmailSender config registration to improve namespacing of settings.

### Before
```json
  "Email": {
    "SendGridSettings": {
      "ApiKey": "{YOUR_SENDGRID_API_KEY_HERE}"
    }
  }
```

### After

```json
  "Endatix": {
   "Integrations": {
      "Email": {
        "SendGridSettings": {
          "ApiKey": "{YOUR_SENDGRID_API_KEY_HERE}"
        }
      }
    }
```

## Related Issues
addresses https://github.com/endatix/corp-website/issues/134

## Type of Change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
