### PR TITLE
feat: Obtain the submitter ID from the "sub" token field

### DIFF
--- a/src/Endatix.Api/Endpoints/MyAccount/ChangePassword.cs
+++ b/src/Endatix.Api/Endpoints/MyAccount/ChangePassword.cs
@@ -37,10 +37,10 @@ public class ChangePassword(IMediator mediator, IUserContext userContext) : Endp
     /// <param name="cancellationToken">Cancellation token for the async operation</param>
     public override async Task<Results<Ok<ChangePasswordResponse>, ProblemHttpResult>> ExecuteAsync(ChangePasswordRequest request, CancellationToken cancellationToken)
     {
-        var userId = userContext.GetCurrentUserId();
+        var userIdString = userContext.GetCurrentUserId();
 
         var changePasswordCmd = new ChangePasswordCommand(
-            userId,
+            long.TryParse(userIdString, out var userId) ? userId : null,
             request.CurrentPassword,
             request.NewPassword
         );

--- a/src/Endatix.Api/Endpoints/Submissions/SubmissionMapper.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/SubmissionMapper.cs
@@ -18,7 +18,7 @@ public class SubmissionMapper
         CreatedAt = submission.CreatedAt,
         ModifiedAt = submission.ModifiedAt,
         Status = submission.Status.Code,
-        SubmittedBy = submission.SubmittedBy?.ToString()
+        SubmittedBy = submission.SubmittedBy
     };
 
     public static SubmissionDetailsModel MapToSubmissionDetails(Submission submission)

--- a/src/Endatix.Core/Abstractions/IUserContext.cs
+++ b/src/Endatix.Core/Abstractions/IUserContext.cs
@@ -25,5 +25,5 @@ public interface IUserContext
     /// <summary>
     /// Gets the current user's ID, or null if not authenticated.
     /// </summary>
-    long? GetCurrentUserId();
+    string? GetCurrentUserId();
 }

--- a/src/Endatix.Core/Entities/Submission.cs
+++ b/src/Endatix.Core/Entities/Submission.cs
@@ -7,7 +7,7 @@ public partial class Submission : TenantEntity, IAggregateRoot
 {
     private Submission() { } // For EF Core
 
-    public Submission(long tenantId, string jsonData, long formId, long formDefinitionId, bool isComplete = true, int currentPage = 0, string? metadata = null, long? submittedBy = null)
+    public Submission(long tenantId, string jsonData, long formId, long formDefinitionId, bool isComplete = true, int currentPage = 0, string? metadata = null, string? submittedBy = null)
         : base(tenantId)
     {
         Guard.Against.NullOrEmpty(jsonData, nameof(jsonData));
@@ -32,7 +32,7 @@ public partial class Submission : TenantEntity, IAggregateRoot
     public long FormDefinitionId { get; private set; }
     public int? CurrentPage { get; private set; }
     public string? Metadata { get; private set; }
-    public long? SubmittedBy { get; private set; }
+    public string? SubmittedBy { get; private set; }
     public DateTime? CompletedAt { get; private set; }
     public Token? Token { get; private set; }
     public SubmissionStatus Status { get; private set; }

--- a/src/Endatix.Core/UseCases/Submissions/Create/CreateSubmissionCommand.cs
+++ b/src/Endatix.Core/UseCases/Submissions/Create/CreateSubmissionCommand.cs
@@ -21,5 +21,5 @@ public record CreateSubmissionCommand(
     int? CurrentPage,
     bool? IsComplete,
     string? ReCaptchaToken,
-    long? SubmittedBy
+    string? SubmittedBy
 ) : ICommand<Result<Submission>>;

--- a/src/Endatix.Core/UseCases/Submissions/SubmissionDto.cs
+++ b/src/Endatix.Core/UseCases/Submissions/SubmissionDto.cs
@@ -18,7 +18,7 @@ namespace Endatix.Core.UseCases.Submissions;
 /// <param name="Metadata">Additional metadata related to the submission.</param>
 /// <param name="Status">The status of the submission.</param>
 /// <param name="SubmittedBy">The unique identifier of the user who created the submission, if applicable.</param>
-public record SubmissionDto(long Id, bool IsComplete, Dictionary<string, object> JsonData, long FormId, long FormDefinitionId, int? CurrentPage, DateTime? CompletedAt, DateTime CreatedAt, string? Metadata, string Status, long? SubmittedBy)
+public record SubmissionDto(long Id, bool IsComplete, Dictionary<string, object> JsonData, long FormId, long FormDefinitionId, int? CurrentPage, DateTime? CompletedAt, DateTime CreatedAt, string? Metadata, string Status, string? SubmittedBy)
 {
     public long Id { get; init; } = Id;
     public bool IsComplete { get; init; } = IsComplete;
@@ -30,7 +30,7 @@ public record SubmissionDto(long Id, bool IsComplete, Dictionary<string, object>
     public DateTime? CompletedAt { get; init; } = CompletedAt;
     public DateTime CreatedAt { get; init; } = CreatedAt;
     public string Status { get; init; } = Status;
-    public long? SubmittedBy { get; init; } = SubmittedBy;
+    public string? SubmittedBy { get; init; } = SubmittedBy;
 
     public static SubmissionDto FromSubmission(Submission submission)
     {

--- a/src/Endatix.Infrastructure/Data/Config/SubmissionConfiguration.cs
+++ b/src/Endatix.Infrastructure/Data/Config/SubmissionConfiguration.cs
@@ -22,6 +22,7 @@ public class SubmissionConfiguration : IEntityTypeConfiguration<Submission>
             .IsRequired();
 
         builder.Property(s => s.SubmittedBy)
+            .HasMaxLength(64)
             .IsRequired(false);
 
         builder.HasOne(s => s.FormDefinition)

--- a/src/Endatix.Infrastructure/Identity/UserContext.cs
+++ b/src/Endatix.Infrastructure/Identity/UserContext.cs
@@ -49,13 +49,19 @@ public class UserContext(IHttpContextAccessor httpContextAccessor) : IUserContex
     }
 
     /// <inheritdoc/>
-    public long? GetCurrentUserId()
+    public string? GetCurrentUserId()
     {
         var principal = httpContextAccessor.HttpContext?.User;
-        var userIdClaim = principal?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
-        if (long.TryParse(userIdClaim, out var userId))
+        var subClaim = principal?.FindFirst("sub")?.Value;
+        if (!string.IsNullOrWhiteSpace(subClaim))
         {
-            return userId;
+            return subClaim;
+        }
+
+        var userIdClaim = principal?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        if (!string.IsNullOrWhiteSpace(userIdClaim))
+        {
+            return userIdClaim;
         }
 
         return null;

--- a/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250909114413_ChangeTypeOfSubmittedBy.Designer.cs
+++ b/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250909114413_ChangeTypeOfSubmittedBy.Designer.cs
@@ -3,24 +3,27 @@ using System;
 using Endatix.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
+namespace Endatix.Persistence.PostgreSql.Migrations.AppEntities
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250909114413_ChangeTypeOfSubmittedBy")]
+    partial class ChangeTypeOfSubmittedBy
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "9.0.4")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("Endatix.Core.Entities.CustomQuestion", b =>
                 {
@@ -28,28 +31,28 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("JsonData")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
@@ -67,39 +70,39 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("FromAddress")
                         .IsRequired()
                         .HasMaxLength(255)
-                        .HasColumnType("nvarchar(255)");
+                        .HasColumnType("character varying(255)");
 
                     b.Property<string>("HtmlContent")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<string>("PlainTextContent")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Subject")
                         .IsRequired()
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("character varying(200)");
 
                     b.HasKey("Id");
 
@@ -118,27 +121,27 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsEnabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
@@ -149,8 +152,7 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                     b.HasKey("Id");
 
                     b.HasIndex("ActiveDefinitionId")
-                        .IsUnique()
-                        .HasFilter("[ActiveDefinitionId] IS NOT NULL");
+                        .IsUnique();
 
                     b.HasIndex("TenantId");
 
@@ -165,26 +167,26 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("FormId")
                         .HasColumnType("bigint");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsDraft")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("JsonData")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
@@ -204,31 +206,31 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsEnabled")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("JsonData")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
@@ -246,16 +248,16 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime?>("CompletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<int?>("CurrentPage")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("FormDefinitionId")
                         .HasColumnType("bigint");
@@ -264,24 +266,24 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<bool>("IsComplete")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("JsonData")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("Metadata")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("SubmittedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
@@ -303,13 +305,13 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                 {
                     b.Property<string>("AnswersModel")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("CompletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("FormId")
                         .HasColumnType("bigint");
@@ -318,10 +320,10 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<bool>("IsComplete")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.ToTable("SubmissionExportRows", null, t =>
                         {
@@ -335,20 +337,20 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("JsonData")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<long>("SubmissionId")
                         .HasColumnType("bigint");
@@ -366,27 +368,27 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<string>("SlackSettingsJson")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -399,28 +401,28 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                         .HasColumnType("bigint");
 
                     b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DeletedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("JsonData")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<DateTime?>("ModifiedAt")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(100)
-                        .HasColumnType("nvarchar(100)");
+                        .HasColumnType("character varying(100)");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");
@@ -517,7 +519,7 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                             b1.Property<string>("Code")
                                 .IsRequired()
                                 .HasMaxLength(16)
-                                .HasColumnType("nvarchar(16)")
+                                .HasColumnType("character varying(16)")
                                 .HasColumnName("Status");
 
                             b1.HasKey("SubmissionId");
@@ -534,12 +536,12 @@ namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
                                 .HasColumnType("bigint");
 
                             b1.Property<DateTime>("ExpiresAt")
-                                .HasColumnType("datetime2");
+                                .HasColumnType("timestamp with time zone");
 
                             b1.Property<string>("Value")
                                 .IsRequired()
                                 .HasMaxLength(64)
-                                .HasColumnType("nvarchar(64)");
+                                .HasColumnType("character varying(64)");
 
                             b1.HasKey("SubmissionId");
 

--- a/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250909114413_ChangeTypeOfSubmittedBy.cs
+++ b/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/20250909114413_ChangeTypeOfSubmittedBy.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Endatix.Persistence.PostgreSql.Migrations.AppEntities
+{
+    /// <inheritdoc />
+    public partial class ChangeTypeOfSubmittedBy : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "SubmittedBy",
+                table: "Submissions",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(long),
+                oldType: "bigint",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                ALTER TABLE ""Submissions"" 
+                ALTER COLUMN ""SubmittedBy"" TYPE bigint 
+                USING (
+                    CASE 
+                        WHEN ""SubmittedBy"" ~ '^[0-9]+$' THEN (""SubmittedBy"")::bigint 
+                        ELSE NULL 
+                    END
+                );
+            ");
+        }
+    }
+}

--- a/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/AppDbContextModelSnapshot.cs
+++ b/src/Endatix.Persistence.PostgreSql/Migrations/AppEntities/AppDbContextModelSnapshot.cs
@@ -278,8 +278,9 @@ namespace Endatix.Persistence.PostgreSQL.Migrations.AppEntities
                     b.Property<DateTime?>("ModifiedAt")
                         .HasColumnType("timestamp with time zone");
 
-                    b.Property<long?>("SubmittedBy")
-                        .HasColumnType("bigint");
+                    b.Property<string>("SubmittedBy")
+                        .HasMaxLength(64)
+                        .HasColumnType("character varying(64)");
 
                     b.Property<long>("TenantId")
                         .HasColumnType("bigint");

--- a/src/Endatix.Persistence.SqlServer/Migrations/AppEntities/20250909114742_ChangeTypeOfSubmittedBy.Designer.cs
+++ b/src/Endatix.Persistence.SqlServer/Migrations/AppEntities/20250909114742_ChangeTypeOfSubmittedBy.Designer.cs
@@ -4,6 +4,7 @@ using Endatix.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250909114742_ChangeTypeOfSubmittedBy")]
+    partial class ChangeTypeOfSubmittedBy
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Endatix.Persistence.SqlServer/Migrations/AppEntities/20250909114742_ChangeTypeOfSubmittedBy.cs
+++ b/src/Endatix.Persistence.SqlServer/Migrations/AppEntities/20250909114742_ChangeTypeOfSubmittedBy.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Endatix.Persistence.SqlServer.Migrations.AppEntities
+{
+    /// <inheritdoc />
+    public partial class ChangeTypeOfSubmittedBy : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "SubmittedBy",
+                table: "Submissions",
+                type: "nvarchar(64)",
+                maxLength: 64,
+                nullable: true,
+                oldClrType: typeof(long),
+                oldType: "bigint",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<long>(
+                name: "SubmittedBy",
+                table: "Submissions",
+                type: "bigint",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(64)",
+                oldMaxLength: 64,
+                oldNullable: true);
+        }
+    }
+}

--- a/tests/Endatix.Api.Tests/Endpoints/MyAccount/ChangePasswordTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/MyAccount/ChangePasswordTests.cs
@@ -31,7 +31,7 @@ public class ChangePasswordTests
     {
         // Arrange
         var request = new ChangePasswordRequest("currentPass123", "newPass123", "newPass123");
-        var userId = 123L;
+        var userId = "123";
 
         _userContext.GetCurrentUserId().Returns(userId);
         _mediator
@@ -53,7 +53,7 @@ public class ChangePasswordTests
     {
         // Arrange
         var request = new ChangePasswordRequest("currentPass123", "newPass123", "newPass123");
-        var userId = 123L;
+        var userId = "123";
 
         _userContext.GetCurrentUserId().Returns(userId);
         _mediator
@@ -79,7 +79,7 @@ public class ChangePasswordTests
     {
         // Arrange
         var request = new ChangePasswordRequest("currentPass123", "newPass123", "newPass123");
-        var userId = 123L;
+        var userId = "123";
 
         _userContext.GetCurrentUserId().Returns(userId);
         _mediator
@@ -104,7 +104,7 @@ public class ChangePasswordTests
     {
         // Arrange
         var request = new ChangePasswordRequest("currentPass123", "newPass123", "newPass123");
-        var userId = 123L;
+        var userId = "123";
 
         _userContext.GetCurrentUserId().Returns(userId);
         _mediator
@@ -119,7 +119,7 @@ public class ChangePasswordTests
             .Received(1)
             .Send(
                 Arg.Is<ChangePasswordCommand>(cmd =>
-                    cmd.UserId == userId &&
+                    cmd.UserId == long.Parse(userId) &&
                     cmd.CurrentPassword == request.CurrentPassword &&
                     cmd.NewPassword == request.NewPassword),
                 Arg.Any<CancellationToken>()

--- a/tests/Endatix.Api.Tests/Endpoints/Submissions/CreateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Submissions/CreateTests.cs
@@ -81,7 +81,7 @@ public class CreateTests
     public async Task ExecuteAsync_ShouldMapRequestToCommandCorrectly()
     {
         // Arrange
-        const long userId = 123;
+        const string userId = "123";
         var request = new CreateSubmissionRequest
         {
             FormId = 123,
@@ -130,7 +130,7 @@ public class CreateTests
         };
         var result = Result<Submission>.Created(new Submission(SampleData.TENANT_ID, """{ "field": "value" }""", 123, 456));
 
-        _userContext.GetCurrentUserId().Returns((long?)null);
+        _userContext.GetCurrentUserId().Returns((string?)null);
         _mediator.Send(Arg.Any<CreateSubmissionCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);
 

--- a/tests/Endatix.Api.Tests/Endpoints/Submissions/ListByFormIdTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Submissions/ListByFormIdTests.cs
@@ -66,7 +66,7 @@ public class ListByFormIdTests
         var submissions = new List<SubmissionDto> 
         { 
             new(3, false, [], 1, 2, 5, DateTime.UtcNow, DateTime.UtcNow.AddMinutes(-5), "{ }", "new", null),
-            new(4, false, [], 1, 2, 6, DateTime.UtcNow, DateTime.UtcNow.AddMinutes(-10), "{ }", "new", 7),
+            new(4, false, [], 1, 2, 6, DateTime.UtcNow, DateTime.UtcNow.AddMinutes(-10), "{ }", "new", "7"),
         };
         var result = Result.Success(submissions.AsEnumerable());
 

--- a/tests/Endatix.Api.Tests/Endpoints/Submissions/UpdateStatusTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Submissions/UpdateStatusTests.cs
@@ -28,7 +28,7 @@ public sealed class UpdateStatusTests
         const string status = "seen";
 
         var request = new UpdateStatusRequest(submissionId, formId, status);
-        var result = Result.Success(new SubmissionDto(submissionId, false, new Dictionary<string, object>(), formId, 1, null, DateTime.UtcNow, DateTime.UtcNow, null, status, 7));
+        var result = Result.Success(new SubmissionDto(submissionId, false, new Dictionary<string, object>(), formId, 1, null, DateTime.UtcNow, DateTime.UtcNow, null, status, "7"));
 
         _mediator.Send(Arg.Any<UpdateStatusCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/Create/CreateSubmissionCommandTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/Create/CreateSubmissionCommandTests.cs
@@ -33,7 +33,7 @@ public class CreateSubmissionCommandTests
         int? currentPage = 3;
         bool? isComplete = true;
         var reCaptchaToken = "test-token";
-        long? submittedBy = 123;
+        var submittedBy = "123";
         // Act
         var command = new CreateSubmissionCommand(formId, jsonData, metadata, currentPage, isComplete, reCaptchaToken, submittedBy);
 

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/Create/CreateSubmissionHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/Create/CreateSubmissionHandlerTests.cs
@@ -69,7 +69,7 @@ public class CreateSubmissionHandlerTests
             CurrentPage: 3,
             Metadata: "{ \"meta\": \"data\" }",
             ReCaptchaToken: "test-token",
-            SubmittedBy: 123
+            SubmittedBy: "123"
         );
 
         _recaptchaService.ValidateReCaptchaAsync(
@@ -153,7 +153,7 @@ public class CreateSubmissionHandlerTests
             CurrentPage: 3,
             Metadata: "{ \"meta\": \"data\" }",
             ReCaptchaToken: "test-token",
-            SubmittedBy: 123
+            SubmittedBy: "123"
         );
 
         _recaptchaService.ValidateReCaptchaAsync(
@@ -235,7 +235,7 @@ public class CreateSubmissionHandlerTests
             CurrentPage: null,
             Metadata: null,
             ReCaptchaToken: "test-token",
-            SubmittedBy: 456
+            SubmittedBy: "456"
         );
 
         _recaptchaService.ValidateReCaptchaAsync(
@@ -266,7 +266,7 @@ public class CreateSubmissionHandlerTests
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
-        var request = new CreateSubmissionCommand(1, "{ }", null, null, true, "test-token", 789);
+        var request = new CreateSubmissionCommand(1, "{ }", null, null, true, "test-token", "789");
 
         _recaptchaService.ValidateReCaptchaAsync(
             Arg.Any<SubmissionVerificationContext>(),
@@ -304,7 +304,7 @@ public class CreateSubmissionHandlerTests
             CurrentPage: 3,
             Metadata: "{ \"meta\": \"data\" }",
             ReCaptchaToken: "test-token",
-            SubmittedBy: userId
+            SubmittedBy: userId.ToString()
         );
 
         _recaptchaService.ValidateReCaptchaAsync(
@@ -333,7 +333,7 @@ public class CreateSubmissionHandlerTests
                 s.IsComplete == request.IsComplete &&
                 s.CurrentPage == request.CurrentPage &&
                 s.Metadata == request.Metadata &&
-                s.SubmittedBy == userId
+                s.SubmittedBy == userId.ToString()
             ),
             Arg.Any<CancellationToken>()
         );

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/ListByFormId/ListByFormIdHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/ListByFormId/ListByFormIdHandlerTests.cs
@@ -46,7 +46,7 @@ public class ListByFormIdHandlerTests
         var submissions = new List<SubmissionDto>
         {
             new(3, false, [], 1, 2, 5, DateTime.UtcNow, DateTime.UtcNow.AddMinutes(-5), "{ }", "new", null),
-            new(4, false, [], 1, 2, 6, DateTime.UtcNow, DateTime.UtcNow.AddMinutes(-10), "{ }", "new", 7),
+            new(4, false, [], 1, 2, 6, DateTime.UtcNow, DateTime.UtcNow.AddMinutes(-10), "{ }", "new", "7"),
         };
         var request = new ListByFormIdQuery(1, 1, 10, []);
 


### PR DESCRIPTION
# Obtain the submitter ID from the "sub" token field

## Description
User context gets the user ID from the "sub" field of the JWT token if there is such. The ID is used when a submission is created and stored in the SubmittedBy field, which becomes string from long.

## Related Issues
closes #480

## Type of Change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] My code follows the style guidelines of this project
