### PR TITLE
fix: Remove default connection string from appsettings.json

### DIFF
--- a/src/Endatix.WebHost/appsettings.Development.json
+++ b/src/Endatix.WebHost/appsettings.Development.json
@@ -1,6 +1,7 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;Integrated Security=true;TrustServerCertificate=true;Initial Catalog=Endatix.App;"
+    "DefaultConnection": "Host=localhost;Port=5432;Database=endatix_db;Username=postgres;Password=CHANGE_ME",
+    "DefaultConnection_DbProvider": "postgresql"
   },
   "Serilog": {
     "Using": ["Serilog.Sinks.Console", "Serilog.Sinks.File"],

--- a/src/Endatix.WebHost/appsettings.json
+++ b/src/Endatix.WebHost/appsettings.json
@@ -1,6 +1,5 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Server=localhost;Integrated Security=true;TrustServerCertificate=true;Initial Catalog=Endatix.App;"
   },
   "Serilog": {
     "Using": ["Serilog.Sinks.Console", "Serilog.Sinks.File"],


### PR DESCRIPTION
# fix: Remove default connection string from appsettings.json

## Description
- Remove default connection string from appsettings.json
- Add default connection string for development environment with placeholder and PostgreSQL provider as default.

_Should provide better setup devX until Endatix CLI is introduced for easier setup_

## Related Issues
- closes https://github.com/endatix/endatix/issues/654

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
