### PR TITLE
feat: Add SMTP email provider, send-verification endpoint and send verification emails

### DIFF
--- a/docs/email-verification.md
+++ b/docs/email-verification.md
@@ -38,10 +38,21 @@ Implements the email verification logic:
 - Updates user verification status
 - Handles token cleanup
 
-### 4. API Endpoint
+### 4. SendVerificationEmail Use Case
 
-Located in `src/Endatix.Api/Endpoints/Auth/VerifyEmail.cs`
+Located in `src/Endatix.Core/UseCases/Identity/SendVerificationEmail/`
 
+Handles the business logic for sending verification emails:
+- Finds users by email address
+- Validates user verification status
+- Creates new verification tokens
+- Implements security measures to prevent email enumeration
+
+### 5. API Endpoints
+
+Located in `src/Endatix.Api/Endpoints/Auth/`
+
+#### Verify Email Endpoint
 - **POST** `/api/auth/verify-email`
 - Accepts a verification token
 - Returns the user ID on success
@@ -50,6 +61,16 @@ Located in `src/Endatix.Api/Endpoints/Auth/VerifyEmail.cs`
   - `400 Bad Request` - Invalid or expired token (with problem details)
   - `404 Not Found` - Token not found
 - Anonymous access (no authentication required)
+
+#### Send Verification Email Endpoint
+- **POST** `/api/auth/send-verification-email`
+- Accepts an email address
+- Creates a new verification token and sends it via email (when email sending is implemented)
+- Returns appropriate HTTP status codes:
+  - `200 OK` - Verification email sent successfully (or would be sent if email sending is implemented)
+  - `400 Bad Request` - Invalid email address (with problem details)
+- Anonymous access (no authentication required)
+- **Security Note**: Always returns success to prevent email enumeration attacks
 
 ## Configuration
 
@@ -96,7 +117,14 @@ The `EmailVerificationTokens` table is located in the `identity` schema and cont
    - Returns the user ID on success
    - User can now log in
 
-3. **Login**
+3. **Send Verification Email** (if resending is needed)
+   - User requests a verification email by calling `POST /api/auth/send-verification-email` with their email address
+   - System validates email format and checks if user exists and is not verified
+   - If valid, a new verification token is generated and the old one is invalidated
+   - New token is sent via email (when email sending is implemented)
+   - Always returns success to prevent email enumeration attacks
+
+4. **Login**
    - User attempts to log in
    - System checks `EmailConfirmed` status
    - Only verified users can log in
@@ -140,11 +168,13 @@ HTTP/1.1 404 Not Found
 The implementation includes comprehensive tests:
 - Entity tests: `tests/Endatix.Core.Tests/Entities/Identity/EmailVerificationTokenTests.cs`
 - Service tests: `tests/Endatix.Infrastructure.Tests/Identity/EmailVerification/EmailVerificationServiceTests.cs`
+- Use case tests: `tests/Endatix.Core.Tests/UseCases/Identity/SendVerificationEmail/SendVerificationEmailHandlerTests.cs`
 - API tests: `tests/Endatix.Api.Tests/Endpoints/Auth/VerifyEmailTests.cs`
+- Send API tests: `tests/Endatix.Api.Tests/Endpoints/Auth/SendVerificationEmailTests.cs`
 
 ## Future Enhancements
 
-1. **Token Resend**: Allow users to request new verification tokens
+1. **Email Sending**: Implement actual email sending for verification tokens
 2. **Rate Limiting**: Prevent abuse of verification endpoints
 3. **Audit Logging**: Track verification attempts and failures
 4. **Custom Expiry**: Allow different expiry times for different user types 

--- a/src/Endatix.Api/Endpoints/Auth/SendVerificationEmail.SendVerificationEmailRequest.cs
+++ b/src/Endatix.Api/Endpoints/Auth/SendVerificationEmail.SendVerificationEmailRequest.cs
@@ -1,0 +1,12 @@
+namespace Endatix.Api.Endpoints.Auth;
+
+/// <summary>
+/// Represents the request for the "/send-verification-email" endpoint.
+/// </summary>
+public record SendVerificationEmailRequest(string Email)
+{
+    /// <summary>
+    /// The email address to send the verification email to.
+    /// </summary>
+    public string Email { get; init; } = Email;
+} 

--- a/src/Endatix.Api/Endpoints/Auth/SendVerificationEmail.SendVerificationEmailValidator.cs
+++ b/src/Endatix.Api/Endpoints/Auth/SendVerificationEmail.SendVerificationEmailValidator.cs
@@ -1,0 +1,20 @@
+using FastEndpoints;
+using FluentValidation;
+
+namespace Endatix.Api.Endpoints.Auth;
+
+/// <summary>
+/// Validator for the SendVerificationEmailRequest used in the email verification sending process.
+/// </summary>
+public class SendVerificationEmailValidator : Validator<SendVerificationEmailRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SendVerificationEmailValidator"/> class.
+    /// </summary>
+    public SendVerificationEmailValidator()
+    {
+        RuleFor(x => x.Email)
+            .NotEmpty()
+            .EmailAddress();
+    }
+} 

--- a/src/Endatix.Api/Endpoints/Auth/SendVerificationEmail.cs
+++ b/src/Endatix.Api/Endpoints/Auth/SendVerificationEmail.cs
@@ -1,0 +1,39 @@
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Errors = Microsoft.AspNetCore.Mvc;
+using Endatix.Core.UseCases.Identity.SendVerificationEmail;
+using Endatix.Api.Infrastructure;
+
+namespace Endatix.Api.Endpoints.Auth;
+
+/// <summary>
+/// Endpoint for sending verification emails to users.
+/// </summary>
+public class SendVerificationEmail(IMediator mediator) : Endpoint<SendVerificationEmailRequest, Results<Ok<string>, BadRequest<Errors.ProblemDetails>>>
+{
+    public override void Configure()
+    {
+        Post("auth/send-verification-email");
+        AllowAnonymous();
+        Summary(s =>
+        {
+            s.Summary = "Send verification email";
+            s.Description = "Sends a verification email to the specified email address if the user exists and is not already verified.";
+            s.Responses[200] = "Verification email has been sent successfully.";
+            s.Responses[400] = "Invalid email address.";
+            s.ExampleRequest = new SendVerificationEmailRequest("user@example.com");
+        });
+    }
+
+    /// <inheritdoc/>
+    public override async Task<Results<Ok<string>, BadRequest<Errors.ProblemDetails>>> ExecuteAsync(SendVerificationEmailRequest request, CancellationToken cancellationToken)
+    {
+        var sendVerificationEmailCommand = new SendVerificationEmailCommand(request.Email);
+        var result = await mediator.Send(sendVerificationEmailCommand, cancellationToken);
+
+        return TypedResultsBuilder
+                .MapResult(result, result => "Verification email sent successfully")
+                .SetTypedResults<Ok<string>, BadRequest<Errors.ProblemDetails>>();
+    }
+} 

--- a/src/Endatix.Core/Abstractions/IEmailTemplateService.cs
+++ b/src/Endatix.Core/Abstractions/IEmailTemplateService.cs
@@ -1,0 +1,17 @@
+using Endatix.Core.Features.Email;
+
+namespace Endatix.Core.Abstractions;
+
+/// <summary>
+/// Defines the contract for email template operations.
+/// </summary>
+public interface IEmailTemplateService
+{
+    /// <summary>
+    /// Creates a verification email template for the specified user and token.
+    /// </summary>
+    /// <param name="userEmail">The email address of the user.</param>
+    /// <param name="token">The verification token.</param>
+    /// <returns>An EmailWithTemplate configured for verification.</returns>
+    EmailWithTemplate CreateVerificationEmail(string userEmail, string token);
+} 

--- a/src/Endatix.Core/Abstractions/IUserService.cs
+++ b/src/Endatix.Core/Abstractions/IUserService.cs
@@ -15,7 +15,15 @@ public interface IUserService
     /// <param name="claimsPrincipal">The ClaimsPrincipal object representing the user.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The User entity associated with the provided ClaimsPrincipal.</returns>
-    public Task<Result<User>> GetUserAsync(ClaimsPrincipal claimsPrincipal, CancellationToken cancellationToken = default);
+    Task<Result<User>> GetUserAsync(ClaimsPrincipal claimsPrincipal, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets a user by email address.
+    /// </summary>
+    /// <param name="email">The email address to search for.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation if needed.</param>
+    /// <returns>A Result containing the User if found, or NotFound if not found.</returns>
+    Task<Result<User>> GetUserAsync(string email, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Changes the password for a user after validating their current password.
@@ -25,5 +33,5 @@ public interface IUserService
     /// <param name="newPassword">The new password to set for the user.</param>
     /// <param name="cancellationToken">Optional cancellation token.</param>
     /// <returns>A Result containing a message if successful, or an error if the operation fails.</returns>
-    public Task<Result<string>> ChangePasswordAsync(User user, string currentPassword, string newPassword, CancellationToken cancellationToken = default);
+    Task<Result<string>> ChangePasswordAsync(User user, string currentPassword, string newPassword, CancellationToken cancellationToken = default);
 }

--- a/src/Endatix.Core/Configuration/EmailTemplateSettings.cs
+++ b/src/Endatix.Core/Configuration/EmailTemplateSettings.cs
@@ -1,0 +1,38 @@
+namespace Endatix.Core.Configuration;
+
+/// <summary>
+/// Configuration for email template settings.
+/// </summary>
+public class EmailTemplateSettings
+{
+    /// <summary>
+    /// The base URL for Endatix Hub application.
+    /// </summary>
+    public string HubUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Email verification template settings.
+    /// </summary>
+    public EmailTemplateConfig EmailVerification { get; set; } = new();
+
+    /// <summary>
+    /// Welcome email template settings.
+    /// </summary>
+    public EmailTemplateConfig WelcomeEmail { get; set; } = new();
+}
+
+/// <summary>
+/// Configuration for a specific email template.
+/// </summary>
+public class EmailTemplateConfig
+{
+    /// <summary>
+    /// Template ID or name (SendGrid template ID or SMTP template name).
+    /// </summary>
+    public string TemplateId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// From email address.
+    /// </summary>
+    public string FromAddress { get; set; } = string.Empty;
+} 

--- a/src/Endatix.Core/Entities/EmailTemplate.cs
+++ b/src/Endatix.Core/Entities/EmailTemplate.cs
@@ -1,0 +1,112 @@
+using Ardalis.GuardClauses;
+using Endatix.Core.Features.Email;
+using Endatix.Core.Infrastructure.Domain;
+
+namespace Endatix.Core.Entities;
+
+/// <summary>
+/// Represents an email template stored in the database.
+/// </summary>
+public class EmailTemplate : BaseEntity, IAggregateRoot
+{
+    public EmailTemplate(string name, string subject, string htmlContent, string plainTextContent, string fromAddress)
+    {
+        Guard.Against.NullOrWhiteSpace(name);
+        Guard.Against.NullOrWhiteSpace(subject);
+        Guard.Against.NullOrWhiteSpace(htmlContent);
+        Guard.Against.NullOrWhiteSpace(plainTextContent);
+        Guard.Against.NullOrWhiteSpace(fromAddress);
+
+        Name = name;
+        Subject = subject;
+        HtmlContent = htmlContent;
+        PlainTextContent = plainTextContent;
+        FromAddress = fromAddress;
+    }
+
+    /// <summary>
+    /// The unique name/identifier for this template.
+    /// </summary>
+    public string Name { get; private set; }
+
+    /// <summary>
+    /// The subject line for emails using this template.
+    /// </summary>
+    public string Subject { get; private set; }
+
+    /// <summary>
+    /// The HTML content of the email template.
+    /// </summary>
+    public string HtmlContent { get; private set; }
+
+    /// <summary>
+    /// The plain text content of the email template.
+    /// </summary>
+    public string PlainTextContent { get; private set; }
+
+    /// <summary>
+    /// The sender email address for emails using this template.
+    /// </summary>
+    public string FromAddress { get; private set; }
+
+    /// <summary>
+    /// Updates the template content.
+    /// </summary>
+    public void UpdateContent(string subject, string htmlContent, string plainTextContent, string fromAddress)
+    {
+        Guard.Against.NullOrWhiteSpace(subject);
+        Guard.Against.NullOrWhiteSpace(htmlContent);
+        Guard.Against.NullOrWhiteSpace(plainTextContent);
+        Guard.Against.NullOrWhiteSpace(fromAddress);
+
+        Subject = subject;
+        HtmlContent = htmlContent;
+        PlainTextContent = plainTextContent;
+        FromAddress = fromAddress;
+    }
+
+    /// <summary>
+    /// Renders the template with the provided variables.
+    /// </summary>
+    /// <param name="to">The recipient email address.</param>
+    /// <param name="variables">The variables to substitute in the template.</param>
+    /// <param name="subject">Optional subject override. If provided, overrides template subject.</param>
+    /// <param name="from">Optional from address override. If provided, overrides template from address.</param>
+    /// <returns>An EmailWithBody model ready to be sent.</returns>
+    public EmailWithBody Render(string to, Dictionary<string, string> variables, string? subject = null, string? from = null)
+    {
+        Guard.Against.NullOrWhiteSpace(to);
+        Guard.Against.Null(variables);
+
+        var htmlContent = ReplaceVariables(HtmlContent, variables);
+        var plainTextContent = ReplaceVariables(PlainTextContent, variables);
+        
+        var finalSubject = !string.IsNullOrEmpty(subject) 
+            ? ReplaceVariables(subject, variables)
+            : ReplaceVariables(Subject, variables);
+        
+        var finalFromAddress = !string.IsNullOrEmpty(from) 
+            ? from
+            : FromAddress;
+
+        return new EmailWithBody
+        {
+            To = to,
+            From = finalFromAddress,
+            Subject = finalSubject,
+            HtmlBody = htmlContent,
+            PlainTextBody = plainTextContent
+        };
+    }
+
+    private static string ReplaceVariables(string content, Dictionary<string, string> variables)
+    {
+        var result = content;
+        foreach (var (key, value) in variables)
+        {
+            var placeholder = $"{{{{{key}}}}}";
+            result = result.Replace(placeholder, value);
+        }
+        return result;
+    }
+} 

--- a/src/Endatix.Core/Specifications/EmailTemplateByNameSpec.cs
+++ b/src/Endatix.Core/Specifications/EmailTemplateByNameSpec.cs
@@ -1,0 +1,15 @@
+using Ardalis.Specification;
+using Endatix.Core.Entities;
+
+namespace Endatix.Core.Specifications;
+
+/// <summary>
+/// Specification to find an email template by name.
+/// </summary>
+public class EmailTemplateByNameSpec : Specification<EmailTemplate>
+{
+    public EmailTemplateByNameSpec(string name)
+    {
+        Query.Where(t => t.Name == name);
+    }
+} 

--- a/src/Endatix.Core/UseCases/Identity/SendVerificationEmail/SendVerificationEmailCommand.cs
+++ b/src/Endatix.Core/UseCases/Identity/SendVerificationEmail/SendVerificationEmailCommand.cs
@@ -1,0 +1,15 @@
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.Identity.SendVerificationEmail;
+
+/// <summary>
+/// Command to send a verification email to a user.
+/// </summary>
+public record SendVerificationEmailCommand(string Email) : ICommand<Result>
+{
+    /// <summary>
+    /// The email address to send the verification email to.
+    /// </summary>
+    public string Email { get; init; } = Email;
+} 

--- a/src/Endatix.Core/UseCases/Identity/SendVerificationEmail/SendVerificationEmailHandler.cs
+++ b/src/Endatix.Core/UseCases/Identity/SendVerificationEmail/SendVerificationEmailHandler.cs
@@ -1,0 +1,62 @@
+using Endatix.Core.Abstractions;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+using Microsoft.Extensions.Logging;
+
+namespace Endatix.Core.UseCases.Identity.SendVerificationEmail;
+
+/// <summary>
+/// Handles the sending of verification emails to users.
+/// </summary>
+public class SendVerificationEmailHandler(
+    IEmailVerificationService emailVerificationService,
+    IUserService userService,
+    ILogger<SendVerificationEmailHandler> logger) : ICommandHandler<SendVerificationEmailCommand, Result>
+{
+    /// <summary>
+    /// Handles the SendVerificationEmailCommand to send a verification email.
+    /// </summary>
+    /// <param name="request">The SendVerificationEmailCommand containing the email address.</param>
+    /// <param name="cancellationToken">A cancellation token that can be used to cancel the work.</param>
+    /// <returns>A Result containing the operation status.</returns>
+    public async Task<Result> Handle(SendVerificationEmailCommand request, CancellationToken cancellationToken)
+    {
+        var userResult = await userService.GetUserAsync(request.Email, cancellationToken);
+        if (!userResult.IsSuccess)
+        {
+            // Log the attempt to send verification email to non-existent user
+            logger.LogWarning("Verification email requested for non-existent user: {Email}", request.Email);
+            
+            // Return success to prevent email enumeration attacks
+            return Result.Success();
+        }
+
+        var user = userResult.Value!;
+        if (user.IsVerified)
+        {
+            // Log the attempt to send verification email to already verified user
+            logger.LogWarning("Verification email requested for already verified user: {Email} (UserId: {UserId})",
+                request.Email, user.Id);
+            
+            // Return success to prevent email enumeration attacks
+            return Result.Success();
+        }
+
+        var tokenResult = await emailVerificationService.CreateVerificationTokenAsync(user.Id, cancellationToken);
+        if (tokenResult.IsSuccess)
+        {
+            // TODO: Implement email sending logic
+        }
+        else
+        {
+            // Log token creation failure
+            logger.LogError("Failed to create verification token for user: {Email} (UserId: {UserId}). Errors: {Errors}", 
+                request.Email, user.Id, string.Join(", ", tokenResult.ValidationErrors.Select(e => e.ErrorMessage)));
+            
+            // If token creation fails, we should still return success but log the error
+            // The user can request a new verification token later
+        }
+
+        return Result.Success();
+    }
+} 

--- a/src/Endatix.Infrastructure/Builders/InfrastructureIntegrationsBuilder.cs
+++ b/src/Endatix.Infrastructure/Builders/InfrastructureIntegrationsBuilder.cs
@@ -33,7 +33,8 @@ public class InfrastructureIntegrationsBuilder
     {
         LogSetupInfo("Configuring integrations with default settings");
 
-        _parentBuilder.Services.AddEmailSender<SendGridEmailSender, SendGridSettings>();
+        _parentBuilder.Services.AddEmailTemplateSettings();
+        _parentBuilder.Services.AddEmailSender<SmtpEmailSender, SmtpSettings>();
 
         LogSetupInfo("Integrations configuration completed");
         return this;

--- a/src/Endatix.Infrastructure/Data/AppDbContext.cs
+++ b/src/Endatix.Infrastructure/Data/AppDbContext.cs
@@ -37,6 +37,8 @@ public class AppDbContext : DbContext
 
     public DbSet<SubmissionExportRow> SubmissionExportRows { get; set; }
 
+    public DbSet<EmailTemplate> EmailTemplates { get; set; }
+
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);

--- a/src/Endatix.Infrastructure/Data/Config/EmailTemplateConfiguration.cs
+++ b/src/Endatix.Infrastructure/Data/Config/EmailTemplateConfiguration.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Endatix.Core.Entities;
+
+namespace Endatix.Infrastructure.Data.Config;
+
+/// <summary>
+/// Configuration for the EmailTemplate entity.
+/// </summary>
+public class EmailTemplateConfiguration : IEntityTypeConfiguration<EmailTemplate>
+{
+    /// <inheritdoc />
+    public void Configure(EntityTypeBuilder<EmailTemplate> builder)
+    {
+        builder.ToTable("EmailTemplates");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Name)
+            .IsRequired()
+            .HasMaxLength(100);
+
+        builder.Property(e => e.Subject)
+            .IsRequired()
+            .HasMaxLength(200);
+
+        builder.Property(e => e.HtmlContent)
+            .IsRequired();
+
+        builder.Property(e => e.PlainTextContent)
+            .IsRequired();
+
+        builder.Property(e => e.FromAddress)
+            .IsRequired()
+            .HasMaxLength(255);
+
+        builder.HasIndex(e => e.Name)
+            .IsUnique();
+    }
+} 

--- a/src/Endatix.Infrastructure/Email/EmailTemplateService.cs
+++ b/src/Endatix.Infrastructure/Email/EmailTemplateService.cs
@@ -1,0 +1,40 @@
+using Endatix.Core;
+using Endatix.Core.Abstractions;
+using Endatix.Core.Configuration;
+using Microsoft.Extensions.Options;
+
+namespace Endatix.Infrastructure.Email;
+
+/// <summary>
+/// Implements email template operations using configuration settings.
+/// </summary>
+public class EmailTemplateService : IEmailTemplateService
+{
+    private readonly IOptions<EmailTemplateSettings> _emailTemplateSettings;
+
+    /// <summary>
+    /// Initializes a new instance of the EmailTemplateService class.
+    /// </summary>
+    /// <param name="emailTemplateSettings">Email template configuration settings.</param>
+    public EmailTemplateService(IOptions<EmailTemplateSettings> emailTemplateSettings)
+    {
+        _emailTemplateSettings = emailTemplateSettings;
+    }
+
+    /// <inheritdoc />
+    public EmailWithTemplate CreateVerificationEmail(string userEmail, string token)
+    {
+        return new EmailWithTemplate
+        {
+            To = userEmail,
+            From = _emailTemplateSettings.Value.EmailVerification.FromAddress,
+            Subject = string.Empty, // Taken from the template
+            TemplateId = _emailTemplateSettings.Value.EmailVerification.TemplateId,
+            Metadata = new Dictionary<string, object>
+            {
+                ["hubUrl"] = _emailTemplateSettings.Value.HubUrl,
+                ["verificationToken"] = token
+            }
+        };
+    }
+} 

--- a/src/Endatix.Infrastructure/Email/SendGridEmailSender.cs
+++ b/src/Endatix.Infrastructure/Email/SendGridEmailSender.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 using SendGrid;
 using SendGrid.Helpers.Mail;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,10 +6,7 @@ using Microsoft.Extensions.Options;
 using Endatix.Core.Abstractions;
 using Endatix.Core.Features.Email;
 using SendGrid.Extensions.DependencyInjection;
-using Newtonsoft.Json;
 using Endatix.Core;
-using Ardalis.GuardClauses;
-using Microsoft.AspNetCore.Mvc;
 
 namespace Endatix.Infrastructure.Email;
 
@@ -74,25 +68,13 @@ public class SendGridEmailSender : IEmailSender, IHasConfigSection<SendGridSetti
         msg.AddTo(new EmailAddress(email.To));
         msg.SetTemplateId(email.TemplateId);
 
-        var dynamicTemplateData = new ExampleTemplateData();
-        if (email.Metadata.TryGetValue("name", out var name))
-        {
-            dynamicTemplateData.Name = (string)name;
-        }
-        msg.SetTemplateData(dynamicTemplateData);
+        msg.SetTemplateData(email.Metadata);
 
         var response = await _sendGridClient
                 .SendEmailAsync(msg, cancellationToken)
                 .ConfigureAwait(false);
 
         var responseBody = await response.Body.ReadAsStringAsync();
-        _logger.LogInformation("Sending SendGrid message with status code {statusCode} and response: {response}", response.StatusCode, responseBody);
-    }
-
-    private class ExampleTemplateData
-    {
-        [JsonProperty("name")]
-        public string Name { get; set; }
-
+        _logger.LogInformation("Sending SendGrid template message with status code {statusCode} and response: {response}", response.StatusCode, responseBody);
     }
 }

--- a/src/Endatix.Infrastructure/Email/SmtpEmailSender.cs
+++ b/src/Endatix.Infrastructure/Email/SmtpEmailSender.cs
@@ -1,0 +1,128 @@
+using System.Net;
+using System.Net.Mail;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Endatix.Core;
+using Endatix.Core.Abstractions;
+using Endatix.Core.Entities;
+using Endatix.Core.Features.Email;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Specifications;
+using Ardalis.GuardClauses;
+
+namespace Endatix.Infrastructure.Email;
+
+/// <summary>
+/// SMTP email sender implementation using .NET's SmtpClient.
+/// Supports both direct HTML/Plain text emails and database template rendering.
+/// </summary>
+public class SmtpEmailSender : IEmailSender, IHasConfigSection<SmtpSettings>, IPluginInitializer
+{
+    private readonly ILogger<SmtpEmailSender> _logger;
+    private readonly SmtpSettings _settings;
+    private readonly IRepository<EmailTemplate> _templateRepository;
+
+    public SmtpEmailSender(
+        ILogger<SmtpEmailSender> logger, 
+        IOptions<SmtpSettings> options,
+        IRepository<EmailTemplate> templateRepository)
+    {
+        _logger = logger;
+        _settings = options.Value;
+        _templateRepository = templateRepository;
+        
+        Guard.Against.Null(_settings);
+        Guard.Against.NullOrEmpty(_settings.Host);
+        Guard.Against.NullOrEmpty(_settings.DefaultFromAddress);
+    }
+
+    public static Action<IServiceCollection> InitializationDelegate => (services) =>
+    {
+        // No additional services needed for SMTP
+        // SmtpClient is created per email for thread safety
+    };
+
+    public async Task SendEmailAsync(EmailWithBody email, CancellationToken cancellationToken = default)
+    {
+        Guard.Against.Null(email);
+        Guard.Against.NullOrEmpty(email.To);
+        Guard.Against.NullOrEmpty(email.Subject);
+
+        using var smtpClient = CreateSmtpClient();
+        using var mailMessage = CreateMailMessage(email);
+
+        await smtpClient.SendMailAsync(mailMessage, cancellationToken);
+
+        _logger.LogInformation("SMTP email sent successfully to {To} with subject {Subject}", 
+            email.To, email.Subject);
+    }
+
+    public async Task SendEmailAsync(EmailWithTemplate email, CancellationToken cancellationToken = default)
+    {
+        Guard.Against.Null(email);
+        Guard.Against.NullOrEmpty(email.To);
+        Guard.Against.NullOrEmpty(email.TemplateId);
+
+        var template = await _templateRepository.FirstOrDefaultAsync(new EmailTemplateByNameSpec(email.TemplateId));
+        if (template == null)
+        {
+            throw new InvalidOperationException($"Email template '{email.TemplateId}' not found in database");
+        }
+
+        // Convert metadata to string dictionary for template rendering
+        var variables = email.Metadata.ToDictionary(kvp => kvp.Key, kvp => kvp.Value?.ToString() ?? string.Empty);
+
+        var emailWithBody = template.Render(
+            email.To,
+            variables, 
+            subject: email.Subject, 
+            from: email.From);
+        
+        await SendEmailAsync(emailWithBody, cancellationToken);
+    }
+
+    private SmtpClient CreateSmtpClient()
+    {
+        var smtpClient = new SmtpClient(_settings.Host, _settings.Port)
+        {
+            EnableSsl = _settings.EnableSsl,
+            UseDefaultCredentials = string.IsNullOrEmpty(_settings.Username)
+        };
+
+        if (!string.IsNullOrEmpty(_settings.Username))
+        {
+            smtpClient.Credentials = new NetworkCredential(_settings.Username, _settings.Password);
+        }
+
+        return smtpClient;
+    }
+
+    private MailMessage CreateMailMessage(EmailWithBody email)
+    {
+        var fromAddress = string.IsNullOrEmpty(email.From) ? _settings.DefaultFromAddress : email.From;
+        var fromDisplayName = _settings.DefaultFromName;
+
+        var mailMessage = new MailMessage
+        {
+            From = new MailAddress(fromAddress, fromDisplayName),
+            Subject = email.Subject,
+            Body = email.HtmlBody ?? email.PlainTextBody ?? string.Empty,
+            IsBodyHtml = !string.IsNullOrEmpty(email.HtmlBody)
+        };
+
+        mailMessage.To.Add(email.To);
+
+        // Add plain text alternative if both HTML and plain text are provided
+        if (!string.IsNullOrEmpty(email.HtmlBody) && !string.IsNullOrEmpty(email.PlainTextBody))
+        {
+            var plainTextView = AlternateView.CreateAlternateViewFromString(
+                email.PlainTextBody, 
+                System.Text.Encoding.UTF8, 
+                "text/plain");
+            mailMessage.AlternateViews.Add(plainTextView);
+        }
+
+        return mailMessage;
+    }
+} 

--- a/src/Endatix.Infrastructure/Email/SmtpSettings.cs
+++ b/src/Endatix.Infrastructure/Email/SmtpSettings.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Endatix.Infrastructure.Email;
+
+/// <summary>
+/// POCO Class for SMTP settings needed for email sending.
+/// </summary>
+public class SmtpSettings
+{
+    /// <summary>
+    /// The SMTP server host name or IP address.
+    /// </summary>
+    [Required]
+    public string Host { get; set; } = "localhost";
+
+    /// <summary>
+    /// The SMTP server port number.
+    /// </summary>
+    public int Port { get; set; } = 587;
+
+    /// <summary>
+    /// Whether to enable SSL/TLS encryption.
+    /// </summary>
+    public bool EnableSsl { get; set; } = true;
+
+    /// <summary>
+    /// The username for SMTP authentication (optional).
+    /// </summary>
+    public string? Username { get; set; }
+
+    /// <summary>
+    /// The password for SMTP authentication (optional).
+    /// </summary>
+    public string? Password { get; set; }
+
+    /// <summary>
+    /// The default sender email address.
+    /// </summary>
+    [Required]
+    [EmailAddress]
+    public string DefaultFromAddress { get; set; } = "noreply@endatix.com";
+
+    /// <summary>
+    /// The default sender display name.
+    /// </summary>
+    public string DefaultFromName { get; set; } = "Endatix";
+} 

--- a/src/Endatix.Infrastructure/Identity/Users/AppUserService.cs
+++ b/src/Endatix.Infrastructure/Identity/Users/AppUserService.cs
@@ -28,6 +28,23 @@ public class AppUserService(UserManager<AppUser> userManager) : IUserService
         return Result.Success(user.ToUserEntity());
     }
 
+    /// <inheritdoc />
+    public async Task<Result<User>> GetUserAsync(string email, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            return Result.NotFound();
+        }
+
+        var user = await userManager.FindByEmailAsync(email);
+        if (user == null)
+        {
+            return Result.NotFound();
+        }
+
+        return Result.Success(user.ToUserEntity());
+    }
+
     public async Task<Result<string>> ChangePasswordAsync(User user, string currentPassword, string newPassword, CancellationToken cancellationToken = default)
     {
         var appUser = await userManager.FindByIdAsync(user.Id.ToString());

--- a/src/Endatix.Infrastructure/Setup/ServiceCollectionExtensions.cs
+++ b/src/Endatix.Infrastructure/Setup/ServiceCollectionExtensions.cs
@@ -3,8 +3,10 @@ using System.Net.Sockets;
 using System.Threading.RateLimiting;
 using Endatix.Core;
 using Endatix.Core.Abstractions;
+using Endatix.Core.Configuration;
 using Endatix.Core.Features.Email;
 using Endatix.Core.Features.WebHooks;
+using Endatix.Infrastructure.Email;
 using Endatix.Infrastructure.Features.WebHooks;
 using Endatix.Infrastructure.Setup;
 using Microsoft.Extensions.Http.Resilience;
@@ -45,6 +47,22 @@ public static class ServiceCollectionExtensions
         }
 
         services.AddScoped<IEmailSender, TEmailSender>();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Adds email template settings configuration to the service collection.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
+    /// <returns>The configured service collection.</returns>
+    public static IServiceCollection AddEmailTemplateSettings(this IServiceCollection services)
+    {
+        services.AddOptions<EmailTemplateSettings>()
+                .BindConfiguration("Endatix:EmailTemplates")
+                .ValidateOnStart();
+
+        services.AddScoped<IEmailTemplateService, EmailTemplateService>();
 
         return services;
     }

--- a/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250630115834_AddEmailTemplates.Designer.cs
+++ b/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250630115834_AddEmailTemplates.Designer.cs
@@ -3,24 +3,27 @@ using System;
 using Endatix.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
+namespace Endatix.Persistence.PostgreSql.Migrations.AppEntities
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250630115834_AddEmailTemplates")]
+    partial class AddEmailTemplates
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "9.0.4")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("Endatix.Core.Entities.CustomQuestion", b =>
                 {
@@ -28,28 +31,28 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("JsonData")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
@@ -67,39 +70,39 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("FromAddress")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("character varying(255)");
 
                     b.Property<string>("HtmlContent")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<string>("PlainTextContent")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Subject")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("character varying(200)");
 
                     b.HasKey("Id");
 
@@ -118,27 +121,27 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsEnabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
@@ -149,8 +152,7 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                     b.HasKey("Id");
 
                     b.HasIndex("ActiveDefinitionId")
-                        .IsUnique()
-                        .HasFilter("[ActiveDefinitionId] IS NOT NULL");
+                        .IsUnique();
 
                     b.HasIndex("TenantId");
 
@@ -165,26 +167,26 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("FormId")
                         .HasColumnType("bigint");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsDraft")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("JsonData")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
@@ -204,31 +206,31 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsEnabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("JsonData")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
@@ -246,16 +248,16 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime?>("CompletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int?>("CurrentPage")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("FormDefinitionId")
                         .HasColumnType("bigint");
@@ -264,20 +266,20 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<bool>("IsComplete")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("JsonData")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Metadata")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
@@ -297,13 +299,13 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                 {
                     b.Property<string>("AnswersModel")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("CompletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("FormId")
                         .HasColumnType("bigint");
@@ -312,10 +314,10 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<bool>("IsComplete")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.ToTable("SubmissionExportRows", null, t =>
                         {
@@ -329,27 +331,27 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<string>("SlackSettingsJson")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -362,28 +364,28 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("JsonData")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
@@ -480,7 +482,7 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                             b1.Property<string>("Code")
                                 .IsRequired()
                                 .HasMaxLength(16)
-                                .HasColumnType("nvarchar(16)")
+                                .HasColumnType("character varying(16)")
                                 .HasColumnName("Status");
 
                             b1.HasKey("SubmissionId");
@@ -497,12 +499,12 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                                 .HasColumnType("bigint");
 
                             b1.Property<DateTime>("ExpiresAt")
-                                .HasColumnType("datetime2");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Value")
                                 .IsRequired()
                                 .HasMaxLength(64)
-                                .HasColumnType("nvarchar(64)");
+                                .HasColumnType("character varying(64)");
 
                             b1.HasKey("SubmissionId");
 

--- a/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250630115834_AddEmailTemplates.cs
+++ b/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250630115834_AddEmailTemplates.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Endatix.Framework.Scripts;
+
+#nullable disable
+
+namespace Endatix.Persistence.PostgreSql.Migrations.AppEntities
+{
+    /// <inheritdoc />
+    public partial class AddEmailTemplates : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EmailTemplates",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    Name = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Subject = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    HtmlContent = table.Column<string>(type: "text", nullable: false),
+                    PlainTextContent = table.Column<string>(type: "text", nullable: false),
+                    FromAddress = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    DeletedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EmailTemplates", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmailTemplates_Name",
+                table: "EmailTemplates",
+                column: "Name",
+                unique: true);
+
+            var script = migrationBuilder.ReadEmbeddedSqlScript("Data/insert-email-verification-template.sql");
+            migrationBuilder.Sql(script);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EmailTemplates");
+        }
+    }
+}

--- a/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/AppDbContextModelSnapshot.cs
+++ b/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/AppDbContextModelSnapshot.cs
@@ -17,7 +17,7 @@ namespace Endatix.Persistence.PostgreSQL.Migrations.AppEntities
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("ProductVersion", "9.0.0")
+                .HasAnnotation("ProductVersion", "9.0.4")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
             NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
@@ -59,6 +59,54 @@ namespace Endatix.Persistence.PostgreSQL.Migrations.AppEntities
                     b.HasIndex("TenantId");
 
                     b.ToTable("CustomQuestions", (string)null);
+                });
+
+            modelBuilder.Entity("Endatix.Core.Entities.EmailTemplate", b =>
+                {
+                    b.Property<long>("Id")
+                        .HasColumnType("bigint");
+
+                    b.Property<DateTime>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<DateTime?>("DeletedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("FromAddress")
+                        .IsRequired()
+                        .HasMaxLength(255)
+                        .HasColumnType("character varying(255)");
+
+                    b.Property<string>("HtmlContent")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<bool>("IsDeleted")
+                        .HasColumnType("boolean");
+
+                    b.Property<DateTime?>("ModifiedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<string>("PlainTextContent")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("Subject")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("Name")
+                        .IsUnique();
+
+                    b.ToTable("EmailTemplates", (string)null);
                 });
 
             modelBuilder.Entity("Endatix.Core.Entities.Form", b =>

--- a/src/Endatix.Persistence.PostgreSql/Scripts/Data/insert-email-verification-template.sql
+++ b/src/Endatix.Persistence.PostgreSql/Scripts/Data/insert-email-verification-template.sql
@@ -1,0 +1,63 @@
+-- Insert the email verification template
+INSERT INTO public."EmailTemplates" ("Id", "Name", "Subject", "HtmlContent", "PlainTextContent", "FromAddress", "CreatedAt", "ModifiedAt", "IsDeleted")
+VALUES (
+    1,
+    'email-verification',
+    'Verify your email to activate your Endatix account',
+    '<html>
+<head>
+    <meta charset="utf-8">
+    <title>Verify your email address</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+    <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+        <h2 style="color: #2c3e50;">Verify your email address</h2>
+        <p>Thank you for creating your Endatix account.</p>
+        
+        <p>To get started, please verify your email address by clicking the button below:</p>
+        
+        <div style="text-align: center; margin: 30px 0;">
+            <a href="{{hubUrl}}/verify-email?token={{verificationToken}}" 
+               style="background-color: #0066ff; color: white; padding: 12px 24px; text-decoration: none; border-radius: 5px; display: inline-block;">
+                Verify email address
+            </a>
+        </div>
+
+        <p>Or copy and paste this link into your browser:</p>
+        <p style="word-break: break-all; color: #7f8c8d;">{{hubUrl}}/verify-email?token={{verificationToken}}</p>
+        
+        <p>This verification link will expire in 24 hours and can only be used once.</p>
+        
+        <p>If you didn’t create an Endatix account, you can safely ignore this email.</p>
+        
+        <p>– The Endatix Team</p>
+
+        <hr style="margin: 30px 0; border: none; border-top: 1px solid #ecf0f1;">
+        <p style="font-size: 12px; color: #7f8c8d;">
+            This is an automated message, please do not reply to this email.
+        </p>
+    </div>
+</body>
+</html>',
+    'Verify your email address
+
+Thank you for creating your Endatix account.
+
+To get started, please verify your email address by clicking the link below:
+
+{{hubUrl}}/verify-email?token={{verificationToken}}
+
+This verification link will expire in 24 hours and can only be used once.
+
+If you didn’t create an Endatix account, you can safely ignore this email.
+
+– The Endatix Team
+
+---
+
+This is an automated message. Please do not reply to this email.',
+    'noreply@endatix.com',
+    NOW(),
+    NOW(),
+    FALSE
+);

--- a/src/Endatix.Persistence.SqlServer/Migrations/AppEntities/20250701142710_AddEmailTemplates.Designer.cs
+++ b/src/Endatix.Persistence.SqlServer/Migrations/AppEntities/20250701142710_AddEmailTemplates.Designer.cs
@@ -4,6 +4,7 @@ using Endatix.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250701142710_AddEmailTemplates")]
+    partial class AddEmailTemplates
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Endatix.Persistence.SqlServer/Migrations/AppEntities/20250701142710_AddEmailTemplates.cs
+++ b/src/Endatix.Persistence.SqlServer/Migrations/AppEntities/20250701142710_AddEmailTemplates.cs
@@ -1,0 +1,51 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Endatix.Framework.Scripts;
+
+#nullable disable
+
+namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
+{
+    /// <inheritdoc />
+    public partial class AddEmailTemplates : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "EmailTemplates",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: false),
+                    Subject = table.Column<string>(type: "nvarchar(200)", maxLength: 200, nullable: false),
+                    HtmlContent = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    PlainTextContent = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    FromAddress = table.Column<string>(type: "nvarchar(255)", maxLength: 255, nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    ModifiedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    DeletedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                    IsDeleted = table.Column<bool>(type: "bit", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EmailTemplates", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EmailTemplates_Name",
+                table: "EmailTemplates",
+                column: "Name",
+                unique: true);
+
+            var script = migrationBuilder.ReadEmbeddedSqlScript("Data/insert-email-verification-template.sql");
+            migrationBuilder.Sql(script);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "EmailTemplates");
+        }
+    }
+}

--- a/src/Endatix.Persistence.SqlServer/Scripts/Data/insert-email-verification-template.sql
+++ b/src/Endatix.Persistence.SqlServer/Scripts/Data/insert-email-verification-template.sql
@@ -1,0 +1,63 @@
+-- Insert the email verification template
+INSERT INTO EmailTemplates (Id, Name, Subject, HtmlContent, PlainTextContent, FromAddress, CreatedAt, ModifiedAt, IsDeleted)
+VALUES (
+    1,
+    'email-verification',
+    'Verify your email to activate your Endatix account',
+    '<html>
+<head>
+    <meta charset="utf-8">
+    <title>Verify your email address</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+    <div style="max-width: 600px; margin: 0 auto; padding: 20px;">
+        <h2 style="color: #2c3e50;">Verify your email address</h2>
+        <p>Thank you for creating your Endatix account.</p>
+        
+        <p>To get started, please verify your email address by clicking the button below:</p>
+        
+        <div style="text-align: center; margin: 30px 0;">
+            <a href="{{hubUrl}}/verify-email?token={{verificationToken}}" 
+               style="background-color: #0066ff; color: white; padding: 12px 24px; text-decoration: none; border-radius: 5px; display: inline-block;">
+                Verify email address
+            </a>
+        </div>
+
+        <p>Or copy and paste this link into your browser:</p>
+        <p style="word-break: break-all; color: #7f8c8d;">{{hubUrl}}/verify-email?token={{verificationToken}}</p>
+        
+        <p>This verification link will expire in 24 hours and can only be used once.</p>
+        
+        <p>If you didn’t create an Endatix account, you can safely ignore this email.</p>
+        
+        <p>– The Endatix Team</p>
+
+        <hr style="margin: 30px 0; border: none; border-top: 1px solid #ecf0f1;">
+        <p style="font-size: 12px; color: #7f8c8d;">
+            This is an automated message, please do not reply to this email.
+        </p>
+    </div>
+</body>
+</html>',
+    'Verify your email address
+
+Thank you for creating your Endatix account.
+
+To get started, please verify your email address by clicking the link below:
+
+{{hubUrl}}/verify-email?token={{verificationToken}}
+
+This verification link will expire in 24 hours and can only be used once.
+
+If you didn’t create an Endatix account, you can safely ignore this email.
+
+– The Endatix Team
+
+---
+
+This is an automated message. Please do not reply to this email.',
+    'noreply@endatix.com',
+    GETUTCDATE(),
+    GETUTCDATE(),
+    0
+);

--- a/src/Endatix.WebHost/appsettings.Development.json
+++ b/src/Endatix.WebHost/appsettings.Development.json
@@ -87,7 +87,21 @@
       "Email": {
         "SendGridSettings": {
           "ApiKey": "{{SENDGRID_API_KEY}}"
+        },
+        "SmtpSettings": {
+          "Host": "localhost",
+          "Port": 587,
+          "EnableSsl": true,
+          "DefaultFromAddress": "noreply@endatix.com",
+          "DefaultFromName": "Endatix"
         }
+      }
+    },
+    "EmailTemplates": {
+      "HubUrl": "https://localhost:3000",
+      "EmailVerification": {
+        "TemplateId": "email-verification",
+        "FromAddress": "noreply@endatix.com"
       }
     }
   }

--- a/src/Endatix.WebHost/appsettings.json
+++ b/src/Endatix.WebHost/appsettings.json
@@ -89,7 +89,21 @@
       "Email": {
         "SendGridSettings": {
           "ApiKey": "{{SENDGRID_API_KEY}}"
+        },
+        "SmtpSettings": {
+          "Host": "localhost",
+          "Port": 587,
+          "EnableSsl": true,
+          "DefaultFromAddress": "noreply@endatix.com",
+          "DefaultFromName": "Endatix"
         }
+      }
+    },
+    "EmailTemplates": {
+      "HubUrl": "https://app.endatix.com",
+      "EmailVerification": {
+        "TemplateId": "email-verification",
+        "FromAddress": "noreply@endatix.com"
       }
     }
   }

--- a/tests/Endatix.Api.Tests/Endpoints/Auth/SendVerificationEmailTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Auth/SendVerificationEmailTests.cs
@@ -1,0 +1,104 @@
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Http;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Api.Endpoints.Auth;
+using Endatix.Core.UseCases.Identity.SendVerificationEmail;
+
+namespace Endatix.Api.Tests.Endpoints.Auth;
+
+public class SendVerificationEmailTests
+{
+    private readonly IMediator _mediator;
+    private readonly SendVerificationEmail _endpoint;
+
+    public SendVerificationEmailTests()
+    {
+        _mediator = Substitute.For<IMediator>();
+        _endpoint = Factory.Create<SendVerificationEmail>(_mediator);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithValidEmail_ReturnsOkResult()
+    {
+        // Arrange
+        var request = new SendVerificationEmailRequest("test@example.com");
+        var successResult = Result.Success();
+
+        _mediator.Send(Arg.Any<SendVerificationEmailCommand>(), Arg.Any<CancellationToken>())
+            .Returns(successResult);
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, default);
+
+        // Assert
+        var okResponse = response!.Result as Ok<string>;
+
+        okResponse.Should().NotBeNull();
+        _endpoint.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        okResponse!.Value.Should().Be("Verification email sent successfully");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithUserNotFound_ReturnsOkResultToPreventEnumeration()
+    {
+        // Arrange
+        var request = new SendVerificationEmailRequest("nonexistent@example.com");
+        var successResult = Result.Success();
+
+        _mediator.Send(Arg.Any<SendVerificationEmailCommand>(), Arg.Any<CancellationToken>())
+            .Returns(successResult);
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, default);
+
+        // Assert
+        var okResponse = response!.Result as Ok<string>;
+
+        okResponse.Should().NotBeNull();
+        _endpoint.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        okResponse!.Value.Should().Be("Verification email sent successfully");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithUserAlreadyVerified_ReturnsOkResultToPreventEnumeration()
+    {
+        // Arrange
+        var request = new SendVerificationEmailRequest("verified@example.com");
+        var successResult = Result.Success();
+
+        _mediator.Send(Arg.Any<SendVerificationEmailCommand>(), Arg.Any<CancellationToken>())
+            .Returns(successResult);
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, default);
+
+        // Assert
+        var okResponse = response!.Result as Ok<string>;
+
+        okResponse.Should().NotBeNull();
+        _endpoint.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        okResponse!.Value.Should().Be("Verification email sent successfully");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithInvalidEmail_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new SendVerificationEmailRequest("invalid-email");
+        var errorResult = Result.Invalid(new ValidationError("Invalid email address"));
+
+        _mediator.Send(Arg.Any<SendVerificationEmailCommand>(), Arg.Any<CancellationToken>())
+            .Returns(errorResult);
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, default);
+
+        // Assert
+        var badResponse = response!.Result as BadRequest<Microsoft.AspNetCore.Mvc.ProblemDetails>;
+
+        badResponse.Should().NotBeNull();
+        badResponse!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+} 

--- a/tests/Endatix.Core.Tests/Entities/EmailTemplateTests.cs
+++ b/tests/Endatix.Core.Tests/Entities/EmailTemplateTests.cs
@@ -1,0 +1,93 @@
+using Endatix.Core.Entities;
+using FluentAssertions;
+
+namespace Endatix.Core.Tests.Entities;
+
+public class EmailTemplateTests
+{
+    [Fact]
+    public void Render_WithDoubleBracePlaceholders_ReplacesCorrectly()
+    {
+        // Arrange
+        var template = new EmailTemplate(
+            name: "test-template",
+            subject: "Hello {{name}}",
+            htmlContent: "<p>Welcome {{name}}! Your token is {{verificationToken}}</p>",
+            plainTextContent: "Welcome {{name}}! Your token is {{verificationToken}}",
+            fromAddress: "noreply@example.com"
+        );
+
+        var variables = new Dictionary<string, string>
+        {
+            ["name"] = "John",
+            ["verificationToken"] = "abc123"
+        };
+
+        // Act
+        var result = template.Render("test@example.com", variables);
+
+        // Assert
+        result.Subject.Should().Be("Hello John");
+        result.HtmlBody.Should().Be("<p>Welcome John! Your token is abc123</p>");
+        result.PlainTextBody.Should().Be("Welcome John! Your token is abc123");
+        result.From.Should().Be("noreply@example.com");
+        result.To.Should().Be("test@example.com");
+    }
+
+    [Fact]
+    public void Render_WithHubUrlAndToken_ConstructsVerificationUrl()
+    {
+        // Arrange
+        var template = new EmailTemplate(
+            name: "verification-template",
+            subject: "Verify Your Email",
+            htmlContent: "<p>Click here to verify: <a href=\"{{hubUrl}}/verify-email?token={{verificationToken}}\">Verify Email</a></p>",
+            plainTextContent: "Click here to verify: {{hubUrl}}/verify-email?token={{verificationToken}}",
+            fromAddress: "noreply@example.com"
+        );
+
+        var variables = new Dictionary<string, string>
+        {
+            ["hubUrl"] = "https://app.example.com",
+            ["verificationToken"] = "abc123"
+        };
+
+        // Act
+        var result = template.Render("test@example.com", variables);
+
+        // Assert
+        result.Subject.Should().Be("Verify Your Email");
+        result.HtmlBody.Should().Be("<p>Click here to verify: <a href=\"https://app.example.com/verify-email?token=abc123\">Verify Email</a></p>");
+        result.PlainTextBody.Should().Be("Click here to verify: https://app.example.com/verify-email?token=abc123");
+        result.From.Should().Be("noreply@example.com");
+        result.To.Should().Be("test@example.com");
+    }
+
+    [Fact]
+    public void Render_WithUnusedPlaceholders_LeavesThemUnchanged()
+    {
+        // Arrange
+        var template = new EmailTemplate(
+            name: "test-template",
+            subject: "Hello {{name}}",
+            htmlContent: "<p>Welcome {{name}}! Your token is {{verificationToken}}</p>",
+            plainTextContent: "Welcome {{name}}! Your token is {{verificationToken}}",
+            fromAddress: "noreply@example.com"
+        );
+
+        var variables = new Dictionary<string, string>
+        {
+            ["name"] = "John"
+            // verificationToken not provided
+        };
+
+        // Act
+        var result = template.Render("test@example.com", variables);
+
+        // Assert
+        result.Subject.Should().Be("Hello John");
+        result.HtmlBody.Should().Be("<p>Welcome John! Your token is {{verificationToken}}</p>");
+        result.PlainTextBody.Should().Be("Welcome John! Your token is {{verificationToken}}");
+        result.To.Should().Be("test@example.com");
+    }
+} 

--- a/tests/Endatix.Core.Tests/UseCases/Identity/SendVerificationEmail/SendVerificationEmailHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Identity/SendVerificationEmail/SendVerificationEmailHandlerTests.cs
@@ -1,0 +1,120 @@
+using Endatix.Core.Abstractions;
+using Endatix.Core.Entities.Identity;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.Identity.SendVerificationEmail;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Endatix.Core.Tests.UseCases.Identity.SendVerificationEmail;
+
+public class SendVerificationEmailHandlerTests
+{
+    private readonly IEmailVerificationService _emailVerificationService;
+    private readonly IUserService _userService;
+    private readonly ILogger<SendVerificationEmailHandler> _logger;
+    private readonly SendVerificationEmailHandler _sut;
+
+    public SendVerificationEmailHandlerTests()
+    {
+        _emailVerificationService = Substitute.For<IEmailVerificationService>();
+        _userService = Substitute.For<IUserService>();
+        _logger = Substitute.For<ILogger<SendVerificationEmailHandler>>();
+        _sut = new SendVerificationEmailHandler(_emailVerificationService, _userService, _logger);
+    }
+
+    [Fact]
+    public async Task Handle_ValidEmail_CreatesTokenSuccessfully()
+    {
+        // Arrange
+        var email = "test@example.com";
+        var userId = 123L;
+        var user = new User(userId, "testuser", email, false);
+        var token = new EmailVerificationToken(userId, "new-token", DateTime.UtcNow.AddHours(24));
+        var command = new SendVerificationEmailCommand(email);
+
+        _userService.GetUserAsync(email, Arg.Any<CancellationToken>())
+            .Returns(Result.Success(user));
+        _emailVerificationService.CreateVerificationTokenAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Result.Success(token));
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeTrue();
+
+        await _userService.Received(1).GetUserAsync(email, Arg.Any<CancellationToken>());
+        await _emailVerificationService.Received(1).CreateVerificationTokenAsync(userId, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_UserNotFound_ReturnsSuccessToPreventEnumeration()
+    {
+        // Arrange
+        var email = "nonexistent@example.com";
+        var command = new SendVerificationEmailCommand(email);
+
+        _userService.GetUserAsync(email, Arg.Any<CancellationToken>())
+            .Returns(Result.NotFound());
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeTrue();
+
+        await _userService.Received(1).GetUserAsync(email, Arg.Any<CancellationToken>());
+        await _emailVerificationService.DidNotReceive().CreateVerificationTokenAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_UserAlreadyVerified_ReturnsSuccessToPreventEnumeration()
+    {
+        // Arrange
+        var email = "verified@example.com";
+        var userId = 123L;
+        var user = new User(userId, "testuser", email, true);
+        var command = new SendVerificationEmailCommand(email);
+
+        _userService.GetUserAsync(email, Arg.Any<CancellationToken>())
+            .Returns(Result.Success(user));
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeTrue();
+
+        await _userService.Received(1).GetUserAsync(email, Arg.Any<CancellationToken>());
+        await _emailVerificationService.DidNotReceive().CreateVerificationTokenAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_TokenCreationFails_ReturnsSuccessButLogsError()
+    {
+        // Arrange
+        var email = "test@example.com";
+        var userId = 123L;
+        var user = new User(userId, "testuser", email, false);
+        var command = new SendVerificationEmailCommand(email);
+
+        _userService.GetUserAsync(email, Arg.Any<CancellationToken>())
+            .Returns(Result.Success(user));
+        _emailVerificationService.CreateVerificationTokenAsync(userId, Arg.Any<CancellationToken>())
+            .Returns(Result.Error("Token creation failed"));
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeTrue();
+
+        await _userService.Received(1).GetUserAsync(email, Arg.Any<CancellationToken>());
+        await _emailVerificationService.Received(1).CreateVerificationTokenAsync(userId, Arg.Any<CancellationToken>());
+    }
+} 

--- a/tests/Endatix.Infrastructure.Tests/Email/EmailTemplateServiceTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Email/EmailTemplateServiceTests.cs
@@ -1,0 +1,194 @@
+using Endatix.Core.Configuration;
+using Endatix.Core.Features.Email;
+using Endatix.Infrastructure.Email;
+using FluentAssertions;
+using Microsoft.Extensions.Options;
+
+namespace Endatix.Infrastructure.Tests.Email;
+
+public class EmailTemplateServiceTests
+{
+    [Fact]
+    public void Constructor_WithValidSettings_CreatesInstance()
+    {
+        // Arrange
+        var settings = new EmailTemplateSettings
+        {
+            HubUrl = "https://app.example.com",
+            EmailVerification = new EmailTemplateConfig
+            {
+                TemplateId = "email-verification",
+                FromAddress = "noreply@example.com"
+            }
+        };
+        var options = Options.Create(settings);
+
+        // Act
+        var service = new EmailTemplateService(options);
+
+        // Assert
+        service.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Constructor_WithNullOptions_CreatesInstance()
+    {
+        // Act
+        var service = new EmailTemplateService(null!);
+
+        // Assert
+        service.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void CreateVerificationEmail_WithValidInputs_ReturnsCorrectEmailWithTemplate()
+    {
+        // Arrange
+        var settings = new EmailTemplateSettings
+        {
+            HubUrl = "https://app.example.com",
+            EmailVerification = new EmailTemplateConfig
+            {
+                TemplateId = "email-verification",
+                FromAddress = "noreply@example.com"
+            }
+        };
+        var options = Options.Create(settings);
+        var service = new EmailTemplateService(options);
+        
+        var userEmail = "test@example.com";
+        var token = "abc123-token";
+
+        // Act
+        var result = service.CreateVerificationEmail(userEmail, token);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.To.Should().Be(userEmail);
+        result.From.Should().Be("noreply@example.com");
+        result.Subject.Should().Be(string.Empty); // Subject comes from template
+        result.TemplateId.Should().Be("email-verification");
+        result.Metadata.Should().NotBeNull();
+        result.Metadata.Should().HaveCount(2);
+        result.Metadata["hubUrl"].Should().Be("https://app.example.com");
+        result.Metadata["verificationToken"].Should().Be("abc123-token");
+    }
+
+    [Fact]
+    public void CreateVerificationEmail_WithEmptyHubUrl_StillCreatesValidEmail()
+    {
+        // Arrange
+        var settings = new EmailTemplateSettings
+        {
+            HubUrl = string.Empty,
+            EmailVerification = new EmailTemplateConfig
+            {
+                TemplateId = "email-verification",
+                FromAddress = "noreply@example.com"
+            }
+        };
+        var options = Options.Create(settings);
+        var service = new EmailTemplateService(options);
+        
+        var userEmail = "test@example.com";
+        var token = "abc123-token";
+
+        // Act
+        var result = service.CreateVerificationEmail(userEmail, token);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Metadata["hubUrl"].Should().Be(string.Empty);
+        result.Metadata["verificationToken"].Should().Be("abc123-token");
+    }
+
+    [Fact]
+    public void CreateVerificationEmail_WithDifferentConfigurations_ReturnsCorrectValues()
+    {
+        // Arrange
+        var settings = new EmailTemplateSettings
+        {
+            HubUrl = "https://custom-app.com",
+            EmailVerification = new EmailTemplateConfig
+            {
+                TemplateId = "custom-verification-template",
+                FromAddress = "custom@example.com"
+            }
+        };
+        var options = Options.Create(settings);
+        var service = new EmailTemplateService(options);
+        
+        var userEmail = "user@test.com";
+        var token = "xyz789-token";
+
+        // Act
+        var result = service.CreateVerificationEmail(userEmail, token);
+
+        // Assert
+        result.To.Should().Be("user@test.com");
+        result.From.Should().Be("custom@example.com");
+        result.TemplateId.Should().Be("custom-verification-template");
+        result.Metadata["hubUrl"].Should().Be("https://custom-app.com");
+        result.Metadata["verificationToken"].Should().Be("xyz789-token");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void CreateVerificationEmail_WithInvalidEmail_StillCreatesEmailWithGivenEmail(string email)
+    {
+        // Arrange
+        var settings = new EmailTemplateSettings
+        {
+            HubUrl = "https://app.example.com",
+            EmailVerification = new EmailTemplateConfig
+            {
+                TemplateId = "email-verification",
+                FromAddress = "noreply@example.com"
+            }
+        };
+        var options = Options.Create(settings);
+        var service = new EmailTemplateService(options);
+        
+        var token = "abc123-token";
+
+        // Act
+        var result = service.CreateVerificationEmail(email, token);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.To.Should().Be(email);
+        result.Metadata["verificationToken"].Should().Be("abc123-token");
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData(null)]
+    public void CreateVerificationEmail_WithInvalidToken_StillCreatesEmailWithGivenToken(string token)
+    {
+        // Arrange
+        var settings = new EmailTemplateSettings
+        {
+            HubUrl = "https://app.example.com",
+            EmailVerification = new EmailTemplateConfig
+            {
+                TemplateId = "email-verification",
+                FromAddress = "noreply@example.com"
+            }
+        };
+        var options = Options.Create(settings);
+        var service = new EmailTemplateService(options);
+        
+        var userEmail = "test@example.com";
+
+        // Act
+        var result = service.CreateVerificationEmail(userEmail, token);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.To.Should().Be("test@example.com");
+        result.Metadata["verificationToken"].Should().Be(token);
+    }
+} 

--- a/tests/Endatix.Infrastructure.Tests/Identity/Users/AppUserRegistrationServiceTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Identity/Users/AppUserRegistrationServiceTests.cs
@@ -2,10 +2,13 @@ using Endatix.Infrastructure.Identity;
 using Endatix.Infrastructure.Identity.Users;
 using Endatix.Core.Abstractions;
 using Endatix.Core.Entities.Identity;
+using Endatix.Core.Features.Email;
 using Endatix.Core.Infrastructure.Result;
 using FluentAssertions;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
 using NSubstitute;
+using Endatix.Core;
 
 namespace Endatix.Infrastructure.Tests.Identity.Users;
 
@@ -15,6 +18,9 @@ public class AppUserRegistrationServiceTests
     private readonly IUserStore<AppUser> _userStore;
     private readonly IUserEmailStore<AppUser> _emailStore;
     private readonly IEmailVerificationService _emailVerificationService;
+    private readonly IEmailSender _emailSender;
+    private readonly IEmailTemplateService _emailTemplateService;
+    private readonly ILogger<AppUserRegistrationService> _logger;
     private readonly AppUserRegistrationService _sut;
 
     public AppUserRegistrationServiceTests()
@@ -23,7 +29,11 @@ public class AppUserRegistrationServiceTests
         _emailStore = (IUserEmailStore<AppUser>)_userStore;
         _userManager = Substitute.For<UserManager<AppUser>>(_userStore, null, null, null, null, null, null, null, null);
         _emailVerificationService = Substitute.For<IEmailVerificationService>();
-        _sut = new AppUserRegistrationService(_userManager, _userStore, _emailVerificationService);
+        _emailSender = Substitute.For<IEmailSender>();
+        _emailTemplateService = Substitute.For<IEmailTemplateService>();
+        _logger = Substitute.For<ILogger<AppUserRegistrationService>>();
+        
+        _sut = new AppUserRegistrationService(_userManager, _userStore, _emailVerificationService, _emailSender, _emailTemplateService, _logger);
     }
 
     [Fact]
@@ -216,5 +226,65 @@ public class AppUserRegistrationServiceTests
         result.IsSuccess.Should().BeTrue();
         result.Value.Should().NotBeNull();
         result.Value.Email.Should().Be(email);
+    }
+
+    [Fact]
+    public async Task RegisterUserAsync_ValidRequest_SendsVerificationEmailWithTemplate()
+    {
+        // Arrange
+        var userId = 123L;
+        var email = "test@example.com";
+        var password = "P@ssw0rd";
+        var cancellationToken = CancellationToken.None;
+        var token = "test-token";
+        var emailWithTemplate = new EmailWithTemplate
+        {
+            To = email,
+            From = "noreply@example.com",
+            Subject = "Verify Your Email Address",
+            TemplateId = "email-verification",
+            Metadata = new Dictionary<string, object>
+            {
+                ["verificationToken"] = token,
+                ["hubUrl"] = "https://app.example.com"
+            }
+        };
+
+        _userManager.SupportsUserEmail.Returns(true);
+        _userManager.CreateAsync(Arg.Any<AppUser>(), Arg.Any<string>())
+            .Returns(callInfo =>
+            {
+                var user = callInfo.Arg<AppUser>();
+                user.Id = userId;
+                return Task.FromResult(IdentityResult.Success);
+            });
+        _userStore.SetUserNameAsync(Arg.Any<AppUser>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var user = callInfo.Arg<AppUser>();
+                var userName = callInfo.Arg<string>();
+                user.UserName = userName;
+                return Task.CompletedTask;
+            });
+        _emailStore.SetEmailAsync(Arg.Any<AppUser>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var user = callInfo.Arg<AppUser>();
+                var emailArg = callInfo.Arg<string>();
+                user.Email = emailArg;
+                return Task.CompletedTask;
+            });
+        _emailVerificationService.CreateVerificationTokenAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new EmailVerificationToken(userId, token, DateTime.UtcNow.AddHours(24))));
+        _emailTemplateService.CreateVerificationEmail(email, token).Returns(emailWithTemplate);
+
+        // Act
+        var result = await _sut.RegisterUserAsync(email, password, cancellationToken);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.IsSuccess.Should().BeTrue();
+        _emailTemplateService.Received(1).CreateVerificationEmail(email, token);
+        await _emailSender.Received(1).SendEmailAsync(emailWithTemplate, cancellationToken);
     }
 }


### PR DESCRIPTION
# Add SMTP email provider, send-verification endpoint and send verification emails

## Description
- A new SMTP email provider is added and set as default. Settings for it are added and a DB table for templates with currently only template for email verification.
- To switch from the default SMTP provider to SendGrid, one needs to add `endatix.Infrastructure.Integrations.AddEmail<SendGridEmailSender, SendGridSettings>();` in the Program class, e.g.
```
builder.Host.ConfigureEndatixWithDefaults(endatix =>
{
    // Configure SendGrid as the email provider instead of SMTP
    endatix.Infrastructure.Integrations.AddEmail<SendGridEmailSender, SendGridSettings>();
});
```
and set the SendGrid API key in the settings (the same way as before) and set the SendGrid email-verification template ID in the settings:
```
      "EmailVerification": {
        "TemplateId": "[SENDGRID_TEMPLATE_ID]",
        "FromAddress": "noreply@endatix.com"
      }
```
- auth/send-verification endpoint sends verification (needed when the user should resend a verification email)

**Note:** Documentation will be added explaining how to switch and configure the email providers but generally the explained above is enough.

## Related Issues
https://github.com/endatix/endatix-private/issues/139

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] My code follows the style guidelines of this project
