### PR TITLE
chore: Add svgo bump override to fix CVE-2026-29074

### DIFF
--- a/docs/endatix-docs/package.json
+++ b/docs/endatix-docs/package.json
@@ -55,10 +55,11 @@
       "qs": "^6.14.1",
       "fast-xml-parser": "^5.3.5",
       "minimatch": "^3.1.4",
-      "serialize-javascript": "^7.0.4"
+      "serialize-javascript": "^7.0.4",
+      "svgo": "^3.3.3"
     },
     "comments": {
-      "overrides": "[node-forge] to version 1.3.2. Remove on next @docusaurus 4x bump | [qs] to 6.14.1 to fix GHSA-6rw7-vpxm-498p. Remove on next @docusaurus 4x bump | [fast-xml-parser] to 5.3.5 to fix CVE-2026-25128 & CVE-2026-25896. Remove on next redocusaurus bump | [minimatch] to 3.1.4 to fix multiple CVEs. Remove on next @docusaurus 4x bump | [serialize-javascript] to 7.0.4 to fix CVE-2020-7660. Remove on next @docusaurus 4x bump"
+      "overrides": "[node-forge] to version 1.3.2. Remove on next @docusaurus 4x bump | [qs] to 6.14.1 to fix GHSA-6rw7-vpxm-498p. Remove on next @docusaurus 4x bump | [fast-xml-parser] to 5.3.5 to fix CVE-2026-25128 & CVE-2026-25896. Remove on next redocusaurus bump | [minimatch] to 3.1.4 to fix multiple CVEs. Remove on next @docusaurus 4x bump | [serialize-javascript] to 7.0.4 to fix CVE-2020-7660. Remove on next @docusaurus 4x bump | [svgo] to 3.3.3 to fix CVE-2026-29074. Remove on next @docusaurus 4x bump"
     }
   },
   "packageManager": "pnpm@10.25.0+sha256.0f3726654b0b5e52e5800904de168afc3c667e2abf84bdb06d9ac1386104bd90"

--- a/docs/endatix-docs/pnpm-lock.yaml
+++ b/docs/endatix-docs/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   fast-xml-parser: ^5.3.5
   minimatch: ^3.1.4
   serialize-javascript: ^7.0.4
+  svgo: ^3.3.3
 
 importers:
 
@@ -1511,10 +1512,6 @@ packages:
   '@szmarczak/http-timer@5.0.1':
     resolution: {integrity: sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==}
     engines: {node: '>=14.16'}
-
-  '@trysound/sax@0.2.0':
-    resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
-    engines: {node: '>=10.13.0'}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -5066,6 +5063,10 @@ packages:
   sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
 
+  sax@1.5.0:
+    resolution: {integrity: sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==}
+    engines: {node: '>=11.0.0'}
+
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
@@ -5368,8 +5369,8 @@ packages:
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
 
-  svgo@3.3.2:
-    resolution: {integrity: sha512-OoohrmuUlBs8B8o6MB2Aevn+pRIH9zDALSR+6hhqVfa6fRwG/Qw9VUMSMW9VNg2CFc/MTIfabtdOVl9ODIJjpw==}
+  svgo@3.3.3:
+    resolution: {integrity: sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -8205,7 +8206,7 @@ snapshots:
       '@svgr/core': 8.1.0(typescript@5.8.3)
       cosmiconfig: 8.3.6(typescript@5.8.3)
       deepmerge: 4.3.1
-      svgo: 3.3.2
+      svgo: 3.3.3
     transitivePeerDependencies:
       - typescript
 
@@ -8226,8 +8227,6 @@ snapshots:
   '@szmarczak/http-timer@5.0.1':
     dependencies:
       defer-to-connect: 2.0.1
-
-  '@trysound/sax@0.2.0': {}
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -12001,7 +12000,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
-      svgo: 3.3.2
+      svgo: 3.3.3
 
   postcss-unique-selectors@6.0.4(postcss@8.5.6):
     dependencies:
@@ -12439,6 +12438,8 @@ snapshots:
 
   sax@1.4.1: {}
 
+  sax@1.5.0: {}
+
   scheduler@0.26.0: {}
 
   schema-dts@1.1.5: {}
@@ -12796,15 +12797,15 @@ snapshots:
 
   svg-parser@2.0.4: {}
 
-  svgo@3.3.2:
+  svgo@3.3.3:
     dependencies:
-      '@trysound/sax': 0.2.0
       commander: 7.2.0
       css-select: 5.2.2
       css-tree: 2.3.1
       css-what: 6.2.2
       csso: 5.0.5
       picocolors: 1.1.1
+      sax: 1.5.0
 
   swagger2openapi@7.0.8:
     dependencies:


### PR DESCRIPTION
# chore: Add svgo bump override to fix CVE-2026-29074

## Description
- chore: Add svgo bump override to fix CVE-2026-29074

## Related Issues
- closes https://github.com/endatix/endatix/issues/630

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Security Fix

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
