### PR TITLE
fix: Get Definition Fields return name instead of title

### DIFF
--- a/src/Endatix.Core/UseCases/FormDefinitions/GetFields/GetFormDefinitionFieldsHandler.cs
+++ b/src/Endatix.Core/UseCases/FormDefinitions/GetFields/GetFormDefinitionFieldsHandler.cs
@@ -73,7 +73,10 @@ public class GetFormDefinitionFieldsHandler(
                 continue;
             }
 
-            AddFieldIfNew(element, name, type, seen);
+            if (!seen.ContainsKey(name))
+            {
+                seen[name] = (name, type);
+            }
         }
     }
 
@@ -128,15 +131,5 @@ public class GetFormDefinitionFieldsHandler(
 
         name = nameValue;
         return true;
-    }
-
-    private static void AddFieldIfNew(JsonElement element, string name, string type, Dictionary<string, (string Title, string Type)> seen)
-    {
-        if (seen.ContainsKey(name))
-        {
-            return;
-        }
-
-        seen[name] = (name, type);
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/FormDefinitions/GetFields/GetFormDefinitionFieldsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/FormDefinitions/GetFields/GetFormDefinitionFieldsHandlerTests.cs
@@ -65,8 +65,8 @@ public class GetFormDefinitionFieldsHandlerTests
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().NotBeNull();
         result.Value.Should().HaveCount(2);
-        result.Value.Should().Contain(f => f.Name == "firstName" && f.Title == "First Name" && f.Type == "text");
-        result.Value.Should().Contain(f => f.Name == "lastName" && f.Title == "Last Name" && f.Type == "text");
+        result.Value.Should().Contain(f => f.Name == "firstName" && f.Title == "firstName" && f.Type == "text");
+        result.Value.Should().Contain(f => f.Name == "lastName" && f.Title == "lastName" && f.Type == "text");
     }
 
     [Fact]
@@ -161,10 +161,10 @@ public class GetFormDefinitionFieldsHandlerTests
 
         // Assert
         result.Should().NotBeNull();
-        result.Value.Should().HaveCount(1);
+        result.Value.Should().HaveCount(1, "duplicate fields should be deduplicated");
         var field = result.Value.First();
         field.Name.Should().Be("fullName");
-        field.Title.Should().Be("New Title", "newest definition should win");
+        field.Title.Should().Be("fullName", "title should always be the same as name");
     }
 
     [Fact]


### PR DESCRIPTION
# Get Definition Fields return name instead of title

## Description
When the form is multi-language the titles are not simple strings but json objects and the Get Definition Field endpoint fails. Logic can be added to extract the title correctly in the multilang questions but actually the title can be long and not appropriate for e.g. a grid column. For that reason the logic will always return just `name`.

## Related Issues
closes #620 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above
