### PR TITLE
fix: Unable to change password due to user not being able to be retrieved

### DIFF
--- a/src/Endatix.Api/Endpoints/MyAccount/ChangePassword.cs
+++ b/src/Endatix.Api/Endpoints/MyAccount/ChangePassword.cs
@@ -5,13 +5,14 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.MyAccount.ChangePassword;
 using Endatix.Infrastructure.Identity.Authorization;
+using Endatix.Core.Abstractions;
 
 namespace Endatix.Api.Endpoints.MyAccount;
 
 /// <summary>
 /// Endpoint for changing a user's password
 /// </summary>
-public class ChangePassword(IMediator mediator) : Endpoint<ChangePasswordRequest, Results<Ok<ChangePasswordResponse>, BadRequest<Errors.ProblemDetails>>>
+public class ChangePassword(IMediator mediator, IUserContext userContext) : Endpoint<ChangePasswordRequest, Results<Ok<ChangePasswordResponse>, BadRequest<Errors.ProblemDetails>>>
 {
     /// <summary>
     /// Configures the endpoint settings for the password change functionality.
@@ -36,8 +37,10 @@ public class ChangePassword(IMediator mediator) : Endpoint<ChangePasswordRequest
     /// <param name="cancellationToken">Cancellation token for the async operation</param>
     public override async Task<Results<Ok<ChangePasswordResponse>, BadRequest<Errors.ProblemDetails>>> ExecuteAsync(ChangePasswordRequest request, CancellationToken cancellationToken)
     {
+        var userId = userContext.GetCurrentUserId();
+
         var changePasswordCmd = new ChangePasswordCommand(
-            User,
+            userId,
             request.CurrentPassword,
             request.NewPassword
         );

--- a/src/Endatix.Core/Abstractions/IUserService.cs
+++ b/src/Endatix.Core/Abstractions/IUserService.cs
@@ -18,6 +18,14 @@ public interface IUserService
     Task<Result<User>> GetUserAsync(ClaimsPrincipal claimsPrincipal, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets a user by user ID.
+    /// </summary>
+    /// <param name="userId">The user ID to search for.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the operation if needed.</param>
+    /// <returns>A Result containing the User if found, or NotFound if not found.</returns>
+    Task<Result<User>> GetUserAsync(long userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets a user by email address.
     /// </summary>
     /// <param name="email">The email address to search for.</param>

--- a/src/Endatix.Core/UseCases/MyAccount/ChangePassword/ChangePasswordCommand.cs
+++ b/src/Endatix.Core/UseCases/MyAccount/ChangePassword/ChangePasswordCommand.cs
@@ -7,7 +7,7 @@ namespace Endatix.Core.UseCases.MyAccount.ChangePassword;
 /// <summary>
 /// Command to change a user's password
 /// </summary>
-/// <param name="User">The ClaimsPrincipal of the authenticated user</param>
+/// <param name="UserId">The user ID of the authenticated user</param>
 /// <param name="CurrentPassword">The user's current password</param>
 /// <param name="NewPassword">The new password to set</param>
-public record ChangePasswordCommand(ClaimsPrincipal User, string CurrentPassword, string NewPassword) : IRequest<Result<string>>;
+public record ChangePasswordCommand(long? UserId, string CurrentPassword, string NewPassword) : IRequest<Result<string>>;

--- a/src/Endatix.Core/UseCases/MyAccount/ChangePassword/ChangePasswordHandler.cs
+++ b/src/Endatix.Core/UseCases/MyAccount/ChangePassword/ChangePasswordHandler.cs
@@ -17,7 +17,12 @@ public class ChangePasswordHandler(IUserService userService) : IRequestHandler<C
     /// <returns>Result indicating success or failure</returns>
     public async Task<Result<string>> Handle(ChangePasswordCommand request, CancellationToken cancellationToken)
     {
-        var userResult = await userService.GetUserAsync(request.User, cancellationToken);
+        if (request.UserId == null)
+        {
+            return Result.Invalid(new ValidationError("User not found"));
+        }
+
+        var userResult = await userService.GetUserAsync(request.UserId.Value, cancellationToken);
 
         if (!userResult.IsSuccess || userResult.Value is not { } user)
         {

--- a/src/Endatix.Infrastructure/Identity/Users/AppUserService.cs
+++ b/src/Endatix.Infrastructure/Identity/Users/AppUserService.cs
@@ -29,6 +29,23 @@ public class AppUserService(UserManager<AppUser> userManager) : IUserService
     }
 
     /// <inheritdoc />
+    public async Task<Result<User>> GetUserAsync(long userId, CancellationToken cancellationToken = default)
+    {
+        if (userId <= 0)
+        {
+            return Result.NotFound();
+        }
+
+        var user = await userManager.FindByIdAsync(userId.ToString());
+        if (user == null)
+        {
+            return Result.NotFound();
+        }
+
+        return Result.Success(user.ToUserEntity());
+    }
+
+    /// <inheritdoc />
     public async Task<Result<User>> GetUserAsync(string email, CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(email))

--- a/tests/Endatix.Api.Tests/Endpoints/MyAccount/ChangePasswordTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/MyAccount/ChangePasswordTests.cs
@@ -6,21 +6,24 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using FastEndpoints;
 using System.Security.Claims;
+using Endatix.Core.Abstractions;
 
 namespace Endatix.Api.Tests.Endpoints.MyAccount;
 
 public class ChangePasswordTests
 {
     private readonly IMediator _mediator;
+    private readonly IUserContext _userContext;
     private readonly ChangePassword _endpoint;
 
     public ChangePasswordTests()
     {
         _mediator = Substitute.For<IMediator>();
+        _userContext = Substitute.For<IUserContext>();
         _endpoint = Factory.Create<ChangePassword>(ctx =>
         {
             ctx.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, "test-user") }));
-        }, _mediator);
+        }, _mediator, _userContext);
     }
 
 
@@ -29,7 +32,9 @@ public class ChangePasswordTests
     {
         // Arrange
         var request = new ChangePasswordRequest("currentPass123", "newPass123", "newPass123");
-
+        var userId = 123L;
+        
+        _userContext.GetCurrentUserId().Returns(userId);
         _mediator
             .Send(Arg.Any<ChangePasswordCommand>())
             .Returns(Result.Success("Password changed successfully"));
@@ -48,7 +53,9 @@ public class ChangePasswordTests
     {
         // Arrange
         var request = new ChangePasswordRequest("currentPass123", "newPass123", "newPass123");
-
+        var userId = 123L;
+        
+        _userContext.GetCurrentUserId().Returns(userId);
         _mediator
             .Send(Arg.Any<ChangePasswordCommand>())
             .Returns(Result.Invalid(new ValidationError("Invalid current password")));
@@ -67,7 +74,9 @@ public class ChangePasswordTests
     {
         // Arrange
         var request = new ChangePasswordRequest("currentPass123", "newPass123", "newPass123");
-
+        var userId = 123L;
+        
+        _userContext.GetCurrentUserId().Returns(userId);
         _mediator
             .Send(Arg.Any<ChangePasswordCommand>())
             .Returns(Result.Success("Success"));
@@ -80,6 +89,7 @@ public class ChangePasswordTests
             .Received(1)
             .Send(
                 Arg.Is<ChangePasswordCommand>(cmd =>
+                    cmd.UserId == userId &&
                     cmd.CurrentPassword == request.CurrentPassword &&
                     cmd.NewPassword == request.NewPassword),
                 Arg.Any<CancellationToken>()

--- a/tests/Endatix.Core.Tests/UseCases/MyAccount/ChangePassword/ChangePasswordCommandTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/MyAccount/ChangePassword/ChangePasswordCommandTests.cs
@@ -1,4 +1,3 @@
-using System.Security.Claims;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.MyAccount.ChangePassword;
 using MediatR;
@@ -11,15 +10,15 @@ public class ChangePasswordCommandTests
     public void Constructor_ShouldSetProperties()
     {
         // Arrange
-        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity());
+        var userId = 123L;
         const string currentPassword = "currentPass123";
         const string newPassword = "newPass123";
 
         // Act
-        var command = new ChangePasswordCommand(claimsPrincipal, currentPassword, newPassword);
+        var command = new ChangePasswordCommand(userId, currentPassword, newPassword);
 
         // Assert
-        command.User.Should().BeSameAs(claimsPrincipal);
+        command.UserId.Should().Be(userId);
         command.CurrentPassword.Should().Be(currentPassword);
         command.NewPassword.Should().Be(newPassword);
     }
@@ -28,8 +27,8 @@ public class ChangePasswordCommandTests
     public void Command_ShouldBeImmutable()
     {
         // Arrange
-        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity());
-        var command = new ChangePasswordCommand(claimsPrincipal, "current", "new");
+        var userId = 123L;
+        var command = new ChangePasswordCommand(userId, "current", "new");
 
         // Act & Assert
         command.Should().BeAssignableTo<IRequest<Result<string>>>();


### PR DESCRIPTION
# Unable to change password due to user not being able to be retrieved

## Description
Loading the user from the db by principal claims was not working due to recent changes. Changed the logic to use the used ID go get the current user from the DB.

## Related Issues
closes https://github.com/endatix/endatix-private/issues/358

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
