### PR TITLE
feat: Add native JSON fields in FormCreate endpoint

### DIFF
--- a/src/Endatix.Api/Endpoints/Forms/Create.CreateFormRequest.cs
+++ b/src/Endatix.Api/Endpoints/Forms/Create.CreateFormRequest.cs
@@ -1,4 +1,6 @@
-﻿namespace Endatix.Api.Endpoints.Forms;
+﻿using System.Text.Json;
+
+namespace Endatix.Api.Endpoints.Forms;
 
 /// <summary>
 /// Request model for creating a form with an active form definition.
@@ -9,7 +11,7 @@ public class CreateFormRequest
     /// The name of the form.
     /// </summary>
     public string? Name { get; set; }
-    
+
     /// <summary>
     /// The description of the form.
     /// </summary>
@@ -21,12 +23,24 @@ public class CreateFormRequest
     public bool? IsEnabled { get; set; }
 
     /// <summary>
-    /// The JSON data of the active form definition.
+    /// The JSON data of the active form definition as a string.
     /// </summary>
+    [Obsolete("Use FormDefinitionSchema instead.")]
     public string? FormDefinitionJsonData { get; set; }
 
     /// <summary>
-    /// The JSON data containing webhook configuration settings for this form.
+    /// The active form definition schema as a JSON object.
     /// </summary>
+    public JsonElement? FormDefinitionSchema { get; set; }
+
+    /// <summary>
+    /// The JSON data containing webhook configuration settings for this form as a string.
+    /// </summary>
+    [Obsolete("Use WebHookSettings instead.")]
     public string? WebHookSettingsJson { get; set; }
+
+    /// <summary>
+    /// The webhook configuration settings as a JSON object.
+    /// </summary>
+    public JsonElement? WebHookSettings { get; set; }
 }

--- a/src/Endatix.Api/Endpoints/Forms/Create.CreateFormValidator.cs
+++ b/src/Endatix.Api/Endpoints/Forms/Create.CreateFormValidator.cs
@@ -22,8 +22,13 @@ public class CreateFormValidator : Validator<CreateFormRequest>
         RuleFor(x => x.IsEnabled)
             .NotEmpty();
 
+        RuleFor(x => x)
+            .Must(x => !string.IsNullOrWhiteSpace(x.FormDefinitionJsonData) || x.FormDefinitionSchema.HasValue)
+            .WithMessage("Either FormDefinitionJsonData or FormDefinitionSchema must be provided.")
+            .WithName("FormDefinition");
+
         RuleFor(x => x.FormDefinitionJsonData)
-            .NotEmpty()
-            .MinimumLength(DataSchemaConstants.MIN_JSON_LENGTH);
+            .MinimumLength(DataSchemaConstants.MIN_JSON_LENGTH)
+            .When(x => x.FormDefinitionJsonData != null);
     }
 }

--- a/src/Endatix.Api/Endpoints/Forms/Create.cs
+++ b/src/Endatix.Api/Endpoints/Forms/Create.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.Forms.Create;
 using Endatix.Infrastructure.Identity.Authorization;
+using System.Text.Json;
 
 namespace Endatix.Api.Endpoints.Forms;
 
@@ -31,7 +32,21 @@ public class Create(IMediator mediator) : Endpoint<CreateFormRequest, Results<Cr
     /// <inheritdoc/>
     public override async Task<Results<Created<CreateFormResponse>, BadRequest>> ExecuteAsync(CreateFormRequest request, CancellationToken cancellationToken)
     {
-        var createFormCommand = new CreateFormCommand(request.Name!, request.Description, request.IsEnabled!.Value, request.FormDefinitionJsonData!, request.WebHookSettingsJson);
+        var formDefinitionJsonData = request.FormDefinitionSchema.HasValue
+            ? JsonSerializer.Serialize(request.FormDefinitionSchema.Value)
+            : request.FormDefinitionJsonData!;
+
+        var webHookSettingsJson = request.WebHookSettings.HasValue
+            ? JsonSerializer.Serialize(request.WebHookSettings.Value)
+            : request.WebHookSettingsJson;
+
+        var createFormCommand = new CreateFormCommand(
+            request.Name!,
+            request.Description,
+            request.IsEnabled!.Value,
+            formDefinitionJsonData,
+            webHookSettingsJson);
+
         var result = await mediator.Send(createFormCommand, cancellationToken);
 
         return TypedResultsBuilder

--- a/src/Endatix.Api/Endpoints/Forms/FormMapper.cs
+++ b/src/Endatix.Api/Endpoints/Forms/FormMapper.cs
@@ -1,5 +1,6 @@
 ﻿using Endatix.Core.Entities;
 using Endatix.Core.UseCases.Forms;
+using System.Text.Json;
 
 namespace Endatix.Api.Endpoints.Forms;
 
@@ -23,8 +24,29 @@ public class FormMapper
         ThemeId = form.ThemeId?.ToString(),
         CreatedAt = form.CreatedAt,
         ModifiedAt = form.ModifiedAt,
-        WebHookSettingsJson = form.WebHookSettingsJson
+        WebHookSettingsJson = form.WebHookSettingsJson,
+        WebHookSettings = ParseJsonString(form.WebHookSettingsJson)
     };
+
+    /// <summary>
+    /// Parses a JSON string to a JsonElement, returning null if the string is empty or invalid.
+    /// </summary>
+    internal static JsonElement? ParseJsonString(string? jsonString)
+    {
+        if (string.IsNullOrWhiteSpace(jsonString))
+        {
+            return null;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<JsonElement>(jsonString);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
 
     /// <summary>
     /// Maps a collection of form entities to a collection of form API models.
@@ -63,6 +85,7 @@ public static class FormMapperExtensions
         CreatedAt = formDto.CreatedAt,
         ModifiedAt = formDto.ModifiedAt,
         SubmissionsCount = formDto.SubmissionsCount,
-        WebHookSettingsJson = formDto.WebHookSettingsJson
+        WebHookSettingsJson = formDto.WebHookSettingsJson,
+        WebHookSettings = FormMapper.ParseJsonString(formDto.WebHookSettingsJson)
     };
 }

--- a/src/Endatix.Api/Endpoints/Forms/FormModel.cs
+++ b/src/Endatix.Api/Endpoints/Forms/FormModel.cs
@@ -1,4 +1,6 @@
-﻿namespace Endatix.Api.Endpoints.Forms;
+﻿using System.Text.Json;
+
+namespace Endatix.Api.Endpoints.Forms;
 
 /// <summary>
 /// Model of a form.
@@ -46,7 +48,13 @@ public class FormModel
     public int? SubmissionsCount { get; init; }
 
     /// <summary>
-    /// The JSON data containing webhook configuration settings for this form.
+    /// The JSON data containing webhook configuration settings for this form as a string.
     /// </summary>
+    [Obsolete("Use WebHookSettings instead.")]
     public string? WebHookSettingsJson { get; set; }
+
+    /// <summary>
+    /// The webhook configuration settings as a JSON object.
+    /// </summary>
+    public JsonElement? WebHookSettings { get; set; }
 }

--- a/tests/Endatix.Api.Tests/Endpoints/Forms/CreateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Forms/CreateTests.cs
@@ -102,4 +102,207 @@ public class CreateTests
             Arg.Any<CancellationToken>()
         );
     }
+
+    [Fact]
+    public async Task ExecuteAsync_WithFormDefinitionSchema_ShouldSerializeToJsonString()
+    {
+        // Arrange
+        var jsonSchema = System.Text.Json.JsonDocument.Parse("""
+            {
+                "pages": [
+                    {
+                        "elements": [
+                            {
+                                "type": "text",
+                                "name": "question1"
+                            }
+                        ]
+                    }
+                ]
+            }
+            """).RootElement;
+
+        var request = new CreateFormRequest
+        {
+            Name = "Test Form",
+            Description = "Test Description",
+            IsEnabled = true,
+            FormDefinitionSchema = jsonSchema
+        };
+        var result = Result<Form>.Created(new Form(SampleData.TENANT_ID, "Test Form"));
+
+        _mediator.Send(Arg.Any<CreateFormCommand>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+
+        // Act
+        await _endpoint.ExecuteAsync(request, CancellationToken.None);
+
+        // Assert
+        await _mediator.Received(1).Send(
+            Arg.Is<CreateFormCommand>(cmd =>
+                cmd.Name == request.Name &&
+                cmd.Description == request.Description &&
+                cmd.IsEnabled == request.IsEnabled &&
+                cmd.FormDefinitionJsonData != null &&
+                cmd.FormDefinitionJsonData.Contains("pages") &&
+                cmd.FormDefinitionJsonData.Contains("question1")
+            ),
+            Arg.Any<CancellationToken>()
+        );
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithWebHookSettings_ShouldSerializeToJsonString()
+    {
+        // Arrange
+        var webhookSettings = System.Text.Json.JsonDocument.Parse("""
+            {
+                "events": {
+                    "SubmissionCreated": {
+                        "isEnabled": true
+                    }
+                }
+            }
+            """).RootElement;
+
+        var request = new CreateFormRequest
+        {
+            Name = "Test Form",
+            Description = "Test Description",
+            IsEnabled = true,
+            FormDefinitionJsonData = """{ "type": "object" }""",
+            WebHookSettings = webhookSettings
+        };
+        var result = Result<Form>.Created(new Form(SampleData.TENANT_ID, "Test Form"));
+
+        _mediator.Send(Arg.Any<CreateFormCommand>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+
+        // Act
+        await _endpoint.ExecuteAsync(request, CancellationToken.None);
+
+        // Assert
+        await _mediator.Received(1).Send(
+            Arg.Is<CreateFormCommand>(cmd =>
+                cmd.WebHookSettingsJson != null &&
+                cmd.WebHookSettingsJson.Contains("events") &&
+                cmd.WebHookSettingsJson.Contains("SubmissionCreated")
+            ),
+            Arg.Any<CancellationToken>()
+        );
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithBothFormDefinitionFormats_PrefersNewJsonObject()
+    {
+        // Arrange
+        var newJsonSchema = System.Text.Json.JsonDocument.Parse("""
+            {
+                "pages": [
+                    {
+                        "elements": [
+                            {
+                                "type": "text",
+                                "name": "newQuestion"
+                            }
+                        ]
+                    }
+                ]
+            }
+            """).RootElement;
+
+        var request = new CreateFormRequest
+        {
+            Name = "Test Form",
+            IsEnabled = true,
+            FormDefinitionJsonData = """{ "type": "old" }""",  // Old string format
+            FormDefinitionSchema = newJsonSchema  // New object format (should win)
+        };
+        var result = Result<Form>.Created(new Form(SampleData.TENANT_ID, "Test Form"));
+
+        _mediator.Send(Arg.Any<CreateFormCommand>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+
+        // Act
+        await _endpoint.ExecuteAsync(request, CancellationToken.None);
+
+        // Assert
+        await _mediator.Received(1).Send(
+            Arg.Is<CreateFormCommand>(cmd =>
+                cmd.FormDefinitionJsonData.Contains("newQuestion") &&
+                !cmd.FormDefinitionJsonData.Contains("old")
+            ),
+            Arg.Any<CancellationToken>()
+        );
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithBothWebHookFormats_PrefersNewJsonObject()
+    {
+        // Arrange
+        var newWebhookSettings = System.Text.Json.JsonDocument.Parse("""
+            {
+                "events": {
+                    "SubmissionCreated": {
+                        "isEnabled": true
+                    }
+                }
+            }
+            """).RootElement;
+
+        var request = new CreateFormRequest
+        {
+            Name = "Test Form",
+            IsEnabled = true,
+            FormDefinitionJsonData = """{ "type": "object" }""",
+            WebHookSettingsJson = """{ "events": {} }""",  // Old string format
+            WebHookSettings = newWebhookSettings  // New object format (should win)
+        };
+        var result = Result<Form>.Created(new Form(SampleData.TENANT_ID, "Test Form"));
+
+        _mediator.Send(Arg.Any<CreateFormCommand>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+
+        // Act
+        await _endpoint.ExecuteAsync(request, CancellationToken.None);
+
+        // Assert
+        await _mediator.Received(1).Send(
+            Arg.Is<CreateFormCommand>(cmd =>
+                cmd.WebHookSettingsJson != null &&
+                cmd.WebHookSettingsJson.Contains("SubmissionCreated")
+            ),
+            Arg.Any<CancellationToken>()
+        );
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WithOnlyOldStringFormat_StillWorks()
+    {
+        // Arrange - Backward compatibility test
+        var request = new CreateFormRequest
+        {
+            Name = "Test Form",
+            Description = "Test Description",
+            IsEnabled = true,
+            FormDefinitionJsonData = """{ "type": "object" }""",
+            WebHookSettingsJson = """{ "events": {} }"""
+        };
+        var result = Result<Form>.Created(new Form(SampleData.TENANT_ID, "Test Form"));
+
+        _mediator.Send(Arg.Any<CreateFormCommand>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+
+        // Act
+        await _endpoint.ExecuteAsync(request, CancellationToken.None);
+
+        // Assert
+        await _mediator.Received(1).Send(
+            Arg.Is<CreateFormCommand>(cmd =>
+                cmd.FormDefinitionJsonData == request.FormDefinitionJsonData &&
+                cmd.WebHookSettingsJson == request.WebHookSettingsJson
+            ),
+            Arg.Any<CancellationToken>()
+        );
+    }
 }


### PR DESCRIPTION
# Add native JSON fields in FormCreate endpoint

## Description
- Add `FormDefinitionSchema` and `WebHookSettings` fields in `POST /forms` endpoint
- Mark `FormDefinitionJsonData` and `WebHookSettingsJson` fields as obsolete
- Add validation logic to check if at least one of the fields for FormDefinition has a value
- Add logic to read the new fields with priority

### Note
This is a POC to confirm native JSON fields fix WAF JSON issue. If it works, all the JSON fields in Endatix API will be changed,

## Related Issues
closes https://github.com/endatix/endatix-private/issues/327

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
