### PR TITLE
feat: Authenticate webhook messages

### DIFF
--- a/docs/endatix-docs/docs/guides/webhooks.mdx
+++ b/docs/endatix-docs/docs/guides/webhooks.mdx
@@ -142,32 +142,57 @@ To test your webhooks:
       "Events": {
         "FormCreated": {
           "IsEnabled": true,
-          "WebHookUrls": [
-            "https://webhook.site/your-unique-id"
+          "WebHookEndpoints": [
+            {
+              "Url": "https://webhook.site/your-unique-id",
+              "Authentication": {
+                "Type": "None"
+              }
+            }
           ]
         },
         "FormUpdated": {
           "IsEnabled": true,
-          "WebHookUrls": [
-            "https://webhook.site/your-unique-id"
+          "WebHookEndpoints": [
+            {
+              "Url": "https://webhook.site/your-unique-id",
+              "Authentication": {
+                "Type": "None"
+              }
+            }
           ]
         },
         "FormEnabledStateChanged": {
           "IsEnabled": true,
-          "WebHookUrls": [
-            "https://webhook.site/your-unique-id"
+          "WebHookEndpoints": [
+            {
+              "Url": "https://webhook.site/your-unique-id",
+              "Authentication": {
+                "Type": "None"
+              }
+            }
           ]
         },
         "SubmissionCompleted": {
           "IsEnabled": true,
-          "WebHookUrls": [
-            "https://webhook.site/your-unique-id"
+          "WebHookEndpoints": [
+            {
+              "Url": "https://webhook.site/your-unique-id",
+              "Authentication": {
+                "Type": "None"
+              }
+            }
           ]
         },
         "FormDeleted": {
           "IsEnabled": true,
-          "WebHookUrls": [
-            "https://webhook.site/your-unique-id"
+          "WebHookEndpoints": [
+            {
+              "Url": "https://webhook.site/your-unique-id",
+              "Authentication": {
+                "Type": "None"
+              }
+            }
           ]
         }
       }
@@ -180,6 +205,76 @@ To test your webhooks:
 
 4. Trigger events in your application
 5. View the incoming webhook requests on webhook.site
+
+## Webhook Authentication
+
+Endatix supports configurable authentication for securing your webhook endpoints. You can configure authentication per endpoint to match your API requirements.
+
+### Authentication Types
+
+#### 1. API Key Authentication (`ApiKey`)
+Sends an API key in a custom header:
+
+```json
+{
+  "Url": "https://api.example.com/webhooks",
+  "Authentication": {
+    "Type": "ApiKey",
+    "ApiKeyHeader": "X-SURVEY-API-KEY",
+    "ApiKey": "your-secret-api-key"
+  }
+}
+```
+
+#### 2. No Authentication (`None`)
+No authentication headers are sent:
+
+```json
+{
+  "Url": "https://api.example.com/webhooks",
+  "Authentication": {
+    "Type": "None"
+  }
+}
+```
+
+### Backward Compatibility
+
+The existing `WebHookUrls` configuration is still supported for backward compatibility. URLs configured this way will be called without authentication:
+
+```json
+{
+  "FormCreated": {
+    "IsEnabled": true,
+    "WebHookUrls": [
+      "https://webhook.site/your-unique-id"
+    ]
+  }
+}
+```
+
+You can also mix both approaches in the same event configuration:
+
+```json
+{
+  "FormCreated": {
+    "IsEnabled": true,
+    "WebHookUrls": [
+      "https://webhook.site/no-auth-endpoint"
+    ],
+    "WebHookEndpoints": [
+      {
+        "Url": "https://api.example.com/secure-endpoint",
+        "Authentication": {
+          "Type": "ApiKey",
+          "ApiKeyHeader": "X-SURVEY-API-KEY",
+          "ApiKey": "secret-key"
+        }
+      }
+    ]
+  }
+}
+```
 
 ## Available Events
 

--- a/src/Endatix.Infrastructure/Features/WebHooks/TaskInstructions.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/TaskInstructions.cs
@@ -12,10 +12,37 @@ public class TaskInstructions
     public TaskInstructions(string uri)
     {
         Uri = uri;
+        Authentication = null;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TaskInstructions"/> class with the specified URI and authentication.
+    /// </summary>
+    /// <param name="uri">The URI associated with the task instruction set.</param>
+    /// <param name="authentication">The authentication configuration for the webhook request.</param>
+    public TaskInstructions(string uri, AuthenticationConfig? authentication)
+    {
+        Uri = uri;
+        Authentication = authentication;
+    }
+
+    /// <summary>
+    /// Creates TaskInstructions from a WebHookEndpoint.
+    /// </summary>
+    /// <param name="endpoint">The webhook endpoint containing URL and authentication configuration.</param>
+    /// <returns>A new TaskInstructions instance.</returns>
+    public static TaskInstructions FromEndpoint(WebHookEndpoint endpoint)
+    {
+        return new TaskInstructions(endpoint.Url, endpoint.Authentication);
     }
 
     /// <summary>
     /// Gets the URI associated with the task instruction set.
     /// </summary>
     public string Uri { get; init; }
+
+    /// <summary>
+    /// Gets the authentication configuration for the webhook request.
+    /// </summary>
+    public AuthenticationConfig? Authentication { get; init; }
 }

--- a/src/Endatix.Infrastructure/Features/WebHooks/WebHookSettings.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/WebHookSettings.cs
@@ -118,8 +118,90 @@ public class WebHookSettings : IEndatixSettings
         public required string EventName { get; init; }
 
         /// <summary>
+        /// Gets or sets the webhook endpoints for this event.
+        /// </summary>
+        public IEnumerable<WebHookEndpoint>? WebHookEndpoints { get; init; }
+
+        /// <summary>
         /// Gets or sets the URLs for the WebHooks associated with this event.
+        /// This property is maintained for backward compatibility.
+        /// If WebHookEndpoints is null or empty, this will be used to create simple endpoints without authentication.
         /// </summary>
         public IEnumerable<string>? WebHookUrls { get; init; }
+
+        /// <summary>
+        /// Gets all webhook endpoints, combining both WebHookEndpoints and WebHookUrls for backward compatibility.
+        /// </summary>
+        public IEnumerable<WebHookEndpoint> GetAllEndpoints()
+        {
+            var endpoints = new List<WebHookEndpoint>();
+
+            // Add configured endpoints
+            if (WebHookEndpoints?.Any() == true)
+            {
+                endpoints.AddRange(WebHookEndpoints);
+            }
+
+            // Add simple URLs as endpoints without authentication (backward compatibility)
+            if (WebHookUrls?.Any() == true)
+            {
+                endpoints.AddRange(WebHookUrls.Select(url => new WebHookEndpoint { Url = url }));
+            }
+
+            return endpoints;
+        }
     }
+}
+
+/// <summary>
+/// Represents a webhook endpoint with its authentication configuration.
+/// </summary>
+public class WebHookEndpoint
+{
+    /// <summary>
+    /// Gets or sets the webhook URL.
+    /// </summary>
+    public required string Url { get; init; }
+
+    /// <summary>
+    /// Gets or sets the authentication configuration for this endpoint.
+    /// </summary>
+    public AuthenticationConfig? Authentication { get; init; }
+}
+
+/// <summary>
+/// Represents the authentication configuration for a webhook endpoint.
+/// </summary>
+public class AuthenticationConfig
+{
+    /// <summary>
+    /// Gets or sets the authentication type.
+    /// </summary>
+    public AuthenticationType Type { get; init; } = AuthenticationType.None;
+
+    /// <summary>
+    /// Gets or sets the API key value. Used when Type is ApiKey.
+    /// </summary>
+    public string? ApiKey { get; init; }
+
+    /// <summary>
+    /// Gets or sets the header name for the API key. Used when Type is ApiKey.
+    /// </summary>
+    public string? ApiKeyHeader { get; init; }
+}
+
+/// <summary>
+/// Defines the available authentication types for webhook endpoints.
+/// </summary>
+public enum AuthenticationType
+{
+    /// <summary>
+    /// No authentication.
+    /// </summary>
+    None,
+
+    /// <summary>
+    /// API key authentication using a custom header.
+    /// </summary>
+    ApiKey
 }

--- a/src/Endatix.WebHost/appsettings.Development.json
+++ b/src/Endatix.WebHost/appsettings.Development.json
@@ -76,23 +76,67 @@
       "Events": {
         "FormCreated": {
           "IsEnabled": false,
-          "WebHookUrls": []
+          "WebHookEndpoints": [
+            {
+              "Url": "",
+              "Authentication": {
+                "Type": "ApiKey",
+                "ApiKeyHeader": "",
+                "ApiKey": ""
+              }
+            }
+          ]
         },
         "FormUpdated": {
           "IsEnabled": false,
-          "WebHookUrls": []
+          "WebHookEndpoints": [
+            {
+              "Url": "",
+              "Authentication": {
+                "Type": "ApiKey",
+                "ApiKeyHeader": "",
+                "ApiKey": ""
+              }
+            }
+          ]
         },
         "FormEnabledStateChanged": {
           "IsEnabled": false,
-          "WebHookUrls": []
-        },
+          "WebHookEndpoints": [
+            {
+              "Url": "",
+              "Authentication": {
+                "Type": "ApiKey",
+                "ApiKeyHeader": "",
+                "ApiKey": ""
+              }
+            }
+          ]        },
         "FormDeleted": {
           "IsEnabled": false,
-          "WebHookUrls": []
+          "WebHookEndpoints": [
+            {
+              "Url": "",
+              "Authentication": {
+                "Type": "ApiKey",
+                "ApiKeyHeader": "",
+                "ApiKey": ""
+              }
+            }
+          ]
         },
         "SubmissionCompleted": {
           "IsEnabled": false,
-          "WebHookUrls": []
+          "WebHookEndpoints": [
+            {
+              "Url": "",
+              "Authentication": {
+                "Type": "ApiKey",
+                "ApiKeyHeader": "",
+                "ApiKey": ""
+              }
+            }
+          ]
         }
       }
     },

--- a/src/Endatix.WebHost/appsettings.json
+++ b/src/Endatix.WebHost/appsettings.json
@@ -78,23 +78,23 @@
       "Events": {
         "FormCreated": {
           "IsEnabled": false,
-          "WebHookUrls": []
+          "WebHookEndpoints": []
         },
         "FormUpdated": {
           "IsEnabled": false,
-          "WebHookUrls": []
+          "WebHookEndpoints": []
         },
         "FormEnabledStateChanged": {
           "IsEnabled": false,
-          "WebHookUrls": []
+          "WebHookEndpoints": []
         },
         "FormDeleted": {
           "IsEnabled": false,
-          "WebHookUrls": []
+          "WebHookEndpoints": []
         },
         "SubmissionCompleted": {
           "IsEnabled": false,
-          "WebHookUrls": []
+          "WebHookEndpoints": []
         }
       }
     },

--- a/tests/Endatix.Infrastructure.Tests/Features/WebHooks/BackgroundTaskWebHookServiceTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/WebHooks/BackgroundTaskWebHookServiceTests.cs
@@ -1,0 +1,393 @@
+using Endatix.Core.Features.WebHooks;
+using Endatix.Infrastructure.Features.WebHooks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+
+namespace Endatix.Infrastructure.Tests.Features.WebHooks;
+
+public class BackgroundTaskWebHookServiceTests
+{
+    private readonly ILogger<BackgroundTaskWebHookService> _logger;
+    private readonly IBackgroundTasksQueue _backgroundQueue;
+    private readonly WebHookServer _webHookServer;
+    private readonly IOptions<WebHookSettings> _options;
+
+    public BackgroundTaskWebHookServiceTests()
+    {
+        _logger = Substitute.For<ILogger<BackgroundTaskWebHookService>>();
+        _backgroundQueue = Substitute.For<IBackgroundTasksQueue>();
+        
+        // WebHookServer requires HttpClient and ILogger<WebHookServer> constructor arguments
+        var httpClient = Substitute.For<HttpClient>();
+        var webHookLogger = Substitute.For<ILogger<WebHookServer>>();
+        _webHookServer = Substitute.For<WebHookServer>(httpClient, webHookLogger);
+        
+        _options = Substitute.For<IOptions<WebHookSettings>>();
+    }
+
+    [Fact]
+    public async Task EnqueueWebHookAsync_WithDisabledEvent_DoesNotEnqueueTasks()
+    {
+        // Arrange
+        var settings = CreateSettingsWithDisabledEvents();
+        _options.Value.Returns(settings);
+
+        var service = new BackgroundTaskWebHookService(_logger, _backgroundQueue, _options, _webHookServer);
+        var message = CreateTestWebHookMessage("form_created");
+
+        // Act
+        await service.EnqueueWebHookAsync(message, CancellationToken.None);
+
+        // Assert
+        await _backgroundQueue.DidNotReceive().EnqueueAsync(Arg.Any<Func<CancellationToken, ValueTask>>());
+    }
+
+    [Fact]
+    public async Task EnqueueWebHookAsync_WithEnabledEventAndEndpoints_EnqueuesTasksForEachEndpoint()
+    {
+        // Arrange
+        var settings = CreateSettingsWithEnabledFormCreated(endpoints: new List<WebHookEndpoint>
+        {
+            new() { Url = "https://api1.example.com/webhooks" },
+            new() { Url = "https://api2.example.com/webhooks" }
+        });
+        _options.Value.Returns(settings);
+
+        var service = new BackgroundTaskWebHookService(_logger, _backgroundQueue, _options, _webHookServer);
+        var message = CreateTestWebHookMessage("form_created");
+
+        // Act
+        await service.EnqueueWebHookAsync(message, CancellationToken.None);
+
+        // Assert
+        await _backgroundQueue.Received(2).EnqueueAsync(Arg.Any<Func<CancellationToken, ValueTask>>());
+    }
+
+    [Fact]
+    public async Task EnqueueWebHookAsync_WithEnabledEventAndUrls_EnqueuesTasksForEachUrl()
+    {
+        // Arrange
+        var settings = CreateSettingsWithEnabledFormUpdated(urls: new List<string>
+        {
+            "https://api1.example.com/webhooks",
+            "https://api2.example.com/webhooks"
+        });
+        _options.Value.Returns(settings);
+
+        var service = new BackgroundTaskWebHookService(_logger, _backgroundQueue, _options, _webHookServer);
+        var message = CreateTestWebHookMessage("form_updated");
+
+        // Act
+        await service.EnqueueWebHookAsync(message, CancellationToken.None);
+
+        // Assert
+        await _backgroundQueue.Received(2).EnqueueAsync(Arg.Any<Func<CancellationToken, ValueTask>>());
+    }
+
+    [Fact]
+    public async Task EnqueueWebHookAsync_WithEnabledEventAndMixedEndpoints_EnqueuesTasksForAll()
+    {
+        // Arrange
+        var endpoints = new List<WebHookEndpoint>
+        {
+            new() { 
+                Url = "https://secure.example.com/webhooks",
+                Authentication = new AuthenticationConfig { Type = AuthenticationType.ApiKey, ApiKey = "key1" }
+            }
+        };
+        var urls = new List<string> { "https://public.example.com/webhooks" };
+
+        var settings = CreateSettingsWithEnabledSubmissionCompleted(endpoints: endpoints, urls: urls);
+        _options.Value.Returns(settings);
+
+        var service = new BackgroundTaskWebHookService(_logger, _backgroundQueue, _options, _webHookServer);
+        var message = CreateTestWebHookMessage("submission_completed");
+
+        // Act
+        await service.EnqueueWebHookAsync(message, CancellationToken.None);
+
+        // Assert
+        await _backgroundQueue.Received(2).EnqueueAsync(Arg.Any<Func<CancellationToken, ValueTask>>());
+    }
+
+    [Fact]
+    public async Task EnqueueWebHookAsync_WithEnabledEventButNoEndpoints_DoesNotEnqueueTasks()
+    {
+        // Arrange
+        var settings = CreateSettingsWithEnabledFormDeleted(endpoints: new List<WebHookEndpoint>(), urls: new List<string>());
+        _options.Value.Returns(settings);
+
+        var service = new BackgroundTaskWebHookService(_logger, _backgroundQueue, _options, _webHookServer);
+        var message = CreateTestWebHookMessage("form_deleted");
+
+        // Act
+        await service.EnqueueWebHookAsync(message, CancellationToken.None);
+
+        // Assert
+        await _backgroundQueue.DidNotReceive().EnqueueAsync(Arg.Any<Func<CancellationToken, ValueTask>>());
+    }
+
+    [Fact]
+    public async Task EnqueueWebHookAsync_WithEnabledEventAndNullEndpoints_DoesNotEnqueueTasks()
+    {
+        // Arrange
+        var settings = CreateSettingsWithEnabledFormEnabledStateChanged(endpoints: null, urls: null);
+        _options.Value.Returns(settings);
+
+        var service = new BackgroundTaskWebHookService(_logger, _backgroundQueue, _options, _webHookServer);
+        var message = CreateTestWebHookMessage("form_enabled_state_changed");
+
+        // Act
+        await service.EnqueueWebHookAsync(message, CancellationToken.None);
+
+        // Assert
+        await _backgroundQueue.DidNotReceive().EnqueueAsync(Arg.Any<Func<CancellationToken, ValueTask>>());
+    }
+
+    [Fact]
+    public async Task EnqueueWebHookAsync_WithEndpointAuthentication_PassesAuthenticationToTaskInstructions()
+    {
+        // Arrange
+        var auth = new AuthenticationConfig
+        {
+            Type = AuthenticationType.ApiKey,
+            ApiKey = "test-key",
+            ApiKeyHeader = "X-API-KEY"
+        };
+
+        var endpoints = new List<WebHookEndpoint>
+        {
+            new() { 
+                Url = "https://api.example.com/webhooks",
+                Authentication = auth
+            }
+        };
+
+        var settings = CreateSettingsWithEnabledFormCreated(endpoints: endpoints);
+        _options.Value.Returns(settings);
+
+        var service = new BackgroundTaskWebHookService(_logger, _backgroundQueue, _options, _webHookServer);
+        var message = CreateTestWebHookMessage("form_created");
+
+        // Act
+        await service.EnqueueWebHookAsync(message, CancellationToken.None);
+
+        // Assert
+        await _backgroundQueue.Received(1).EnqueueAsync(Arg.Any<Func<CancellationToken, ValueTask>>());
+    }
+
+    [Fact]
+    public async Task EnqueueWebHookAsync_WithCancellationToken_PassesTokenCorrectly()
+    {
+        // Arrange
+        var settings = CreateSettingsWithEnabledFormCreated(endpoints: new List<WebHookEndpoint>
+        {
+            new() { Url = "https://api.example.com/webhooks" }
+        });
+        _options.Value.Returns(settings);
+
+        var service = new BackgroundTaskWebHookService(_logger, _backgroundQueue, _options, _webHookServer);
+        var message = CreateTestWebHookMessage("form_created");
+        var cancellationToken = new CancellationToken();
+
+        // Act
+        await service.EnqueueWebHookAsync(message, cancellationToken);
+
+        // Assert
+        await _backgroundQueue.Received(1).EnqueueAsync(Arg.Any<Func<CancellationToken, ValueTask>>());
+    }
+
+    [Theory]
+    [InlineData("form_created")]
+    [InlineData("form_updated")]
+    [InlineData("form_enabled_state_changed")]
+    [InlineData("submission_completed")]
+    [InlineData("form_deleted")]
+    public async Task EnqueueWebHookAsync_WithKnownEventNames_HandlesCorrectly(string eventName)
+    {
+        // Arrange
+        var settings = CreateSettingsWithEnabledEvent(eventName, endpoints: new List<WebHookEndpoint>
+        {
+            new() { Url = "https://api.example.com/webhooks" }
+        });
+        _options.Value.Returns(settings);
+
+        var service = new BackgroundTaskWebHookService(_logger, _backgroundQueue, _options, _webHookServer);
+        var message = CreateTestWebHookMessage(eventName);
+
+        // Act
+        await service.EnqueueWebHookAsync(message, CancellationToken.None);
+
+        // Assert
+        await _backgroundQueue.Received(1).EnqueueAsync(Arg.Any<Func<CancellationToken, ValueTask>>());
+    }
+
+    private static WebHookMessage<TestPayload> CreateTestWebHookMessage(string eventName)
+    {
+        var operation = eventName switch
+        {
+            "form_created" => WebHookOperation.FormCreated,
+            "form_updated" => WebHookOperation.FormUpdated,
+            "form_enabled_state_changed" => WebHookOperation.FormEnabledStateChanged,
+            "submission_completed" => WebHookOperation.SubmissionCompleted,
+            "form_deleted" => WebHookOperation.FormDeleted,
+            _ => WebHookOperation.FormCreated // Use a valid operation for unknown events in tests
+        };
+
+        var payload = new TestPayload { Name = "Test" };
+        return new WebHookMessage<TestPayload>(123, operation, payload);
+    }
+
+    private static WebHookSettings CreateSettingsWithDisabledEvents()
+    {
+        return new WebHookSettings
+        {
+            Events = new WebHookSettings.WebHookEvents
+            {
+                FormCreated = new WebHookSettings.EventSetting { EventName = "form_created", IsEnabled = false },
+                FormUpdated = new WebHookSettings.EventSetting { EventName = "form_updated", IsEnabled = false },
+                FormEnabledStateChanged = new WebHookSettings.EventSetting { EventName = "form_enabled_state_changed", IsEnabled = false },
+                SubmissionCompleted = new WebHookSettings.EventSetting { EventName = "submission_completed", IsEnabled = false },
+                FormDeleted = new WebHookSettings.EventSetting { EventName = "form_deleted", IsEnabled = false }
+            }
+        };
+    }
+
+    private static WebHookSettings CreateSettingsWithEnabledFormCreated(
+        IEnumerable<WebHookEndpoint>? endpoints = null, 
+        IEnumerable<string>? urls = null)
+    {
+        return new WebHookSettings
+        {
+            Events = new WebHookSettings.WebHookEvents
+            {
+                FormCreated = new WebHookSettings.EventSetting 
+                { 
+                    EventName = "form_created", 
+                    IsEnabled = true,
+                    WebHookEndpoints = endpoints,
+                    WebHookUrls = urls
+                },
+                FormUpdated = new WebHookSettings.EventSetting { EventName = "form_updated", IsEnabled = false },
+                FormEnabledStateChanged = new WebHookSettings.EventSetting { EventName = "form_enabled_state_changed", IsEnabled = false },
+                SubmissionCompleted = new WebHookSettings.EventSetting { EventName = "submission_completed", IsEnabled = false },
+                FormDeleted = new WebHookSettings.EventSetting { EventName = "form_deleted", IsEnabled = false }
+            }
+        };
+    }
+
+    private static WebHookSettings CreateSettingsWithEnabledFormUpdated(
+        IEnumerable<WebHookEndpoint>? endpoints = null, 
+        IEnumerable<string>? urls = null)
+    {
+        return new WebHookSettings
+        {
+            Events = new WebHookSettings.WebHookEvents
+            {
+                FormCreated = new WebHookSettings.EventSetting { EventName = "form_created", IsEnabled = false },
+                FormUpdated = new WebHookSettings.EventSetting 
+                { 
+                    EventName = "form_updated", 
+                    IsEnabled = true,
+                    WebHookEndpoints = endpoints,
+                    WebHookUrls = urls
+                },
+                FormEnabledStateChanged = new WebHookSettings.EventSetting { EventName = "form_enabled_state_changed", IsEnabled = false },
+                SubmissionCompleted = new WebHookSettings.EventSetting { EventName = "submission_completed", IsEnabled = false },
+                FormDeleted = new WebHookSettings.EventSetting { EventName = "form_deleted", IsEnabled = false }
+            }
+        };
+    }
+
+    private static WebHookSettings CreateSettingsWithEnabledSubmissionCompleted(
+        IEnumerable<WebHookEndpoint>? endpoints = null, 
+        IEnumerable<string>? urls = null)
+    {
+        return new WebHookSettings
+        {
+            Events = new WebHookSettings.WebHookEvents
+            {
+                FormCreated = new WebHookSettings.EventSetting { EventName = "form_created", IsEnabled = false },
+                FormUpdated = new WebHookSettings.EventSetting { EventName = "form_updated", IsEnabled = false },
+                FormEnabledStateChanged = new WebHookSettings.EventSetting { EventName = "form_enabled_state_changed", IsEnabled = false },
+                SubmissionCompleted = new WebHookSettings.EventSetting 
+                { 
+                    EventName = "submission_completed", 
+                    IsEnabled = true,
+                    WebHookEndpoints = endpoints,
+                    WebHookUrls = urls
+                },
+                FormDeleted = new WebHookSettings.EventSetting { EventName = "form_deleted", IsEnabled = false }
+            }
+        };
+    }
+
+    private static WebHookSettings CreateSettingsWithEnabledFormDeleted(
+        IEnumerable<WebHookEndpoint>? endpoints = null, 
+        IEnumerable<string>? urls = null)
+    {
+        return new WebHookSettings
+        {
+            Events = new WebHookSettings.WebHookEvents
+            {
+                FormCreated = new WebHookSettings.EventSetting { EventName = "form_created", IsEnabled = false },
+                FormUpdated = new WebHookSettings.EventSetting { EventName = "form_updated", IsEnabled = false },
+                FormEnabledStateChanged = new WebHookSettings.EventSetting { EventName = "form_enabled_state_changed", IsEnabled = false },
+                SubmissionCompleted = new WebHookSettings.EventSetting { EventName = "submission_completed", IsEnabled = false },
+                FormDeleted = new WebHookSettings.EventSetting 
+                { 
+                    EventName = "form_deleted", 
+                    IsEnabled = true,
+                    WebHookEndpoints = endpoints,
+                    WebHookUrls = urls
+                }
+            }
+        };
+    }
+
+    private static WebHookSettings CreateSettingsWithEnabledFormEnabledStateChanged(
+        IEnumerable<WebHookEndpoint>? endpoints = null, 
+        IEnumerable<string>? urls = null)
+    {
+        return new WebHookSettings
+        {
+            Events = new WebHookSettings.WebHookEvents
+            {
+                FormCreated = new WebHookSettings.EventSetting { EventName = "form_created", IsEnabled = false },
+                FormUpdated = new WebHookSettings.EventSetting { EventName = "form_updated", IsEnabled = false },
+                FormEnabledStateChanged = new WebHookSettings.EventSetting 
+                { 
+                    EventName = "form_enabled_state_changed", 
+                    IsEnabled = true,
+                    WebHookEndpoints = endpoints,
+                    WebHookUrls = urls
+                },
+                SubmissionCompleted = new WebHookSettings.EventSetting { EventName = "submission_completed", IsEnabled = false },
+                FormDeleted = new WebHookSettings.EventSetting { EventName = "form_deleted", IsEnabled = false }
+            }
+        };
+    }
+
+    private static WebHookSettings CreateSettingsWithEnabledEvent(
+        string eventName,
+        IEnumerable<WebHookEndpoint>? endpoints = null, 
+        IEnumerable<string>? urls = null)
+    {
+        return eventName switch
+        {
+            "form_created" => CreateSettingsWithEnabledFormCreated(endpoints, urls),
+            "form_updated" => CreateSettingsWithEnabledFormUpdated(endpoints, urls),
+            "form_enabled_state_changed" => CreateSettingsWithEnabledFormEnabledStateChanged(endpoints, urls),
+            "submission_completed" => CreateSettingsWithEnabledSubmissionCompleted(endpoints, urls),
+            "form_deleted" => CreateSettingsWithEnabledFormDeleted(endpoints, urls),
+            _ => throw new ArgumentException($"Unknown event name: {eventName}")
+        };
+    }
+
+    private class TestPayload
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+} 

--- a/tests/Endatix.Infrastructure.Tests/Features/WebHooks/TaskInstructionsTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/WebHooks/TaskInstructionsTests.cs
@@ -1,0 +1,171 @@
+using Endatix.Infrastructure.Features.WebHooks;
+using FluentAssertions;
+
+namespace Endatix.Infrastructure.Tests.Features.WebHooks;
+
+public class TaskInstructionsTests
+{
+    [Fact]
+    public void Constructor_WithUri_ShouldInitializeCorrectly()
+    {
+        // Arrange
+        var uri = "https://api.example.com/webhooks";
+
+        // Act
+        var instructions = new TaskInstructions(uri);
+
+        // Assert
+        instructions.Uri.Should().Be(uri);
+        instructions.Authentication.Should().BeNull();
+    }
+
+    [Fact]
+    public void Constructor_WithUriAndAuthentication_ShouldInitializeCorrectly()
+    {
+        // Arrange
+        var uri = "https://api.example.com/webhooks";
+        var auth = new AuthenticationConfig
+        {
+            Type = AuthenticationType.ApiKey,
+            ApiKey = "test-key",
+            ApiKeyHeader = "X-API-KEY"
+        };
+
+        // Act
+        var instructions = new TaskInstructions(uri, auth);
+
+        // Assert
+        instructions.Uri.Should().Be(uri);
+        instructions.Authentication.Should().Be(auth);
+        instructions.Authentication!.Type.Should().Be(AuthenticationType.ApiKey);
+        instructions.Authentication!.ApiKey.Should().Be("test-key");
+        instructions.Authentication!.ApiKeyHeader.Should().Be("X-API-KEY");
+    }
+
+    [Fact]
+    public void Constructor_WithUriAndNullAuthentication_ShouldInitializeCorrectly()
+    {
+        // Arrange
+        var uri = "https://api.example.com/webhooks";
+
+        // Act
+        var instructions = new TaskInstructions(uri, null);
+
+        // Assert
+        instructions.Uri.Should().Be(uri);
+        instructions.Authentication.Should().BeNull();
+    }
+
+    [Fact]
+    public void FromEndpoint_WithEndpointWithoutAuthentication_ShouldCreateCorrectInstructions()
+    {
+        // Arrange
+        var endpoint = new WebHookEndpoint
+        {
+            Url = "https://api.example.com/webhooks"
+        };
+
+        // Act
+        var instructions = TaskInstructions.FromEndpoint(endpoint);
+
+        // Assert
+        instructions.Uri.Should().Be("https://api.example.com/webhooks");
+        instructions.Authentication.Should().BeNull();
+    }
+
+    [Fact]
+    public void FromEndpoint_WithEndpointWithAuthentication_ShouldCreateCorrectInstructions()
+    {
+        // Arrange
+        var auth = new AuthenticationConfig
+        {
+            Type = AuthenticationType.ApiKey,
+            ApiKey = "secret-key",
+            ApiKeyHeader = "X-SURVEY-API-KEY"
+        };
+
+        var endpoint = new WebHookEndpoint
+        {
+            Url = "https://api.example.com/webhooks",
+            Authentication = auth
+        };
+
+        // Act
+        var instructions = TaskInstructions.FromEndpoint(endpoint);
+
+        // Assert
+        instructions.Uri.Should().Be("https://api.example.com/webhooks");
+        instructions.Authentication.Should().Be(auth);
+        instructions.Authentication!.Type.Should().Be(AuthenticationType.ApiKey);
+        instructions.Authentication!.ApiKey.Should().Be("secret-key");
+        instructions.Authentication!.ApiKeyHeader.Should().Be("X-SURVEY-API-KEY");
+    }
+
+    [Fact]
+    public void FromEndpoint_WithEndpointWithNoneAuthentication_ShouldCreateCorrectInstructions()
+    {
+        // Arrange
+        var auth = new AuthenticationConfig
+        {
+            Type = AuthenticationType.None
+        };
+
+        var endpoint = new WebHookEndpoint
+        {
+            Url = "https://api.example.com/webhooks",
+            Authentication = auth
+        };
+
+        // Act
+        var instructions = TaskInstructions.FromEndpoint(endpoint);
+
+        // Assert
+        instructions.Uri.Should().Be("https://api.example.com/webhooks");
+        instructions.Authentication.Should().Be(auth);
+        instructions.Authentication!.Type.Should().Be(AuthenticationType.None);
+        instructions.Authentication!.ApiKey.Should().BeNull();
+        instructions.Authentication!.ApiKeyHeader.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("https://api.example.com/webhooks")]
+    [InlineData("http://localhost:3000/webhooks")]
+    [InlineData("https://webhook.site/unique-id")]
+    public void Constructor_WithVariousUris_ShouldInitializeCorrectly(string uri)
+    {
+        // Act
+        var instructions = new TaskInstructions(uri);
+
+        // Assert
+        instructions.Uri.Should().Be(uri);
+        instructions.Authentication.Should().BeNull();
+    }
+
+    [Fact]
+    public void FromEndpoint_WithComplexEndpoint_ShouldPreserveAllProperties()
+    {
+        // Arrange
+        var auth = new AuthenticationConfig
+        {
+            Type = AuthenticationType.ApiKey,
+            ApiKey = "complex-secret-key-123",
+            ApiKeyHeader = "X-CUSTOM-AUTH-HEADER"
+        };
+
+        var endpoint = new WebHookEndpoint
+        {
+            Url = "https://complex-api.example.com/v2/webhooks/events",
+            Authentication = auth
+        };
+
+        // Act
+        var instructions = TaskInstructions.FromEndpoint(endpoint);
+
+        // Assert
+        instructions.Uri.Should().Be("https://complex-api.example.com/v2/webhooks/events");
+        instructions.Authentication.Should().NotBeNull();
+        instructions.Authentication!.Type.Should().Be(AuthenticationType.ApiKey);
+        instructions.Authentication!.ApiKey.Should().Be("complex-secret-key-123");
+        instructions.Authentication!.ApiKeyHeader.Should().Be("X-CUSTOM-AUTH-HEADER");
+    }
+} 

--- a/tests/Endatix.Infrastructure.Tests/Features/WebHooks/WebHookServerTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/WebHooks/WebHookServerTests.cs
@@ -1,0 +1,349 @@
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using Endatix.Core.Features.WebHooks;
+using Endatix.Infrastructure.Features.WebHooks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Endatix.Infrastructure.Tests.Features.WebHooks;
+
+public class WebHookServerTests
+{
+    private readonly ILogger<WebHookServer> _logger;
+
+    public WebHookServerTests()
+    {
+        _logger = Substitute.For<ILogger<WebHookServer>>();
+    }
+
+    [Fact]
+    public async Task FireWebHookAsync_WithValidRequest_ReturnsTrue()
+    {
+        // Arrange
+        var handler = new MockHttpHandler(HttpStatusCode.OK, "Success");
+        var httpClient = new HttpClient(handler);
+        var server = new WebHookServer(httpClient, _logger);
+
+        var message = CreateTestWebHookMessage();
+        var instructions = new TaskInstructions("https://api.example.com/webhooks");
+
+        // Act
+        var result = await server.FireWebHookAsync(message, instructions, CancellationToken.None);
+
+        // Assert
+        result.Should().BeTrue();
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.Method.Should().Be(HttpMethod.Post);
+        handler.LastRequest!.RequestUri.Should().Be("https://api.example.com/webhooks");
+    }
+
+    [Fact]
+    public async Task FireWebHookAsync_WithInvalidUri_ReturnsFalse()
+    {
+        // Arrange
+        var handler = new MockHttpHandler(HttpStatusCode.OK, "Success");
+        var httpClient = new HttpClient(handler);
+        var server = new WebHookServer(httpClient, _logger);
+
+        var message = CreateTestWebHookMessage();
+        var instructions = new TaskInstructions("not-a-valid-uri");
+
+        // Act
+        var result = await server.FireWebHookAsync(message, instructions, CancellationToken.None);
+
+        // Assert
+        result.Should().BeFalse();
+        handler.LastRequest.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task FireWebHookAsync_WithNullUri_ReturnsFalse()
+    {
+        // Arrange
+        var handler = new MockHttpHandler(HttpStatusCode.OK, "Success");
+        var httpClient = new HttpClient(handler);
+        var server = new WebHookServer(httpClient, _logger);
+
+        var message = CreateTestWebHookMessage();
+        var instructions = new TaskInstructions(null!);
+
+        // Act
+        var result = await server.FireWebHookAsync(message, instructions, CancellationToken.None);
+
+        // Assert
+        result.Should().BeFalse();
+        handler.LastRequest.Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.BadRequest)]
+    [InlineData(HttpStatusCode.Unauthorized)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    public async Task FireWebHookAsync_WithErrorStatusCode_ReturnsFalse(HttpStatusCode statusCode)
+    {
+        // Arrange
+        var handler = new MockHttpHandler(statusCode, "Error");
+        var httpClient = new HttpClient(handler);
+        var server = new WebHookServer(httpClient, _logger);
+
+        var message = CreateTestWebHookMessage();
+        var instructions = new TaskInstructions("https://api.example.com/webhooks");
+
+        // Act
+        var result = await server.FireWebHookAsync(message, instructions, CancellationToken.None);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task FireWebHookAsync_WithHttpException_ReturnsFalse()
+    {
+        // Arrange
+        var handler = new ThrowingHttpHandler();
+        var httpClient = new HttpClient(handler);
+        var server = new WebHookServer(httpClient, _logger);
+
+        var message = CreateTestWebHookMessage();
+        var instructions = new TaskInstructions("https://api.example.com/webhooks");
+
+        // Act
+        var result = await server.FireWebHookAsync(message, instructions, CancellationToken.None);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task FireWebHookAsync_WithApiKeyAuthentication_AddsCorrectHeaders()
+    {
+        // Arrange
+        var handler = new MockHttpHandler(HttpStatusCode.OK, "Success");
+        var httpClient = new HttpClient(handler);
+        var server = new WebHookServer(httpClient, _logger);
+
+        var message = CreateTestWebHookMessage();
+        var auth = new AuthenticationConfig
+        {
+            Type = AuthenticationType.ApiKey,
+            ApiKey = "test-api-key",
+            ApiKeyHeader = "X-API-KEY"
+        };
+        var instructions = new TaskInstructions("https://api.example.com/webhooks", auth);
+
+        // Act
+        var result = await server.FireWebHookAsync(message, instructions, CancellationToken.None);
+
+        // Assert
+        result.Should().BeTrue();
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.Headers.Should().Contain(h => h.Key == "X-API-KEY" && h.Value.First() == "test-api-key");
+    }
+
+    [Fact]
+    public async Task FireWebHookAsync_WithNoAuthentication_DoesNotAddAuthHeaders()
+    {
+        // Arrange
+        var handler = new MockHttpHandler(HttpStatusCode.OK, "Success");
+        var httpClient = new HttpClient(handler);
+        var server = new WebHookServer(httpClient, _logger);
+
+        var message = CreateTestWebHookMessage();
+        var instructions = new TaskInstructions("https://api.example.com/webhooks");
+
+        // Act
+        var result = await server.FireWebHookAsync(message, instructions, CancellationToken.None);
+
+        // Assert
+        result.Should().BeTrue();
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.Headers.Should().NotContain(h => h.Key.StartsWith("X-API") || h.Key == "Authorization");
+    }
+
+    [Fact]
+    public async Task FireWebHookAsync_WithNoneAuthentication_DoesNotAddAuthHeaders()
+    {
+        // Arrange
+        var handler = new MockHttpHandler(HttpStatusCode.OK, "Success");
+        var httpClient = new HttpClient(handler);
+        var server = new WebHookServer(httpClient, _logger);
+
+        var message = CreateTestWebHookMessage();
+        var auth = new AuthenticationConfig { Type = AuthenticationType.None };
+        var instructions = new TaskInstructions("https://api.example.com/webhooks", auth);
+
+        // Act
+        var result = await server.FireWebHookAsync(message, instructions, CancellationToken.None);
+
+        // Assert
+        result.Should().BeTrue();
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.Headers.Should().NotContain(h => h.Key.StartsWith("X-API") || h.Key == "Authorization");
+    }
+
+    [Fact]
+    public async Task FireWebHookAsync_AddsStandardWebHookHeaders()
+    {
+        // Arrange
+        var handler = new MockHttpHandler(HttpStatusCode.OK, "Success");
+        var httpClient = new HttpClient(handler);
+        var server = new WebHookServer(httpClient, _logger);
+
+        var message = CreateTestWebHookMessage();
+        var instructions = new TaskInstructions("https://api.example.com/webhooks");
+
+        // Act
+        var result = await server.FireWebHookAsync(message, instructions, CancellationToken.None);
+
+        // Assert
+        result.Should().BeTrue();
+        handler.LastRequest.Should().NotBeNull();
+        
+        var headers = handler.LastRequest!.Headers.ToDictionary(h => h.Key, h => h.Value.First());
+        headers.Should().ContainKey("X-Endatix-Event");
+        headers.Should().ContainKey("X-Endatix-Entity");
+        headers.Should().ContainKey("X-Endatix-Action");
+        headers.Should().ContainKey("X-Endatix-Hook-Id");
+        
+        headers["X-Endatix-Event"].Should().Be("submission_completed");
+        headers["X-Endatix-Entity"].Should().Be("Submission");
+        headers["X-Endatix-Action"].Should().Be("updated");
+        headers["X-Endatix-Hook-Id"].Should().Be("123");
+    }
+
+    [Fact]
+    public async Task FireWebHookAsync_SendsCorrectJsonPayload()
+    {
+        // Arrange
+        var handler = new MockHttpHandler(HttpStatusCode.OK, "Success");
+        var httpClient = new HttpClient(handler);
+        var server = new WebHookServer(httpClient, _logger);
+
+        var message = CreateTestWebHookMessage();
+        var instructions = new TaskInstructions("https://api.example.com/webhooks");
+
+        // Act
+        var result = await server.FireWebHookAsync(message, instructions, CancellationToken.None);
+
+        // Assert
+        result.Should().BeTrue();
+        handler.LastRequest.Should().NotBeNull();
+        handler.LastRequest!.Content.Should().NotBeNull();
+        
+        var content = handler.LastRequestContent;
+        content.Should().NotBeNullOrEmpty();
+        
+        // Parse JSON without full deserialization to avoid constructor issues
+        using var jsonDoc = JsonDocument.Parse(content);
+        var root = jsonDoc.RootElement;
+        
+        root.GetProperty("id").GetInt64().Should().Be(123);
+        root.GetProperty("eventName").GetString().Should().Be("submission_completed");
+        root.GetProperty("action").GetString().Should().Be("updated");
+        
+        var payload = root.GetProperty("payload");
+        payload.GetProperty("Name").GetString().Should().Be("Test");
+    }
+
+    [Fact]
+    public async Task FireWebHookAsync_WithApiKeyAuthenticationMissingKey_ReturnsFalse()
+    {
+        // Arrange
+        var handler = new MockHttpHandler(HttpStatusCode.OK, "Success");
+        var httpClient = new HttpClient(handler);
+        var server = new WebHookServer(httpClient, _logger);
+
+        var message = CreateTestWebHookMessage();
+        var auth = new AuthenticationConfig
+        {
+            Type = AuthenticationType.ApiKey,
+            ApiKey = null, // Missing API key
+            ApiKeyHeader = "X-API-KEY"
+        };
+        var instructions = new TaskInstructions("https://api.example.com/webhooks", auth);
+
+        // Act
+        var result = await server.FireWebHookAsync(message, instructions, CancellationToken.None);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task FireWebHookAsync_WithApiKeyAuthenticationMissingHeader_ReturnsFalse()
+    {
+        // Arrange
+        var handler = new MockHttpHandler(HttpStatusCode.OK, "Success");
+        var httpClient = new HttpClient(handler);
+        var server = new WebHookServer(httpClient, _logger);
+
+        var message = CreateTestWebHookMessage();
+        var auth = new AuthenticationConfig
+        {
+            Type = AuthenticationType.ApiKey,
+            ApiKey = "test-key",
+            ApiKeyHeader = null // Missing header name
+        };
+        var instructions = new TaskInstructions("https://api.example.com/webhooks", auth);
+
+        // Act
+        var result = await server.FireWebHookAsync(message, instructions, CancellationToken.None);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    private static WebHookMessage<TestPayload> CreateTestWebHookMessage()
+    {
+        var operation = WebHookOperation.SubmissionCompleted;
+        var payload = new TestPayload { Name = "Test" };
+        return new WebHookMessage<TestPayload>(123, operation, payload);
+    }
+
+    private class TestPayload
+    {
+        public string Name { get; set; } = string.Empty;
+    }
+
+    // Helper classes for HTTP mocking
+    private class MockHttpHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _statusCode;
+        private readonly string _content;
+
+        public HttpRequestMessage? LastRequest { get; private set; }
+        public string? LastRequestContent { get; private set; }
+
+        public MockHttpHandler(HttpStatusCode statusCode, string content)
+        {
+            _statusCode = statusCode;
+            _content = content;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            LastRequest = request;
+            
+            // Capture the request content before it gets disposed
+            if (request.Content != null)
+            {
+                LastRequestContent = await request.Content.ReadAsStringAsync();
+            }
+            
+            return new HttpResponseMessage(_statusCode)
+            {
+                Content = new StringContent(_content, Encoding.UTF8, "application/json")
+            };
+        }
+    }
+
+    private class ThrowingHttpHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            throw new HttpRequestException("Simulated network error");
+        }
+    }
+} 

--- a/tests/Endatix.Infrastructure.Tests/Features/WebHooks/WebHookSettingsTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/WebHooks/WebHookSettingsTests.cs
@@ -1,0 +1,263 @@
+using Endatix.Infrastructure.Features.WebHooks;
+using FluentAssertions;
+
+namespace Endatix.Infrastructure.Tests.Features.WebHooks;
+
+public class WebHookSettingsTests
+{
+    [Fact]
+    public void WebHookEndpoint_WithValidUrl_ShouldInitializeCorrectly()
+    {
+        // Arrange
+        var url = "https://api.example.com/webhooks";
+
+        // Act
+        var endpoint = new WebHookEndpoint { Url = url };
+
+        // Assert
+        endpoint.Url.Should().Be(url);
+        endpoint.Authentication.Should().BeNull();
+    }
+
+    [Fact]
+    public void WebHookEndpoint_WithAuthentication_ShouldInitializeCorrectly()
+    {
+        // Arrange
+        var url = "https://api.example.com/webhooks";
+        var auth = new AuthenticationConfig
+        {
+            Type = AuthenticationType.ApiKey,
+            ApiKey = "test-key",
+            ApiKeyHeader = "X-API-KEY"
+        };
+
+        // Act
+        var endpoint = new WebHookEndpoint { Url = url, Authentication = auth };
+
+        // Assert
+        endpoint.Url.Should().Be(url);
+        endpoint.Authentication.Should().Be(auth);
+        endpoint.Authentication!.Type.Should().Be(AuthenticationType.ApiKey);
+        endpoint.Authentication!.ApiKey.Should().Be("test-key");
+        endpoint.Authentication!.ApiKeyHeader.Should().Be("X-API-KEY");
+    }
+
+    [Fact]
+    public void AuthenticationConfig_DefaultValues_ShouldBeCorrect()
+    {
+        // Act
+        var auth = new AuthenticationConfig();
+
+        // Assert
+        auth.Type.Should().Be(AuthenticationType.None);
+        auth.ApiKey.Should().BeNull();
+        auth.ApiKeyHeader.Should().BeNull();
+    }
+
+    [Fact]
+    public void AuthenticationConfig_ApiKeyType_ShouldInitializeCorrectly()
+    {
+        // Arrange & Act
+        var auth = new AuthenticationConfig
+        {
+            Type = AuthenticationType.ApiKey,
+            ApiKey = "secret-key",
+            ApiKeyHeader = "X-SURVEY-API-KEY"
+        };
+
+        // Assert
+        auth.Type.Should().Be(AuthenticationType.ApiKey);
+        auth.ApiKey.Should().Be("secret-key");
+        auth.ApiKeyHeader.Should().Be("X-SURVEY-API-KEY");
+    }
+
+    [Fact]
+    public void EventSetting_GetAllEndpoints_WithOnlyWebHookEndpoints_ReturnsEndpoints()
+    {
+        // Arrange
+        var endpoints = new List<WebHookEndpoint>
+        {
+            new() { Url = "https://api1.example.com/webhooks" },
+            new() { Url = "https://api2.example.com/webhooks" }
+        };
+
+        var eventSetting = new WebHookSettings.EventSetting
+        {
+            EventName = "test_event",
+            IsEnabled = true,
+            WebHookEndpoints = endpoints
+        };
+
+        // Act
+        var result = eventSetting.GetAllEndpoints();
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().Contain(e => e.Url == "https://api1.example.com/webhooks");
+        result.Should().Contain(e => e.Url == "https://api2.example.com/webhooks");
+    }
+
+    [Fact]
+    public void EventSetting_GetAllEndpoints_WithOnlyWebHookUrls_ReturnsEndpointsFromUrls()
+    {
+        // Arrange
+        var urls = new List<string>
+        {
+            "https://api1.example.com/webhooks",
+            "https://api2.example.com/webhooks"
+        };
+
+        var eventSetting = new WebHookSettings.EventSetting
+        {
+            EventName = "test_event",
+            IsEnabled = true,
+            WebHookUrls = urls
+        };
+
+        // Act
+        var result = eventSetting.GetAllEndpoints();
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().Contain(e => e.Url == "https://api1.example.com/webhooks" && e.Authentication == null);
+        result.Should().Contain(e => e.Url == "https://api2.example.com/webhooks" && e.Authentication == null);
+    }
+
+    [Fact]
+    public void EventSetting_GetAllEndpoints_WithBothEndpointsAndUrls_ReturnsCombined()
+    {
+        // Arrange
+        var endpoints = new List<WebHookEndpoint>
+        {
+            new() { 
+                Url = "https://secure.example.com/webhooks",
+                Authentication = new AuthenticationConfig { Type = AuthenticationType.ApiKey, ApiKey = "key1" }
+            }
+        };
+
+        var urls = new List<string>
+        {
+            "https://public.example.com/webhooks"
+        };
+
+        var eventSetting = new WebHookSettings.EventSetting
+        {
+            EventName = "test_event",
+            IsEnabled = true,
+            WebHookEndpoints = endpoints,
+            WebHookUrls = urls
+        };
+
+        // Act
+        var result = eventSetting.GetAllEndpoints();
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Should().Contain(e => e.Url == "https://secure.example.com/webhooks" && e.Authentication != null);
+        result.Should().Contain(e => e.Url == "https://public.example.com/webhooks" && e.Authentication == null);
+    }
+
+    [Fact]
+    public void EventSetting_GetAllEndpoints_WithEmptyCollections_ReturnsEmpty()
+    {
+        // Arrange
+        var eventSetting = new WebHookSettings.EventSetting
+        {
+            EventName = "test_event",
+            IsEnabled = true,
+            WebHookEndpoints = new List<WebHookEndpoint>(),
+            WebHookUrls = new List<string>()
+        };
+
+        // Act
+        var result = eventSetting.GetAllEndpoints();
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void EventSetting_GetAllEndpoints_WithNullCollections_ReturnsEmpty()
+    {
+        // Arrange
+        var eventSetting = new WebHookSettings.EventSetting
+        {
+            EventName = "test_event",
+            IsEnabled = true,
+            WebHookEndpoints = null,
+            WebHookUrls = null
+        };
+
+        // Act
+        var result = eventSetting.GetAllEndpoints();
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Theory]
+    [InlineData(AuthenticationType.None)]
+    [InlineData(AuthenticationType.ApiKey)]
+    public void AuthenticationType_AllValues_ShouldBeSupported(AuthenticationType type)
+    {
+        // Arrange & Act
+        var auth = new AuthenticationConfig { Type = type };
+
+        // Assert
+        auth.Type.Should().Be(type);
+    }
+
+    [Fact]
+    public void WebHookSettings_DefaultValues_ShouldBeCorrect()
+    {
+        // Act
+        var settings = new WebHookSettings();
+
+        // Assert
+        settings.ServerSettings.Should().NotBeNull();
+        settings.Events.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void HttpServerSettings_DefaultValues_ShouldBeCorrect()
+    {
+        // Act
+        var serverSettings = new WebHookSettings.HttpServerSettings();
+
+        // Assert
+        serverSettings.PipelineTimeoutInSeconds.Should().Be(120);
+        serverSettings.AttemptTimeoutInSeconds.Should().Be(10);
+        serverSettings.RetryAttempts.Should().Be(5);
+        serverSettings.Delay.Should().Be(10);
+        serverSettings.MaxConcurrentRequests.Should().Be(5);
+        serverSettings.MaxQueueSize.Should().Be(25);
+    }
+
+    [Fact]
+    public void WebHookEvents_DefaultValues_ShouldBeCorrect()
+    {
+        // Act
+        var events = new WebHookSettings.WebHookEvents();
+
+        // Assert
+        events.FormCreated.Should().NotBeNull();
+        events.FormCreated.IsEnabled.Should().BeFalse();
+        events.FormCreated.EventName.Should().Be("form_created");
+
+        events.FormUpdated.Should().NotBeNull();
+        events.FormUpdated.IsEnabled.Should().BeFalse();
+        events.FormUpdated.EventName.Should().Be("form_updated");
+
+        events.FormEnabledStateChanged.Should().NotBeNull();
+        events.FormEnabledStateChanged.IsEnabled.Should().BeFalse();
+        events.FormEnabledStateChanged.EventName.Should().Be("form_enabled_state_changed");
+
+        events.SubmissionCompleted.Should().NotBeNull();
+        events.SubmissionCompleted.IsEnabled.Should().BeFalse();
+        events.SubmissionCompleted.EventName.Should().Be("submission_completed");
+
+        events.FormDeleted.Should().NotBeNull();
+        events.FormDeleted.IsEnabled.Should().BeFalse();
+        events.FormDeleted.EventName.Should().Be("form_deleted");
+    }
+} 


### PR DESCRIPTION
# Authenticate webhook messages

## Description
Authentication can be configured now for each webhook endpoint like
```
    "WebHooks": {
      "Events": {
        "FormCreated": {
          "IsEnabled": true,
          "WebHookEndpoints": [
            {
              "Url": "https://api.example.com/webhooks",
              "Authentication": {
                "Type": "ApiKey",
                "ApiKeyHeader": "X-SURVEY-API-KEY",
                "ApiKey": "your-secret-api-key"
              }
            }
          ]
        },
        ...
```

The old format
```
    "WebHookUrls": [
      "https://webhook.site/no-auth-endpoint"
    ]
```
is kept for compatibility and can be used in a mixed way with the new auth format.

There wasn't any test coverage of the webhook logic I tests were added for the files where there are changes.

Future enhancements will involve configuring per tenant and with more options.

## Related Issues
closes #458 

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
