### PR TITLE
feat: Webhook message ID fields changes

### DIFF
--- a/docs/endatix-docs/docs/guides/webhooks.mdx
+++ b/docs/endatix-docs/docs/guides/webhooks.mdx
@@ -42,6 +42,7 @@ Add the following NuGet packages to your project:
 Create handlers for the events you want to process. Here's an example of a `FormCreated` event handler:
 
 ```csharp
+using Endatix.Core.Abstractions;
 using Endatix.Core.Events;
 using Endatix.Core.Features.WebHooks;
 using MediatR;
@@ -49,7 +50,7 @@ using Microsoft.Extensions.Logging;
 
 namespace YourCompany.Endatix.WebHooks.FormEventHandlers;
 
-public class FormCreatedHandler(IWebHookService webHookService, ILogger<FormCreatedHandler> logger) : INotificationHandler<FormCreatedEvent>
+public class FormCreatedHandler(IWebHookService webHookService, ILogger<FormCreatedHandler> logger, IIdGenerator<long> idGenerator) : INotificationHandler<FormCreatedEvent>
 {
     public async Task Handle(FormCreatedEvent notification, CancellationToken cancellationToken)
     {
@@ -57,19 +58,19 @@ public class FormCreatedHandler(IWebHookService webHookService, ILogger<FormCrea
 
         var form = new
         {
-            notification.Form.Id,
-            notification.Form.TenantId,
-            notification.Form.Name,
-            notification.Form.Description,
-            notification.Form.IsEnabled,
-            notification.Form.ActiveDefinitionId,
-            notification.Form.ThemeId,
-            notification.Form.CreatedAt,
-            notification.Form.ModifiedAt,
+            formId = notification.Form.Id,
+            tenantId = notification.Form.TenantId,
+            name = notification.Form.Name,
+            description = notification.Form.Description,
+            isEnabled = notification.Form.IsEnabled,
+            activeDefinitionId = notification.Form.ActiveDefinitionId,
+            themeId = notification.Form.ThemeId,
+            createdAt = notification.Form.CreatedAt,
+            modifiedAt = notification.Form.ModifiedAt,
         };
 
         var message = new WebHookMessage<object>(
-            notification.Form.Id,
+            idGenerator.CreateId(),
             WebHookOperation.FormCreated,
             form);
 
@@ -320,10 +321,10 @@ You can also mix both approaches in the same event configuration:
 
 Each webhook message contains:
 
-- `Id`: The ID of the entity that triggered the event
+- `Id`: Unique Snowflake-generated webhook message id
 - `EventName`: The type of event (e.g., `form_created`, `form_updated`, `form_enabled_state_changed`, `form_deleted`, `submission_completed`)
 - `Action`: The action that triggered the event (e.g., `created`, `updated`, `deleted`)
-- `Payload`: The event data specific to the operation, containing the complete entity data
+- `Payload`: The event data specific to the operation, containing the complete entity data. It includes explicit entity identifier fields, such as `formId` for form events and `submissionId` for submission events
 
 ## Best Practices
 

--- a/src/Endatix.Infrastructure/Features/WebHooks/Handlers/FormCreatedHandler.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/Handlers/FormCreatedHandler.cs
@@ -1,3 +1,4 @@
+using Endatix.Core.Abstractions;
 using Endatix.Core.Events;
 using Endatix.Core.Features.WebHooks;
 using MediatR;
@@ -8,7 +9,7 @@ namespace Endatix.Infrastructure.Features.WebHooks.Handlers;
 /// <summary>
 /// Webhook handler for FormCreatedEvent.
 /// </summary>
-public class FormCreatedHandler(IWebHookService webHookService, ILogger<FormCreatedHandler> logger) : INotificationHandler<FormCreatedEvent>
+public class FormCreatedHandler(IWebHookService webHookService, ILogger<FormCreatedHandler> logger, IIdGenerator<long> idGenerator) : INotificationHandler<FormCreatedEvent>
 {
     public async Task Handle(FormCreatedEvent notification, CancellationToken cancellationToken)
     {
@@ -16,7 +17,7 @@ public class FormCreatedHandler(IWebHookService webHookService, ILogger<FormCrea
 
         var form = new
         {
-            id = notification.Form.Id,
+            formId = notification.Form.Id,
             tenantId = notification.Form.TenantId,
             name = notification.Form.Name,
             description = notification.Form.Description,
@@ -28,7 +29,7 @@ public class FormCreatedHandler(IWebHookService webHookService, ILogger<FormCrea
         };
 
         var message = new WebHookMessage<object>(
-            notification.Form.Id,
+            idGenerator.CreateId(),
             WebHookOperation.FormCreated,
             form);
 

--- a/src/Endatix.Infrastructure/Features/WebHooks/Handlers/FormDeletedHandler.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/Handlers/FormDeletedHandler.cs
@@ -1,3 +1,4 @@
+using Endatix.Core.Abstractions;
 using Endatix.Core.Events;
 using Endatix.Core.Features.WebHooks;
 using MediatR;
@@ -8,7 +9,7 @@ namespace Endatix.Infrastructure.Features.WebHooks.Handlers;
 /// <summary>
 /// Webhook handler for FormDeletedEvent.
 /// </summary>
-public class FormDeletedHandler(IWebHookService webHookService, ILogger<FormDeletedHandler> logger) : INotificationHandler<FormDeletedEvent>
+public class FormDeletedHandler(IWebHookService webHookService, ILogger<FormDeletedHandler> logger, IIdGenerator<long> idGenerator) : INotificationHandler<FormDeletedEvent>
 {
     public async Task Handle(FormDeletedEvent notification, CancellationToken cancellationToken)
     {
@@ -16,7 +17,7 @@ public class FormDeletedHandler(IWebHookService webHookService, ILogger<FormDele
 
         var form = new
         {
-            id = notification.Form.Id,
+            formId = notification.Form.Id,
             tenantId = notification.Form.TenantId,
             name = notification.Form.Name,
             description = notification.Form.Description,
@@ -28,7 +29,7 @@ public class FormDeletedHandler(IWebHookService webHookService, ILogger<FormDele
         };
 
         var message = new WebHookMessage<object>(
-            notification.Form.Id,
+            idGenerator.CreateId(),
             WebHookOperation.FormDeleted,
             form);
 

--- a/src/Endatix.Infrastructure/Features/WebHooks/Handlers/FormEnabledStateChangedHandler.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/Handlers/FormEnabledStateChangedHandler.cs
@@ -1,3 +1,4 @@
+using Endatix.Core.Abstractions;
 using Endatix.Core.Events;
 using Endatix.Core.Features.WebHooks;
 using MediatR;
@@ -8,7 +9,7 @@ namespace Endatix.Infrastructure.Features.WebHooks.Handlers;
 /// <summary>
 /// Webhook handler for FormEnabledStateChangedEvent.
 /// </summary>
-public class FormEnabledStateChangedWebHookHandler(IWebHookService webHookService, ILogger<FormEnabledStateChangedWebHookHandler> logger) : INotificationHandler<FormEnabledStateChangedEvent>
+public class FormEnabledStateChangedWebHookHandler(IWebHookService webHookService, ILogger<FormEnabledStateChangedWebHookHandler> logger, IIdGenerator<long> idGenerator) : INotificationHandler<FormEnabledStateChangedEvent>
 {
     public async Task Handle(FormEnabledStateChangedEvent notification, CancellationToken cancellationToken)
     {
@@ -16,7 +17,7 @@ public class FormEnabledStateChangedWebHookHandler(IWebHookService webHookServic
 
         var form = new
         {
-            id = notification.Form.Id,
+            formId = notification.Form.Id,
             tenantId = notification.Form.TenantId,
             name = notification.Form.Name,
             description = notification.Form.Description,
@@ -28,7 +29,7 @@ public class FormEnabledStateChangedWebHookHandler(IWebHookService webHookServic
         };
 
         var message = new WebHookMessage<object>(
-            notification.Form.Id,
+            idGenerator.CreateId(),
             WebHookOperation.FormEnabledStateChanged,
             form);
 

--- a/src/Endatix.Infrastructure/Features/WebHooks/Handlers/FormUpdatedHandler.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/Handlers/FormUpdatedHandler.cs
@@ -1,3 +1,4 @@
+using Endatix.Core.Abstractions;
 using Endatix.Core.Events;
 using Endatix.Core.Features.WebHooks;
 using MediatR;
@@ -8,7 +9,7 @@ namespace Endatix.Infrastructure.Features.WebHooks.Handlers;
 /// <summary>
 /// Webhook handler for FormUpdatedEvent.
 /// </summary>
-public class FormUpdatedWebHookHandler(IWebHookService webHookService, ILogger<FormUpdatedWebHookHandler> logger) : INotificationHandler<FormUpdatedEvent>
+public class FormUpdatedWebHookHandler(IWebHookService webHookService, ILogger<FormUpdatedWebHookHandler> logger, IIdGenerator<long> idGenerator) : INotificationHandler<FormUpdatedEvent>
 {
     public async Task Handle(FormUpdatedEvent notification, CancellationToken cancellationToken)
     {
@@ -16,7 +17,7 @@ public class FormUpdatedWebHookHandler(IWebHookService webHookService, ILogger<F
 
         var form = new
         {
-            id = notification.Form.Id,
+            formId = notification.Form.Id,
             tenantId = notification.Form.TenantId,
             name = notification.Form.Name,
             description = notification.Form.Description,
@@ -28,7 +29,7 @@ public class FormUpdatedWebHookHandler(IWebHookService webHookService, ILogger<F
         };
 
         var message = new WebHookMessage<object>(
-            notification.Form.Id,
+            idGenerator.CreateId(),
             WebHookOperation.FormUpdated,
             form);
 

--- a/src/Endatix.Infrastructure/Features/WebHooks/Handlers/SubmissionCompletedHandler.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/Handlers/SubmissionCompletedHandler.cs
@@ -1,3 +1,4 @@
+using Endatix.Core.Abstractions;
 using Endatix.Core.Events;
 using Endatix.Core.Features.WebHooks;
 using MediatR;
@@ -8,7 +9,7 @@ namespace Endatix.Infrastructure.Features.WebHooks.Handlers;
 /// <summary>
 /// Webhook handler for SubmissionCompletedEvent.
 /// </summary>
-public class SubmissionCompletedWebHookHandler(IWebHookService webHookService, ILogger<SubmissionCompletedWebHookHandler> logger) : INotificationHandler<SubmissionCompletedEvent>
+public class SubmissionCompletedWebHookHandler(IWebHookService webHookService, ILogger<SubmissionCompletedWebHookHandler> logger, IIdGenerator<long> idGenerator) : INotificationHandler<SubmissionCompletedEvent>
 {
     public async Task Handle(SubmissionCompletedEvent notification, CancellationToken cancellationToken)
     {
@@ -16,7 +17,7 @@ public class SubmissionCompletedWebHookHandler(IWebHookService webHookService, I
 
         var submission = new
         {
-            id = notification.Submission.Id,
+            submissionId = notification.Submission.Id,
             formId = notification.Submission.FormId,
             formDefinitionId = notification.Submission.FormDefinitionId,
             tenantId = notification.Submission.TenantId,
@@ -32,7 +33,7 @@ public class SubmissionCompletedWebHookHandler(IWebHookService webHookService, I
         };
 
         var message = new WebHookMessage<object>(
-            notification.Submission.Id,
+            idGenerator.CreateId(),
             WebHookOperation.SubmissionCompleted,
             submission);
 


### PR DESCRIPTION
# Webhook message ID fields changes

## Description
- Webhook message id is a snowflake generated ID for the message
- Webhook message payload has explicit ID field names, like e.g. `formId`, `submissionId`, etc

## Related Issues
closes #466 

## Type of Change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] My code follows the style guidelines of this project
