### PR TITLE
feat: Get Submission by Access Token supports "export" permission

### DIFF
--- a/src/Endatix.Core/UseCases/Submissions/GetByAccessToken/GetByAccessTokenHandler.cs
+++ b/src/Endatix.Core/UseCases/Submissions/GetByAccessToken/GetByAccessTokenHandler.cs
@@ -24,8 +24,9 @@ public class GetByAccessTokenHandler(
         }
 
         var tokenClaims = tokenValidationResult.Value;
-
-        if (!tokenClaims.Permissions.Contains(SubmissionAccessTokenPermissions.View.Name))
+        var hasRequiredPermission = tokenClaims.Permissions.Contains(SubmissionAccessTokenPermissions.View.Name) ||
+                                    tokenClaims.Permissions.Contains(SubmissionAccessTokenPermissions.Export.Name);
+        if (!hasRequiredPermission)
         {
             return Result.Forbidden("Token does not have view permission");
         }


### PR DESCRIPTION
# Get Submission by Access Token supports "export" permission

## Description
Get Submission by Access Token needs "export" permission for the Export PDF feature to work with the new access tokens.

## Related Issues
#582

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above
