### PR TITLE
feat: Fix Docker images names and add a guide in the Docs website

### DIFF
--- a/docker/setup.bat
+++ b/docker/setup.bat
@@ -30,9 +30,9 @@ echo Creating .env file and setting the necessary environment variables...
 REM Set default values for all variables
 set "ENDATIX_API_PORT=8080"
 set "ENDATIX_DB_PASSWORD=DbPa$$w0rD"
-set "ENDATIX_API_IMAGE=endatix-api:latest"
+set "ENDATIX_API_IMAGE=endatix/endatix-api:latest"
 set "ASPNETCORE_ENVIRONMENT=Development"
-set "ENDATIX_HUB_IMAGE=endatix-hub:latest"
+set "ENDATIX_HUB_IMAGE=endatix/endatix-hub:latest"
 
 REM Enable delayed expansion for data collection
 setlocal enabledelayedexpansion

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -26,9 +26,9 @@ echo "Creating .env file and setting the necessary environment variables..."
 ENDATIX_API_PORT="8080"
 # ENDATIX_DB_PASSWORD="DbPa\$\$w0rD"
 ENDATIX_DB_PASSWORD="MyDbPass1234"
-ENDATIX_API_IMAGE="endatix-api:latest"
+ENDATIX_API_IMAGE="endatix/endatix-api:latest"
 ASPNETCORE_ENVIRONMENT="Development"
-ENDATIX_HUB_IMAGE="endatix-hub:latest"
+ENDATIX_HUB_IMAGE="endatix/endatix-hub:latest"
 
 # Prompt for environment variables with default values if nothing is entered
 read -p "Enter USER_EMAIL - Initial admin user email (skip to use the default value 'admin@endatix.com'): " USER_EMAIL

--- a/docs/endatix-docs/docs/guides/docker-setup.mdx
+++ b/docs/endatix-docs/docs/guides/docker-setup.mdx
@@ -1,0 +1,149 @@
+---
+sidebar_position: 2
+title: Running with Docker
+description: Deploy and run Endatix Platform using Docker containers for development and testing environments
+---
+
+# Running with Docker
+
+This guide will help you quickly set up and run Endatix using Docker containers for **development and testing purposes**. The setup script handles everything automatically - just run it and you're ready to go.
+
+:::warning
+**Important:** This is a development setup not suitable for production use. It uses HTTP (not HTTPS), default passwords, and simplified configuration. For production deployments, please contact Endatix for guidance on secure, scalable setups.
+:::
+
+## What is Endatix?
+
+Endatix is a modern platform for creating and managing SurveyJS based forms and surveys. It consists of:
+- **Endatix API**: Backend service for form management and data collection
+- **Endatix Hub**: Web interface for creating forms and viewing responses
+
+## Prerequisites
+
+Before proceeding, ensure you have installed:
+
+- **Docker Desktop** (includes Docker and Docker Compose)
+
+Download from: [https://docs.docker.com/get-docker/](https://docs.docker.com/get-docker/)
+
+Tested with Docker version 28.3.2 and Docker Compose v2.38.2.
+
+---
+
+## Quick Start
+
+### Step 1: Get Setup Files
+
+You need these files to get Endatix running:
+- `setup.bat` (Windows) or `setup.sh` (Linux/macOS)  
+- `docker-compose.yaml`
+
+**Option A: Direct Download**
+- **Windows**: [setup.bat](https://raw.githubusercontent.com/endatix/endatix/main/docker/setup.bat) + [docker-compose.yaml](https://raw.githubusercontent.com/endatix/endatix/main/docker/docker-compose.yaml)
+- **Linux/macOS**: [setup.sh](https://raw.githubusercontent.com/endatix/endatix/main/docker/setup.sh) + [docker-compose.yaml](https://raw.githubusercontent.com/endatix/endatix/main/docker/docker-compose.yaml)
+
+**Option B: Using Command Line**
+
+Windows (PowerShell/Command Prompt):
+```bash
+curl -o setup.bat https://raw.githubusercontent.com/endatix/endatix/main/docker/setup.bat
+curl -o docker-compose.yaml https://raw.githubusercontent.com/endatix/endatix/main/docker/docker-compose.yaml
+```
+
+Linux/macOS (Terminal):
+```bash
+curl -o setup.sh https://raw.githubusercontent.com/endatix/endatix/main/docker/setup.sh
+curl -o docker-compose.yaml https://raw.githubusercontent.com/endatix/endatix/main/docker/docker-compose.yaml
+```
+
+### Step 2: Check Port Availability
+
+Make sure these ports are free on your machine:
+- **8080** - Endatix API  
+- **3000** - Endatix Hub
+
+### Step 3: Run the Setup Script
+
+**Windows:** Double-click `setup.bat` or run in Command Prompt/PowerShell:
+```bash
+setup.bat
+```
+
+**Linux/macOS:** First make executable, then run:
+```bash
+chmod +x setup.sh
+./setup.sh
+```
+
+### Step 4: Enter Admin Credentials
+
+The script will prompt you for:
+- **Admin Email**: Default is `admin@endatix.com`
+- **Admin Password**: Default is `P@ssw0rd`
+
+:::info
+**Note:** For testing purposes, you can use the defaults. Change these credentials before any production use.
+:::
+
+Press Enter to use defaults, or type your own values.
+
+The script will automatically:
+1. Download the required Docker images
+2. Create and start all containers
+3. Set up the database and initial admin user
+
+---
+
+## Access Your Endatix Platform
+
+Once setup is complete, open your browser and visit:
+
+- **📊 Endatix Hub** (main interface): http://localhost:3000
+- **🔧 Endatix API** (for developers): http://localhost:8080
+
+Sign in using the admin credentials you set during setup.
+
+:::warning
+**Security Note:** This setup uses HTTP connections for simplicity. Production environments require HTTPS, secure passwords, and additional security measures.
+:::
+
+---
+
+## Managing Containers
+
+**Stop containers:**
+```bash
+docker compose -f docker-compose.yaml stop
+```
+
+**Start containers again:**
+```bash
+docker compose -f docker-compose.yaml start
+```
+
+**Remove containers (keeps data):**
+```bash
+docker compose -f docker-compose.yaml down
+```
+
+**View logs:**
+```bash
+docker compose -f docker-compose.yaml logs
+```
+
+---
+
+## Troubleshooting
+
+If you encounter issues:
+1. Ensure Docker Desktop is running
+2. Check that required ports (8080, 3000) are available
+3. Review the setup script output for error messages
+
+For support, visit [endatix.com](https://endatix.com/contact) or [GitHub Discussions](https://github.com/endatix/endatix/discussions).
+
+For **production deployments**, contact Endatix for guidance on secure, scalable setups with HTTPS, proper authentication, monitoring, and backup strategies.
+
+---
+
+**That's it! 🚀 Your Endatix Platform is ready for exploring.**


### PR DESCRIPTION
# Fix Docker images names and add a guide in the Docs website

## Description
- Image names were wrong in the setup scripts so they are changed.
- Added a guide for the docs website

## Related Issues
https://github.com/endatix/endatix-private/issues/185

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project
