### PR TITLE
feat: verify-email endpoint

### DIFF
--- a/docs/email-verification.md
+++ b/docs/email-verification.md
@@ -1,0 +1,150 @@
+# Email Verification
+
+This document describes the email verification functionality implemented in Endatix.
+
+## Overview
+
+When a new user registers, they are created with `EmailConfirmed = false` and a verification token is generated. The user must verify their email address by clicking a link or using the verification token before they can log in.
+
+**Architecture Note**: The `EmailVerificationToken` entity is located in the `AppIdentityDbContext` (identity schema) to maintain proper foreign key relationships with the `AppUser` entity and ensure data integrity through cascade deletes when users are removed.
+
+## Components
+
+### 1. EmailVerificationToken Entity
+
+Located in `src/Endatix.Core/Entities/Identity/EmailVerificationToken.cs`
+
+- Represents a verification token for a user
+- Contains token value, expiry time, and usage status
+- Tokens expire after 24 hours by default
+- Tokens can only be used once
+- **Note**: Inherits from `BaseEntity` (not `TenantEntity`) since tokens are created before users are assigned to tenants
+
+### 2. IEmailVerificationService Interface
+
+Located in `src/Endatix.Core/Abstractions/IEmailVerificationService.cs`
+
+Defines the contract for email verification operations:
+- `CreateVerificationTokenAsync` - Creates a new verification token for a user
+- `VerifyEmailAsync` - Verifies a user's email and invalidates the token
+
+### 3. EmailVerificationService Implementation
+
+Located in `src/Endatix.Infrastructure/Identity/EmailVerification/EmailVerificationService.cs`
+
+Implements the email verification logic:
+- Generates secure 256-bit tokens
+- Manages token lifecycle (creation, expiration)
+- Updates user verification status
+- Handles token cleanup
+
+### 4. API Endpoint
+
+Located in `src/Endatix.Api/Endpoints/Auth/VerifyEmail.cs`
+
+- **POST** `/api/auth/verify-email`
+- Accepts a verification token
+- Returns the user ID on success
+- Returns appropriate HTTP status codes:
+  - `200 OK` - Email verified successfully (returns user ID)
+  - `400 Bad Request` - Invalid or expired token (with problem details)
+  - `404 Not Found` - Token not found
+- Anonymous access (no authentication required)
+
+## Configuration
+
+Email verification settings can be configured in `appsettings.json`:
+
+```json
+{
+  "Endatix": {
+    "EmailVerification": {
+      "TokenExpiryInHours": 24
+    }
+  }
+}
+```
+
+## Database Schema
+
+The `EmailVerificationTokens` table is located in the `identity` schema and contains:
+- `Id` - Primary key
+- `UserId` - User identifier (foreign key to `AspNetUsers.Id`)
+- `Token` - Verification token value (64 characters)
+- `ExpiresAt` - Token expiration timestamp
+- `IsUsed` - Whether the token has been used
+- `CreatedAt` - Token creation timestamp
+- `ModifiedAt` - Last modification timestamp
+- `DeletedAt` - Soft delete timestamp (nullable)
+- `IsDeleted` - Soft delete flag
+
+**Note**: The table is located in the `AppIdentityDbContext` (identity schema) rather than the main `AppDbContext` to maintain proper foreign key relationships with the `AppUser` entity and ensure data integrity through cascade deletes.
+
+## Usage Flow
+
+1. **User Registration**
+   - User registers with email and password
+   - User is created with `EmailConfirmed = false`
+   - Verification token is generated and stored
+   - Token should be sent to user via email (not implemented in this version)
+
+2. **Email Verification**
+   - User receives verification token (via email)
+   - User calls `POST /api/auth/verify-email` with the token
+   - System validates token (not expired, not used, user exists, user not verified)
+   - If valid, user's `EmailConfirmed` is set to `true` and token is marked as used
+   - Returns the user ID on success
+   - User can now log in
+
+3. **Login**
+   - User attempts to log in
+   - System checks `EmailConfirmed` status
+   - Only verified users can log in
+
+## API Response Format
+
+### Success Response (200 OK)
+```json
+{
+  "value": "12345"
+}
+```
+Where `12345` is the user ID as a string.
+
+### Error Response (400 Bad Request)
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc7231#section-6.5.1",
+  "title": "There was a problem with your request.",
+  "status": 400,
+  "detail": "User is already verified"
+}
+```
+
+### Error Response (404 Not Found)
+```http
+HTTP/1.1 404 Not Found
+```
+
+## Security Considerations
+
+- Tokens are cryptographically secure (256-bit random)
+- Tokens expire after 24 hours
+- Tokens can only be used once
+- Tokens are invalidated when user is already verified
+- No sensitive information is exposed in tokens
+- Tokens are not tenant-scoped since they're created before tenant assignment
+
+## Testing
+
+The implementation includes comprehensive tests:
+- Entity tests: `tests/Endatix.Core.Tests/Entities/Identity/EmailVerificationTokenTests.cs`
+- Service tests: `tests/Endatix.Infrastructure.Tests/Identity/EmailVerification/EmailVerificationServiceTests.cs`
+- API tests: `tests/Endatix.Api.Tests/Endpoints/Auth/VerifyEmailTests.cs`
+
+## Future Enhancements
+
+1. **Token Resend**: Allow users to request new verification tokens
+2. **Rate Limiting**: Prevent abuse of verification endpoints
+3. **Audit Logging**: Track verification attempts and failures
+4. **Custom Expiry**: Allow different expiry times for different user types 

--- a/samples/Endatix.Samples.SelfHosted/appsettings.json
+++ b/samples/Endatix.Samples.SelfHosted/appsettings.json
@@ -42,6 +42,9 @@
     }
   },
   "Endatix": {
+    "EmailVerification": {
+      "TokenExpiryInHours": 24
+    },
     "Jwt": {
       "SigningKey": "{YOUR_JWT_SIGNING_KEY_HERE}",
       "ExpiryInMinutes": 1440,

--- a/src/Endatix.Api/Endpoints/Auth/Register.cs
+++ b/src/Endatix.Api/Endpoints/Auth/Register.cs
@@ -3,7 +3,6 @@ using MediatR;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Errors = Microsoft.AspNetCore.Mvc;
 using Endatix.Core.UseCases.Identity.Register;
-using Endatix.Infrastructure.Identity.Authorization;
 using Endatix.Api.Infrastructure;
 
 namespace Endatix.Api.Endpoints.Auth;
@@ -16,7 +15,7 @@ public class Register(IMediator mediator) : Endpoint<RegisterRequest, Results<Ok
     public override void Configure()
     {
         Post("auth/register");
-        Permissions(Allow.AllowAll);
+        AllowAnonymous();
         Summary(s =>
         {
             s.Summary = "Register a new user";
@@ -33,19 +32,8 @@ public class Register(IMediator mediator) : Endpoint<RegisterRequest, Results<Ok
         var registerUserCommand = new RegisterCommand(request.Email, request.Password);
         var userRegistrationResult = await mediator.Send(registerUserCommand, cancellationToken);
 
-        var errorMessage = "Registration failed. ";
-        if (userRegistrationResult.Status == Core.Infrastructure.Result.ResultStatus.Invalid && userRegistrationResult.ValidationErrors.Any())
-        {
-            errorMessage += userRegistrationResult.ValidationErrors.First().ErrorMessage;
-        }
-        else
-        {
-            errorMessage += "Please check your input and try again.";
-        }
-
         return TypedResultsBuilder
                 .MapResult(userRegistrationResult, (user) => new RegisterResponse(Success: true, Message: "User has been successfully registered"))
-                .SetErrorMessage(errorMessage)
                 .SetTypedResults<Ok<RegisterResponse>, BadRequest<Errors.ProblemDetails>>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Auth/VerifyEmail.VerifyEmailRequest.cs
+++ b/src/Endatix.Api/Endpoints/Auth/VerifyEmail.VerifyEmailRequest.cs
@@ -1,0 +1,12 @@
+namespace Endatix.Api.Endpoints.Auth;
+
+/// <summary>
+/// Represents the request for the "/verify-email" endpoint.
+/// </summary>
+public record VerifyEmailRequest(string Token)
+{
+    /// <summary>
+    /// The verification token.
+    /// </summary>
+    public string Token { get; init; } = Token;
+} 

--- a/src/Endatix.Api/Endpoints/Auth/VerifyEmail.VerifyEmailValidator.cs
+++ b/src/Endatix.Api/Endpoints/Auth/VerifyEmail.VerifyEmailValidator.cs
@@ -1,0 +1,19 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Endatix.Api.Endpoints.Auth;
+
+/// <summary>
+/// Validator for the VerifyEmailRequest used in the email verification process.
+/// </summary>
+public class VerifyEmailValidator : Validator<VerifyEmailRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VerifyEmailValidator"/> class.
+    /// </summary>
+    public VerifyEmailValidator()
+    {
+        RuleFor(x => x.Token)
+            .NotEmpty();
+    }
+}

--- a/src/Endatix.Api/Endpoints/Auth/VerifyEmail.cs
+++ b/src/Endatix.Api/Endpoints/Auth/VerifyEmail.cs
@@ -1,0 +1,40 @@
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Errors = Microsoft.AspNetCore.Mvc;
+using Endatix.Core.UseCases.Identity.VerifyEmail;
+using Endatix.Api.Infrastructure;
+
+namespace Endatix.Api.Endpoints.Auth;
+
+/// <summary>
+/// Endpoint for verifying user email addresses.
+/// </summary>
+public class VerifyEmail(IMediator mediator) : Endpoint<VerifyEmailRequest, Results<Ok<string>, BadRequest<Errors.ProblemDetails>, NotFound>>
+{
+    public override void Configure()
+    {
+        Post("auth/verify-email");
+        AllowAnonymous();
+        Summary(s =>
+        {
+            s.Summary = "Verify email address";
+            s.Description = "Verifies a user's email address using a verification token.";
+            s.Responses[200] = "Email has been successfully verified. Returns the user ID.";
+            s.Responses[400] = "Invalid or expired verification token.";
+            s.Responses[404] = "Verification token not found.";
+            s.ExampleRequest = new VerifyEmailRequest("abc123def456...");
+        });
+    }
+
+    /// <inheritdoc/>
+    public override async Task<Results<Ok<string>, BadRequest<Errors.ProblemDetails>, NotFound>> ExecuteAsync(VerifyEmailRequest request, CancellationToken cancellationToken)
+    {
+        var verifyEmailCommand = new VerifyEmailCommand(request.Token);
+        var emailVerificationResult = await mediator.Send(verifyEmailCommand, cancellationToken);
+
+        return TypedResultsBuilder
+                .MapResult(emailVerificationResult, user => user.Id.ToString())
+                .SetTypedResults<Ok<string>, BadRequest<Errors.ProblemDetails>, NotFound>();
+    }
+} 

--- a/src/Endatix.Api/Infrastructure/TypedResultsBuilder.cs
+++ b/src/Endatix.Api/Infrastructure/TypedResultsBuilder.cs
@@ -260,4 +260,17 @@ where TResult3 : HttpResults.IResult
         ResultStatus.NotFound => resultMapper.SourceResult.ToNotFound(),
         _ => throw new InvalidCastException($"Cannot cast the {resultMapper.SourceResult.ValueType} with status {resultMapper.SourceResult.Status}")
     };
+
+    /// <summary>
+    /// Implicitly converts the TypedResultsBuilder to a Results instance for Ok, BadRequest with <see cref="ProblemDetails"/>, and NotFound.
+    /// </summary>
+    /// <param name="resultMapper">The TypedResultsBuilder instance to convert.</param>
+    /// <returns>A Results instance for Ok, BadRequest with <see cref="ProblemDetails"/>, and NotFound.</returns>
+    public static implicit operator Results<Ok<TData>, BadRequest<ProblemDetails>, NotFound>(TypedResultsBuilder<TData, TResult1, TResult2, TResult3> resultMapper) => resultMapper.SourceResult.Status switch
+    {
+        ResultStatus.Ok => TypedResults.Ok(resultMapper.SourceResult.Value),
+        ResultStatus.Invalid => resultMapper.SourceResult.ToBadRequest(resultMapper.ErrorMessage),
+        ResultStatus.NotFound => TypedResults.NotFound(),
+        _ => throw new InvalidCastException($"Cannot cast the {resultMapper.SourceResult.ValueType} with status {resultMapper.SourceResult.Status}")
+    };
 }

--- a/src/Endatix.Core/Abstractions/IEmailVerificationService.cs
+++ b/src/Endatix.Core/Abstractions/IEmailVerificationService.cs
@@ -1,0 +1,26 @@
+using Endatix.Core.Entities.Identity;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.Abstractions;
+
+/// <summary>
+/// Defines the contract for email verification operations.
+/// </summary>
+public interface IEmailVerificationService
+{
+    /// <summary>
+    /// Creates an email verification token for the specified user.
+    /// </summary>
+    /// <param name="userId">The ID of the user to create a token for.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation if needed.</param>
+    /// <returns>A Result containing the created EmailVerificationToken if successful.</returns>
+    Task<Result<EmailVerificationToken>> CreateVerificationTokenAsync(long userId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Verifies a user's email and invalidates the verification token.
+    /// </summary>
+    /// <param name="token">The verification token.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation if needed.</param>
+    /// <returns>A Result containing the verified User if successful.</returns>
+    Task<Result<User>> VerifyEmailAsync(string token, CancellationToken cancellationToken);
+} 

--- a/src/Endatix.Core/Entities/Identity/EmailVerificationToken.cs
+++ b/src/Endatix.Core/Entities/Identity/EmailVerificationToken.cs
@@ -1,0 +1,56 @@
+using Ardalis.GuardClauses;
+using Endatix.Core.Infrastructure.Domain;
+
+namespace Endatix.Core.Entities.Identity;
+
+/// <summary>
+/// Represents an email verification token for a user.
+/// </summary>
+public class EmailVerificationToken : BaseEntity, IAggregateRoot
+{
+    private EmailVerificationToken() { } // For EF Core
+
+    public EmailVerificationToken(long userId, string token, DateTime expiresAt)
+    {
+        Guard.Against.NegativeOrZero(userId, nameof(userId));
+        Guard.Against.NullOrWhiteSpace(token, nameof(token));
+        Guard.Against.InvalidInput(expiresAt, nameof(expiresAt), dt => dt > DateTime.UtcNow);
+
+        UserId = userId;
+        Token = token;
+        ExpiresAt = expiresAt;
+    }
+
+    /// <summary>
+    /// The ID of the user this token belongs to.
+    /// </summary>
+    public long UserId { get; private set; }
+
+    /// <summary>
+    /// The verification token value.
+    /// </summary>
+    public string Token { get; private set; }
+
+    /// <summary>
+    /// When the token expires.
+    /// </summary>
+    public DateTime ExpiresAt { get; private set; }
+
+    /// <summary>
+    /// Whether the token has expired.
+    /// </summary>
+    public bool IsExpired => DateTime.UtcNow > ExpiresAt;
+
+    /// <summary>
+    /// Whether the token has been used.
+    /// </summary>
+    public bool IsUsed { get; private set; }
+
+    /// <summary>
+    /// Marks the token as used.
+    /// </summary>
+    public void MarkAsUsed()
+    {
+        IsUsed = true;
+    }
+} 

--- a/src/Endatix.Core/Specifications/EmailVerificationTokenByTokenSpec.cs
+++ b/src/Endatix.Core/Specifications/EmailVerificationTokenByTokenSpec.cs
@@ -1,0 +1,17 @@
+using Ardalis.Specification;
+using Endatix.Core.Entities.Identity;
+
+namespace Endatix.Core.Specifications;
+
+/// <summary>
+/// Specification to find email verification tokens by token value.
+/// </summary>
+public class EmailVerificationTokenByTokenSpec : Specification<EmailVerificationToken>
+{
+    public EmailVerificationTokenByTokenSpec(string token)
+    {
+        Query
+            .AsNoTracking()
+            .Where(t => t.Token == token);
+    }
+} 

--- a/src/Endatix.Core/Specifications/EmailVerificationTokenByUserIdSpec.cs
+++ b/src/Endatix.Core/Specifications/EmailVerificationTokenByUserIdSpec.cs
@@ -1,0 +1,17 @@
+using Ardalis.Specification;
+using Endatix.Core.Entities.Identity;
+
+namespace Endatix.Core.Specifications;
+
+/// <summary>
+/// Specification to find email verification tokens by user ID.
+/// </summary>
+public class EmailVerificationTokenByUserIdSpec : Specification<EmailVerificationToken>
+{
+    public EmailVerificationTokenByUserIdSpec(long userId)
+    {
+        Query
+            .AsNoTracking()
+            .Where(t => t.UserId == userId);
+    }
+} 

--- a/src/Endatix.Core/UseCases/Identity/VerifyEmail/VerifyEmailCommand.cs
+++ b/src/Endatix.Core/UseCases/Identity/VerifyEmail/VerifyEmailCommand.cs
@@ -1,0 +1,16 @@
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Entities.Identity;
+
+namespace Endatix.Core.UseCases.Identity.VerifyEmail;
+
+/// <summary>
+/// Command to verify a user's email address.
+/// </summary>
+public record VerifyEmailCommand(string Token) : ICommand<Result<User>>
+{
+    /// <summary>
+    /// The verification token.
+    /// </summary>
+    public string Token { get; init; } = Token;
+} 

--- a/src/Endatix.Core/UseCases/Identity/VerifyEmail/VerifyEmailHandler.cs
+++ b/src/Endatix.Core/UseCases/Identity/VerifyEmail/VerifyEmailHandler.cs
@@ -1,0 +1,23 @@
+using Endatix.Core.Abstractions;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Entities.Identity;
+
+namespace Endatix.Core.UseCases.Identity.VerifyEmail;
+
+/// <summary>
+/// Handles the verification of a user's email address.
+/// </summary>
+public class VerifyEmailHandler(IEmailVerificationService emailVerificationService) : ICommandHandler<VerifyEmailCommand, Result<User>>
+{
+    /// <summary>
+    /// Handles the VerifyEmailCommand to verify a user's email address.
+    /// </summary>
+    /// <param name="request">The VerifyEmailCommand containing the verification token.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the work.</param>
+    /// <returns>A Result containing the verified User if successful.</returns>
+    public async Task<Result<User>> Handle(VerifyEmailCommand request, CancellationToken cancellationToken)
+    {
+        return await emailVerificationService.VerifyEmailAsync(request.Token, cancellationToken);
+    }
+} 

--- a/src/Endatix.Infrastructure/Identity/AppIdentityDbContext.cs
+++ b/src/Endatix.Infrastructure/Identity/AppIdentityDbContext.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Endatix.Infrastructure.Data;
+using Endatix.Core.Entities.Identity;
+using Endatix.Core.Abstractions;
 
 namespace Endatix.Infrastructure.Identity;
 
@@ -10,11 +12,15 @@ namespace Endatix.Infrastructure.Identity;
 public class AppIdentityDbContext : IdentityDbContext<AppUser, AppRole, long>
 {
     private readonly EfCoreValueGeneratorFactory _valueGeneratorFactory;
+    private readonly IIdGenerator<long> _idGenerator;
 
-    public AppIdentityDbContext(DbContextOptions<AppIdentityDbContext> options, EfCoreValueGeneratorFactory valueGeneratorFactory) : base(options)
+    public AppIdentityDbContext(DbContextOptions<AppIdentityDbContext> options, EfCoreValueGeneratorFactory valueGeneratorFactory, IIdGenerator<long> idGenerator) : base(options)
     {
         _valueGeneratorFactory = valueGeneratorFactory;
+        _idGenerator = idGenerator;
     }
+
+    public DbSet<EmailVerificationToken> EmailVerificationTokens { get; set; }
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -31,5 +37,92 @@ public class AppIdentityDbContext : IdentityDbContext<AppUser, AppRole, long>
                .Property(e => e.Id)
                 .HasValueGenerator((property, _) => _valueGeneratorFactory.Create<long>(property))
                .ValueGeneratedNever();
+
+        builder.Entity<EmailVerificationToken>(entity =>
+        {
+            entity.ToTable("EmailVerificationTokens");
+
+            entity.Property(t => t.Id)
+                .IsRequired();
+
+            entity.Property(t => t.UserId)
+                .IsRequired();
+
+            entity.Property(t => t.Token)
+                .IsRequired()
+                .HasMaxLength(64);
+
+            entity.Property(t => t.ExpiresAt)
+                .IsRequired();
+
+            entity.Property(t => t.IsUsed)
+                .IsRequired()
+                .HasDefaultValue(false);
+
+            // Create unique index on token value
+            entity.HasIndex(t => t.Token)
+                .IsUnique();
+
+            // Create index on user ID for quick lookups
+            entity.HasIndex(t => t.UserId);
+
+            // Create index on expiry for cleanup operations
+            entity.HasIndex(t => t.ExpiresAt);
+
+            // Add foreign key relationship to AppUser
+            entity.HasOne<AppUser>()
+                .WithMany()
+                .HasForeignKey(t => t.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+    }
+
+    public override int SaveChanges()
+    {
+        ProcessEntities();
+        return base.SaveChanges();
+    }
+
+    /// <inheritdoc/>
+    public override async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        ProcessEntities();
+        return await base.SaveChangesAsync(true, cancellationToken);
+    }
+
+    private void ProcessEntities()
+    {
+        var entries = ChangeTracker.Entries()
+            .Where(e => e.State == EntityState.Added || e.State == EntityState.Modified);
+
+        foreach (var entry in entries)
+        {
+            switch (entry.State)
+            {
+                case EntityState.Added:
+                    // Generate an id if necessary
+                    if (entry.CurrentValues.Properties.Any(p => p.Name == "Id") &&
+                        entry.CurrentValues["Id"] is default(long))
+                    {
+                        entry.CurrentValues["Id"] = _idGenerator.CreateId();
+                    }
+
+                    // Set the CreatedAt value
+                    if (entry.CurrentValues.Properties.Any(p => p.Name == "CreatedAt"))
+                    {
+                        entry.CurrentValues["CreatedAt"] = DateTime.UtcNow;
+                    }
+
+                    break;
+                case EntityState.Modified:
+                    // Set the ModifiedAt value
+                    if (entry.CurrentValues.Properties.Any(p => p.Name == "ModifiedAt"))
+                    {
+                        entry.CurrentValues["ModifiedAt"] = DateTime.UtcNow;
+                    }
+
+                    break;
+            }
+        }
     }
 }

--- a/src/Endatix.Infrastructure/Identity/EmailVerification/EmailVerificationOptions.cs
+++ b/src/Endatix.Infrastructure/Identity/EmailVerification/EmailVerificationOptions.cs
@@ -1,0 +1,19 @@
+using Endatix.Framework.Configuration;
+
+namespace Endatix.Infrastructure.Identity.EmailVerification;
+
+/// <summary>
+/// Configuration options for email verification.
+/// </summary>
+public class EmailVerificationOptions : EndatixOptionsBase
+{
+    /// <summary>
+    /// Gets the section path for these options.
+    /// </summary>
+    public override string SectionPath => "EmailVerification";
+
+    /// <summary>
+    /// Gets or sets the token expiry in hours.
+    /// </summary>
+    public int TokenExpiryInHours { get; set; } = 24;
+} 

--- a/src/Endatix.Infrastructure/Identity/EmailVerification/EmailVerificationService.cs
+++ b/src/Endatix.Infrastructure/Identity/EmailVerification/EmailVerificationService.cs
@@ -1,0 +1,133 @@
+using System.Security.Cryptography;
+using Ardalis.GuardClauses;
+using Endatix.Core.Abstractions;
+using Endatix.Core.Entities.Identity;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+
+namespace Endatix.Infrastructure.Identity.EmailVerification;
+
+/// <summary>
+/// Implements the email verification service.
+/// </summary>
+public class EmailVerificationService : IEmailVerificationService
+{
+    private const int TOKEN_SIZE_BYTES = 32; // 256 bits
+    private readonly IRepository<EmailVerificationToken> _tokenRepository;
+    private readonly UserManager<AppUser> _userManager;
+    private readonly EmailVerificationOptions _options;
+
+    public EmailVerificationService(
+        IRepository<EmailVerificationToken> tokenRepository,
+        UserManager<AppUser> userManager,
+        IOptions<EmailVerificationOptions> options)
+    {
+        Guard.Against.Null(tokenRepository);
+        Guard.Against.Null(userManager);
+        Guard.Against.Null(options.Value);
+        Guard.Against.NegativeOrZero(options.Value.TokenExpiryInHours);
+
+        _tokenRepository = tokenRepository;
+        _userManager = userManager;
+        _options = options.Value;
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<EmailVerificationToken>> CreateVerificationTokenAsync(long userId, CancellationToken cancellationToken)
+    {
+        Guard.Against.NegativeOrZero(userId);
+
+        // Check if user exists and is not already verified
+        var user = await _userManager.FindByIdAsync(userId.ToString());
+        if (user == null)
+        {
+            return Result.NotFound("User not found");
+        }
+
+        if (user.EmailConfirmed)
+        {
+            return Result.Invalid(new ValidationError("User is already verified"));
+        }
+
+        // Delete any existing tokens for this user
+        var existingTokens = await _tokenRepository.ListAsync(
+            new EmailVerificationTokenByUserIdSpec(userId), 
+            cancellationToken);
+        
+        foreach (var existingToken in existingTokens)
+        {
+            await _tokenRepository.DeleteAsync(existingToken, cancellationToken);
+        }
+
+        // Create new token
+        var tokenValue = GenerateToken();
+        var expiresAt = DateTime.UtcNow.AddHours(_options.TokenExpiryInHours);
+        var verificationToken = new EmailVerificationToken(userId, tokenValue, expiresAt);
+
+        await _tokenRepository.AddAsync(verificationToken, cancellationToken);
+        await _tokenRepository.SaveChangesAsync(cancellationToken);
+
+        return Result.Success(verificationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<User>> VerifyEmailAsync(string token, CancellationToken cancellationToken)
+    {
+        Guard.Against.NullOrEmpty(token);
+
+        var verificationToken = await _tokenRepository.FirstOrDefaultAsync(
+            new EmailVerificationTokenByTokenSpec(token), 
+            cancellationToken);
+
+        if (verificationToken == null)
+        {
+            return Result.NotFound("Invalid verification token");
+        }
+
+        if (verificationToken.IsExpired)
+        {
+            return Result.Invalid(new ValidationError("Verification token has expired"));
+        }
+
+        if (verificationToken.IsUsed)
+        {
+            return Result.Invalid(new ValidationError("Verification token has already been used"));
+        }
+
+        var user = await _userManager.FindByIdAsync(verificationToken.UserId.ToString());
+        if (user == null)
+        {
+            return Result.NotFound("User not found");
+        }
+
+        if (user.EmailConfirmed)
+        {
+            return Result.Invalid(new ValidationError("User is already verified"));
+        }
+
+        // Mark user as verified
+        user.EmailConfirmed = true;
+        var updateResult = await _userManager.UpdateAsync(user);
+        if (!updateResult.Succeeded)
+        {
+            return Result.Error("Failed to verify user");
+        }
+
+        // Mark token as used
+        verificationToken.MarkAsUsed();
+        await _tokenRepository.UpdateAsync(verificationToken, cancellationToken);
+        await _tokenRepository.SaveChangesAsync(cancellationToken);
+
+        return Result.Success(user.ToUserEntity());
+    }
+
+    private string GenerateToken()
+    {
+        var tokenBytes = new byte[TOKEN_SIZE_BYTES];
+        RandomNumberGenerator.Fill(tokenBytes);
+        return Convert.ToHexString(tokenBytes);
+    }
+} 

--- a/src/Endatix.Infrastructure/Identity/EmailVerification/EmailVerificationTokenRepository.cs
+++ b/src/Endatix.Infrastructure/Identity/EmailVerification/EmailVerificationTokenRepository.cs
@@ -1,0 +1,16 @@
+using Ardalis.Specification.EntityFrameworkCore;
+using Endatix.Core.Abstractions.Repositories;
+using Endatix.Core.Entities.Identity;
+using Endatix.Core.Infrastructure.Domain;
+
+namespace Endatix.Infrastructure.Identity.EmailVerification;
+
+/// <summary>
+/// Repository for EmailVerificationToken that uses AppIdentityDbContext.
+/// </summary>
+public class EmailVerificationTokenRepository : RepositoryBase<EmailVerificationToken>, IRepository<EmailVerificationToken>
+{
+    public EmailVerificationTokenRepository(AppIdentityDbContext dbContext) : base(dbContext)
+    {
+    }
+} 

--- a/src/Endatix.Infrastructure/Identity/IdentityServiceCollectionExtensions.cs
+++ b/src/Endatix.Infrastructure/Identity/IdentityServiceCollectionExtensions.cs
@@ -1,7 +1,11 @@
 using System.IdentityModel.Tokens.Jwt;
 using Endatix.Core.Abstractions;
+using Endatix.Core.Entities.Identity;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Framework.Configuration;
 using Endatix.Infrastructure.Identity.Authentication;
 using Endatix.Infrastructure.Identity.Users;
+using Endatix.Infrastructure.Identity.EmailVerification;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -73,6 +77,16 @@ public static class IdentityServiceCollectionExtensions
         services.AddScoped<IAuthService, AuthService>();
         services.AddScoped<IUserService, AppUserService>();
         services.AddScoped<IUserRegistrationService, AppUserRegistrationService>();
+        services.AddScoped<IEmailVerificationService, EmailVerificationService>();
+
+        // Register email verification options
+        services.AddOptions<EmailVerificationOptions>()
+                .BindConfiguration(EndatixOptionsBase.GetSectionName<EmailVerificationOptions>())
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
+
+        // Register EmailVerificationToken repository to use AppIdentityDbContext
+        services.AddScoped<IRepository<EmailVerificationToken>, EmailVerificationTokenRepository>();
 
         return services;
     }

--- a/src/Endatix.Persistence.PostgreSql/Migrations/AppIdentity/20250625124302_AddEmailVerificationTokens.Designer.cs
+++ b/src/Endatix.Persistence.PostgreSql/Migrations/AppIdentity/20250625124302_AddEmailVerificationTokens.Designer.cs
@@ -3,17 +3,20 @@ using System;
 using Endatix.Infrastructure.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace Endatix.Persistence.PostgreSQL.Migrations.AppIdentity
+namespace Endatix.Persistence.PostgreSql.Migrations.AppIdentity
 {
     [DbContext(typeof(AppIdentityDbContext))]
-    partial class AppIdentityDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250625124302_AddEmailVerificationTokens")]
+    partial class AddEmailVerificationTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Endatix.Persistence.PostgreSql/Migrations/AppIdentity/20250625124302_AddEmailVerificationTokens.cs
+++ b/src/Endatix.Persistence.PostgreSql/Migrations/AppIdentity/20250625124302_AddEmailVerificationTokens.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Endatix.Persistence.PostgreSql.Migrations.AppIdentity
+{
+    /// <inheritdoc />
+    public partial class AddEmailVerificationTokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EmailVerificationTokens",
+                schema: "identity",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    UserId = table.Column<long>(type: "bigint", nullable: false),
+                    Token = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    ExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    IsUsed = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EmailVerificationTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_EmailVerificationTokens_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalSchema: "identity",
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmailVerificationTokens_ExpiresAt",
+                schema: "identity",
+                table: "EmailVerificationTokens",
+                column: "ExpiresAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmailVerificationTokens_Token",
+                schema: "identity",
+                table: "EmailVerificationTokens",
+                column: "Token",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmailVerificationTokens_UserId",
+                schema: "identity",
+                table: "EmailVerificationTokens",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EmailVerificationTokens",
+                schema: "identity");
+        }
+    }
+}

--- a/src/Endatix.Persistence.SqlServer/Migrations/AppIdentity/20250625123426_AddEmailVerificationTokens.Designer.cs
+++ b/src/Endatix.Persistence.SqlServer/Migrations/AppIdentity/20250625123426_AddEmailVerificationTokens.Designer.cs
@@ -3,25 +3,28 @@ using System;
 using Endatix.Infrastructure.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace Endatix.Persistence.PostgreSQL.Migrations.AppIdentity
+namespace Endatix.Persistence.SqlServer.Migrations.AppIdentity
 {
     [DbContext(typeof(AppIdentityDbContext))]
-    partial class AppIdentityDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250625123426_AddEmailVerificationTokens")]
+    partial class AddEmailVerificationTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasDefaultSchema("identity")
                 .HasAnnotation("ProductVersion", "9.0.4")
-                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+                .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
-            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
 
             modelBuilder.Entity("Endatix.Core.Entities.Identity.EmailVerificationToken", b =>
                 {
@@ -29,29 +32,29 @@ namespace Endatix.Persistence.PostgreSQL.Migrations.AppIdentity
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime2");
 
                     b.Property<DateTime>("ExpiresAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime2");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("IsUsed")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("boolean")
+                        .HasColumnType("bit")
                         .HasDefaultValue(false);
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("Token")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("character varying(64)");
+                        .HasColumnType("nvarchar(64)");
 
                     b.Property<long>("UserId")
                         .HasColumnType("bigint");
@@ -75,24 +78,25 @@ namespace Endatix.Persistence.PostgreSQL.Migrations.AppIdentity
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken()
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Description")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("NormalizedName")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("NormalizedName")
                         .IsUnique()
-                        .HasDatabaseName("RoleNameIndex");
+                        .HasDatabaseName("RoleNameIndex")
+                        .HasFilter("[NormalizedName] IS NOT NULL");
 
                     b.ToTable("AspNetRoles", "identity");
                 });
@@ -103,60 +107,60 @@ namespace Endatix.Persistence.PostgreSQL.Migrations.AppIdentity
                         .HasColumnType("bigint");
 
                     b.Property<int>("AccessFailedCount")
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
                     b.Property<string>("ConcurrencyStamp")
                         .IsConcurrencyToken()
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Email")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<bool>("EmailConfirmed")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<bool>("LockoutEnabled")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<DateTimeOffset?>("LockoutEnd")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetimeoffset");
 
                     b.Property<string>("NormalizedEmail")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("NormalizedUserName")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.Property<string>("PasswordHash")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("PhoneNumber")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("PhoneNumberConfirmed")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<DateTime?>("RefreshTokenExpireAt")
-                        .HasColumnType("timestamp with time zone");
+                        .HasColumnType("datetime2");
 
                     b.Property<string>("RefreshTokenHash")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("SecurityStamp")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
 
                     b.Property<bool>("TwoFactorEnabled")
-                        .HasColumnType("boolean");
+                        .HasColumnType("bit");
 
                     b.Property<string>("UserName")
                         .HasMaxLength(256)
-                        .HasColumnType("character varying(256)");
+                        .HasColumnType("nvarchar(256)");
 
                     b.HasKey("Id");
 
@@ -165,7 +169,8 @@ namespace Endatix.Persistence.PostgreSQL.Migrations.AppIdentity
 
                     b.HasIndex("NormalizedUserName")
                         .IsUnique()
-                        .HasDatabaseName("UserNameIndex");
+                        .HasDatabaseName("UserNameIndex")
+                        .HasFilter("[NormalizedUserName] IS NOT NULL");
 
                     b.ToTable("AspNetUsers", "identity");
                 });
@@ -174,15 +179,15 @@ namespace Endatix.Persistence.PostgreSQL.Migrations.AppIdentity
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("ClaimType")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ClaimValue")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<long>("RoleId")
                         .HasColumnType("bigint");
@@ -198,15 +203,15 @@ namespace Endatix.Persistence.PostgreSQL.Migrations.AppIdentity
                 {
                     b.Property<int>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
+                        .HasColumnType("int");
 
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+                    SqlServerPropertyBuilderExtensions.UseIdentityColumn(b.Property<int>("Id"));
 
                     b.Property<string>("ClaimType")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("ClaimValue")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<long>("UserId")
                         .HasColumnType("bigint");
@@ -221,13 +226,13 @@ namespace Endatix.Persistence.PostgreSQL.Migrations.AppIdentity
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityUserLogin<long>", b =>
                 {
                     b.Property<string>("LoginProvider")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ProviderKey")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("ProviderDisplayName")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<long>("UserId")
                         .HasColumnType("bigint");
@@ -260,13 +265,13 @@ namespace Endatix.Persistence.PostgreSQL.Migrations.AppIdentity
                         .HasColumnType("bigint");
 
                     b.Property<string>("LoginProvider")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Name")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Value")
-                        .HasColumnType("text");
+                        .HasColumnType("nvarchar(max)");
 
                     b.HasKey("UserId", "LoginProvider", "Name");
 

--- a/src/Endatix.Persistence.SqlServer/Migrations/AppIdentity/20250625123426_AddEmailVerificationTokens.cs
+++ b/src/Endatix.Persistence.SqlServer/Migrations/AppIdentity/20250625123426_AddEmailVerificationTokens.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Endatix.Persistence.SqlServer.Migrations.AppIdentity
+{
+    /// <inheritdoc />
+    public partial class AddEmailVerificationTokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EmailVerificationTokens",
+                schema: "identity",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    UserId = table.Column<long>(type: "bigint", nullable: false),
+                    Token = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    ExpiresAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    IsUsed = table.Column<bool>(type: "bit", nullable: false, defaultValue: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    DeletedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EmailVerificationTokens", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_EmailVerificationTokens_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalSchema: "identity",
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmailVerificationTokens_ExpiresAt",
+                schema: "identity",
+                table: "EmailVerificationTokens",
+                column: "ExpiresAt");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmailVerificationTokens_Token",
+                schema: "identity",
+                table: "EmailVerificationTokens",
+                column: "Token",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmailVerificationTokens_UserId",
+                schema: "identity",
+                table: "EmailVerificationTokens",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EmailVerificationTokens",
+                schema: "identity");
+        }
+    }
+}

--- a/src/Endatix.Persistence.SqlServer/Migrations/AppIdentity/AppIdentityDbContextModelSnapshot.cs
+++ b/src/Endatix.Persistence.SqlServer/Migrations/AppIdentity/AppIdentityDbContextModelSnapshot.cs
@@ -18,10 +18,55 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppIdentity
 #pragma warning disable 612, 618
             modelBuilder
                 .HasDefaultSchema("identity")
-                .HasAnnotation("ProductVersion", "9.0.0")
+                .HasAnnotation("ProductVersion", "9.0.4")
                 .HasAnnotation("Relational:MaxIdentifierLength", 128);
 
             SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+
+            modelBuilder.Entity("Endatix.Core.Entities.Identity.EmailVerificationToken", b =>
+                {
+                    b.Property<long>("Id")
+                        .HasColumnType("bigint");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<DateTime?>("DeletedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<DateTime>("ExpiresAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("bit");
+
+                    b.Property<bool>("IsUsed")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("bit")
+                        .HasDefaultValue(false);
+
+                    b.Property<DateTime?>("ModifiedAt")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("Token")
+                        .IsRequired()
+                        .HasMaxLength(64)
+                        .HasColumnType("nvarchar(64)");
+
+                    b.Property<long>("UserId")
+                        .HasColumnType("bigint");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ExpiresAt");
+
+                    b.HasIndex("Token")
+                        .IsUnique();
+
+                    b.HasIndex("UserId");
+
+                    b.ToTable("EmailVerificationTokens", "identity");
+                });
 
             modelBuilder.Entity("Endatix.Infrastructure.Identity.AppRole", b =>
                 {
@@ -228,6 +273,15 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppIdentity
                     b.HasKey("UserId", "LoginProvider", "Name");
 
                     b.ToTable("AspNetUserTokens", "identity");
+                });
+
+            modelBuilder.Entity("Endatix.Core.Entities.Identity.EmailVerificationToken", b =>
+                {
+                    b.HasOne("Endatix.Infrastructure.Identity.AppUser", null)
+                        .WithMany()
+                        .HasForeignKey("UserId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
                 });
 
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRoleClaim<long>", b =>

--- a/src/Endatix.WebHost/appsettings.Development.json
+++ b/src/Endatix.WebHost/appsettings.Development.json
@@ -50,6 +50,9 @@
         "Password": "P@ssw0rd"
       }
     },
+    "EmailVerification": {
+      "TokenExpiryInHours": 24
+    },
     "Jwt": {
       "SigningKey": "L2yGC_Vpd3k#L[<9Zb,h?.HT:n'T/5CTDmBpDskU?NAaT$sLfRU",
       "AccessExpiryInMinutes": 90,

--- a/src/Endatix.WebHost/appsettings.json
+++ b/src/Endatix.WebHost/appsettings.json
@@ -52,6 +52,9 @@
         "Password": "P@ssw0rd"
       }
     },
+    "EmailVerification": {
+      "TokenExpiryInHours": 24
+    },
     "Jwt": {
       "SigningKey": "L2yGC_Vpd3k#L[<9Zb,h?.HT:n'T/5CTDmBpDskU?NAaT$sLfRU",
       "AccessExpiryInMinutes": 90,

--- a/tests/Endatix.Api.Tests/Endpoints/Auth/RegisterTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Auth/RegisterTests.cs
@@ -61,6 +61,6 @@ public class RegisterTests
         badResponse.Should().NotBeNull();
         badResponse!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
         badResponse!.Value!.Status.Should().Be(StatusCodes.Status400BadRequest);
-        badResponse!.Value!.Title.Should().Be("Registration failed. Please check your input and try again.");
+        badResponse!.Value!.Title.Should().Be("There was a problem with your request.");
     }
 }

--- a/tests/Endatix.Api.Tests/Endpoints/Auth/VerifyEmailTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Auth/VerifyEmailTests.cs
@@ -1,0 +1,83 @@
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Http;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Api.Endpoints.Auth;
+using Endatix.Core.UseCases.Identity.VerifyEmail;
+using Endatix.Core.Entities.Identity;
+
+namespace Endatix.Api.Tests.Endpoints.Auth;
+
+public class VerifyEmailTests
+{
+    private readonly IMediator _mediator;
+    private readonly VerifyEmail _endpoint;
+
+    public VerifyEmailTests()
+    {
+        _mediator = Substitute.For<IMediator>();
+        _endpoint = Factory.Create<VerifyEmail>(_mediator);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithValidToken_ReturnsOkResult()
+    {
+        // Arrange
+        var request = new VerifyEmailRequest("valid-token");
+        var user = new User(123L, "testuser", "test@example.com", false);
+        var successResult = Result.Success(user);
+
+        _mediator.Send(Arg.Any<VerifyEmailCommand>(), Arg.Any<CancellationToken>())
+            .Returns(successResult);
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, default);
+
+        // Assert
+        var okResponse = response!.Result as Ok<string>;
+
+        okResponse.Should().NotBeNull();
+        _endpoint.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        okResponse!.Value.Should().Be("123");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithInvalidToken_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new VerifyEmailRequest("invalid-token");
+        var errorResult = Result.Invalid(new ValidationError("Invalid or expired verification token"));
+
+        _mediator.Send(Arg.Any<VerifyEmailCommand>(), Arg.Any<CancellationToken>())
+            .Returns(errorResult);
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, default);
+
+        // Assert
+        var badResponse = response!.Result as BadRequest<Microsoft.AspNetCore.Mvc.ProblemDetails>;
+
+        badResponse.Should().NotBeNull();
+        badResponse!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithNotFoundToken_ReturnsNotFound()
+    {
+        // Arrange
+        var request = new VerifyEmailRequest("not-found-token");
+        var notFoundResult = Result.NotFound("Verification token not found");
+
+        _mediator.Send(Arg.Any<VerifyEmailCommand>(), Arg.Any<CancellationToken>())
+            .Returns(notFoundResult);
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, default);
+
+        // Assert
+        var notFoundResponse = response!.Result as NotFound;
+
+        notFoundResponse.Should().NotBeNull();
+    }
+} 

--- a/tests/Endatix.Core.Tests/Entities/Identity/EmailVerificationTokenTests.cs
+++ b/tests/Endatix.Core.Tests/Entities/Identity/EmailVerificationTokenTests.cs
@@ -1,0 +1,122 @@
+using Endatix.Core.Entities.Identity;
+
+namespace Endatix.Core.Tests.Entities.Identity;
+
+public class EmailVerificationTokenTests
+{
+    [Fact]
+    public void Constructor_ValidParameters_CreatesTokenSuccessfully()
+    {
+        // Arrange
+        var userId = 123L;
+        var token = "test-token";
+        var expiresAt = DateTime.UtcNow.AddHours(24);
+
+        // Act
+        var verificationToken = new EmailVerificationToken(userId, token, expiresAt);
+
+        // Assert
+        verificationToken.Should().NotBeNull();
+        verificationToken.UserId.Should().Be(userId);
+        verificationToken.Token.Should().Be(token);
+        verificationToken.ExpiresAt.Should().Be(expiresAt);
+        verificationToken.IsUsed.Should().BeFalse();
+        verificationToken.IsExpired.Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Constructor_InvalidUserId_ThrowsArgumentException(long userId)
+    {
+        // Arrange
+        var token = "test-token";
+        var expiresAt = DateTime.UtcNow.AddHours(24);
+
+        // Act
+        var action = () => new EmailVerificationToken(userId, token, expiresAt);
+
+        // Assert
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    public void Constructor_InvalidToken_ThrowsArgumentException(string token)
+    {
+        // Arrange
+        var userId = 123L;
+        var expiresAt = DateTime.UtcNow.AddHours(24);
+
+        // Act
+        var action = () => new EmailVerificationToken(userId, token, expiresAt);
+
+        // Assert
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Constructor_ExpiredDate_ThrowsArgumentException()
+    {
+        // Arrange
+        var userId = 123L;
+        var token = "test-token";
+        var expiresAt = DateTime.UtcNow.AddHours(-1);
+
+        // Act
+        var action = () => new EmailVerificationToken(userId, token, expiresAt);
+
+        // Assert
+        action.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void IsExpired_TokenNotExpired_ReturnsFalse()
+    {
+        // Arrange
+        var userId = 123L;
+        var token = "test-token";
+        var expiresAt = DateTime.UtcNow.AddHours(1);
+        var verificationToken = new EmailVerificationToken(userId, token, expiresAt);
+
+        // Act & Assert
+        verificationToken.IsExpired.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsExpired_TokenExpired_ReturnsTrue()
+    {
+        // Arrange
+        var userId = 123L;
+        var token = "test-token";
+        var expiresAt = DateTime.UtcNow.AddHours(-1);
+        
+        // We need to create the token with a valid expiry first, then modify it
+        var verificationToken = new EmailVerificationToken(userId, token, DateTime.UtcNow.AddHours(1));
+        
+        // Use reflection to set the expired date for testing
+        var expiresAtProperty = typeof(EmailVerificationToken).GetProperty("ExpiresAt");
+        expiresAtProperty!.SetValue(verificationToken, expiresAt);
+
+        // Act & Assert
+        verificationToken.IsExpired.Should().BeTrue();
+    }
+
+    [Fact]
+    public void MarkAsUsed_TokenNotUsed_MarksAsUsed()
+    {
+        // Arrange
+        var userId = 123L;
+        var token = "test-token";
+        var expiresAt = DateTime.UtcNow.AddHours(24);
+        var verificationToken = new EmailVerificationToken(userId, token, expiresAt);
+
+        // Act
+        verificationToken.MarkAsUsed();
+
+        // Assert
+        verificationToken.IsUsed.Should().BeTrue();
+    }
+} 

--- a/tests/Endatix.Infrastructure.Tests/Identity/EmailVerification/EmailVerificationServiceTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Identity/EmailVerification/EmailVerificationServiceTests.cs
@@ -1,0 +1,154 @@
+using Endatix.Core.Entities.Identity;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
+using Endatix.Infrastructure.Identity;
+using Endatix.Infrastructure.Identity.EmailVerification;
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Endatix.Infrastructure.Tests.Identity.EmailVerification;
+
+public class EmailVerificationServiceTests
+{
+    private readonly IRepository<EmailVerificationToken> _tokenRepository;
+    private readonly UserManager<AppUser> _userManager;
+    private readonly EmailVerificationOptions _options;
+    private readonly EmailVerificationService _sut;
+
+    public EmailVerificationServiceTests()
+    {
+        _tokenRepository = Substitute.For<IRepository<EmailVerificationToken>>();
+        _userManager = Substitute.For<UserManager<AppUser>>(
+            Substitute.For<IUserStore<AppUser>>(), null, null, null, null, null, null, null, null);
+        _options = new EmailVerificationOptions { TokenExpiryInHours = 24 };
+        var optionsWrapper = Substitute.For<IOptions<EmailVerificationOptions>>();
+        optionsWrapper.Value.Returns(_options);
+        _sut = new EmailVerificationService(_tokenRepository, _userManager, optionsWrapper);
+    }
+
+    [Fact]
+    public async Task CreateVerificationTokenAsync_ValidUserId_CreatesTokenSuccessfully()
+    {
+        // Arrange
+        var userId = 123L;
+        var user = new AppUser { Id = userId, EmailConfirmed = false };
+
+        _userManager.FindByIdAsync(userId.ToString()).Returns(user);
+        _tokenRepository.ListAsync(Arg.Any<EmailVerificationTokenByUserIdSpec>(), Arg.Any<CancellationToken>())
+            .Returns(new List<EmailVerificationToken>());
+
+        // Act
+        var result = await _sut.CreateVerificationTokenAsync(userId, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.UserId.Should().Be(userId);
+        result.Value!.Token.Should().NotBeNullOrEmpty();
+        result.Value!.ExpiresAt.Should().BeCloseTo(DateTime.UtcNow.AddHours(24), TimeSpan.FromSeconds(1));
+        result.Value!.IsUsed.Should().BeFalse();
+
+        await _tokenRepository.Received(1).AddAsync(Arg.Any<EmailVerificationToken>(), Arg.Any<CancellationToken>());
+        await _tokenRepository.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task CreateVerificationTokenAsync_UserAlreadyVerified_ReturnsInvalidResult()
+    {
+        // Arrange
+        var userId = 123L;
+        var user = new AppUser { Id = userId, EmailConfirmed = true };
+
+        _userManager.FindByIdAsync(userId.ToString()).Returns(user);
+
+        // Act
+        var result = await _sut.CreateVerificationTokenAsync(userId, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeFalse();
+        result.ValidationErrors.Should().ContainSingle(ve => ve.ErrorMessage == "User is already verified");
+    }
+
+    [Fact]
+    public async Task VerifyEmailAsync_ValidToken_VerifiesUserAndMarksTokenAsUsed()
+    {
+        // Arrange
+        var token = "valid-token";
+        var userId = 123L;
+        var user = new AppUser 
+        { 
+            Id = userId, 
+            UserName = "testuser",
+            Email = "test@example.com",
+            EmailConfirmed = false 
+        };
+        var verificationToken = new EmailVerificationToken(userId, token, DateTime.UtcNow.AddHours(1));
+
+        _tokenRepository.FirstOrDefaultAsync(Arg.Any<EmailVerificationTokenByTokenSpec>(), Arg.Any<CancellationToken>())
+            .Returns(verificationToken);
+        _userManager.FindByIdAsync(userId.ToString()).Returns(user);
+        _userManager.UpdateAsync(user).Returns(IdentityResult.Success);
+
+        // Act
+        var result = await _sut.VerifyEmailAsync(token, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeTrue();
+
+        user.EmailConfirmed.Should().BeTrue();
+        verificationToken.IsUsed.Should().BeTrue();
+
+        _userManager.Received(1).UpdateAsync(user);
+        await _tokenRepository.Received(1).UpdateAsync(verificationToken, Arg.Any<CancellationToken>());
+        await _tokenRepository.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task VerifyEmailAsync_ExpiredToken_ReturnsInvalidResult()
+    {
+        // Arrange
+        var token = "expired-token";
+        var userId = 123L;
+        // Create token with valid expiry first, then modify it to be expired
+        var verificationToken = new EmailVerificationToken(userId, token, DateTime.UtcNow.AddHours(1));
+        
+        // Use reflection to set the expired date for testing
+        var expiresAtProperty = typeof(EmailVerificationToken).GetProperty("ExpiresAt");
+        expiresAtProperty!.SetValue(verificationToken, DateTime.UtcNow.AddHours(-1));
+
+        _tokenRepository.FirstOrDefaultAsync(Arg.Any<EmailVerificationTokenByTokenSpec>(), Arg.Any<CancellationToken>())
+            .Returns(verificationToken);
+
+        // Act
+        var result = await _sut.VerifyEmailAsync(token, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeFalse();
+        result.ValidationErrors.Should().ContainSingle(ve => ve.ErrorMessage == "Verification token has expired");
+    }
+
+    [Fact]
+    public async Task VerifyEmailAsync_TokenNotFound_ReturnsNotFoundResult()
+    {
+        // Arrange
+        var token = "not-found-token";
+
+        _tokenRepository.FirstOrDefaultAsync(Arg.Any<EmailVerificationTokenByTokenSpec>(), Arg.Any<CancellationToken>())
+            .Returns((EmailVerificationToken?)null);
+
+        // Act
+        var result = await _sut.VerifyEmailAsync(token, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+} 


### PR DESCRIPTION
# verify-email endpoint

## Description
- Creates entity `EmailVerificationToken` and its persistance
- Creates endpoint POST `auth/verify-email`
- On user registration the new user has `EmailConfirmed=false` and `TenantId=0`
- On user registration a verification token is created and stored in the DB
- `auth/verify-email` verifies the user if the provided token is valid, not expired and not user.

Note: There are details about the verification described [here](https://github.com/endatix/endatix/blob/63ac60e11852a9a917b58fb6c422d65b133ef759/docs/email-verification.md).

## Related Issues
[[FEATURE] Create email verification endpoints](https://github.com/endatix/endatix-private/issues/145)

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
