### PR TITLE
chore: bump fast-xml-parser to 5.5.7 to address CVE-2026-33349

### DIFF
--- a/docs/endatix-docs/package.json
+++ b/docs/endatix-docs/package.json
@@ -53,7 +53,7 @@
     "overrides": {
       "node-forge": "^1.3.2",
       "qs": "^6.14.2",
-      "fast-xml-parser": "^5.5.6",
+      "fast-xml-parser": "^5.5.7",
       "minimatch": "^3.1.4",
       "serialize-javascript": "^7.0.4",
       "svgo": "^3.3.3",
@@ -63,7 +63,7 @@
       "webpack": "^5.105.4"
     },
     "comments": {
-      "overrides": "[node-forge] to version 1.3.2. Remove on @docusaurus 4x bump | [qs] to 6.14.1 to fix GHSA-6rw7-vpxm-498p & CVE-2026-2391. Remove on @docusaurus 4x bump | [fast-xml-parser] to 5.5.6 to fix CVE-2026-2512, CVE-2026-25896, CVE-2026-27942 & CVE-2026-33036. Remove on next redocusaurus bump | [minimatch] to 3.1.4 to fix multiple CVEs. Remove on @docusaurus 4x bump | [serialize-javascript] to 7.0.4 to fix CVE-2020-7660. Remove on @docusaurus 4x bump | [svgo] to 3.3.3 to fix CVE-2026-29074. Remove on @docusaurus 4x bump | [lodash] to 4.17.23 to fix CVE-2025-13465. Remove on @docusaurus 4x bump | [lodash-es] to 4.17.23 to fix CVE-2025-13465. Remove on @docusaurus 4x bump | [dompurify] to 3.3.3 to fix CVE-2026-0540. Remove on next redocusaurus bump | [webpack] to 5.105.4 to fix CVE-2025-68458 & CVE-2025-68157. Remove on @docusaurus 4x bump"
+      "overrides": "[node-forge] to version 1.3.2. Remove on @docusaurus 4x bump | [qs] to 6.14.1 to fix GHSA-6rw7-vpxm-498p & CVE-2026-2391. Remove on @docusaurus 4x bump | [fast-xml-parser] to 5.5.7 to fix CVE-2026-2512, CVE-2026-25896, CVE-2026-27942, CVE-2026-33036 & CVE-2026-33349. Remove on next redocusaurus bump | [minimatch] to 3.1.4 to fix multiple CVEs. Remove on @docusaurus 4x bump | [serialize-javascript] to 7.0.4 to fix CVE-2020-7660. Remove on @docusaurus 4x bump | [svgo] to 3.3.3 to fix CVE-2026-29074. Remove on @docusaurus 4x bump | [lodash] to 4.17.23 to fix CVE-2025-13465. Remove on @docusaurus 4x bump | [lodash-es] to 4.17.23 to fix CVE-2025-13465. Remove on @docusaurus 4x bump | [dompurify] to 3.3.3 to fix CVE-2026-0540. Remove on next redocusaurus bump | [webpack] to 5.105.4 to fix CVE-2025-68458 & CVE-2025-68157. Remove on @docusaurus 4x bump"
     },
     "onlyBuiltDependencies": [
       "core-js",

--- a/docs/endatix-docs/pnpm-lock.yaml
+++ b/docs/endatix-docs/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   node-forge: ^1.3.2
   qs: ^6.14.2
-  fast-xml-parser: ^5.5.6
+  fast-xml-parser: ^5.5.7
   minimatch: ^3.1.4
   serialize-javascript: ^7.0.4
   svgo: ^3.3.3
@@ -3010,8 +3010,8 @@ packages:
   fast-xml-builder@1.1.4:
     resolution: {integrity: sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==}
 
-  fast-xml-parser@5.5.6:
-    resolution: {integrity: sha512-3+fdZyBRVg29n4rXP0joHthhcHdPUHaIC16cuyyd1iLsuaO6Vea36MPrxgAzbZna8lhvZeRL8Bc9GP56/J9xEw==}
+  fast-xml-parser@5.5.8:
+    resolution: {integrity: sha512-Z7Fh2nVQSb2d+poDViM063ix2ZGt9jmY1nWhPfHBOK2Hgnb/OW3P4Et3P/81SEej0J7QbWtJqxO05h8QYfK7LQ==}
     hasBin: true
 
   fastq@1.19.1:
@@ -4274,8 +4274,8 @@ packages:
     resolution: {integrity: sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
-  path-expression-matcher@1.1.3:
-    resolution: {integrity: sha512-qdVgY8KXmVdJZRSS1JdEPOKPdTiEK/pi0RkcT2sw1RhXxohdujUlJFPuS1TSkevZ9vzd3ZlL7ULl1MHGTApKzQ==}
+  path-expression-matcher@1.2.0:
+    resolution: {integrity: sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==}
     engines: {node: '>=14.0.0'}
 
   path-is-inside@1.0.2:
@@ -5314,8 +5314,8 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  strnum@2.1.2:
-    resolution: {integrity: sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==}
+  strnum@2.2.1:
+    resolution: {integrity: sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==}
 
   style-to-js@1.1.17:
     resolution: {integrity: sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==}
@@ -9861,13 +9861,13 @@ snapshots:
 
   fast-xml-builder@1.1.4:
     dependencies:
-      path-expression-matcher: 1.1.3
+      path-expression-matcher: 1.2.0
 
-  fast-xml-parser@5.5.6:
+  fast-xml-parser@5.5.8:
     dependencies:
       fast-xml-builder: 1.1.4
-      path-expression-matcher: 1.1.3
-      strnum: 2.1.2
+      path-expression-matcher: 1.2.0
+      strnum: 2.2.1
 
   fastq@1.19.1:
     dependencies:
@@ -11356,7 +11356,7 @@ snapshots:
   openapi-sampler@1.6.1:
     dependencies:
       '@types/json-schema': 7.0.15
-      fast-xml-parser: 5.5.6
+      fast-xml-parser: 5.5.8
       json-pointer: 0.6.2
 
   opener@1.5.2: {}
@@ -11451,7 +11451,7 @@ snapshots:
 
   path-exists@5.0.0: {}
 
-  path-expression-matcher@1.1.3: {}
+  path-expression-matcher@1.2.0: {}
 
   path-is-inside@1.0.2: {}
 
@@ -12679,7 +12679,7 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strnum@2.1.2: {}
+  strnum@2.2.1: {}
 
   style-to-js@1.1.17:
     dependencies:


### PR DESCRIPTION
# chore: bump fast-xml-parser to 5.5.7 to address CVE-2026-33349

## Description
- bump `fast-xml-parser` to 5.5.7 to address CVE-2026-33349

## Related Issues
- closes https://github.com/endatix/endatix/issues/650
- addresses https://github.com/endatix/endatix/security/dependabot/75

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Security Fix

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
