### PR TITLE
fix: Seed initial user with default tenant and verified email

### DIFF
--- a/src/Endatix.Infrastructure/Identity/Users/AppUserRegistrationService.cs
+++ b/src/Endatix.Infrastructure/Identity/Users/AppUserRegistrationService.cs
@@ -52,7 +52,8 @@ public class AppUserRegistrationService(UserManager<AppUser> userManager, IUserS
 
         var newUser = new AppUser
         {
-            EmailConfirmed = false
+            TenantId = 1,           // TODO: This must 0 for a user that still does not have a tenant. Set to 1 for the initial user seeding
+            EmailConfirmed = true   // TODO: This must be false when we have a proper email verification
         };
 
         var emailStore = (IUserEmailStore<AppUser>)userStore;


### PR DESCRIPTION
# Seed initial user with default tenant and verified email

## Description
Temporarily set the tenant of a registered user to 1 (default tenant) and confirmed email so the seed of an initial user works fine. When the email verification is implemented, remove these changes.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] My code follows the style guidelines of this project
