### PR TITLE
feat: Update webhooks implementation

### DIFF
--- a/docs/endatix-docs/docs/guides/webhooks.mdx
+++ b/docs/endatix-docs/docs/guides/webhooks.mdx
@@ -158,7 +158,7 @@ To test your webhooks:
             "https://webhook.site/your-unique-id"
           ]
         },
-        "FormSubmitted": {
+        "SubmissionCompleted": {
           "IsEnabled": true,
           "WebHookUrls": [
             "https://webhook.site/your-unique-id"
@@ -226,7 +226,7 @@ To test your webhooks:
 Each webhook message contains:
 
 - `Id`: The ID of the entity that triggered the event
-- `EventName`: The type of event (e.g., `form_created`, `form_updated`, `form_enabled_state_changed`, `form_deleted`, `form_submitted`)
+- `EventName`: The type of event (e.g., `form_created`, `form_updated`, `form_enabled_state_changed`, `form_deleted`, `submission_completed`)
 - `Action`: The action that triggered the event (e.g., `created`, `updated`, `deleted`)
 - `Payload`: The event data specific to the operation, containing the complete entity data
 

--- a/samples/Endatix.Samples.CustomEventHandlers/WebHooks/SubmissionEventHandlers/SubmissionCompletedHandler.cs
+++ b/samples/Endatix.Samples.CustomEventHandlers/WebHooks/SubmissionEventHandlers/SubmissionCompletedHandler.cs
@@ -29,7 +29,7 @@ internal class SubmissionCompletedHandler(IWebHookService webHookService, ILogge
 
         var message = new WebHookMessage<object>(
             notification.Submission.Id,
-            WebHookOperation.FormSubmitted,
+            WebHookOperation.SubmissionCompleted,
             submission);
 
         await webHookService.EnqueueWebHookAsync(message, cancellationToken);

--- a/src/Endatix.Core/Features/WebHooks/WebHookOperation.cs
+++ b/src/Endatix.Core/Features/WebHooks/WebHookOperation.cs
@@ -23,9 +23,9 @@ public record WebHookOperation
     public static readonly WebHookOperation FormEnabledStateChanged = new("form_enabled_state_changed", nameof(Form), ActionName.Updated);
 
     /// <summary>
-    /// A static instance of WebHookOperation representing a form submission.
+    /// A static instance of WebHookOperation representing a submission set as completed.
     /// </summary>
-    public static readonly WebHookOperation FormSubmitted = new("form_submitted", nameof(Submission), ActionName.Created);
+    public static readonly WebHookOperation SubmissionCompleted = new("submission_completed", nameof(Submission), ActionName.Updated);
 
     /// <summary>
     /// A static instance of WebHookOperation representing a form deletion.

--- a/src/Endatix.Infrastructure/Features/WebHooks/BackgroundTaskWebHookService.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/BackgroundTaskWebHookService.cs
@@ -54,7 +54,7 @@ internal class BackgroundTaskWebHookService(
             WebHooksPlugin.EventNames.FORM_CREATED => _webHookSettings.Events.FormCreated,
             WebHooksPlugin.EventNames.FORM_UPDATED => _webHookSettings.Events.FormUpdated,
             WebHooksPlugin.EventNames.FORM_ENABLED_STATE_CHANGED => _webHookSettings.Events.FormEnabledStateChanged,
-            WebHooksPlugin.EventNames.FORM_SUBMITTED => _webHookSettings.Events.FormSubmitted,
+            WebHooksPlugin.EventNames.SUBMISSION_COMPLETED => _webHookSettings.Events.SubmissionCompleted,
             WebHooksPlugin.EventNames.FORM_DELETED => _webHookSettings.Events.FormDeleted,
             _ => throw new ArgumentException($"Unknown event name: {eventName}", nameof(eventName))
         };

--- a/src/Endatix.Infrastructure/Features/WebHooks/Handlers/FormCreatedHandler.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/Handlers/FormCreatedHandler.cs
@@ -16,15 +16,15 @@ public class FormCreatedHandler(IWebHookService webHookService, ILogger<FormCrea
 
         var form = new
         {
-            notification.Form.Id,
-            notification.Form.TenantId,
-            notification.Form.Name,
-            notification.Form.Description,
-            notification.Form.IsEnabled,
-            notification.Form.ActiveDefinitionId,
-            notification.Form.ThemeId,
-            notification.Form.CreatedAt,
-            notification.Form.ModifiedAt,
+            id = notification.Form.Id,
+            tenantId = notification.Form.TenantId,
+            name = notification.Form.Name,
+            description = notification.Form.Description,
+            isEnabled = notification.Form.IsEnabled,
+            activeDefinitionId = notification.Form.ActiveDefinitionId,
+            themeId = notification.Form.ThemeId,
+            createdAt = notification.Form.CreatedAt,
+            modifiedAt = notification.Form.ModifiedAt,
         };
 
         var message = new WebHookMessage<object>(

--- a/src/Endatix.Infrastructure/Features/WebHooks/Handlers/FormDeletedHandler.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/Handlers/FormDeletedHandler.cs
@@ -16,15 +16,15 @@ public class FormDeletedHandler(IWebHookService webHookService, ILogger<FormDele
 
         var form = new
         {
-            notification.Form.Id,
-            notification.Form.TenantId,
-            notification.Form.Name,
-            notification.Form.Description,
-            notification.Form.IsEnabled,
-            notification.Form.ActiveDefinitionId,
-            notification.Form.ThemeId,
-            notification.Form.CreatedAt,
-            notification.Form.ModifiedAt,
+            id = notification.Form.Id,
+            tenantId = notification.Form.TenantId,
+            name = notification.Form.Name,
+            description = notification.Form.Description,
+            isEnabled = notification.Form.IsEnabled,
+            activeDefinitionId = notification.Form.ActiveDefinitionId,
+            themeId = notification.Form.ThemeId,
+            createdAt = notification.Form.CreatedAt,
+            modifiedAt = notification.Form.ModifiedAt,
         };
 
         var message = new WebHookMessage<object>(

--- a/src/Endatix.Infrastructure/Features/WebHooks/Handlers/FormEnabledStateChangedHandler.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/Handlers/FormEnabledStateChangedHandler.cs
@@ -16,15 +16,15 @@ public class FormEnabledStateChangedWebHookHandler(IWebHookService webHookServic
 
         var form = new
         {
-            notification.Form.Id,
-            notification.Form.TenantId,
-            notification.Form.Name,
-            notification.Form.Description,
-            notification.Form.IsEnabled,
-            notification.Form.ActiveDefinitionId,
-            notification.Form.ThemeId,
-            notification.Form.CreatedAt,
-            notification.Form.ModifiedAt,
+            id = notification.Form.Id,
+            tenantId = notification.Form.TenantId,
+            name = notification.Form.Name,
+            description = notification.Form.Description,
+            isEnabled = notification.Form.IsEnabled,
+            activeDefinitionId = notification.Form.ActiveDefinitionId,
+            themeId = notification.Form.ThemeId,
+            createdAt = notification.Form.CreatedAt,
+            modifiedAt = notification.Form.ModifiedAt,
         };
 
         var message = new WebHookMessage<object>(

--- a/src/Endatix.Infrastructure/Features/WebHooks/Handlers/FormUpdatedHandler.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/Handlers/FormUpdatedHandler.cs
@@ -16,15 +16,15 @@ public class FormUpdatedWebHookHandler(IWebHookService webHookService, ILogger<F
 
         var form = new
         {
-            notification.Form.Id,
-            notification.Form.TenantId,
-            notification.Form.Name,
-            notification.Form.Description,
-            notification.Form.IsEnabled,
-            notification.Form.ActiveDefinitionId,
-            notification.Form.ThemeId,
-            notification.Form.CreatedAt,
-            notification.Form.ModifiedAt,
+            id = notification.Form.Id,
+            tenantId = notification.Form.TenantId,
+            name = notification.Form.Name,
+            description = notification.Form.Description,
+            isEnabled = notification.Form.IsEnabled,
+            activeDefinitionId = notification.Form.ActiveDefinitionId,
+            themeId = notification.Form.ThemeId,
+            createdAt = notification.Form.CreatedAt,
+            modifiedAt = notification.Form.ModifiedAt,
         };
 
         var message = new WebHookMessage<object>(

--- a/src/Endatix.Infrastructure/Features/WebHooks/Handlers/SubmissionCompletedHandler.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/Handlers/SubmissionCompletedHandler.cs
@@ -16,23 +16,24 @@ public class SubmissionCompletedWebHookHandler(IWebHookService webHookService, I
 
         var submission = new
         {
-            notification.Submission.Id,
-            notification.Submission.FormId,
-            notification.Submission.FormDefinitionId,
-            notification.Submission.TenantId,
-            notification.Submission.IsComplete,
-            notification.Submission.JsonData,
-            notification.Submission.CurrentPage,
-            notification.Submission.Metadata,
-            Status = notification.Submission.Status.Code,
-            notification.Submission.CreatedAt,
-            notification.Submission.ModifiedAt,
-            notification.Submission.CompletedAt,
+            id = notification.Submission.Id,
+            formId = notification.Submission.FormId,
+            formDefinitionId = notification.Submission.FormDefinitionId,
+            tenantId = notification.Submission.TenantId,
+            isComplete = notification.Submission.IsComplete,
+            jsonData = notification.Submission.JsonData,
+            currentPage = notification.Submission.CurrentPage,
+            metadata = notification.Submission.Metadata,
+            submittedBy = notification.Submission.SubmittedBy,
+            status = notification.Submission.Status.Code,
+            createdAt = notification.Submission.CreatedAt,
+            modifiedAt = notification.Submission.ModifiedAt,
+            completedAt = notification.Submission.CompletedAt,
         };
 
         var message = new WebHookMessage<object>(
             notification.Submission.Id,
-            WebHookOperation.FormSubmitted,
+            WebHookOperation.SubmissionCompleted,
             submission);
 
         await webHookService.EnqueueWebHookAsync(message, cancellationToken);

--- a/src/Endatix.Infrastructure/Features/WebHooks/WebHookSettings.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/WebHookSettings.cs
@@ -92,9 +92,9 @@ public class WebHookSettings : IEndatixSettings
         public EventSetting FormEnabledStateChanged { get; set; } = new() { EventName = EventNames.FORM_ENABLED_STATE_CHANGED };
 
         /// <summary>
-        /// Represents the settings for the 'FormSubmitted' event.
+        /// Represents the settings for the 'SubmissionCompleted' event.
         /// </summary>
-        public EventSetting FormSubmitted { get; set; } = new() { EventName = EventNames.FORM_SUBMITTED };
+        public EventSetting SubmissionCompleted { get; set; } = new() { EventName = EventNames.SUBMISSION_COMPLETED };
 
         /// <summary>
         /// Represents the settings for the 'FormDeleted' event.

--- a/src/Endatix.Infrastructure/Features/WebHooks/WebHooksPlugin.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/WebHooksPlugin.cs
@@ -10,7 +10,7 @@ public class WebHooksPlugin : IPluginInitializer
         public const string FORM_CREATED = "form_created";
         public const string FORM_UPDATED = "form_updated";
         public const string FORM_ENABLED_STATE_CHANGED = "form_enabled_state_changed";
-        public const string FORM_SUBMITTED = "form_submitted";
+        public const string SUBMISSION_COMPLETED = "submission_completed";
         public const string FORM_DELETED = "form_deleted";
     }
 

--- a/src/Endatix.WebHost/appsettings.Development.json
+++ b/src/Endatix.WebHost/appsettings.Development.json
@@ -90,7 +90,7 @@
           "IsEnabled": false,
           "WebHookUrls": []
         },
-        "FormSubmitted": {
+        "SubmissionCompleted": {
           "IsEnabled": false,
           "WebHookUrls": []
         }

--- a/src/Endatix.WebHost/appsettings.json
+++ b/src/Endatix.WebHost/appsettings.json
@@ -92,7 +92,7 @@
           "IsEnabled": false,
           "WebHookUrls": []
         },
-        "FormSubmitted": {
+        "SubmissionCompleted": {
           "IsEnabled": false,
           "WebHookUrls": []
         }

--- a/tests/Endatix.Core.Tests/Features/WebHooks/WebHookMessageTests.cs
+++ b/tests/Endatix.Core.Tests/Features/WebHooks/WebHookMessageTests.cs
@@ -10,17 +10,17 @@ public class WebHookMessageTests
     {
         // Arrange
         long expectedId = 1;
-        var formSubmittedOperation = WebHookOperation.FormSubmitted;
+        var submissionCompletedOperation = WebHookOperation.SubmissionCompleted;
         var expectedPayload = new Submission(SampleData.TENANT_ID, expectedId.ToString(), formId: 123, formDefinitionId: 456);
 
         // Act
-        var webHookMessage = new WebHookMessage<Submission>(expectedId, formSubmittedOperation, expectedPayload);
+        var webHookMessage = new WebHookMessage<Submission>(expectedId, submissionCompletedOperation, expectedPayload);
 
         // Assert
         webHookMessage.Id.Should().Be(expectedId);
-        webHookMessage.Operation.Should().Be(formSubmittedOperation);
+        webHookMessage.Operation.Should().Be(submissionCompletedOperation);
         webHookMessage.Payload.Should().Be(expectedPayload);
-        webHookMessage.Action.Should().Be("created");
+        webHookMessage.Action.Should().Be("updated");
     }
 
     [Fact]
@@ -28,7 +28,7 @@ public class WebHookMessageTests
     {
         // Arrange
         long expectedId = 1;
-        var expectedOperation = WebHookOperation.FormSubmitted;
+        var expectedOperation = WebHookOperation.SubmissionCompleted;
         Submission? nullPayload = null;
 
         // Act
@@ -38,6 +38,6 @@ public class WebHookMessageTests
         message.Id.Should().Be(expectedId);
         message.Operation.Should().Be(expectedOperation);
         message.Payload.Should().BeNull();
-        message.Action.Should().Be("created");
+        message.Action.Should().Be("updated");
     }
 }

--- a/tests/Endatix.Core.Tests/Features/WebHooks/WebHookOperationTests.cs
+++ b/tests/Endatix.Core.Tests/Features/WebHooks/WebHookOperationTests.cs
@@ -5,27 +5,27 @@ namespace Endatix.Core.Tests.Features.WebHooks;
 public class WebHookOperationTests
 {
     [Fact]
-    public void FormSubmitted_Operation_ShouldHaveCorrectValues()
+    public void SubmissionCompleted_Operation_ShouldHaveCorrectValues()
     {
         // Arrange & Act
-        var formSubmitted = WebHookOperation.FormSubmitted;
+        var submissionCompleted = WebHookOperation.SubmissionCompleted;
 
         // Assert
-        formSubmitted.Should().NotBeNull();
-        formSubmitted.EventName.Should().Be("form_submitted");
-        formSubmitted.Entity.Should().Be("Submission");
-        formSubmitted.Action.Should().Be(ActionName.Created);
-        formSubmitted.Action.GetDisplayName().Should().Be("created");
+        submissionCompleted.Should().NotBeNull();
+        submissionCompleted.EventName.Should().Be("submission_completed");
+        submissionCompleted.Entity.Should().Be("Submission");
+        submissionCompleted.Action.Should().Be(ActionName.Updated);
+        submissionCompleted.Action.GetDisplayName().Should().Be("updated");
     }
 
     [Fact]
     public void WebHookOperation_Equality_ShouldBeValueBased()
     {
         // Arrange
-        var formSubmittedOperation1 = WebHookOperation.FormSubmitted;
-        var formSubmittedOperation2 = WebHookOperation.FormSubmitted;
+        var submissionCompletedOperation1 = WebHookOperation.SubmissionCompleted;
+        var submissionCompletedOperation2 = WebHookOperation.SubmissionCompleted;
 
         // Act & Assert
-        formSubmittedOperation1.Should().Be(formSubmittedOperation2);
+        submissionCompletedOperation1.Should().Be(submissionCompletedOperation2);
     }
 }


### PR DESCRIPTION
# Update webhooks implementation (camelCase payload names, SubmissionCompleted event name, return submittedBy)

## Description
- Use camelCase in payload field names
- FormSubmitted event becomes SubmissionCompleted
- Return submittedBy in SubmissionCompleted

## Related Issues
closes #453 

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
