### PR TITLE
feat: Create Submission endpoint supports setting submittedBy

### DIFF
--- a/src/Endatix.Api/Endpoints/Submissions/Create.CreateSubmissionRequest.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/Create.CreateSubmissionRequest.cs
@@ -7,4 +7,10 @@ namespace Endatix.Api.Endpoints.Submissions;
 /// </summary>
 public class CreateSubmissionRequest : BaseSubmissionRequest
 {
+    /// <summary>
+    /// Optional identifier of the user who submitted the form.
+    /// When not provided, defaults to the current authenticated user's ID.
+    /// Cannot be an empty string.
+    /// </summary>
+    public string? SubmittedBy { get; set; }
 }

--- a/src/Endatix.Api/Endpoints/Submissions/Create.CreateSubmissionValidator.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/Create.CreateSubmissionValidator.cs
@@ -26,5 +26,8 @@ public class CreateSubmissionValidator : Validator<CreateSubmissionRequest>
             .MinimumLength(DataSchemaConstants.MIN_JSON_LENGTH)
             .When(x => x.Metadata != null);
 
+        RuleFor(x => x.SubmittedBy)
+            .Must(value => !string.IsNullOrWhiteSpace(value))
+            .When(x => x.SubmittedBy != null);
     }
 }

--- a/src/Endatix.Api/Endpoints/Submissions/Create.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/Create.cs
@@ -31,7 +31,7 @@ public class Create(IMediator mediator, IUserContext userContext) : Endpoint<Cre
     /// <inheritdoc/>
     public override async Task<Results<Created<CreateSubmissionResponse>, ProblemHttpResult>> ExecuteAsync(CreateSubmissionRequest request, CancellationToken cancellationToken)
     {
-        var userId = userContext.GetCurrentUserId();
+        var submittedBy = request.SubmittedBy ?? userContext.GetCurrentUserId();
 
         var createCommand = new CreateSubmissionCommand(
             FormId: request.FormId,
@@ -40,7 +40,7 @@ public class Create(IMediator mediator, IUserContext userContext) : Endpoint<Cre
             CurrentPage: request.CurrentPage,
             IsComplete: request.IsComplete,
             ReCaptchaToken: request.ReCaptchaToken,
-            SubmittedBy: userId,
+            SubmittedBy: submittedBy,
             RequiredPermission: Actions.Submissions.Create
         );
 


### PR DESCRIPTION
# Create Submission endpoint supports setting submittedBy

## Description
Create Submission endpoint receives optionally `submittedBy` that is set when provided. Otherwise the value is got from user context.

## Related Issues
closes #566

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above
