### PR TITLE
chore: Bump qs to 6.14.2 override to fix CVE-2026-2391

### DIFF
--- a/docs/endatix-docs/package.json
+++ b/docs/endatix-docs/package.json
@@ -52,7 +52,7 @@
   "pnpm": {
     "overrides": {
       "node-forge": "^1.3.2",
-      "qs": "^6.14.1",
+      "qs": "^6.14.2",
       "fast-xml-parser": "^5.3.5",
       "minimatch": "^3.1.4",
       "serialize-javascript": "^7.0.4",
@@ -63,7 +63,7 @@
       "dompurify": "^3.3.3"
     },
     "comments": {
-      "overrides": "[node-forge] to version 1.3.2. Remove on next @docusaurus 4x bump | [qs] to 6.14.1 to fix GHSA-6rw7-vpxm-498p. Remove on next @docusaurus 4x bump | [fast-xml-parser] to 5.3.5 to fix CVE-2026-25128 & CVE-2026-25896. Remove on next redocusaurus bump | [minimatch] to 3.1.4 to fix multiple CVEs. Remove on next @docusaurus 4x bump | [serialize-javascript] to 7.0.4 to fix CVE-2020-7660. Remove on next @docusaurus 4x bump | [svgo] to 3.3.3 to fix CVE-2026-29074. Remove on next @docusaurus 4x bump | [lodash] to 4.17.23 to fix CVE-2025-13465. Remove on next @docusaurus 4x bump | [lodash-es] to 4.17.23 to fix CVE-2025-13465. Remove on next @docusaurus 4x bump | [ajv] to 8.18.0 to fix CVE-2025-69873. Remove on next @docusaurus 4x bump | [dompurify] to 3.3.3 to fix CVE-2026-0540. Remove on next redocusaurus bump "
+      "overrides": "[node-forge] to version 1.3.2. Remove on next @docusaurus 4x bump | [qs] to 6.14.1 to fix GHSA-6rw7-vpxm-498p & CVE-2026-2391. Remove on next @docusaurus 4x bump | [fast-xml-parser] to 5.3.5 to fix CVE-2026-25128 & CVE-2026-25896. Remove on next redocusaurus bump | [minimatch] to 3.1.4 to fix multiple CVEs. Remove on next @docusaurus 4x bump | [serialize-javascript] to 7.0.4 to fix CVE-2020-7660. Remove on next @docusaurus 4x bump | [svgo] to 3.3.3 to fix CVE-2026-29074. Remove on next @docusaurus 4x bump | [lodash] to 4.17.23 to fix CVE-2025-13465. Remove on next @docusaurus 4x bump | [lodash-es] to 4.17.23 to fix CVE-2025-13465. Remove on next @docusaurus 4x bump | [ajv] to 8.18.0 to fix CVE-2025-69873. Remove on next @docusaurus 4x bump | [dompurify] to 3.3.3 to fix CVE-2026-0540. Remove on next redocusaurus bump "
     }
   },
   "packageManager": "pnpm@10.25.0+sha256.0f3726654b0b5e52e5800904de168afc3c667e2abf84bdb06d9ac1386104bd90"

--- a/docs/endatix-docs/pnpm-lock.yaml
+++ b/docs/endatix-docs/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   node-forge: ^1.3.2
-  qs: ^6.14.1
+  qs: ^6.14.2
   fast-xml-parser: ^5.3.5
   minimatch: ^3.1.4
   serialize-javascript: ^7.0.4
@@ -4779,8 +4779,8 @@ packages:
     resolution: {integrity: sha512-LjgDO2zPtoXP2wJpDjZrGdojii1uqO0cnwKoIoUzkfS98HDmbeiGmYiXo3lXeFlq2xvne1QFQhwYXSUCLKtEuA==}
     engines: {node: '>=12.20'}
 
-  qs@6.14.1:
-    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -8785,7 +8785,7 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.1
+      qs: 6.15.0
       raw-body: 2.5.2
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -9843,7 +9843,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
-      qs: 6.14.1
+      qs: 6.15.0
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.0
@@ -12014,7 +12014,7 @@ snapshots:
     dependencies:
       escape-goat: 4.0.0
 
-  qs@6.14.1:
+  qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
 


### PR DESCRIPTION
# chore: Bump qs to 6.14.2 override to fix CVE-2026-2391

## Description
Bump `qs` to 6.14.2 override to fix CVE-2026-2391

## Related Issues
- fixes https://github.com/endatix/endatix/issues/638

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Security fix

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
