### PR TITLE
feat: Add form events and webhook samples

### DIFF
--- a/docs/endatix-docs/docs/building-your-solution/_category_.json
+++ b/docs/endatix-docs/docs/building-your-solution/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Building Your Solution",
-  "position": 2
+  "position": 3
 }

--- a/docs/endatix-docs/docs/configuration/_category_.json
+++ b/docs/endatix-docs/docs/configuration/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Configuration",
-  "position": 3
+  "position": 4
 } 

--- a/docs/endatix-docs/docs/guides/_category_.json
+++ b/docs/endatix-docs/docs/guides/_category_.json
@@ -1,0 +1,7 @@
+{
+  "label": "Guides",
+  "position": 2,
+  "link": {
+    "type": "generated-index"
+  }
+} 

--- a/docs/endatix-docs/docs/guides/webhooks.mdx
+++ b/docs/endatix-docs/docs/guides/webhooks.mdx
@@ -1,0 +1,226 @@
+---
+sidebar_position: 1
+title: Webhooks
+description: Learn how to work with webhooks in Endatix
+---
+
+# Webhooks
+
+Endatix provides a flexible webhook system that allows you to send notifications to external systems when specific events occur in your application. This guide will show you how to implement custom webhook handlers in an external assembly.
+
+## Overview
+
+Webhooks in Endatix are implemented as event handlers that process specific events and send them to configured webhook endpoints. The system supports various types of events, including:
+
+- Form events (`FormCreated`, `FormUpdated`, `FormEnabledStateChanged`)
+- Submission events (`SubmissionCompleted`)
+
+## Implementation Steps
+
+### 1. Create a New Project
+
+First, create a new class library project that will contain your webhook handlers:
+
+```bash
+dotnet new classlib -n YourCompany.Endatix.WebHooks
+```
+
+### 2. Add Required Dependencies
+
+Add the following NuGet packages to your project:
+
+```xml
+<ItemGroup>
+    ...
+    <PackageReference Include="Endatix.Core" Version="1.0.0" />
+    ...
+</ItemGroup>
+```
+
+### 3. Create Webhook Handlers
+
+Create handlers for the events you want to process. Here's an example of a `FormCreated` event handler:
+
+```csharp
+using Endatix.Core.Events;
+using Endatix.Core.Features.WebHooks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace YourCompany.Endatix.WebHooks.FormEventHandlers;
+
+public class FormCreatedHandler(IWebHookService webHookService, ILogger<FormCreatedHandler> logger) : INotificationHandler<FormCreatedEvent>
+{
+    public async Task Handle(FormCreatedEvent notification, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling FormCreatedEvent for form {FormId}", notification.Form.Id);
+
+        var form = new
+        {
+            notification.Form.Id,
+            notification.Form.TenantId,
+            notification.Form.Name,
+            notification.Form.Description,
+            notification.Form.IsEnabled,
+            notification.Form.ActiveDefinitionId,
+            notification.Form.ThemeId,
+            notification.Form.CreatedAt,
+            notification.Form.ModifiedAt,
+        };
+
+        var message = new WebHookMessage<object>(
+            notification.Form.Id,
+            WebHookOperation.FormCreated,
+            form);
+
+        await webHookService.EnqueueWebHookAsync(message, cancellationToken);
+    }
+}
+```
+
+You can find this example and others in the [Endatix.Samples.CustomEventHandlers](https://github.com/endatix/endatix/tree/main/samples/Endatix.Samples.CustomEventHandlers) project in the Endatix open source repository.
+
+> **Note**: These are basic examples. Production code may include additional logging, should have proper error handling, etc.
+
+### 4. Create an Assembly Reference
+
+Create a static class to reference your assembly:
+
+```csharp
+namespace YourCompany.Endatix.WebHooks;
+
+public static class AssemblyReference
+{
+    public static readonly Assembly Assembly = typeof(AssemblyReference).Assembly;
+}
+```
+
+### 5. Register the Assembly in Endatix
+
+First, add a project reference to your custom assembly in your Endatix application's project file:
+
+```xml
+<ItemGroup>
+    ...
+    <ProjectReference Include="../YourCompany.Endatix.WebHooks/YourCompany.Endatix.WebHooks.csproj" />
+    ...
+</ItemGroup>
+```
+
+Then, in your Endatix application's `Program.cs`, register your webhook handlers assembly:
+
+```csharp
+builder.Host.ConfigureEndatixWithDefaults(endatix =>
+{
+    endatix.Infrastructure.Messaging.AddAssembly(YourCompany.Endatix.WebHooks.AssemblyReference.Assembly);
+});
+```
+
+> **Note**: If your Endatix application is configured with the basic `builder.Host.ConfigureEndatix()`, you need to change it to `ConfigureEndatixWithDefaults` as shown in the example above.
+
+## Testing Webhooks
+
+You can use [webhook.site](https://webhook.site/) to test your webhook implementation. This service provides a unique URL that you can use as your webhook endpoint. It will display all incoming requests in real-time, allowing you to:
+
+- View the complete request payload
+- Inspect headers
+- See the exact format of the data being sent
+- Test different event types
+- Verify the webhook message structure
+
+To test your webhooks:
+1. Go to [webhook.site](https://webhook.site/)
+2. Copy the unique URL provided
+3. Configure this URL as your webhook endpoint in Endatix by adding it to your `appsettings.Development.json`:
+
+```json
+{
+  ...
+  "Endatix": {
+    ...
+    "WebHooks": {
+      "Events": {
+        "FormCreated": {
+          "IsEnabled": true,
+          "WebHookUrls": [
+            "https://webhook.site/your-unique-id"
+          ]
+        },
+        "FormUpdated": {
+          "IsEnabled": true,
+          "WebHookUrls": [
+            "https://webhook.site/your-unique-id"
+          ]
+        },
+        "FormEnabledStateChanged": {
+          "IsEnabled": true,
+          "WebHookUrls": [
+            "https://webhook.site/your-unique-id"
+          ]
+        },
+        "FormSubmitted": {
+          "IsEnabled": true,
+          "WebHookUrls": [
+            "https://webhook.site/your-unique-id"
+          ]
+        }
+      }
+    }
+    ...
+  }
+  ...
+}
+```
+
+4. Trigger events in your application
+5. View the incoming webhook requests on webhook.site
+
+## Available Events
+
+### Form Events
+
+- `FormCreatedEvent`: Triggered when a new form is created
+  - Endpoints that can trigger the event:
+    - `POST api/forms`
+  - Useful for synchronizing form data with external systems or triggering notifications
+
+- `FormUpdatedEvent`: Triggered when a form is updated
+  - Endpoints that can trigger the event:
+    - `PUT api/forms/{formId}`
+    - `PATCH api/forms/{formId}`
+  - This event is triggered when performing form update action even if all the data remains the same
+  - Can be used to track form changes and update related systems
+
+- `FormEnabledStateChangedEvent`: Triggered when a form's enabled state changes
+  - Endpoints that can trigger the event:
+    - `PUT api/forms/{formId}`
+    - `PATCH api/forms/{formId}`
+  - This event is triggered only when the value of `IsEnabled` field changes
+  - Useful for managing form availability in external systems
+
+### Submission Events
+
+- `SubmissionCompletedEvent`: Triggered when a form submission is completed
+  - Endpoints that can trigger the event:
+    - `POST api/forms/{formId}/submissions`
+    - `PUT api/forms/{formId}/submissions/{submissionId}`
+    - `PATCH api/forms/{formId}/submissions/{submissionId}`
+    - `PATCH api/forms/{formId}/submissions/by-token/{submissionToken}`
+  - This event is triggered once per submission when `IsComplete` field is set to true
+  - Can be used to process form responses, trigger workflows, or update external systems
+
+## Webhook Message Structure
+
+Each webhook message contains:
+
+- `Id`: The ID of the entity that triggered the event
+- `EventName`: The type of event (e.g., `form_created`, `form_updated`, `form_enabled_state_changed`, `form_submitted`)
+- `Action`: The action that triggered the event (e.g., `created`, `updated`)
+- `Payload`: The event data specific to the operation, containing the complete entity data
+
+## Best Practices
+
+1. **Error Handling**: Always implement proper error handling in your webhook handlers
+2. **Logging**: Use logging to track webhook processing
+3. **Idempotency**: Design your webhook handlers to be idempotent to handle potential duplicate deliveries
+4. **Validation**: Validate the payload structure and required fields before processing 

--- a/docs/endatix-docs/package.json
+++ b/docs/endatix-docs/package.json
@@ -2,6 +2,9 @@
   "name": "endatix-docs",
   "version": "0.0.0",
   "private": true,
+  "workspaces": [
+    "."
+  ],
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",

--- a/docs/endatix-docs/pnpm-workspace.yaml
+++ b/docs/endatix-docs/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 onlyBuiltDependencies:
   - core-js
   - core-js-pure
+
+packages:
+  - '.'

--- a/samples/Endatix.Samples.CustomEventHandlers/WebHooks/FormEventHandlers/FormCreatedHandler.cs
+++ b/samples/Endatix.Samples.CustomEventHandlers/WebHooks/FormEventHandlers/FormCreatedHandler.cs
@@ -1,0 +1,34 @@
+using Endatix.Core.Events;
+using Endatix.Core.Features.WebHooks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Endatix.Samples.CustomEventHandlers.WebHooks.FormEventHandlers;
+
+public class FormCreatedHandler(IWebHookService webHookService, ILogger<FormCreatedHandler> logger) : INotificationHandler<FormCreatedEvent>
+{
+    public async Task Handle(FormCreatedEvent notification, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling FormCreatedEvent for form {FormId}", notification.Form.Id);
+
+        var form = new
+        {
+            notification.Form.Id,
+            notification.Form.TenantId,
+            notification.Form.Name,
+            notification.Form.Description,
+            notification.Form.IsEnabled,
+            notification.Form.ActiveDefinitionId,
+            notification.Form.ThemeId,
+            notification.Form.CreatedAt,
+            notification.Form.ModifiedAt,
+        };
+
+        var message = new WebHookMessage<object>(
+            notification.Form.Id,
+            WebHookOperation.FormCreated,
+            form);
+
+        await webHookService.EnqueueWebHookAsync(message, cancellationToken);
+    }
+}

--- a/samples/Endatix.Samples.CustomEventHandlers/WebHooks/FormEventHandlers/FormEnabledStateChangedHandler.cs
+++ b/samples/Endatix.Samples.CustomEventHandlers/WebHooks/FormEventHandlers/FormEnabledStateChangedHandler.cs
@@ -1,0 +1,34 @@
+using Endatix.Core.Events;
+using Endatix.Core.Features.WebHooks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Endatix.Samples.CustomEventHandlers.WebHooks.FormEventHandlers;
+
+public class FormEnabledStateChangedHandler(IWebHookService webHookService, ILogger<FormEnabledStateChangedHandler> logger) : INotificationHandler<FormEnabledStateChangedEvent>
+{
+    public async Task Handle(FormEnabledStateChangedEvent notification, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling FormEnabledStateChangedEvent for form {FormId}", notification.Form.Id);
+
+        var form = new
+        {
+            notification.Form.Id,
+            notification.Form.TenantId,
+            notification.Form.Name,
+            notification.Form.Description,
+            notification.Form.IsEnabled,
+            notification.Form.ActiveDefinitionId,
+            notification.Form.ThemeId,
+            notification.Form.CreatedAt,
+            notification.Form.ModifiedAt,
+        };
+
+        var message = new WebHookMessage<object>(
+            notification.Form.Id,
+            WebHookOperation.FormEnabledStateChanged,
+            form);
+
+        await webHookService.EnqueueWebHookAsync(message, cancellationToken);
+    }
+}

--- a/samples/Endatix.Samples.CustomEventHandlers/WebHooks/FormEventHandlers/FormUpdatedHandler.cs
+++ b/samples/Endatix.Samples.CustomEventHandlers/WebHooks/FormEventHandlers/FormUpdatedHandler.cs
@@ -1,0 +1,34 @@
+using Endatix.Core.Events;
+using Endatix.Core.Features.WebHooks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Endatix.Samples.CustomEventHandlers.WebHooks.FormEventHandlers;
+
+public class FormUpdatedHandler(IWebHookService webHookService, ILogger<FormUpdatedHandler> logger) : INotificationHandler<FormUpdatedEvent>
+{
+    public async Task Handle(FormUpdatedEvent notification, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling FormUpdatedEvent for form {FormId}", notification.Form.Id);
+
+        var form = new
+        {
+            notification.Form.Id,
+            notification.Form.TenantId,
+            notification.Form.Name,
+            notification.Form.Description,
+            notification.Form.IsEnabled,
+            notification.Form.ActiveDefinitionId,
+            notification.Form.ThemeId,
+            notification.Form.CreatedAt,
+            notification.Form.ModifiedAt,
+        };
+
+        var message = new WebHookMessage<object>(
+            notification.Form.Id,
+            WebHookOperation.FormUpdated,
+            form);
+
+        await webHookService.EnqueueWebHookAsync(message, cancellationToken);
+    }
+}

--- a/samples/Endatix.Samples.CustomEventHandlers/WebHooks/SubmissionEventHandlers/SubmissionCompletedHandler.cs
+++ b/samples/Endatix.Samples.CustomEventHandlers/WebHooks/SubmissionEventHandlers/SubmissionCompletedHandler.cs
@@ -1,0 +1,37 @@
+using Endatix.Core.Events;
+using Endatix.Core.Features.WebHooks;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Endatix.Samples.CustomEventHandlers.WebHooks.SubmissionEventHandlers;
+
+internal class SubmissionCompletedHandler(IWebHookService webHookService, ILogger<SubmissionCompletedHandler> logger) : INotificationHandler<SubmissionCompletedEvent>
+{
+    public async Task Handle(SubmissionCompletedEvent notification, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Handling SubmissionCompletedEvent for submission {SubmissionId}", notification.Submission.Id);
+
+        var submission = new
+        {
+            notification.Submission.Id,
+            notification.Submission.FormId,
+            notification.Submission.FormDefinitionId,
+            notification.Submission.TenantId,
+            notification.Submission.IsComplete,
+            notification.Submission.JsonData,
+            notification.Submission.CurrentPage,
+            notification.Submission.Metadata,
+            Status = notification.Submission.Status.Code,
+            notification.Submission.CreatedAt,
+            notification.Submission.ModifiedAt,
+            notification.Submission.CompletedAt,
+        };
+
+        var message = new WebHookMessage<object>(
+            notification.Submission.Id,
+            WebHookOperation.FormSubmitted,
+            submission);
+
+        await webHookService.EnqueueWebHookAsync(message, cancellationToken);
+    }
+}

--- a/src/Endatix.Core/Events/FormCreatedEvent.cs
+++ b/src/Endatix.Core/Events/FormCreatedEvent.cs
@@ -1,0 +1,12 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
+
+namespace Endatix.Core.Events;
+
+/// <summary>
+/// Event dispatched when a new form is created.
+/// </summary>
+public sealed class FormCreatedEvent(Form form) : DomainEventBase
+{
+    public Form Form { get; init; } = form;
+}

--- a/src/Endatix.Core/Events/FormEnabledStateChangedEvent.cs
+++ b/src/Endatix.Core/Events/FormEnabledStateChangedEvent.cs
@@ -1,0 +1,13 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
+
+namespace Endatix.Core.Events;
+
+/// <summary>
+/// Event dispatched when a form's enabled state changes.
+/// </summary>
+public sealed class FormEnabledStateChangedEvent(Form form, bool isEnabled) : DomainEventBase
+{
+    public Form Form { get; init; } = form;
+    public bool IsEnabled { get; init; } = isEnabled;
+}

--- a/src/Endatix.Core/Events/FormUpdatedEvent.cs
+++ b/src/Endatix.Core/Events/FormUpdatedEvent.cs
@@ -1,0 +1,12 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
+
+namespace Endatix.Core.Events;
+
+/// <summary>
+/// Event dispatched when a form is updated.
+/// </summary>
+public sealed class FormUpdatedEvent(Form form) : DomainEventBase
+{
+    public Form Form { get; init; } = form;
+}

--- a/src/Endatix.Core/Features/WebHooks/WebHookOperation.cs
+++ b/src/Endatix.Core/Features/WebHooks/WebHookOperation.cs
@@ -8,6 +8,21 @@ namespace Endatix.Core.Features.WebHooks;
 public record WebHookOperation
 {
     /// <summary>
+    /// A static instance of WebHookOperation representing a form creation.
+    /// </summary>
+    public static readonly WebHookOperation FormCreated = new("form_created", nameof(Form), ActionName.Created);
+
+    /// <summary>
+    /// A static instance of WebHookOperation representing a form update.
+    /// </summary>
+    public static readonly WebHookOperation FormUpdated = new("form_updated", nameof(Form), ActionName.Updated);
+
+    /// <summary>
+    /// A static instance of WebHookOperation representing a form enabled state change.
+    /// </summary>
+    public static readonly WebHookOperation FormEnabledStateChanged = new("form_enabled_state_changed", nameof(Form), ActionName.Updated);
+
+    /// <summary>
     /// A static instance of WebHookOperation representing a form submission.
     /// </summary>
     public static readonly WebHookOperation FormSubmitted = new("form_submitted", nameof(Submission), ActionName.Created);

--- a/src/Endatix.Core/UseCases/Forms/Create/CreateFormHandler.cs
+++ b/src/Endatix.Core/UseCases/Forms/Create/CreateFormHandler.cs
@@ -2,12 +2,17 @@
 using Endatix.Core.Abstractions;
 using Endatix.Core.Abstractions.Repositories;
 using Endatix.Core.Entities;
+using Endatix.Core.Events;
 using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
+using MediatR;
 
 namespace Endatix.Core.UseCases.Forms.Create;
 
-public class CreateFormHandler(IFormsRepository formsRepository, ITenantContext tenantContext) : ICommandHandler<CreateFormCommand, Result<Form>>
+public class CreateFormHandler(
+    IFormsRepository formsRepository, 
+    ITenantContext tenantContext,
+    IMediator mediator) : ICommandHandler<CreateFormCommand, Result<Form>>
 {
     public async Task<Result<Form>> Handle(CreateFormCommand request, CancellationToken cancellationToken)
     {
@@ -17,6 +22,8 @@ public class CreateFormHandler(IFormsRepository formsRepository, ITenantContext 
         var newFormDefinition = new FormDefinition(tenantContext.TenantId, isDraft: true, jsonData: request.FormDefinitionJsonData);
 
         var form = await formsRepository.CreateFormWithDefinitionAsync(newForm, newFormDefinition, cancellationToken);
+
+        await mediator.Publish(new FormCreatedEvent(form), cancellationToken);
 
         return Result<Form>.Created(form);
     }

--- a/src/Endatix.Core/UseCases/Forms/PartialUpdate/PartialUpdateFormHandler.cs
+++ b/src/Endatix.Core/UseCases/Forms/PartialUpdate/PartialUpdateFormHandler.cs
@@ -1,43 +1,49 @@
 ﻿using Endatix.Core.Entities;
+using Endatix.Core.Events;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
+using MediatR;
 
 namespace Endatix.Core.UseCases.Forms.PartialUpdate;
 
-public class PartialUpdateFormHandler : ICommandHandler<PartialUpdateFormCommand, Result<Form>>
+public class PartialUpdateFormHandler(
+    IRepository<Form> repository,
+    IRepository<Theme> themeRepository,
+    IMediator mediator) : ICommandHandler<PartialUpdateFormCommand, Result<Form>>
 {
-    private readonly IRepository<Form> _repository;
-    private readonly IRepository<Theme> _themeRepository;
-
-    public PartialUpdateFormHandler(IRepository<Form> repository, IRepository<Theme> themeRepository)
-    {
-        _repository = repository;
-        _themeRepository = themeRepository;
-    }
-
     public async Task<Result<Form>> Handle(PartialUpdateFormCommand request, CancellationToken cancellationToken)
     {
-        var form = await _repository.GetByIdAsync(request.FormId, cancellationToken);
+        var form = await repository.GetByIdAsync(request.FormId, cancellationToken);
         if (form == null)
         {
             return Result.NotFound("Form not found.");
         }
 
+        var oldIsEnabled = form.IsEnabled;
         form.Name = request.Name ?? form.Name;
         form.Description = request.Description ?? form.Description;
         form.IsEnabled = request.IsEnabled ?? form.IsEnabled;
 
         if (request.ThemeId.HasValue && form.ThemeId != request.ThemeId)
         {
-            var theme = await _themeRepository.GetByIdAsync(request.ThemeId.Value, cancellationToken);
+            var theme = await themeRepository.GetByIdAsync(request.ThemeId.Value, cancellationToken);
             if (theme == null)
             {
                 return Result.NotFound("Form Theme not found.");
             }
             form.SetTheme(theme);
         }
-        await _repository.UpdateAsync(form, cancellationToken);
+
+        await repository.UpdateAsync(form, cancellationToken);
+
+        await mediator.Publish(new FormUpdatedEvent(form), cancellationToken);
+
+        if (request.IsEnabled.HasValue && oldIsEnabled != request.IsEnabled.Value)
+        {
+            await mediator.Publish(new FormEnabledStateChangedEvent(form, request.IsEnabled.Value), cancellationToken);
+        }
+
         return Result.Success(form);
     }
 }

--- a/src/Endatix.Core/UseCases/Forms/Update/UpdateFormHandler.cs
+++ b/src/Endatix.Core/UseCases/Forms/Update/UpdateFormHandler.cs
@@ -1,24 +1,37 @@
 ﻿using Endatix.Core.Entities;
+using Endatix.Core.Events;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
+using MediatR;
 
 namespace Endatix.Core.UseCases.Forms.Update;
 
-public class UpdateFormHandler(IRepository<Form> _repository) : ICommandHandler<UpdateFormCommand, Result<Form>>
+public class UpdateFormHandler(
+    IRepository<Form> repository,
+    IMediator mediator) : ICommandHandler<UpdateFormCommand, Result<Form>>
 {
     public async Task<Result<Form>> Handle(UpdateFormCommand request, CancellationToken cancellationToken)
     {
-        var form = await _repository.GetByIdAsync(request.FormId, cancellationToken);
+        var form = await repository.GetByIdAsync(request.FormId, cancellationToken);
         if (form == null)
         {
             return Result.NotFound("Form not found.");
         }
 
+        var oldIsEnabled = form.IsEnabled;
         form.Name = request.Name;
         form.Description = request.Description;
         form.IsEnabled = request.IsEnabled;
-        await _repository.UpdateAsync(form, cancellationToken);
+        await repository.UpdateAsync(form, cancellationToken);
+
+        await mediator.Publish(new FormUpdatedEvent(form), cancellationToken);
+
+        if (oldIsEnabled != request.IsEnabled)
+        {
+            await mediator.Publish(new FormEnabledStateChangedEvent(form, request.IsEnabled), cancellationToken);
+        }
+
         return Result.Success(form);
     }
 }

--- a/src/Endatix.Infrastructure/Features/WebHooks/WebHookSettings.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/WebHookSettings.cs
@@ -77,6 +77,21 @@ public class WebHookSettings : IEndatixSettings
     public class WebHookEvents
     {
         /// <summary>
+        /// Represents the settings for the 'FormCreated' event.
+        /// </summary>
+        public EventSetting FormCreated { get; set; } = new() { EventName = EventNames.FORM_CREATED };
+
+        /// <summary>
+        /// Represents the settings for the 'FormUpdated' event.
+        /// </summary>
+        public EventSetting FormUpdated { get; set; } = new() { EventName = EventNames.FORM_UPDATED };
+
+        /// <summary>
+        /// Represents the settings for the 'FormEnabledStateChanged' event.
+        /// </summary>
+        public EventSetting FormEnabledStateChanged { get; set; } = new() { EventName = EventNames.FORM_ENABLED_STATE_CHANGED };
+
+        /// <summary>
         /// Represents the settings for the 'FormSubmitted' event.
         /// </summary>
         public EventSetting FormSubmitted { get; set; } = new() { EventName = EventNames.FORM_SUBMITTED };

--- a/src/Endatix.Infrastructure/Features/WebHooks/WebHooksPlugin.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/WebHooksPlugin.cs
@@ -7,6 +7,9 @@ public class WebHooksPlugin : IPluginInitializer
 {
     public class EventNames
     {
+        public const string FORM_CREATED = "form_created";
+        public const string FORM_UPDATED = "form_updated";
+        public const string FORM_ENABLED_STATE_CHANGED = "form_enabled_state_changed";
         public const string FORM_SUBMITTED = "form_submitted";
     }
 

--- a/src/Endatix.WebHost/Endatix.WebHost.csproj
+++ b/src/Endatix.WebHost/Endatix.WebHost.csproj
@@ -6,7 +6,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
     <ProjectReference Include="../Endatix.Hosting/Endatix.Hosting.csproj" />
-    <ProjectReference Include="..\Endatix.Api.Host\Endatix.Api.Host.csproj" />
+    <ProjectReference Include="../Endatix.Api.Host/Endatix.Api.Host.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/tests/Endatix.Core.Tests/UseCases/Forms/Update/UpdateFormHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/Update/UpdateFormHandlerTests.cs
@@ -1,19 +1,23 @@
 using Endatix.Core.Entities;
+using Endatix.Core.Events;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.Forms.Update;
+using MediatR;
 
 namespace Endatix.Core.Tests.UseCases.Forms.Update;
 
 public class UpdateFormHandlerTests
 {
     private readonly IRepository<Form> _repository;
+    private readonly IMediator _mediator;
     private readonly UpdateFormHandler _handler;
 
     public UpdateFormHandlerTests()
     {
         _repository = Substitute.For<IRepository<Form>>();
-        _handler = new UpdateFormHandler(_repository);
+        _mediator = Substitute.For<IMediator>();
+        _handler = new UpdateFormHandler(_repository, _mediator);
     }
 
     [Fact]
@@ -53,5 +57,37 @@ public class UpdateFormHandlerTests
         result.Value.Description.Should().Be(request.Description);
         result.Value.IsEnabled.Should().Be(request.IsEnabled);
         await _repository.Received(1).UpdateAsync(form, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_PublishesFormUpdatedEvent()
+    {
+        // Arrange
+        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1, Description = SampleData.FORM_DESCRIPTION_1, IsEnabled = true };
+        var request = new UpdateFormCommand(1, SampleData.FORM_NAME_2, SampleData.FORM_DESCRIPTION_2, false);
+        _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
+                   .Returns(form);
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        await _mediator.Received(1).Publish(Arg.Is<FormUpdatedEvent>(e => e.Form == form), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_EnabledStateChanged_PublishesFormEnabledStateChangedEvent()
+    {
+        // Arrange
+        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1, Description = SampleData.FORM_DESCRIPTION_1, IsEnabled = true };
+        var request = new UpdateFormCommand(1, SampleData.FORM_NAME_1, SampleData.FORM_DESCRIPTION_1, false);
+        _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
+                   .Returns(form);
+
+        // Act
+        await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        await _mediator.Received(1).Publish(Arg.Is<FormEnabledStateChangedEvent>(e => e.Form == form && e.IsEnabled == false), Arg.Any<CancellationToken>());
     }
 }


### PR DESCRIPTION
# Add form events and webhook samples

## Description
Added events:
- FormCreatedEvent
- FormUpdatedEvent
- FormEnabledStateChangedEvent

Added webhook event handlers in Endatix.Samples.CustomEventHandlers project:
- FormCreatedHandler
- FormUpdatedHandler
- FormEnabledStateChangedHandler
- SubmissionCompletedHandler

## Related Issues
#170

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
