### PR TITLE
fix: Sets the value of legacy HubUrl to the new HubBaseUrl from Hub Settings

### DIFF
--- a/src/Endatix.Infrastructure/Setup/ServiceCollectionExtensions.cs
+++ b/src/Endatix.Infrastructure/Setup/ServiceCollectionExtensions.cs
@@ -83,9 +83,7 @@ public static class ServiceCollectionExtensions
     {
         services.AddOptions<EmailTemplateSettings>()
                 .BindConfiguration("Endatix:EmailTemplates")
-                .PostConfigure<IOptions<HubSettings>>((options, hubSettings) =>{
-                    options.HubUrl = hubSettings.Value.HubBaseUrl;
-                })
+                .PostConfigure<IOptions<HubSettings>>(HandleLegacyHubUrl)
                 .ValidateOnStart();
 
         services.AddScoped<IEmailTemplateService, EmailTemplateService>();
@@ -185,5 +183,20 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IExporter>(sp => sp.GetRequiredService<TExporter>());
 
         return services;
+    }
+
+
+    [Obsolete("Sets the HubUrl from the HubSettings.HubBaseUrl if the HubUrl is not set. Will be removed in the future.")]
+    private static void HandleLegacyHubUrl(EmailTemplateSettings options, IOptions<HubSettings> hubSettings)
+    {
+        if (!string.IsNullOrWhiteSpace(options.HubUrl))
+        {
+            return;
+        }
+
+        if (hubSettings.Value.HubBaseUrl is { Length: > 0 } hubBaseUrl)
+        {
+            options.HubUrl = hubBaseUrl;
+        }
     }
 }


### PR DESCRIPTION
# fix: Sets the value of legacy HubUrl to the new HubBaseUrl from Hub Settings

## Description
We still keep the legacy value, but use PostConfigure to set its value from the `HubBaseUrl` from Hub Settings to avoid breaking changes for now

## Related Issues
- fixes https://github.com/endatix/endatix-saas/issues/119

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
