### PR TITLE
fix: Fix prefixing logic of file names

### DIFF
--- a/src/Endatix.Infrastructure/Features/Submissions/SubmissionFileExtractor.cs
+++ b/src/Endatix.Infrastructure/Features/Submissions/SubmissionFileExtractor.cs
@@ -102,7 +102,7 @@ public sealed class SubmissionFileExtractor : ISubmissionFileExtractor
 
         var originalName = nameProp.GetString() ?? "file";
         var ext = Path.GetExtension(originalName);
-        var baseName = string.IsNullOrEmpty(context.Prefix) ? "" : context.Prefix + "-";
+        var baseName = string.IsNullOrEmpty(context.Prefix) ? "" : context.Prefix;
         baseName += questionName;
         if (total > 1)
         {

--- a/tests/Endatix.Infrastructure.Tests/Features/Submissions/SubmissionFileExtractorTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Submissions/SubmissionFileExtractorTests.cs
@@ -166,7 +166,7 @@ public sealed class SubmissionFileExtractorTests
         // Assert
         Assert.Single(files);
         var file = files[0];
-        Assert.Equal("myprefix-fileQuestion.txt", file.FileName);
+        Assert.Equal("myprefixfileQuestion.txt", file.FileName);
         Assert.Equal("text/plain", file.MimeType);
         using var reader = new StreamReader(file.Content);
         Assert.Equal("Hello world", reader.ReadToEnd());


### PR DESCRIPTION
# fix: Fix prefixing logic of file names

## Description
- Removes the hard coded - to give more control to users

## Related Issues
closes https://github.com/endatix/endatix-hub/issues/74

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules 

## Screenshots
If applicable, add screenshots to help explain your changes.
