### PR TITLE
fix: Ensure consistent error message for invalid credentials

### DIFF
--- a/src/Endatix.Infrastructure/Identity/Authentication/AuthService.cs
+++ b/src/Endatix.Infrastructure/Identity/Authentication/AuthService.cs
@@ -14,6 +14,8 @@ internal sealed class AuthService(UserManager<AppUser> userManager, IPasswordHas
     private readonly UserManager<AppUser> _userManager = userManager;
     private readonly IPasswordHasher<AppUser> _passwordHasher = passwordHasher;
 
+    public static readonly string INVALID_CREDENTIALS_ERROR_MESSAGE = "The supplied credentials are invalid";
+
     /// <inheritdoc/>
     public async Task<Result<User>> ValidateCredentials(string email, string password, CancellationToken cancellationToken)
     {
@@ -24,13 +26,13 @@ internal sealed class AuthService(UserManager<AppUser> userManager, IPasswordHas
 
         if (user is null || !user.EmailConfirmed)
         {
-            return Result.Invalid(new ValidationError("User not found"));
+            return Result.Invalid(new ValidationError(INVALID_CREDENTIALS_ERROR_MESSAGE));
         }
 
         var userVerified = await _userManager.CheckPasswordAsync(user, password);
         if (!userVerified)
         {
-            return Result.Invalid(new ValidationError("The supplied credentials are invalid!"));
+            return Result.Invalid(new ValidationError(INVALID_CREDENTIALS_ERROR_MESSAGE));
         }
 
         return Result.Success(user.ToUserEntity());

--- a/tests/Endatix.Infrastructure.Tests/Identity/Authentication/AuthServiceTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Identity/Authentication/AuthServiceTests.cs
@@ -96,7 +96,7 @@ public class AuthServiceTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.ValidationErrors.Should().NotBeNull();
-        result.ValidationErrors.First().ErrorMessage.Should().Contain("User not found");
+        result.ValidationErrors.First().ErrorMessage.Should().Contain(AuthService.INVALID_CREDENTIALS_ERROR_MESSAGE);
     }
 
     [Fact]
@@ -114,7 +114,7 @@ public class AuthServiceTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.ValidationErrors.Should().NotBeNull();
-        result.ValidationErrors.First().ErrorMessage.Should().Contain("User not found");
+        result.ValidationErrors.First().ErrorMessage.Should().Contain(AuthService.INVALID_CREDENTIALS_ERROR_MESSAGE);
     }
 
     [Fact]
@@ -133,7 +133,7 @@ public class AuthServiceTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.ValidationErrors.Should().NotBeNull();
-        result.ValidationErrors.First().ErrorMessage.Should().Contain("The supplied credentials are invalid!");
+        result.ValidationErrors.First().ErrorMessage.Should().Contain(AuthService.INVALID_CREDENTIALS_ERROR_MESSAGE);
     }
 
     [Fact]


### PR DESCRIPTION
# fix: Ensure consistent error message for invalid credentials

## Description
- Ensure consistent error message for invalid credentials
- Update tests

## Related Issues
- fixes https://github.com/endatix/endatix-private/issues/301

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Screenshots
<img width="463" height="214" alt="image" src="https://github.com/user-attachments/assets/ed3714ec-dd8a-43a0-bf7a-af6f0e3f070a" />
