### PR TITLE
fix: Assigning seeded user to PlatformAdmin role

### DIFF
--- a/docs/endatix-docs/docs/configuration/settings/data-settings.md
+++ b/docs/endatix-docs/docs/configuration/settings/data-settings.md
@@ -18,9 +18,7 @@ To configure the data settings, add the following snippet to your `appsettings.j
         "SeedSampleData": true,
         "InitialUser": {
             "Email": "admin@example.com",
-            "Password": "StrongPassword123!",
-            "FirstName": "Admin", 
-            "LastName": "User"
+            "Password": "StrongPassword123!"
         }
     }
 }
@@ -42,8 +40,6 @@ When `SeedSampleData` is enabled, you can configure the initial user with these 
 |----------|-------------|----------|
 | `Email` | Email address for the initial user | Yes |
 | `Password` | Password for the initial user | Yes |
-| `FirstName` | First name for the initial user | No |
-| `LastName` | Last name for the initial user | No |
 
 ## Programmatic Configuration
 

--- a/src/Endatix.Hosting/README.md
+++ b/src/Endatix.Hosting/README.md
@@ -290,9 +290,7 @@ You can control migrations and data seeding through configuration:
       "SeedSampleData": true,
       "InitialUser": {
         "Email": "admin@example.com",
-        "Password": "SecurePassword123!",
-        "FirstName": "Admin",
-        "LastName": "User"
+        "Password": "SecurePassword123!"
       }
     }
   }

--- a/src/Endatix.Infrastructure/Data/DataSeedingExtensions.cs
+++ b/src/Endatix.Infrastructure/Data/DataSeedingExtensions.cs
@@ -19,7 +19,7 @@ public static class DataSeedingExtensions
 {
     // This private class is only used as a logger category
     private class DataSeedingLogger { }
-    
+
     /// <summary>
     /// Seeds initial user data.
     /// </summary>
@@ -39,29 +39,31 @@ public static class DataSeedingExtensions
     {
         var loggerFactory = serviceProvider.GetService<ILoggerFactory>();
         var logger = loggerFactory?.CreateLogger<DataSeedingLogger>();
-        
+
         try
         {
             logger?.LogInformation("Seeding initial user data");
-            
+
             // Get required services
             using var scope = serviceProvider.CreateScope();
             var scopedProvider = scope.ServiceProvider;
-            
+
             var userManager = scopedProvider.GetRequiredService<UserManager<AppUser>>();
             var userRegistrationService = scopedProvider.GetRequiredService<IUserRegistrationService>();
+            var roleManagementService = scopedProvider.GetRequiredService<IRoleManagementService>();
             var dataOptions = scopedProvider.GetRequiredService<IOptions<DataOptions>>().Value;
-            
+
             // Create a suitable logger for IdentitySeed (ILogger instead of ILogger<T>)
             ILogger seedLogger = logger != null ? (ILogger)logger : NullLogger.Instance;
-            
+
             // Call the implementation in IdentitySeed
             await IdentitySeed.SeedInitialUser(
                 userManager,
                 userRegistrationService,
+                roleManagementService,
                 dataOptions,
                 seedLogger);
-            
+
             logger?.LogInformation("Initial user data seeded successfully");
         }
         catch (Exception ex)
@@ -70,4 +72,4 @@ public static class DataSeedingExtensions
             throw; // Rethrow for explicit seeding calls
         }
     }
-} 
+}

--- a/src/Endatix.Infrastructure/Data/DataSeedingService.cs
+++ b/src/Endatix.Infrastructure/Data/DataSeedingService.cs
@@ -54,11 +54,13 @@ public class DataSeedingService : IHostedService
             using var scope = _serviceProvider.CreateScope();
             var userManager = scope.ServiceProvider.GetRequiredService<UserManager<AppUser>>();
             var userRegistrationService = scope.ServiceProvider.GetRequiredService<IUserRegistrationService>();
+            var roleManagementService = scope.ServiceProvider.GetRequiredService<IRoleManagementService>();
 
             // Call the identity seed method
             await IdentitySeed.SeedInitialUser(
                 userManager,
                 userRegistrationService,
+                roleManagementService,
                 _options,
                 _logger);
 

--- a/src/Endatix.Infrastructure/Data/DatabaseMigrationExtensions.cs
+++ b/src/Endatix.Infrastructure/Data/DatabaseMigrationExtensions.cs
@@ -35,7 +35,7 @@ public static class DatabaseMigrationExtensions
 
             using var identityDbContext = scopedProvider.GetRequiredService<AppIdentityDbContext>();
             await ApplyMigrationForContextAsync(identityDbContext, logger);
-            
+
             logger?.LogDebug("{Operation} operation executed successfully", nameof(ApplyDbMigrationsAsync));
         }
         catch (Exception ex)
@@ -50,15 +50,12 @@ public static class DatabaseMigrationExtensions
         Guard.Against.Null(dbContext);
         Guard.Against.Null(logger);
 
-        if (dbContext.Database.GetPendingMigrations().Any())
-        {
-            var startTime = Stopwatch.GetTimestamp();
-            logger.LogWarning("💽 Applying database migrations for {dbContextName}", typeof(T).Name);
+        var startTime = Stopwatch.GetTimestamp();
+        logger.LogWarning("💽 Applying database migrations for {dbContextName}", typeof(T).Name);
 
-            await dbContext.Database.MigrateAsync();
+        await dbContext.Database.MigrateAsync();
 
-            var elapsedTime = Stopwatch.GetElapsedTime(startTime);
-            logger.LogWarning("💽 Database migrations applied for {dbContextName}. Took: {elapsedTime} ms.", typeof(T).Name, elapsedTime.TotalMilliseconds);
-        }
+        var elapsedTime = Stopwatch.GetElapsedTime(startTime);
+        logger.LogWarning("💽 Database migrations applied for {dbContextName}. Took: {elapsedTime} ms.", typeof(T).Name, elapsedTime.TotalMilliseconds);
     }
 }

--- a/src/Endatix.WebHost/appsettings.Development.json
+++ b/src/Endatix.WebHost/appsettings.Development.json
@@ -8,7 +8,8 @@
       "Default": "Debug",
       "Override": {
         "Microsoft": "Information",
-        "System": "Warning"
+        "System": "Warning",
+        "Endatix": "Debug"
       }
     },
     "WriteTo": [


### PR DESCRIPTION
# fix: Assigning seeded user to PlatformAdmin role

## Description
- Assigning seeded user to PlatformAdmin role
- Fixing security issue with emitting password in logs - https://github.com/endatix/endatix/security/code-scanning/5
- Update docs
- Fixing issue with first migration error 
```bash
[ 11:29:34.009 Level:WRN] 💽 Applying database migrations for AppDbContext
[ 11:29:34.032 Level:ERR] Failed executing DbCommand (14ms) [Parameters=[], CommandType='Text', CommandTimeout='30']
SELECT "MigrationId", "ProductVersion"
FROM "__EFMigrationsHistory"
ORDER BY "MigrationId";
```
- Fixing tests

## Related Issues
- closes https://github.com/endatix/endatix/issues/552

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Other - security fix

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
