### PR TITLE
chore(deps): override node-forge to >=1.3.2 due to CVE-2025-66031

### DIFF
--- a/.github/workflows/deploy-endatix-docs.yml
+++ b/.github/workflows/deploy-endatix-docs.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   deploy-endatix-docs:
     env:
-      STORE_PATH:
+      STORE_PATH: ""
     runs-on: ubuntu-latest
     environment:
       name: Production
@@ -31,7 +31,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.10
+          version: 10.25.0
           run_install: false
 
       - name: Get pnpm store directory

--- a/docs/endatix-docs/package.json
+++ b/docs/endatix-docs/package.json
@@ -15,7 +15,8 @@
     "serve": "docusaurus serve",
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "pnpm:comments": "node ./scripts/echo-pnpm-comments.mjs"
   },
   "dependencies": {
     "@docusaurus/core": "^3.9.2",
@@ -50,5 +51,13 @@
   "engines": {
     "node": ">=18.0"
   },
-  "packageManager": "pnpm@10.8.0+sha256.29bf2c5ceaea7991ee82eec15fe7162e0fad816d0c4a6b35a16c01d39274bf69"
+  "pnpm": {
+    "overrides": {
+      "node-forge": "^1.3.2"
+    },
+    "comments": {
+      "overrides": "Override node-forge to version 1.3.2 until issue is addressed by Docusaurus"
+    }
+  },
+  "packageManager": "pnpm@10.25.0+sha256.0f3726654b0b5e52e5800904de168afc3c667e2abf84bdb06d9ac1386104bd90"
 }

--- a/docs/endatix-docs/pnpm-lock.yaml
+++ b/docs/endatix-docs/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  node-forge: ^1.3.2
+
 importers:
 
   .:
@@ -7605,7 +7608,7 @@ snapshots:
 
   '@docusaurus/react-loadable@6.0.0(react@19.1.1)':
     dependencies:
-      '@types/react': 19.1.9
+      '@types/react': 19.2.7
       react: 19.1.1
 
   '@docusaurus/theme-classic@3.9.2(@types/react@19.2.7)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.8.3)':

--- a/docs/endatix-docs/scripts/echo-pnpm-comments.mjs
+++ b/docs/endatix-docs/scripts/echo-pnpm-comments.mjs
@@ -1,0 +1,23 @@
+import fs from "fs";
+
+const pkg = JSON.parse(fs.readFileSync("package.json", "utf8"));
+
+const comments = pkg.pnpm?.comments;
+
+if (!comments) process.exit(0);
+
+console.log("\nℹ️ pnpm comments:\n");
+
+for (const [key, value] of Object.entries(comments)) {
+  if (typeof value === "string" && value.includes("|")) {
+    const items = value.split("|").map((item) => item.trim()).filter((item) => item.length > 0);
+    console.log(`❯ ${key}:`);
+    for (const item of items) {
+      console.log(`  - ${item}`);
+    }
+  } else {
+    console.log(`❯ ${key}: ${typeof value === "string" ? value : JSON.stringify(value, null, 2)}`);
+  }
+}
+
+console.log("");


### PR DESCRIPTION
# chore(deps): override node-forge to >=1.3.2 due to CVE-2025-66031

## Description
- Add override of node-forge to 1.32 
- Add echo-pnpm-comments to emit comments, so overrides can be tracked and monitored for removal once no longer needed
- Updates pnpm to 10.25.0

## Related Issues
- fixes https://github.com/endatix/endatix/issues/547

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Other (CI script)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
