### PR TITLE
chore: Bump dompurify to 3.3.3 override to fix CVE-2026-0540

### DIFF
--- a/docs/endatix-docs/package.json
+++ b/docs/endatix-docs/package.json
@@ -59,10 +59,11 @@
       "svgo": "^3.3.3",
       "lodash": "^4.17.23",
       "lodash-es": "^4.17.23",
-      "ajv": "^8.18.0"
+      "ajv": "^8.18.0",
+      "dompurify": "^3.3.3"
     },
     "comments": {
-      "overrides": "[node-forge] to version 1.3.2. Remove on next @docusaurus 4x bump | [qs] to 6.14.1 to fix GHSA-6rw7-vpxm-498p. Remove on next @docusaurus 4x bump | [fast-xml-parser] to 5.3.5 to fix CVE-2026-25128 & CVE-2026-25896. Remove on next redocusaurus bump | [minimatch] to 3.1.4 to fix multiple CVEs. Remove on next @docusaurus 4x bump | [serialize-javascript] to 7.0.4 to fix CVE-2020-7660. Remove on next @docusaurus 4x bump | [svgo] to 3.3.3 to fix CVE-2026-29074. Remove on next @docusaurus 4x bump | [lodash] to 4.17.23 to fix CVE-2025-13465. Remove on next @docusaurus 4x bump | [lodash-es] to 4.17.23 to fix CVE-2025-13465. Remove on next @docusaurus 4x bump | [ajv] to 8.18.0 to fix CVE-2025-69873. Remove on next @docusaurus 4x bump"
+      "overrides": "[node-forge] to version 1.3.2. Remove on next @docusaurus 4x bump | [qs] to 6.14.1 to fix GHSA-6rw7-vpxm-498p. Remove on next @docusaurus 4x bump | [fast-xml-parser] to 5.3.5 to fix CVE-2026-25128 & CVE-2026-25896. Remove on next redocusaurus bump | [minimatch] to 3.1.4 to fix multiple CVEs. Remove on next @docusaurus 4x bump | [serialize-javascript] to 7.0.4 to fix CVE-2020-7660. Remove on next @docusaurus 4x bump | [svgo] to 3.3.3 to fix CVE-2026-29074. Remove on next @docusaurus 4x bump | [lodash] to 4.17.23 to fix CVE-2025-13465. Remove on next @docusaurus 4x bump | [lodash-es] to 4.17.23 to fix CVE-2025-13465. Remove on next @docusaurus 4x bump | [ajv] to 8.18.0 to fix CVE-2025-69873. Remove on next @docusaurus 4x bump | [dompurify] to 3.3.3 to fix CVE-2026-0540. Remove on next redocusaurus bump "
     }
   },
   "packageManager": "pnpm@10.25.0+sha256.0f3726654b0b5e52e5800904de168afc3c667e2abf84bdb06d9ac1386104bd90"

--- a/docs/endatix-docs/pnpm-lock.yaml
+++ b/docs/endatix-docs/pnpm-lock.yaml
@@ -14,6 +14,7 @@ overrides:
   lodash: ^4.17.23
   lodash-es: ^4.17.23
   ajv: ^8.18.0
+  dompurify: ^3.3.3
 
 importers:
 
@@ -2773,11 +2774,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.2.6:
-    resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
-
-  dompurify@3.2.7:
-    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
+  dompurify@3.3.3:
+    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
 
   domutils@2.8.0:
     resolution: {integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==}
@@ -9624,11 +9622,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.2.6:
-    optionalDependencies:
-      '@types/trusted-types': 2.0.7
-
-  dompurify@3.2.7:
+  dompurify@3.3.3:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -10858,7 +10852,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.11
       dayjs: 1.11.18
-      dompurify: 3.2.7
+      dompurify: 3.3.3
       katex: 0.16.22
       khroma: 2.1.0
       lodash-es: 4.17.23
@@ -11528,7 +11522,7 @@ snapshots:
 
   polished@4.3.1:
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.28.6
 
   postcss-attribute-case-insensitive@7.0.1(postcss@8.5.6):
     dependencies:
@@ -12160,7 +12154,7 @@ snapshots:
       classnames: 2.5.1
       core-js: 3.45.1
       decko: 1.2.0
-      dompurify: 3.2.6
+      dompurify: 3.3.3
       eventemitter3: 5.0.1
       json-pointer: 0.6.2
       lunr: 2.3.9


### PR DESCRIPTION
# chore: Bump dompurify to 3.3.3 override to fix CVE-2026-0540

## Description
- chore: Bump dompurify to 3.3.3 override to fix CVE-2026-0540

## Related Issues
- closes https://github.com/endatix/endatix/issues/636
- https://github.com/endatix/endatix/security/dependabot/72
- https://github.com/endatix/endatix/security/dependabot/71

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Security update

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
