### PR TITLE
feat: Return failure details in /register and /verify-email endpoints

### DIFF
--- a/src/Endatix.Api/Endpoints/Auth/Register.cs
+++ b/src/Endatix.Api/Endpoints/Auth/Register.cs
@@ -32,8 +32,19 @@ public class Register(IMediator mediator) : Endpoint<RegisterRequest, Results<Ok
         var registerUserCommand = new RegisterCommand(request.Email, request.Password);
         var userRegistrationResult = await mediator.Send(registerUserCommand, cancellationToken);
 
+        var errorMessage = "Registration failed. ";
+        if (userRegistrationResult.Status == Core.Infrastructure.Result.ResultStatus.Invalid && userRegistrationResult.ValidationErrors.Any())
+        {
+            errorMessage += userRegistrationResult.ValidationErrors.First().ErrorMessage;
+        }
+        else
+        {
+            errorMessage += "Please check your input and try again.";
+        }
+
         return TypedResultsBuilder
                 .MapResult(userRegistrationResult, (user) => new RegisterResponse(Success: true, Message: "User has been successfully registered"))
+                .SetErrorMessage(errorMessage)
                 .SetTypedResults<Ok<RegisterResponse>, BadRequest<Errors.ProblemDetails>>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Auth/VerifyEmail.cs
+++ b/src/Endatix.Api/Endpoints/Auth/VerifyEmail.cs
@@ -33,8 +33,19 @@ public class VerifyEmail(IMediator mediator) : Endpoint<VerifyEmailRequest, Resu
         var verifyEmailCommand = new VerifyEmailCommand(request.Token);
         var emailVerificationResult = await mediator.Send(verifyEmailCommand, cancellationToken);
 
+        var errorMessage = string.Empty;
+        if (emailVerificationResult.Status == Core.Infrastructure.Result.ResultStatus.Invalid && emailVerificationResult.ValidationErrors.Any())
+        {
+            errorMessage += emailVerificationResult.ValidationErrors.First().ErrorMessage;
+        }
+        else
+        {
+            errorMessage += "Please check the verification token and try again.";
+        }
+
         return TypedResultsBuilder
                 .MapResult(emailVerificationResult, user => user.Id.ToString())
+                .SetErrorMessage(errorMessage)
                 .SetTypedResults<Ok<string>, BadRequest<Errors.ProblemDetails>, NotFound>();
     }
 } 

--- a/tests/Endatix.Api.Tests/Endpoints/Auth/RegisterTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Auth/RegisterTests.cs
@@ -61,6 +61,7 @@ public class RegisterTests
         badResponse.Should().NotBeNull();
         badResponse!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
         badResponse!.Value!.Status.Should().Be(StatusCodes.Status400BadRequest);
-        badResponse!.Value!.Title.Should().Be("There was a problem with your request.");
+        badResponse!.Value!.Title.Should().Be("Registration failed. Please check your input and try again.");
+        badResponse!.Value!.Detail.Should().Be("There was a problem with your request.");
     }
 }


### PR DESCRIPTION
# Return failure details in /register and /verify-email endpoints

## Description
Return failure details in /register and /verify-email endpoints in the cases of invalid requests

## Related Issues
https://github.com/endatix/endatix-private/issues/139

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
