### PR TITLE
chore: bump fast-xml-parser to 5.3.7 to address CVE-2026-25896

### DIFF
--- a/docs/endatix-docs/package.json
+++ b/docs/endatix-docs/package.json
@@ -56,10 +56,10 @@
     "overrides": {
       "node-forge": "^1.3.2",
       "qs": "^6.14.1",
-      "fast-xml-parser" : "^5.3.4"
+      "fast-xml-parser" : "^5.3.5"
     },
     "comments": {
-      "overrides": "[node-forge] to version 1.3.2 until issue is addressed by Docusaurus | [qs] to 6.14.1 to fix GHSA-6rw7-vpxm-498p. Remove on next Docusaurus bump | [fast-xml-parser] to 5.3.4 to fix CVE-2026-25128. Remove on next redocusaurus bump"
+      "overrides": "[node-forge] to version 1.3.2 until issue is addressed by Docusaurus | [qs] to 6.14.1 to fix GHSA-6rw7-vpxm-498p. Remove on next Docusaurus bump | [fast-xml-parser] to 5.3.5 to fix CVE-2026-25128 & CVE-2026-25896. Remove on next redocusaurus bump"
     }
   },
   "packageManager": "pnpm@10.25.0+sha256.0f3726654b0b5e52e5800904de168afc3c667e2abf84bdb06d9ac1386104bd90"

--- a/docs/endatix-docs/pnpm-lock.yaml
+++ b/docs/endatix-docs/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   node-forge: ^1.3.2
   qs: ^6.14.1
-  fast-xml-parser: ^5.3.4
+  fast-xml-parser: ^5.3.5
 
 importers:
 
@@ -3014,8 +3014,8 @@ packages:
   fast-uri@3.0.6:
     resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
 
-  fast-xml-parser@5.3.4:
-    resolution: {integrity: sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==}
+  fast-xml-parser@5.3.7:
+    resolution: {integrity: sha512-JzVLro9NQv92pOM/jTCR6mHlJh2FGwtomH8ZQjhFj/R29P2Fnj38OgPJVtcvYw6SuKClhgYuwUZf5b3rd8u2mA==}
     hasBin: true
 
   fastq@1.19.1:
@@ -9921,7 +9921,7 @@ snapshots:
 
   fast-uri@3.0.6: {}
 
-  fast-xml-parser@5.3.4:
+  fast-xml-parser@5.3.7:
     dependencies:
       strnum: 2.1.2
 
@@ -11416,7 +11416,7 @@ snapshots:
   openapi-sampler@1.6.1:
     dependencies:
       '@types/json-schema': 7.0.15
-      fast-xml-parser: 5.3.4
+      fast-xml-parser: 5.3.7
       json-pointer: 0.6.2
 
   opener@1.5.2: {}


### PR DESCRIPTION
# chore: bump fast-xml-parser to 5.3.7 to address CVE-2026-25896

## Description
- via override as Docusaurus has not been patched

## Related Issues
- fixes https://github.com/endatix/endatix/issues/610

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Security Fix

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
