### PR TITLE
fix: Merge submission metadata on update

### DIFF
--- a/src/Endatix.Core/Helpers/JsonHelpers.cs
+++ b/src/Endatix.Core/Helpers/JsonHelpers.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Endatix.Core.Helpers;
+
+public static class JsonHelpers
+{
+    private static readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = false };
+
+    /// <summary>
+    /// Merges two top-level JSON objects. Keys from patchJson overwrite or add to originalJson. If either is invalid or not an object, it is treated as an empty object.
+    /// </summary>
+    /// <param name="originalJson"></param>
+    /// <param name="patchJson"></param>
+    /// <returns></returns>
+    public static string MergeTopLevelObject(string? originalJson, string? patchJson)
+    {
+        JsonObject originalObj;
+        JsonObject patchObj;
+
+        if (string.IsNullOrWhiteSpace(originalJson))
+        {
+            originalObj = [];
+        }
+        else
+        {
+            try
+            {
+                var root = JsonNode.Parse(originalJson);
+                originalObj = root as JsonObject ?? [];
+            }
+            catch
+            {
+                originalObj = [];
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(patchJson))
+        {
+            patchObj = [];
+        }
+        else
+        {
+            try
+            {
+                var root = JsonNode.Parse(patchJson);
+                patchObj = root as JsonObject ?? [];
+            }
+            catch
+            {
+                patchObj = [];
+            }
+        }
+
+        foreach (var kvp in patchObj)
+        {
+            // Clone the value to avoid "node already has a parent" when moving between objects
+            var clonedValue = kvp.Value is null ? null : JsonNode.Parse(kvp.Value.ToJsonString());
+            originalObj[kvp.Key] = clonedValue;
+        }
+
+        return originalObj.ToJsonString(_jsonOptions);
+    }
+}

--- a/src/Endatix.Core/UseCases/Submissions/PartialUpdate/PartialUpdateSubmissionHandler.cs
+++ b/src/Endatix.Core/UseCases/Submissions/PartialUpdate/PartialUpdateSubmissionHandler.cs
@@ -1,6 +1,7 @@
 ﻿
 using Endatix.Core.Entities;
 using Endatix.Core.Events;
+using Endatix.Core.Helpers;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
@@ -34,12 +35,16 @@ public class PartialUpdateSubmissionHandler(IRepository<Submission> repository, 
         // TODO: add more advanced PATCH-ing where we can not only replace individual properties, but merge, remove and other typical operations. This is valid especially for the JSON based JsonData and Metadata properties, so we can keep payloads and client logic light, e.g. submit one answer at a time and update JsonData
         // TODO: investigate if IsComplete and CurrentPage should be auto calculated as part of processing the submission
         var originalJson = submission.JsonData;
+        var mergedMetadata = request.Metadata != null
+            ? JsonHelpers.MergeTopLevelObject(submission.Metadata, request.Metadata)
+            : submission.Metadata;
+
         submission.Update(
             request.JsonData ?? submission.JsonData,
             submission.FormDefinitionId,
             request.IsComplete ?? submission.IsComplete,
             request.CurrentPage ?? submission.CurrentPage ?? DEFAULT_CURRENT_PAGE,
-            request.Metadata ?? submission.Metadata
+            mergedMetadata
         );
 
         if (!string.Equals(originalJson, submission.JsonData, StringComparison.Ordinal))

--- a/tests/Endatix.Core.Tests/Helpers/JsonHelpersTests.cs
+++ b/tests/Endatix.Core.Tests/Helpers/JsonHelpersTests.cs
@@ -1,0 +1,56 @@
+using System.Text.Json.Nodes;
+using Endatix.Core.Helpers;
+
+namespace Endatix.Core.Tests.Helpers;
+
+public class JsonHelpersTests
+{
+    [Fact]
+    public void MergeTopLevelObject_OriginalAndPatch_MergesAndOverwrites()
+    {
+        // Arrange
+        var original = "{ \"a\": 1, \"key\": \"old\" }";
+        var patch = "{ \"b\": 2, \"key\": \"new\" }";
+
+        // Act
+        var result = JsonHelpers.MergeTopLevelObject(original, patch);
+
+        // Assert
+        var obj = JsonNode.Parse(result) as JsonObject;
+        obj.Should().NotBeNull();
+        obj!["a"]!.GetValue<int>().Should().Be(1);
+        obj["b"]!.GetValue<int>().Should().Be(2);
+        obj["key"]!.GetValue<string>().Should().Be("new");
+    }
+
+    [Fact]
+    public void MergeTopLevelObject_InvalidInputs_TreatedAsEmpty()
+    {
+        // Arrange
+        var original = "not-json";
+        var patch = "{ \"x\": 10 }";
+
+        // Act
+        var result = JsonHelpers.MergeTopLevelObject(original, patch);
+
+        // Assert
+        var obj = JsonNode.Parse(result) as JsonObject;
+        obj.Should().NotBeNull();
+        obj!["x"]!.GetValue<int>().Should().Be(10);
+    }
+
+    [Fact]
+    public void MergeTopLevelObject_PatchNull_ReturnsOriginalNormalized()
+    {
+        // Arrange
+        var original = "{ \"a\": 1 }";
+
+        // Act
+        var result = JsonHelpers.MergeTopLevelObject(original, null);
+
+        // Assert
+        var obj = JsonNode.Parse(result) as JsonObject;
+        obj.Should().NotBeNull();
+        obj!["a"]!.GetValue<int>().Should().Be(1);
+    }
+}


### PR DESCRIPTION
# Merge submission metadata on update

## Description
Merge submission metadata on submission partial update in the endpoints:
- `PATCH forms/{formId}/submissions/{submissionId}`
- `PATCH forms/{formId}/submissions/by-token/{submissionToken}`
- `PATCH forms/{formId}/submissions/by-access-token/{token}`

## Related Issues
closes https://github.com/endatix/endatix-hub/issues/351

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above
