### PR TITLE
fix: Using hidden tag to hide endpoints from the API documentation

### DIFF
--- a/src/Endatix.Api/Builders/ApiConfigurationBuilder.cs
+++ b/src/Endatix.Api/Builders/ApiConfigurationBuilder.cs
@@ -155,6 +155,10 @@ public class ApiConfigurationBuilder
                 settings.Description = "The Endatix Platform is an open-source .NET library for data collection and management. This product is actively developed, and some API design characteristics may evolve. For more information, visit <a href=\"https://docs.endatix.com\">Endatix Documentation</a>.";
                 settings.SchemaSettings.SchemaType = SchemaType.OpenApi3;
             };
+            options.EndpointFilter = ep => {
+                var hasHiddenTag = ep.EndpointTags?.Contains("hidden") ?? false;
+                return hasHiddenTag ? false : true;
+            };
         });
 
         LogSetupInfo("Swagger documentation configured successfully");

--- a/src/Endatix.Api/Endpoints/Integrations/SlackToken.cs
+++ b/src/Endatix.Api/Endpoints/Integrations/SlackToken.cs
@@ -10,7 +10,7 @@ namespace Endatix.Api.Endpoints.Integrations;
 /// <summary>
 /// Endpoint for receiving the slack token.
 /// </summary>
-public class SlackToken(IMediator mediator, ILogger<SlackToken> logger, IEmailSender emailSender) : Endpoint<SlackTokenRequest, Results<Ok<string>, BadRequest>>
+public class SlackToken(ILogger<SlackToken> logger, IEmailSender emailSender) : Endpoint<SlackTokenRequest, Results<Ok<string>, BadRequest>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -19,6 +19,7 @@ public class SlackToken(IMediator mediator, ILogger<SlackToken> logger, IEmailSe
     {
         Post("slacktoken");
         AllowAnonymous();
+        Tags("hidden"); // With this tag, the endpoint is hidden from the API documentation
         Summary(s =>
         {
             s.Summary = "Receives a Slack token";


### PR DESCRIPTION
# Hide Slacktoken endpoint from Swagger

## Description
- Adds "hidden" Tag to the `SlackToken` endpoint
- Adds new filter based of the "hidden" tag associated with the endpoints

## Related Issues
closes https://github.com/endatix/endatix-private/issues/208

## Type of Change
- [x] Bugfix

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 

## Screenshots
<img width="1483" alt="image" src="https://github.com/user-attachments/assets/f14bad1d-78b6-4a0c-8b1f-a2a8dd761bfe" />
