### PR TITLE
chore: bump minimatch to ^3.1.4 to fix multiple CVEs. Remove obsolete files

### DIFF
--- a/docs/endatix-docs/package.json
+++ b/docs/endatix-docs/package.json
@@ -56,10 +56,11 @@
     "overrides": {
       "node-forge": "^1.3.2",
       "qs": "^6.14.1",
-      "fast-xml-parser" : "^5.3.5"
+      "fast-xml-parser": "^5.3.5",
+      "minimatch": "^3.1.4"
     },
     "comments": {
-      "overrides": "[node-forge] to version 1.3.2 until issue is addressed by Docusaurus | [qs] to 6.14.1 to fix GHSA-6rw7-vpxm-498p. Remove on next Docusaurus bump | [fast-xml-parser] to 5.3.5 to fix CVE-2026-25128 & CVE-2026-25896. Remove on next redocusaurus bump"
+      "overrides": "[node-forge] to version 1.3.2. Remove on next @docusaurus 4x bump | [qs] to 6.14.1 to fix GHSA-6rw7-vpxm-498p. Remove on next @docusaurus 4x bump | [fast-xml-parser] to 5.3.5 to fix CVE-2026-25128 & CVE-2026-25896. Remove on next redocusaurus bump | [minimatch] to 3.1.4 to fix multiple CVEs. Remove on next @docusaurus 4x bump"
     }
   },
   "packageManager": "pnpm@10.25.0+sha256.0f3726654b0b5e52e5800904de168afc3c667e2abf84bdb06d9ac1386104bd90"

--- a/docs/endatix-docs/pnpm-lock.yaml
+++ b/docs/endatix-docs/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   node-forge: ^1.3.2
   qs: ^6.14.1
   fast-xml-parser: ^5.3.5
+  minimatch: ^3.1.4
 
 importers:
 
@@ -2031,9 +2032,6 @@ packages:
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
-
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -4008,12 +4006,8 @@ packages:
   minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
-  minimatch@5.1.6:
-    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
-    engines: {node: '>=10'}
+  minimatch@3.1.5:
+    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -8110,7 +8104,7 @@ snapshots:
       js-levenshtein: 1.1.6
       js-yaml: 4.1.1
       lodash.isequal: 4.5.0
-      minimatch: 5.1.6
+      minimatch: 3.1.5
       node-fetch: 2.7.0
       pluralize: 8.0.0
       yaml-ast-parser: 0.0.43
@@ -8866,10 +8860,6 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-
-  brace-expansion@2.0.2:
-    dependencies:
-      balanced-match: 1.0.2
 
   braces@3.0.3:
     dependencies:
@@ -11236,13 +11226,9 @@ snapshots:
 
   minimalistic-assert@1.0.1: {}
 
-  minimatch@3.1.2:
+  minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.12
-
-  minimatch@5.1.6:
-    dependencies:
-      brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
 
@@ -12501,7 +12487,7 @@ snapshots:
       bytes: 3.0.0
       content-disposition: 0.5.2
       mime-types: 2.1.18
-      minimatch: 3.1.2
+      minimatch: 3.1.5
       path-is-inside: 1.0.2
       path-to-regexp: 3.3.0
       range-parser: 1.2.0

--- a/docs/endatix-docs/pnpm-workspace.yaml
+++ b/docs/endatix-docs/pnpm-workspace.yaml
@@ -1,6 +1,0 @@
-onlyBuiltDependencies:
-  - core-js
-  - core-js-pure
-
-packages:
-  - '.'

--- a/samples/Endatix.Samples.SelfHosted/package-lock.json
+++ b/samples/Endatix.Samples.SelfHosted/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "Endatix.Samples.SelfHosted",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
# chore: bump minimatch to ^3.1.4 to fix multiple CVEs. Remove obsolete files

## Description
Adds minimatch override as Docusaurus has no updates

## Related Issues
- fixes https://github.com/endatix/endatix/issues/626
- https://github.com/endatix/endatix/security/dependabot/63
- https://github.com/endatix/endatix/security/dependabot/62
- https://github.com/endatix/endatix/security/dependabot/66
- https://github.com/endatix/endatix/security/dependabot/68
- https://github.com/endatix/endatix/security/dependabot/65
- https://github.com/endatix/endatix/security/dependabot/67


## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
