### PR TITLE
feat: Support create submission via metadata only + fixes for default submission page

### DIFF
--- a/src/Endatix.Api/Endpoints/Submissions/Create.CreateSubmissionValidator.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/Create.CreateSubmissionValidator.cs
@@ -19,7 +19,12 @@ public class CreateSubmissionValidator : Validator<CreateSubmissionRequest>
             .GreaterThan(0);
 
         RuleFor(x => x.JsonData)
-            .NotEmpty()
-            .MinimumLength(DataSchemaConstants.MIN_JSON_LENGTH);
+            .MinimumLength(DataSchemaConstants.MIN_JSON_LENGTH)
+            .When(x => x.JsonData != null);
+
+        RuleFor(x => x.Metadata)
+            .MinimumLength(DataSchemaConstants.MIN_JSON_LENGTH)
+            .When(x => x.Metadata != null);
+
     }
 }

--- a/src/Endatix.Core/Entities/Submission.cs
+++ b/src/Endatix.Core/Entities/Submission.cs
@@ -7,7 +7,7 @@ public partial class Submission : TenantEntity, IAggregateRoot
 {
     private Submission() { } // For EF Core
 
-    public Submission(long tenantId, string jsonData, long formId, long formDefinitionId, bool isComplete = true, int currentPage = 1, string? metadata = null)
+    public Submission(long tenantId, string jsonData, long formId, long formDefinitionId, bool isComplete = true, int currentPage = 0, string? metadata = null)
         : base(tenantId)
     {
         Guard.Against.NullOrEmpty(jsonData, nameof(jsonData));

--- a/src/Endatix.Core/UseCases/Submissions/Create/CreateSubmissionCommand.cs
+++ b/src/Endatix.Core/UseCases/Submissions/Create/CreateSubmissionCommand.cs
@@ -12,4 +12,4 @@ namespace Endatix.Core.UseCases.Submissions.Create;
 /// <param name="Metadata"></param>
 /// <param name="CurrentPage"></param>
 /// <param name="IsComplete"></param>
-public record CreateSubmissionCommand(long FormId, string JsonData, string? Metadata, int? CurrentPage, bool? IsComplete) : ICommand<Result<Submission>>;
+public record CreateSubmissionCommand(long FormId, string? JsonData, string? Metadata, int? CurrentPage, bool? IsComplete) : ICommand<Result<Submission>>;

--- a/src/Endatix.Core/UseCases/Submissions/Create/CreateSubmissionHandler.cs
+++ b/src/Endatix.Core/UseCases/Submissions/Create/CreateSubmissionHandler.cs
@@ -18,8 +18,10 @@ public class CreateSubmissionHandler(
     ) : ICommandHandler<CreateSubmissionCommand, Result<Submission>>
 {
     private const bool DEFAULT_IS_COMPLETE = false;
-    private const int DEFAULT_CURRENT_PAGE = 1;
-    private const string DEFAULT_METADATA = null;
+    private const int DEFAULT_CURRENT_PAGE = 0;
+    private const string DEFAULT_METADATA = "{}";
+
+    private const string DEFAULT_JSON_DATA = "{}";
 
     public async Task<Result<Submission>> Handle(CreateSubmissionCommand request, CancellationToken cancellationToken)
     {
@@ -36,7 +38,7 @@ public class CreateSubmissionHandler(
 
         var submission = new Submission(
             activeDefinition!.TenantId,
-            jsonData: request.JsonData,
+            jsonData: request.JsonData ?? DEFAULT_JSON_DATA,
             formId: request.FormId,
             formDefinitionId: activeDefinition!.Id,
             isComplete: request.IsComplete ?? DEFAULT_IS_COMPLETE,
@@ -46,8 +48,9 @@ public class CreateSubmissionHandler(
 
         await submissionRepository.AddAsync(submission, cancellationToken);
         await tokenService.ObtainTokenAsync(submission.Id, cancellationToken);
-        
-        if(submission.IsComplete) {
+
+        if (submission.IsComplete)
+        {
             await mediator.Publish(new SubmissionCompletedEvent(submission), cancellationToken);
         }
 

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/Create/CreateSubmissionCommandTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/Create/CreateSubmissionCommandTests.cs
@@ -1,0 +1,64 @@
+using Endatix.Core.UseCases.Submissions.Create;
+
+namespace Endatix.Core.Tests.UseCases.Submissions.Create;
+
+public class CreateSubmissionCommandTests
+{
+    [Fact]
+    public void Constructor_NullJsonData_SetsPropertyToNull()
+    {
+        // Arrange & Act
+        var command = new CreateSubmissionCommand(
+            FormId: 1,
+            JsonData: null,
+            Metadata: null,
+            CurrentPage: null,
+            IsComplete: null
+        );
+
+        // Assert
+        Assert.Null(command.JsonData);
+        Assert.Equal(1, command.FormId);
+    }
+
+    [Fact]
+    public void Constructor_AllParameters_SetsPropertiesCorrectly()
+    {
+        // Arrange
+        var formId = 2L;
+        var jsonData = "{\"key\":\"value\"}";
+        var metadata = "{\"meta\":\"data\"}";
+        int? currentPage = 3;
+        bool? isComplete = true;
+
+        // Act
+        var command = new CreateSubmissionCommand(formId, jsonData, metadata, currentPage, isComplete);
+
+        // Assert
+        Assert.Equal(formId, command.FormId);
+        Assert.Equal(jsonData, command.JsonData);
+        Assert.Equal(metadata, command.Metadata);
+        Assert.Equal(currentPage, command.CurrentPage);
+        Assert.Equal(isComplete, command.IsComplete);
+    }
+
+    [Fact]
+    public void Constructor_NullOptionalParameters_SetsPropertiesToNull()
+    {
+        // Arrange & Act
+        var command = new CreateSubmissionCommand(
+            FormId: 5,
+            JsonData: null,
+            Metadata: null,
+            CurrentPage: null,
+            IsComplete: null
+        );
+
+        // Assert
+        Assert.Equal(5, command.FormId);
+        Assert.Null(command.JsonData);
+        Assert.Null(command.Metadata);
+        Assert.Null(command.CurrentPage);
+        Assert.Null(command.IsComplete);
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/Create/CreateSubmissionHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/Create/CreateSubmissionHandlerTests.cs
@@ -25,7 +25,7 @@ public class CreateSubmissionHandlerTests
         _submissionTokenService = Substitute.For<ISubmissionTokenService>();
         _mediator = Substitute.For<IMediator>();
         _handler = new CreateSubmissionHandler(
-            _submissionsRepository, 
+            _submissionsRepository,
             _formsRepository,
             _submissionTokenService,
             _mediator);
@@ -37,7 +37,7 @@ public class CreateSubmissionHandlerTests
         // Arrange
         var request = new CreateSubmissionCommand(1, "{ }", null, null, null);
         _formsRepository.SingleOrDefaultAsync(
-            Arg.Any<ActiveFormDefinitionByFormIdSpec>(), 
+            Arg.Any<ActiveFormDefinitionByFormIdSpec>(),
             Arg.Any<CancellationToken>())
             .Returns((Form?)null);
         // Act
@@ -58,15 +58,15 @@ public class CreateSubmissionHandlerTests
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
         var request = new CreateSubmissionCommand(
-            FormId: 1, 
-            JsonData: "{ \"field\": \"value\" }", 
+            FormId: 1,
+            JsonData: "{ \"field\": \"value\" }",
             IsComplete: true,
             CurrentPage: 3,
             Metadata: "{ \"meta\": \"data\" }"
         );
-        
+
         _formsRepository.SingleOrDefaultAsync(
-            Arg.Any<ActiveFormDefinitionByFormIdSpec>(), 
+            Arg.Any<ActiveFormDefinitionByFormIdSpec>(),
             Arg.Any<CancellationToken>())
             .Returns(form);
 
@@ -77,16 +77,16 @@ public class CreateSubmissionHandlerTests
         result.Should().NotBeNull();
         result.Status.Should().Be(ResultStatus.Created);
         result.Value.Should().NotBeNull();
-        
+
         await _submissionsRepository.Received(1).AddAsync(
-            Arg.Is<Submission>(s => 
+            Arg.Is<Submission>(s =>
                 s.FormId == request.FormId &&
                 s.FormDefinitionId == formDefinition.Id &&
                 s.JsonData == request.JsonData &&
                 s.IsComplete == request.IsComplete &&
                 s.CurrentPage == request.CurrentPage &&
                 s.Metadata == request.Metadata
-            ), 
+            ),
             Arg.Any<CancellationToken>()
         );
     }
@@ -100,9 +100,9 @@ public class CreateSubmissionHandlerTests
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
         var request = new CreateSubmissionCommand(1, "{ }", null, null, null);
-        
+
         _formsRepository.SingleOrDefaultAsync(
-            Arg.Any<ActiveFormDefinitionByFormIdSpec>(), 
+            Arg.Any<ActiveFormDefinitionByFormIdSpec>(),
             Arg.Any<CancellationToken>())
             .Returns(form);
 
@@ -113,7 +113,7 @@ public class CreateSubmissionHandlerTests
         result.Should().NotBeNull();
         result.Status.Should().Be(ResultStatus.Created);
         result.Value.Should().NotBeNull();
-        
+
         await _submissionTokenService.Received(1).ObtainTokenAsync(
             Arg.Any<long>(),
             Arg.Any<CancellationToken>()
@@ -129,9 +129,9 @@ public class CreateSubmissionHandlerTests
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
         var request = new CreateSubmissionCommand(1, "{ }", null, null, true);
-        
+
         _formsRepository.SingleOrDefaultAsync(
-            Arg.Any<ActiveFormDefinitionByFormIdSpec>(), 
+            Arg.Any<ActiveFormDefinitionByFormIdSpec>(),
             Arg.Any<CancellationToken>())
             .Returns(form);
 
@@ -143,11 +143,73 @@ public class CreateSubmissionHandlerTests
         result.Status.Should().Be(ResultStatus.Created);
 
         await _mediator.Received(1).Publish(
-            Arg.Is<SubmissionCompletedEvent>(e => 
-                e.Submission.FormId == request.FormId && 
+            Arg.Is<SubmissionCompletedEvent>(e =>
+                e.Submission.FormId == request.FormId &&
                 e.Submission.JsonData == request.JsonData
-            ), 
+            ),
             Arg.Any<CancellationToken>()
         );
+    }
+
+    [Fact]
+    public async Task Handle_NullJsonData_SetsDefaultJsonData()
+    {
+        // Arrange
+        const string DEFAULT_JSON_DATA = "{}";
+        var form = new Form(SampleData.TENANT_ID, "Test Form") { Id = 1 };
+        var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
+        form.AddFormDefinition(formDefinition);
+        form.SetActiveFormDefinition(formDefinition);
+        var request = new CreateSubmissionCommand(
+            FormId: 1,
+            JsonData: null,
+            IsComplete: false,
+            CurrentPage: 5,
+            Metadata: null
+        );
+        _formsRepository.SingleOrDefaultAsync(
+            Arg.Any<ActiveFormDefinitionByFormIdSpec>(),
+            Arg.Any<CancellationToken>())
+            .Returns(form);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be(ResultStatus.Created);
+        result.Value.Should().NotBeNull();
+        result.Value.JsonData.Should().Be(DEFAULT_JSON_DATA);
+    }
+
+    [Fact]
+    public async Task Handle_NullCurrentPage_SetsDefaultCurrentPage()
+    {
+        // Arrange
+        const int DEFAULT_CURRENT_PAGE = 0;
+        var form = new Form(SampleData.TENANT_ID, "Test Form") { Id = 1 };
+        var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
+        form.AddFormDefinition(formDefinition);
+        form.SetActiveFormDefinition(formDefinition);
+        var request = new CreateSubmissionCommand(
+            FormId: 1,
+            JsonData: "{ }",
+            IsComplete: false,
+            CurrentPage: null,
+            Metadata: null
+        );
+        _formsRepository.SingleOrDefaultAsync(
+            Arg.Any<ActiveFormDefinitionByFormIdSpec>(),
+            Arg.Any<CancellationToken>())
+            .Returns(form);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be(ResultStatus.Created);
+        result.Value.Should().NotBeNull();
+        result.Value.CurrentPage.Should().Be(DEFAULT_CURRENT_PAGE);
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/PartialUpdate/PartialUpdateSubmissionCommandTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/PartialUpdate/PartialUpdateSubmissionCommandTests.cs
@@ -1,0 +1,73 @@
+using Endatix.Core.UseCases.Submissions.PartialUpdate;
+
+namespace Endatix.Core.Tests.UseCases.Submissions.PartialUpdate;
+
+public class PartialUpdateSubmissionCommandTests
+{
+    [Fact]
+    public void Constructor_AllParameters_SetsPropertiesCorrectly()
+    {
+        // Arrange
+        long submissionId = 10;
+        long formId = 20;
+        bool? isComplete = true;
+        int? currentPage = 2;
+        var jsonData = "{\"key\":\"value\"}";
+        var metadata = "{\"meta\":\"data\"}";
+
+        // Act
+        var command = new PartialUpdateSubmissionCommand(submissionId, formId, isComplete, currentPage, jsonData, metadata);
+
+        // Assert
+        Assert.Equal(submissionId, command.SubmissionId);
+        Assert.Equal(formId, command.FormId);
+        Assert.Equal(isComplete, command.IsComplete);
+        Assert.Equal(currentPage, command.CurrentPage);
+        Assert.Equal(jsonData, command.JsonData);
+        Assert.Equal(metadata, command.Metadata);
+    }
+
+    [Fact]
+    public void Constructor_NullOptionalParameters_SetsPropertiesToNull()
+    {
+        // Arrange & Act
+        var command = new PartialUpdateSubmissionCommand(
+            SubmissionId: 1,
+            FormId: 2,
+            IsComplete: null,
+            CurrentPage: null,
+            JsonData: null,
+            Metadata: null
+        );
+
+        // Assert
+        Assert.Equal(1, command.SubmissionId);
+        Assert.Equal(2, command.FormId);
+        Assert.Null(command.IsComplete);
+        Assert.Null(command.CurrentPage);
+        Assert.Null(command.JsonData);
+        Assert.Null(command.Metadata);
+    }
+
+    [Fact]
+    public void Constructor_NullJsonData_SetsPropertyToNull()
+    {
+        // Arrange & Act
+        var command = new PartialUpdateSubmissionCommand(
+            SubmissionId: 3,
+            FormId: 4,
+            IsComplete: false,
+            CurrentPage: 1,
+            JsonData: null,
+            Metadata: "meta"
+        );
+
+        // Assert
+        Assert.Equal(3, command.SubmissionId);
+        Assert.Equal(4, command.FormId);
+        Assert.False(command.IsComplete);
+        Assert.Equal(1, command.CurrentPage);
+        Assert.Null(command.JsonData);
+        Assert.Equal("meta", command.Metadata);
+    }
+} 

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/PartialUpdate/PartialUpdateSubmissionHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/PartialUpdate/PartialUpdateSubmissionHandlerTests.cs
@@ -26,7 +26,7 @@ public class PartialUpdateSubmissionHandlerTests
         // Arrange
         var request = new PartialUpdateSubmissionCommand(1, 1, null, null, null, null);
         _repository.SingleOrDefaultAsync(
-            Arg.Any<SubmissionByFormIdAndSubmissionIdSpec>(), 
+            Arg.Any<SubmissionByFormIdAndSubmissionIdSpec>(),
             Arg.Any<CancellationToken>())
             .Returns((Submission?)null);
 
@@ -47,9 +47,9 @@ public class PartialUpdateSubmissionHandlerTests
         var request = new PartialUpdateSubmissionCommand(
             1, 2, true, 1, "{ \"updated\": true }", "metadata"
         );
-        
+
         _repository.SingleOrDefaultAsync(
-            Arg.Any<SubmissionByFormIdAndSubmissionIdSpec>(), 
+            Arg.Any<SubmissionByFormIdAndSubmissionIdSpec>(),
             Arg.Any<CancellationToken>())
             .Returns(submission);
 
@@ -65,7 +65,74 @@ public class PartialUpdateSubmissionHandlerTests
         result.Value.CurrentPage.Should().Be(request.CurrentPage!.Value);
         result.Value.Metadata.Should().Be(request.Metadata);
         result.Value.FormId.Should().Be(request.FormId);
-        
+
         await _repository.Received(1).SaveChangesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_NoPageInCommand_KeepsExistingPage()
+    {
+        // Arrange
+        var existingPage = 7;
+        var submission = new Submission(
+            tenantId: SampleData.TENANT_ID,
+            jsonData: "{ }",
+            formId: 2,
+            formDefinitionId: 3,
+            isComplete: false,
+            currentPage: existingPage,
+            metadata: null);
+
+        var request = new PartialUpdateSubmissionCommand(
+            SubmissionId: 1,
+            FormId: 2,
+            IsComplete: null,
+            CurrentPage: null,
+            JsonData: null,
+            Metadata: null
+        );
+        _repository.SingleOrDefaultAsync(
+            Arg.Any<SubmissionByFormIdAndSubmissionIdSpec>(),
+            Arg.Any<CancellationToken>())
+            .Returns(submission);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().NotBeNull();
+        result.Value.CurrentPage.Should().Be(existingPage);
+    }
+
+    [Fact]
+    public async Task Handle_NoPageInCommandAndSubmission_SetsDefaultPageFallbackValue()
+    {
+        // Arrange
+        const int DEFAULT_CURRENT_PAGE = 0;
+        var submission = new Submission(
+            tenantId: SampleData.TENANT_ID,
+            jsonData: "{ }",
+            formId: 2,
+            formDefinitionId: 3,
+            isComplete: false,
+            metadata: null);
+        var request = new PartialUpdateSubmissionCommand(
+            1, 2, null, null, null, null
+        );
+        _repository.SingleOrDefaultAsync(
+            Arg.Any<SubmissionByFormIdAndSubmissionIdSpec>(),
+            Arg.Any<CancellationToken>())
+            .Returns(submission);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().NotBeNull();
+        result.Value.CurrentPage.Should().Be(DEFAULT_CURRENT_PAGE);
     }
 }


### PR DESCRIPTION
# feat: Support create submission via metadata only + fixes for default submission page

## Description
This task adds needed fixes to support working with dynamic survey variables. In details:
- proper default values for submission commands and handlers
- allow for null json data and metadata in create and partial update submission commands and handlers
- add tests for submission commands and handlers

## Related Issues
- part of [Show Original Variables in Submission View](https://github.com/endatix/endatix-private/issues/182)

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 
