### PR TITLE
feat: Custom Questions persistence and create/list endpoints

### DIFF
--- a/src/Endatix.Api/Endpoints/CustomQuestions/Create/Create.CreateCustomQuestionRequest.cs
+++ b/src/Endatix.Api/Endpoints/CustomQuestions/Create/Create.CreateCustomQuestionRequest.cs
@@ -1,0 +1,22 @@
+namespace Endatix.Api.Endpoints.CustomQuestions;
+
+/// <summary>
+/// Request model for creating a new custom question.
+/// </summary>
+public class CreateCustomQuestionRequest
+{
+    /// <summary>
+    /// The name of the custom question.
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// The description of the custom question (optional).
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// The JSON data representing custom question properties.
+    /// </summary>
+    public string? JsonData { get; set; }
+} 

--- a/src/Endatix.Api/Endpoints/CustomQuestions/Create/Create.CreateCustomQuestionResponse.cs
+++ b/src/Endatix.Api/Endpoints/CustomQuestions/Create/Create.CreateCustomQuestionResponse.cs
@@ -1,0 +1,8 @@
+namespace Endatix.Api.Endpoints.CustomQuestions;
+
+/// <summary>
+/// Response model for creating a custom question.
+/// </summary>
+public class CreateCustomQuestionResponse : CustomQuestionModel
+{
+} 

--- a/src/Endatix.Api/Endpoints/CustomQuestions/Create/Create.CreateCustomQuestionValidator.cs
+++ b/src/Endatix.Api/Endpoints/CustomQuestions/Create/Create.CreateCustomQuestionValidator.cs
@@ -1,0 +1,26 @@
+using FastEndpoints;
+using FluentValidation;
+using Endatix.Infrastructure.Data.Config;
+
+namespace Endatix.Api.Endpoints.CustomQuestions;
+
+/// <summary>
+/// Validation rules for the <c>CreateCustomQuestionRequest</c> class.
+/// </summary>
+public class CreateCustomQuestionValidator : Validator<CreateCustomQuestionRequest>
+{
+    /// <summary>
+    /// Default constructor
+    /// </summary>
+    public CreateCustomQuestionValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MinimumLength(DataSchemaConstants.MIN_NAME_LENGTH)
+            .MaximumLength(DataSchemaConstants.MAX_NAME_LENGTH);
+
+        RuleFor(x => x.JsonData)
+            .NotEmpty()
+            .MinimumLength(DataSchemaConstants.MIN_JSON_LENGTH);
+    }
+} 

--- a/src/Endatix.Api/Endpoints/CustomQuestions/Create/Create.cs
+++ b/src/Endatix.Api/Endpoints/CustomQuestions/Create/Create.cs
@@ -1,0 +1,44 @@
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Endatix.Api.Infrastructure;
+using Endatix.Infrastructure.Identity.Authorization;
+using Endatix.Core.UseCases.CustomQuestions.Create;
+
+namespace Endatix.Api.Endpoints.CustomQuestions;
+
+/// <summary>
+/// Endpoint for creating a new custom question.
+/// </summary>
+public class Create(IMediator mediator) : Endpoint<CreateCustomQuestionRequest, Results<Created<CreateCustomQuestionResponse>, BadRequest>>
+{
+    /// <summary>
+    /// Configures the endpoint settings.
+    /// </summary>
+    public override void Configure()
+    {
+        Post("customization/questions");
+        Permissions(Allow.AllowAll);
+        Summary(s =>
+        {
+            s.Summary = "Create a new custom question";
+            s.Description = "Creates a new custom question with the provided data.";
+            s.Responses[201] = "Custom question created successfully.";
+            s.Responses[400] = "Invalid input data.";
+        });
+    }
+
+    /// <inheritdoc/>
+    public override async Task<Results<Created<CreateCustomQuestionResponse>, BadRequest>> ExecuteAsync(CreateCustomQuestionRequest request, CancellationToken cancellationToken)
+    {
+        var command = new CreateCustomQuestionCommand(
+            request.Name!,
+            request.JsonData!,
+            request.Description);
+        var result = await mediator.Send(command, cancellationToken);
+        
+        return TypedResultsBuilder
+            .MapResult(result, CustomQuestionMapper.Map<CreateCustomQuestionResponse>)
+            .SetTypedResults<Created<CreateCustomQuestionResponse>, BadRequest>();
+    }
+}

--- a/src/Endatix.Api/Endpoints/CustomQuestions/CustomQuestionMapper.cs
+++ b/src/Endatix.Api/Endpoints/CustomQuestions/CustomQuestionMapper.cs
@@ -1,0 +1,34 @@
+using Endatix.Core.Entities;
+
+namespace Endatix.Api.Endpoints.CustomQuestions;
+
+/// <summary>
+/// Mapper from a custom question entity to a custom question API model.
+/// </summary>
+public static class CustomQuestionMapper
+{
+    /// <summary>
+    /// Maps a custom question entity to a custom question API model.
+    /// </summary>
+    /// <typeparam name="T">The type of the custom question API model, which inherits CustomQuestionModel.</typeparam>
+    /// <param name="question">The custom question entity.</param>
+    /// <returns>The mapped custom question API model.</returns>
+    public static T Map<T>(CustomQuestion question) where T : CustomQuestionModel, new() => new T
+    {
+        Id = question.Id.ToString(),
+        Name = question.Name,
+        Description = question.Description,
+        JsonData = question.JsonData,
+        CreatedAt = question.CreatedAt,
+        ModifiedAt = question.ModifiedAt
+    };
+
+    /// <summary>
+    /// Maps a collection of custom question entities to a collection of custom question API models.
+    /// </summary>
+    /// <typeparam name="T">The type of the custom question API model, which inherits CustomQuestionModel.</typeparam>
+    /// <param name="questions">The collection of custom question entities.</param>
+    /// <returns>A collection of mapped custom question API models.</returns>
+    public static IEnumerable<T> Map<T>(IEnumerable<CustomQuestion> questions) where T : CustomQuestionModel, new() =>
+        questions.Select(Map<T>).ToList();
+} 

--- a/src/Endatix.Api/Endpoints/CustomQuestions/CustomQuestionModel.cs
+++ b/src/Endatix.Api/Endpoints/CustomQuestions/CustomQuestionModel.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Serialization;
+
+namespace Endatix.Api.Endpoints.CustomQuestions;
+
+/// <summary>
+/// API model representing a custom question.
+/// </summary>
+public class CustomQuestionModel
+{
+    /// <summary>
+    /// The ID of the custom question.
+    /// </summary>
+    public string Id { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The name of the custom question.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The description of the custom question.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// The JSON data representing the custom question properties.
+    /// </summary>
+    public string JsonData { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The date and time when the custom question was created.
+    /// </summary>
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// The date and time when the custom question was last modified.
+    /// </summary>
+    public DateTime? ModifiedAt { get; set; }
+}

--- a/src/Endatix.Api/Endpoints/CustomQuestions/List/List.CustomQuestionsListRequest.cs
+++ b/src/Endatix.Api/Endpoints/CustomQuestions/List/List.CustomQuestionsListRequest.cs
@@ -1,0 +1,8 @@
+namespace Endatix.Api.Endpoints.CustomQuestions;
+
+/// <summary>
+/// Request model for listing custom questions.
+/// </summary>
+public class CustomQuestionsListRequest
+{
+} 

--- a/src/Endatix.Api/Endpoints/CustomQuestions/List/List.cs
+++ b/src/Endatix.Api/Endpoints/CustomQuestions/List/List.cs
@@ -1,0 +1,41 @@
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Endatix.Api.Infrastructure;
+using Endatix.Infrastructure.Identity.Authorization;
+using Endatix.Core.UseCases.CustomQuestions.List;
+
+namespace Endatix.Api.Endpoints.CustomQuestions;
+
+/// <summary>
+/// Endpoint for listing custom questions.
+/// </summary>
+public class List(IMediator mediator) : Endpoint<EmptyRequest, Results<Ok<IEnumerable<CustomQuestionModel>>, BadRequest>>
+{
+    /// <summary>
+    /// Configures the endpoint settings.
+    /// </summary>
+    public override void Configure()
+    {
+        Get("customization/questions");
+        Permissions(Allow.AllowAll);
+        Summary(s =>
+        {
+            s.Summary = "List custom questions";
+            s.Description = "Lists all custom questions for the current tenant.";
+            s.Responses[200] = "Custom questions retrieved successfully.";
+            s.Responses[400] = "Invalid input data.";
+        });
+    }
+
+    /// <inheritdoc/>
+    public override async Task<Results<Ok<IEnumerable<CustomQuestionModel>>, BadRequest>> ExecuteAsync(EmptyRequest request, CancellationToken cancellationToken)
+    {
+        var query = new ListCustomQuestionsQuery();
+        var result = await mediator.Send(query, cancellationToken);
+
+        return TypedResultsBuilder
+            .MapResult(result, CustomQuestionMapper.Map<CustomQuestionModel>)
+            .SetTypedResults<Ok<IEnumerable<CustomQuestionModel>>, BadRequest>();
+    }
+} 

--- a/src/Endatix.Api/Endpoints/FormDefinitions/FormDefinitionMapper.cs
+++ b/src/Endatix.Api/Endpoints/FormDefinitions/FormDefinitionMapper.cs
@@ -38,7 +38,8 @@ public class FormDefinitionMapper
         FormId = formDefinition.FormId.ToString(),
         CreatedAt = formDefinition.CreatedAt,
         ModifiedAt = formDefinition.ModifiedAt,
-        ThemeModel = formDefinition.ThemeJsonData
+        ThemeModel = formDefinition.ThemeJsonData,
+        CustomQuestions = formDefinition.CustomQuestions
     };
 
     /// <summary>

--- a/src/Endatix.Api/Endpoints/FormDefinitions/FormDefinitionModel.cs
+++ b/src/Endatix.Api/Endpoints/FormDefinitions/FormDefinitionModel.cs
@@ -40,4 +40,9 @@ public class FormDefinitionModel
     /// The model of the associated theme stored as a stringified JSON object.
     /// </summary>
     public string? ThemeModel { get; set; }
+
+    /// <summary>
+    /// The list of custom questions' JSON data associated with this form definition.
+    /// </summary>
+    public IEnumerable<string>? CustomQuestions { get; set; }
 }

--- a/src/Endatix.Core/Entities/CustomQuestion.cs
+++ b/src/Endatix.Core/Entities/CustomQuestion.cs
@@ -1,0 +1,64 @@
+using Ardalis.GuardClauses;
+using Endatix.Core.Infrastructure.Domain;
+using System.Text.Json;
+
+namespace Endatix.Core.Entities;
+
+public class CustomQuestion : TenantEntity, IAggregateRoot
+{
+    private CustomQuestion() { } // For EF Core
+
+    public CustomQuestion(long tenantId, string name, string jsonData, string? description = null)
+        : base(tenantId)
+    {
+        Guard.Against.NullOrEmpty(name, nameof(name));
+        Guard.Against.NullOrEmpty(jsonData, nameof(jsonData));
+
+        Name = name;
+        Description = description;
+        JsonData = jsonData;
+    }
+
+    public string Name { get; private set; }
+    public string? Description { get; private set; }
+
+    /// <summary>
+    /// The JSON data representing the custom question properties.
+    /// Uses JSONB in PostgreSQL and NVARCHAR(MAX) in SQL Server.
+    /// </summary>
+    public string JsonData { get; private set; }
+
+    /// <summary>
+    /// Updates the custom question's name
+    /// </summary>
+    public void UpdateName(string name)
+    {
+        Guard.Against.NullOrEmpty(name, nameof(name));
+        Name = name;
+    }
+
+    /// <summary>
+    /// Updates the custom question's description
+    /// </summary>
+    public void UpdateDescription(string? description)
+    {
+        Description = description;
+    }
+
+    /// <summary>
+    /// Updates the custom question's JSON data
+    /// </summary>
+    public void UpdateJsonData(string jsonData)
+    {
+        Guard.Against.NullOrEmpty(jsonData, nameof(jsonData));
+        JsonData = jsonData;
+    }
+
+    public override void Delete()
+    {
+        if (!IsDeleted)
+        {
+            base.Delete();
+        }
+    }
+} 

--- a/src/Endatix.Core/Specifications/CustomQuestionSpecifications.cs
+++ b/src/Endatix.Core/Specifications/CustomQuestionSpecifications.cs
@@ -1,0 +1,31 @@
+using Ardalis.Specification;
+using Endatix.Core.Entities;
+using Endatix.Core.Specifications.Common;
+using Endatix.Core.Infrastructure.Domain;
+
+namespace Endatix.Core.Specifications;
+
+/// <summary>
+/// Specifications for working with CustomQuestion entities
+/// </summary>
+public static class CustomQuestionSpecifications
+{
+    /// <summary>
+    /// Specification to get a custom question by name (case-insensitive)
+    /// </summary>
+    public sealed class ByName : Specification<CustomQuestion>, ISingleResultSpecification<CustomQuestion>
+    {
+        public ByName(string name)
+        {
+            Query.Where(q => q.Name.ToLower() == name.ToLower());
+        }
+    }
+
+    public class ByTenantId : Specification<CustomQuestion>
+    {
+        public ByTenantId(long tenantId)
+        {
+            Query.Where(q => q.TenantId == tenantId);
+        }
+    }
+}

--- a/src/Endatix.Core/UseCases/CustomQuestions/Create/CreateCustomQuestionCommand.cs
+++ b/src/Endatix.Core/UseCases/CustomQuestions/Create/CreateCustomQuestionCommand.cs
@@ -1,0 +1,43 @@
+using Ardalis.GuardClauses;
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.CustomQuestions.Create;
+
+/// <summary>
+/// Command for creating a new custom question.
+/// </summary>
+public record CreateCustomQuestionCommand : ICommand<Result<CustomQuestion>>
+{
+    /// <summary>
+    /// The name of the custom question.
+    /// </summary>
+    public string Name { get; }
+
+    /// <summary>
+    /// Optional description for the custom question.
+    /// </summary>
+    public string? Description { get; }
+
+    /// <summary>
+    /// JSON data containing custom question properties.
+    /// </summary>
+    public string JsonData { get; }
+
+    /// <summary>
+    /// Creates a new instance of CreateCustomQuestionCommand.
+    /// </summary>
+    /// <param name="name">The name of the custom question.</param>
+    /// <param name="jsonData">JSON data containing custom question properties.</param>
+    /// <param name="description">Optional description for the custom question.</param>
+    public CreateCustomQuestionCommand(string name, string jsonData, string? description = null)
+    {
+        Guard.Against.NullOrWhiteSpace(name);
+        Guard.Against.NullOrWhiteSpace(jsonData);
+
+        Name = name;
+        JsonData = jsonData;
+        Description = description;
+    }
+} 

--- a/src/Endatix.Core/UseCases/CustomQuestions/Create/CreateCustomQuestionHandler.cs
+++ b/src/Endatix.Core/UseCases/CustomQuestions/Create/CreateCustomQuestionHandler.cs
@@ -1,0 +1,46 @@
+using Ardalis.GuardClauses;
+using Endatix.Core.Abstractions;
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
+
+namespace Endatix.Core.UseCases.CustomQuestions.Create;
+
+/// <summary>
+/// Handler for creating a new custom question.
+/// </summary>
+public class CreateCustomQuestionHandler(
+    IRepository<CustomQuestion> customQuestionsRepository,
+    ITenantContext tenantContext
+) : ICommandHandler<CreateCustomQuestionCommand, Result<CustomQuestion>>
+{
+    /// <summary>
+    /// Handles the creation of a new custom question.
+    /// </summary>
+    /// <param name="request">The command containing custom question creation data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing the created custom question.</returns>
+    public async Task<Result<CustomQuestion>> Handle(CreateCustomQuestionCommand request, CancellationToken cancellationToken)
+    {
+        Guard.Against.NullOrEmpty(request.Name);
+        Guard.Against.NullOrEmpty(request.JsonData);
+        Guard.Against.NegativeOrZero(tenantContext.TenantId);
+
+        // Check if a custom question with the same name already exists for this tenant
+        var existingQuestion = await customQuestionsRepository.FirstOrDefaultAsync(
+            new CustomQuestionSpecifications.ByName(request.Name),
+            cancellationToken);
+
+        if (existingQuestion != null)
+        {
+            return Result.Invalid(new ValidationError($"A custom question with the name '{request.Name}' already exists"));
+        }
+
+        var customQuestion = new CustomQuestion(tenantContext.TenantId, request.Name, request.JsonData, request.Description);
+        await customQuestionsRepository.AddAsync(customQuestion, cancellationToken);
+
+        return Result<CustomQuestion>.Created(customQuestion);
+    }
+} 

--- a/src/Endatix.Core/UseCases/CustomQuestions/List/ListCustomQuestionsHandler.cs
+++ b/src/Endatix.Core/UseCases/CustomQuestions/List/ListCustomQuestionsHandler.cs
@@ -1,0 +1,26 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
+
+namespace Endatix.Core.UseCases.CustomQuestions.List;
+
+/// <summary>
+/// Handler for retrieving all custom questions for the current tenant.
+/// </summary>
+public class ListCustomQuestionsHandler(IRepository<CustomQuestion> customQuestionsRepository)
+    : IQueryHandler<ListCustomQuestionsQuery, Result<IEnumerable<CustomQuestion>>>
+{
+    /// <summary>
+    /// Handles the retrieval of all custom questions for the current tenant.
+    /// </summary>
+    /// <param name="request">The query.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Result containing the list of custom questions.</returns>
+    public async Task<Result<IEnumerable<CustomQuestion>>> Handle(ListCustomQuestionsQuery request, CancellationToken cancellationToken)
+    {
+        var questions = await customQuestionsRepository.ListAsync(cancellationToken);
+        return Result<IEnumerable<CustomQuestion>>.Success(questions);
+    }
+} 

--- a/src/Endatix.Core/UseCases/CustomQuestions/List/ListCustomQuestionsQuery.cs
+++ b/src/Endatix.Core/UseCases/CustomQuestions/List/ListCustomQuestionsQuery.cs
@@ -1,0 +1,12 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.CustomQuestions.List;
+
+/// <summary>
+/// Query for retrieving all custom questions for the current tenant.
+/// </summary>
+public record ListCustomQuestionsQuery : IQuery<Result<IEnumerable<CustomQuestion>>>
+{
+} 

--- a/src/Endatix.Core/UseCases/FormDefinitions/ActiveDefinitionDto.cs
+++ b/src/Endatix.Core/UseCases/FormDefinitions/ActiveDefinitionDto.cs
@@ -8,7 +8,7 @@ namespace Endatix.Core.UseCases.FormDefinitions;
 /// </summary>
 public class ActiveDefinitionDto
 {
-    public ActiveDefinitionDto(FormDefinition formDefinition, string? themeJsonData = null)
+    public ActiveDefinitionDto(FormDefinition formDefinition, string? themeJsonData = null, IEnumerable<string>? customQuestions = null)
     {
         Id = formDefinition.Id;
         FormId = formDefinition.FormId;
@@ -17,6 +17,7 @@ public class ActiveDefinitionDto
         ThemeJsonData = themeJsonData;
         ModifiedAt = formDefinition.ModifiedAt;
         CreatedAt = formDefinition.CreatedAt;
+        CustomQuestions = customQuestions ?? Enumerable.Empty<string>();
     }
 
     /// <summary>
@@ -54,4 +55,9 @@ public class ActiveDefinitionDto
     /// The timestamp when this form definition was created.
     /// </summary>
     public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// The list of custom questions' JSON data associated with this form definition's tenant.
+    /// </summary>
+    public IEnumerable<string> CustomQuestions { get; set; }
 }

--- a/src/Endatix.Core/UseCases/FormDefinitions/GetActive/GetActiveFormDefinitionHandler.cs
+++ b/src/Endatix.Core/UseCases/FormDefinitions/GetActive/GetActiveFormDefinitionHandler.cs
@@ -2,10 +2,15 @@
 using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
 
 namespace Endatix.Core.UseCases.FormDefinitions.GetActive;
 
-public class GetActiveFormDefinitionHandler(IFormsRepository formRepository) : IQueryHandler<GetActiveFormDefinitionQuery, Result<ActiveDefinitionDto>>
+public class GetActiveFormDefinitionHandler(
+    IFormsRepository formRepository,
+    IRepository<CustomQuestion> customQuestionsRepository) 
+    : IQueryHandler<GetActiveFormDefinitionQuery, Result<ActiveDefinitionDto>>
 {
     public async Task<Result<ActiveDefinitionDto>> Handle(GetActiveFormDefinitionQuery request, CancellationToken cancellationToken)
     {
@@ -17,9 +22,18 @@ public class GetActiveFormDefinitionHandler(IFormsRepository formRepository) : I
             return Result.NotFound("Active form definition not found.");
         }
 
+        var tenantId = formWithActiveDefinition.TenantId;
+
+        var customQuestions = await customQuestionsRepository.ListAsync(
+            new CustomQuestionSpecifications.ByTenantId(tenantId),
+            cancellationToken);
+
+        var customQuestionsJson = customQuestions?.Select(q => q.JsonData);
+
         var activeDefinitionDto = new ActiveDefinitionDto(
             formWithActiveDefinition.ActiveDefinition,
-            formWithActiveDefinition.Theme?.JsonData);
+            formWithActiveDefinition.Theme?.JsonData,
+            customQuestionsJson);
 
         return Result.Success(activeDefinitionDto);
     }

--- a/src/Endatix.Infrastructure/Data/AppDbContext.cs
+++ b/src/Endatix.Infrastructure/Data/AppDbContext.cs
@@ -35,6 +35,8 @@ public class AppDbContext : DbContext
 
     public DbSet<Theme> Themes { get; set; }
 
+    public DbSet<CustomQuestion> CustomQuestions { get; set; }
+
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);

--- a/src/Endatix.Infrastructure/Data/Config/CustomQuestionConfiguration.cs
+++ b/src/Endatix.Infrastructure/Data/Config/CustomQuestionConfiguration.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Endatix.Core.Entities;
+
+namespace Endatix.Infrastructure.Data.Config;
+
+public class CustomQuestionConfiguration : IEntityTypeConfiguration<CustomQuestion>
+{
+    public void Configure(EntityTypeBuilder<CustomQuestion> builder)
+    {
+        builder.ToTable("CustomQuestions");
+
+        builder.Property(q => q.Id)
+            .IsRequired();
+
+        builder.Property(q => q.Name)
+            .HasMaxLength(DataSchemaConstants.MAX_NAME_LENGTH)
+            .IsRequired();
+
+        builder.Property(q => q.JsonData)
+            .IsRequired();
+    }
+} 

--- a/src/Endatix.Persistence.PostgreSql/Config/CustomQuestionConfigurationPostgreSql.cs
+++ b/src/Endatix.Persistence.PostgreSql/Config/CustomQuestionConfigurationPostgreSql.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Endatix.Core.Configuration;
+using Endatix.Core.Entities;
+
+namespace Endatix.Persistence.PostgreSql.Config
+{
+    public class CustomQuestionConfigurationPostgreSql : IEntityTypeConfiguration<CustomQuestion> 
+    {
+        public void Configure(EntityTypeBuilder<CustomQuestion> builder)
+        {
+            if(!EndatixConfig.Configuration.UseSnowflakeIds)
+            {
+                builder.Property(q => q.Id)
+                    .UseIdentityColumn();
+            }
+            
+            // Configure JsonData as JSONB for better query performance
+            builder.Property(q => q.JsonData)
+                .HasColumnType("jsonb");
+        }
+    }
+} 

--- a/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250424200639_AddCustomQuestions.Designer.cs
+++ b/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250424200639_AddCustomQuestions.Designer.cs
@@ -3,24 +3,27 @@ using System;
 using Endatix.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
+namespace Endatix.Persistence.PostgreSQL.Migrations.AppEntities
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250424200639_AddCustomQuestions")]
+    partial class AddCustomQuestions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "9.0.0")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("Endatix.Core.Entities.CustomQuestion", b =>
                 {
@@ -28,28 +31,28 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("JsonData")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
@@ -70,27 +73,27 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsEnabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
@@ -101,8 +104,7 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                     b.HasKey("Id");
 
                     b.HasIndex("ActiveDefinitionId")
-                        .IsUnique()
-                        .HasFilter("[ActiveDefinitionId] IS NOT NULL");
+                        .IsUnique();
 
                     b.HasIndex("TenantId");
 
@@ -117,26 +119,26 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("FormId")
                         .HasColumnType("bigint");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsDraft")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("JsonData")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
@@ -156,31 +158,31 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsEnabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("JsonData")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
@@ -198,16 +200,16 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime?>("CompletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int?>("CurrentPage")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("FormDefinitionId")
                         .HasColumnType("bigint");
@@ -216,20 +218,20 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<bool>("IsComplete")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("JsonData")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Metadata")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
@@ -251,27 +253,27 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<string>("SlackSettingsJson")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -284,28 +286,28 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("JsonData")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
@@ -402,7 +404,7 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                             b1.Property<string>("Code")
                                 .IsRequired()
                                 .HasMaxLength(16)
-                                .HasColumnType("nvarchar(16)")
+                                .HasColumnType("character varying(16)")
                                 .HasColumnName("Status");
 
                             b1.HasKey("SubmissionId");
@@ -419,12 +421,12 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                                 .HasColumnType("bigint");
 
                             b1.Property<DateTime>("ExpiresAt")
-                                .HasColumnType("datetime2");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Value")
                                 .IsRequired()
                                 .HasMaxLength(64)
-                                .HasColumnType("nvarchar(64)");
+                                .HasColumnType("character varying(64)");
 
                             b1.HasKey("SubmissionId");
 

--- a/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250424200639_AddCustomQuestions.cs
+++ b/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250424200639_AddCustomQuestions.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Endatix.Persistence.PostgreSQL.Migrations.AppEntities
+{
+    /// <inheritdoc />
+    public partial class AddCustomQuestions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CustomQuestions",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Description = table.Column<string>(type: "text", nullable: true),
+                    JsonData = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false),
+                    TenantId = table.Column<long>(type: "bigint", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CustomQuestions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CustomQuestions_Tenants_TenantId",
+                        column: x => x.TenantId,
+                        principalTable: "Tenants",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+                
+            migrationBuilder.InsertData(
+                table: "CustomQuestions",
+                columns: ["Id", "Name", "Description", "JsonData", "CreatedAt", "IsDeleted", "TenantId"],
+                values: [1368840969541124096, "video", "Video question", @"{
+   ""name"":""video"",
+   ""title"":""Video"",
+   ""iconName"":""icon-preview-24x24"",
+   ""category"":""choice"",
+   ""orderedAfter"":""file"",
+   ""defaultQuestionTitle"":""Video"",
+   ""inheritBaseProps"":true,
+   ""questionJSON"":
+   {
+      ""type"":""file"",
+      ""title"":""Video Upload"",
+	  ""description"": ""Upload existing video"",
+      ""acceptedTypes"": ""video/*"",
+      ""storeDataAsText"": false,
+      ""waitForUpload"": true,
+      ""maxSize"": 150000000,
+      ""needConfirmRemoveFile"": true,
+      ""fileOrPhotoPlaceholder"": ""Drag and drop or select a video file to upload. Up to 150 MB"",
+      ""filePlaceholder"": ""Drag and drop a video file or click \""Select File\""""
+   }
+}", DateTime.UtcNow, false, 1]);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CustomQuestions_TenantId",
+                table: "CustomQuestions",
+                column: "TenantId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CustomQuestions");
+        }
+    }
+}

--- a/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/AppDbContextModelSnapshot.cs
+++ b/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/AppDbContextModelSnapshot.cs
@@ -22,6 +22,45 @@ namespace Endatix.Persistence.PostgreSQL.Migrations.AppEntities
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
+            modelBuilder.Entity("Endatix.Core.Entities.CustomQuestion", b =>
+                {
+                    b.Property<long>("Id")
+                        .HasColumnType("bigint");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<DateTime?>("DeletedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Description")
+                        .HasColumnType("text");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<string>("JsonData")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<DateTime?>("ModifiedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<long>("TenantId")
+                        .HasColumnType("bigint");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("TenantId");
+
+                    b.ToTable("CustomQuestions", (string)null);
+                });
+
             modelBuilder.Entity("Endatix.Core.Entities.Form", b =>
                 {
                     b.Property<long>("Id")
@@ -275,6 +314,17 @@ namespace Endatix.Persistence.PostgreSQL.Migrations.AppEntities
                     b.HasIndex("TenantId");
 
                     b.ToTable("Themes", (string)null);
+                });
+
+            modelBuilder.Entity("Endatix.Core.Entities.CustomQuestion", b =>
+                {
+                    b.HasOne("Endatix.Core.Entities.Tenant", "Tenant")
+                        .WithMany()
+                        .HasForeignKey("TenantId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Tenant");
                 });
 
             modelBuilder.Entity("Endatix.Core.Entities.Form", b =>

--- a/src/Endatix.Persistence.SqlServer/Config/CustomQuestionConfigurationSqlServer.cs
+++ b/src/Endatix.Persistence.SqlServer/Config/CustomQuestionConfigurationSqlServer.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Endatix.Core.Configuration;
+using Endatix.Core.Entities;
+
+namespace Endatix.Persistence.SqlServer.Config
+{
+    public class CustomQuestionConfigurationSqlServer : IEntityTypeConfiguration<CustomQuestion> 
+    {
+        public void Configure(EntityTypeBuilder<CustomQuestion> builder)
+        {
+            if(!EndatixConfig.Configuration.UseSnowflakeIds)
+            {
+                builder.Property(q => q.Id)
+                    .UseIdentityColumn();
+            }
+            
+            // Configure JsonData as NVARCHAR(MAX) for SQL Server
+            builder.Property(q => q.JsonData)
+                .HasColumnType("nvarchar(max)");
+        }
+    }
+} 

--- a/src/Endatix.Persistence.SqlServer/Migrations/AppEntities/20250506172231_AddCustomQuestions.Designer.cs
+++ b/src/Endatix.Persistence.SqlServer/Migrations/AppEntities/20250506172231_AddCustomQuestions.Designer.cs
@@ -4,6 +4,7 @@ using Endatix.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250506172231_AddCustomQuestions")]
+    partial class AddCustomQuestions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Endatix.Persistence.SqlServer/Migrations/AppEntities/20250506172231_AddCustomQuestions.cs
+++ b/src/Endatix.Persistence.SqlServer/Migrations/AppEntities/20250506172231_AddCustomQuestions.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
+{
+    /// <inheritdoc />
+    public partial class AddCustomQuestions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CustomQuestions",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    JsonData = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    DeletedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false),
+                    TenantId = table.Column<long>(type: "bigint", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CustomQuestions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CustomQuestions_Tenants_TenantId",
+                        column: x => x.TenantId,
+                        principalTable: "Tenants",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.InsertData(
+                table: "CustomQuestions",
+                columns: ["Id", "Name", "Description", "JsonData", "CreatedAt", "IsDeleted", "TenantId"],
+                values: [1368840969541124096, "video", "Video question", @"{
+   ""name"":""video"",
+   ""title"":""Video"",
+   ""iconName"":""icon-preview-24x24"",
+   ""category"":""choice"",
+   ""orderedAfter"":""file"",
+   ""defaultQuestionTitle"":""Video"",
+   ""inheritBaseProps"":true,
+   ""questionJSON"":
+   {
+      ""type"":""file"",
+      ""title"":""Video Upload"",
+	  ""description"": ""Upload existing video"",
+      ""acceptedTypes"": ""video/*"",
+      ""storeDataAsText"": false,
+      ""waitForUpload"": true,
+      ""maxSize"": 150000000,
+      ""needConfirmRemoveFile"": true,
+      ""fileOrPhotoPlaceholder"": ""Drag and drop or select a video file to upload. Up to 150 MB"",
+      ""filePlaceholder"": ""Drag and drop a video file or click \""Select File\""""
+   }
+}", DateTime.UtcNow, false, 1]);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CustomQuestions_TenantId",
+                table: "CustomQuestions",
+                column: "TenantId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CustomQuestions");
+        }
+    }
+}


### PR DESCRIPTION
# Custom Questions persistence and create/list endpoints

## Description
- CustomQuestion domain class
- Migrations to create the CustomQuestions table and insert Video question
- Command and Query to add and list Custom Questions
- API endpoints to add and list Custom Questions

### Note
Unit tests to be added

## Related Issues
closes https://github.com/endatix/endatix-private/issues/187

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] My code follows the style guidelines of this project
