### PR TITLE
fix: Return webhooks payload long values as string

### DIFF
--- a/src/Endatix.Api/Builders/ApiConfigurationBuilder.cs
+++ b/src/Endatix.Api/Builders/ApiConfigurationBuilder.cs
@@ -3,6 +3,7 @@ using Endatix.Api.Infrastructure;
 using Endatix.Api.Infrastructure.Cors;
 using Endatix.Api.Setup;
 using Endatix.Framework.Hosting;
+using Endatix.Framework.Serialization;
 using Endatix.Framework.Setup;
 using FastEndpoints;
 using FastEndpoints.Swagger;

--- a/src/Endatix.Api/Setup/ApiApplicationBuilderExtensions.cs
+++ b/src/Endatix.Api/Setup/ApiApplicationBuilderExtensions.cs
@@ -1,6 +1,7 @@
 using System.Security.Claims;
 using Endatix.Api.Builders;
 using Endatix.Api.Infrastructure;
+using Endatix.Framework.Serialization;
 using Endatix.Infrastructure.Identity;
 using FastEndpoints;
 using FastEndpoints.Swagger;

--- a/src/Endatix.Api/Setup/EndatixAppExtensions.cs
+++ b/src/Endatix.Api/Setup/EndatixAppExtensions.cs
@@ -5,6 +5,7 @@ using FastEndpoints.Swagger;
 using Microsoft.AspNetCore.Http.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Endatix.Api.Infrastructure;
+using Endatix.Framework.Serialization;
 using Ardalis.GuardClauses;
 using Microsoft.Extensions.Configuration;
 using Endatix.Infrastructure.Identity;

--- a/src/Endatix.Framework/Serialization/LongToStringConverter.cs
+++ b/src/Endatix.Framework/Serialization/LongToStringConverter.cs
@@ -1,7 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace Endatix.Api.Infrastructure;
+namespace Endatix.Framework.Serialization;
 
 /// <summary>
 /// Processes the Long to JavaScript converter into string, so there's no precision issues due to JavaScript number min/max values.

--- a/src/Endatix.Hosting/Builders/EndatixApiBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixApiBuilder.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using System.Security.Claims;
 using Endatix.Api.Builders;
 using Endatix.Api.Infrastructure;
+using Endatix.Framework.Serialization;
 using Endatix.Infrastructure.Identity;
 using FastEndpoints;
 using FastEndpoints.Swagger;

--- a/src/Endatix.Hosting/Builders/EndatixMiddlewareBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixMiddlewareBuilder.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Endatix.Api.Builders;
 using Endatix.Api.Infrastructure;
 using Endatix.Api.Setup;
+using Endatix.Framework.Serialization;
 using Endatix.Infrastructure.Identity;
 using Endatix.Infrastructure.Multitenancy;
 using FastEndpoints;

--- a/src/Endatix.Infrastructure/Features/WebHooks/WebHookServer.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/WebHookServer.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 using Ardalis.GuardClauses;
 using Endatix.Core.Features.WebHooks;
+using Endatix.Framework.Serialization;
 using Microsoft.Extensions.Logging;
 using Polly.Timeout;
 
@@ -72,7 +73,9 @@ public class WebHookServer(HttpClient httpClient, ILogger<WebHookServer> logger)
 
     private StringContent CreateContent<T>(WebHookMessage<T> message)
     {
-        var jsonContent = JsonSerializer.Serialize(message);
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new LongToStringConverter());
+        var jsonContent = JsonSerializer.Serialize(message, options);
         return new StringContent(jsonContent, Encoding.UTF8, "application/json");
     }
 

--- a/tests/Endatix.Infrastructure.Tests/Features/WebHooks/WebHookServerTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/WebHooks/WebHookServerTests.cs
@@ -238,8 +238,8 @@ public class WebHookServerTests
         // Parse JSON without full deserialization to avoid constructor issues
         using var jsonDoc = JsonDocument.Parse(content);
         var root = jsonDoc.RootElement;
-        
-        root.GetProperty("id").GetInt64().Should().Be(123);
+
+        root.GetProperty("id").GetString().Should().Be("123");
         root.GetProperty("eventName").GetString().Should().Be("submission_completed");
         root.GetProperty("action").GetString().Should().Be("updated");
         


### PR DESCRIPTION
# Return webhooks payload long values as string

## Description
Return webhooks payload long values as string

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
