### PR TITLE
chore: bump lodash to 4.18.0

### DIFF
--- a/docs/endatix-docs/package.json
+++ b/docs/endatix-docs/package.json
@@ -57,13 +57,13 @@
       "minimatch": "^3.1.4",
       "serialize-javascript": "^7.0.4",
       "svgo": "^3.3.3",
-      "lodash": "^4.17.23",
+      "lodash": "^4.18.0",
       "lodash-es": "^4.18.0",
       "dompurify": "^3.3.3",
       "webpack": "^5.105.4"
     },
     "comments": {
-      "overrides": "[node-forge] to version 1.3.2. Remove on @docusaurus 4x bump | [qs] to 6.14.1 to fix GHSA-6rw7-vpxm-498p & CVE-2026-2391. Remove on @docusaurus 4x bump | [fast-xml-parser] to 5.5.7 to fix CVE-2026-2512, CVE-2026-25896, CVE-2026-27942, CVE-2026-33036 & CVE-2026-33349. Remove on next redocusaurus bump | [minimatch] to 3.1.4 to fix multiple CVEs. Remove on @docusaurus 4x bump | [serialize-javascript] to 7.0.4 to fix CVE-2020-7660. Remove on @docusaurus 4x bump | [svgo] to 3.3.3 to fix CVE-2026-29074. Remove on @docusaurus 4x bump | [lodash] to 4.17.23 to fix CVE-2025-13465. Remove on @docusaurus 4x bump | [lodash-es] to 4.18.0 to fix CVE-2025-13465, CVE-2026-4800 & CVE-2026-2950. Remove on @docusaurus 4x bump | [dompurify] to 3.3.3 to fix CVE-2026-0540. Remove on next redocusaurus bump | [webpack] to 5.105.4 to fix CVE-2025-68458 & CVE-2025-68157. Remove on @docusaurus 4x bump"
+      "overrides": "[node-forge] to version 1.3.2. Remove on @docusaurus 4x bump | [qs] to 6.14.1 to fix GHSA-6rw7-vpxm-498p & CVE-2026-2391. Remove on @docusaurus 4x bump | [fast-xml-parser] to 5.5.7 to fix CVE-2026-2512, CVE-2026-25896, CVE-2026-27942, CVE-2026-33036 & CVE-2026-33349. Remove on next redocusaurus bump | [minimatch] to 3.1.4 to fix multiple CVEs. Remove on @docusaurus 4x bump | [serialize-javascript] to 7.0.4 to fix CVE-2020-7660. Remove on @docusaurus 4x bump | [svgo] to 3.3.3 to fix CVE-2026-29074. Remove on @docusaurus 4x bump | [lodash] to 4.18.0 to fix CVE-2025-13465, CVE-2026-2950 & CVE-2026-4800. Remove on @docusaurus 4x bump | [lodash-es] to 4.18.0 to fix CVE-2025-13465, CVE-2026-4800 & CVE-2026-2950. Remove on @docusaurus 4x bump | [dompurify] to 3.3.3 to fix CVE-2026-0540. Remove on next redocusaurus bump | [webpack] to 5.105.4 to fix CVE-2025-68458 & CVE-2025-68157. Remove on @docusaurus 4x bump"
     },
     "onlyBuiltDependencies": [
       "core-js",

--- a/docs/endatix-docs/pnpm-lock.yaml
+++ b/docs/endatix-docs/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   minimatch: ^3.1.4
   serialize-javascript: ^7.0.4
   svgo: ^3.3.3
-  lodash: ^4.17.23
+  lodash: ^4.18.0
   lodash-es: ^4.18.0
   dompurify: ^3.3.3
   webpack: ^5.105.4
@@ -3688,8 +3688,8 @@ packages:
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -7166,7 +7166,7 @@ snapshots:
       html-tags: 3.3.1
       html-webpack-plugin: 5.6.4(webpack@5.105.4)
       leven: 3.1.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       open: 8.4.2
       p-map: 4.0.0
       prompts: 2.4.2
@@ -7283,7 +7283,7 @@ snapshots:
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.3.2
-      lodash: 4.17.23
+      lodash: 4.18.1
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       schema-dts: 1.1.5
@@ -7325,7 +7325,7 @@ snapshots:
       combine-promises: 1.2.0
       fs-extra: 11.3.2
       js-yaml: 4.1.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       schema-dts: 1.1.5
@@ -7638,7 +7638,7 @@ snapshots:
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.1.1)
       clsx: 2.1.1
       infima: 0.2.0-alpha.45
-      lodash: 4.17.23
+      lodash: 4.18.1
       nprogress: 0.2.0
       postcss: 8.5.6
       prism-react-renderer: 2.4.1(react@19.1.1)
@@ -7736,7 +7736,7 @@ snapshots:
       clsx: 2.1.1
       eta: 2.2.0
       fs-extra: 11.3.2
-      lodash: 4.17.23
+      lodash: 4.18.1
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       tslib: 2.8.1
@@ -7811,7 +7811,7 @@ snapshots:
       fs-extra: 11.3.2
       joi: 17.13.3
       js-yaml: 4.1.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc/core'
@@ -7836,7 +7836,7 @@ snapshots:
       gray-matter: 4.0.3
       jiti: 1.21.7
       js-yaml: 4.1.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       micromatch: 4.0.8
       p-queue: 6.6.2
       prompts: 2.4.2
@@ -9567,7 +9567,7 @@ snapshots:
       '@docusaurus/theme-common': 3.9.2(@docusaurus/plugin-content-docs@3.9.2(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.8.3))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@redocly/openapi-core': 1.16.0
       clsx: 1.2.1
-      lodash: 4.17.23
+      lodash: 4.18.1
       mobx: 6.13.7
       postcss: 8.5.6
       postcss-prefix-selector: 1.16.1(postcss@8.5.6)
@@ -10208,7 +10208,7 @@ snapshots:
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       pretty-error: 4.0.0
       tapable: 2.2.3
     optionalDependencies:
@@ -10570,7 +10570,7 @@ snapshots:
 
   lodash.uniq@4.5.0: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   longest-streak@3.1.0: {}
 
@@ -11955,7 +11955,7 @@ snapshots:
 
   pretty-error@4.0.0:
     dependencies:
-      lodash: 4.17.23
+      lodash: 4.18.1
       renderkid: 3.0.0
 
   pretty-time@1.1.0: {}
@@ -12301,7 +12301,7 @@ snapshots:
       css-select: 4.3.0
       dom-converter: 0.2.0
       htmlparser2: 6.1.0
-      lodash: 4.17.23
+      lodash: 4.18.1
       strip-ansi: 6.0.1
 
   repeat-string@1.6.1: {}


### PR DESCRIPTION
# chore: bump lodash to 4.18.0

## Description
chore: bump lodash to 4.18.0 to fix CVE-2026-2950 & CVE-2026-4800

## Related Issues
- closes https://github.com/endatix/endatix/issues/663
- fixes https://github.com/endatix/endatix/security/dependabot/88
- fixes https://github.com/endatix/endatix/security/dependabot/89

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Security fix

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
