### PR TITLE
chore: bump node-forge to 1.4.0

### DIFF
--- a/docs/endatix-docs/package.json
+++ b/docs/endatix-docs/package.json
@@ -51,7 +51,7 @@
   },
   "pnpm": {
     "overrides": {
-      "node-forge": "^1.3.2",
+      "node-forge": "^1.4.0",
       "qs": "^6.14.2",
       "fast-xml-parser": "^5.5.7",
       "minimatch": "^3.1.4",
@@ -64,7 +64,7 @@
       "picomatch": "^2.3.2"
     },
     "comments": {
-      "overrides": "[node-forge] to version 1.3.2. Remove on @docusaurus 4x bump | [qs] to 6.14.1 to fix GHSA-6rw7-vpxm-498p & CVE-2026-2391. Remove on @docusaurus 4x bump | [fast-xml-parser] to 5.5.7 to fix CVE-2026-2512, CVE-2026-25896, CVE-2026-27942, CVE-2026-33036 & CVE-2026-33349. Remove on next redocusaurus bump | [minimatch] to 3.1.4 to fix multiple CVEs. Remove on @docusaurus 4x bump | [serialize-javascript] to 7.0.4 to fix CVE-2020-7660. Remove on @docusaurus 4x bump | [svgo] to 3.3.3 to fix CVE-2026-29074. Remove on @docusaurus 4x bump | [lodash] to 4.18.0 to fix CVE-2025-13465, CVE-2026-2950 & CVE-2026-4800. Remove on @docusaurus 4x bump | [lodash-es] to 4.18.0 to fix CVE-2025-13465, CVE-2026-4800 & CVE-2026-2950. Remove on @docusaurus 4x bump | [dompurify] to 3.3.3 to fix CVE-2026-0540. Remove on next redocusaurus bump | [webpack] to 5.105.4 to fix CVE-2025-68458 & CVE-2025-68157. Remove on @docusaurus 4x bump | [picomatch] to 2.3.2 to fix CVE-2026-33672 & CVE-2026-33671. Remove on @docusaurus 4x bump"
+      "overrides": "[node-forge] to version 1.4.0 to fix CVE-2026-33895, CVE-2026-33894, CVE-2026-33896 & CVE-2026-33891. Remove on @docusaurus 4x bump | [qs] to 6.14.1 to fix GHSA-6rw7-vpxm-498p & CVE-2026-2391. Remove on @docusaurus 4x bump | [fast-xml-parser] to 5.5.7 to fix CVE-2026-2512, CVE-2026-25896, CVE-2026-27942, CVE-2026-33036 & CVE-2026-33349. Remove on next redocusaurus bump | [minimatch] to 3.1.4 to fix multiple CVEs. Remove on @docusaurus 4x bump | [serialize-javascript] to 7.0.4 to fix CVE-2020-7660. Remove on @docusaurus 4x bump | [svgo] to 3.3.3 to fix CVE-2026-29074. Remove on @docusaurus 4x bump | [lodash] to 4.18.0 to fix CVE-2025-13465, CVE-2026-2950 & CVE-2026-4800. Remove on @docusaurus 4x bump | [lodash-es] to 4.18.0 to fix CVE-2025-13465, CVE-2026-4800 & CVE-2026-2950. Remove on @docusaurus 4x bump | [dompurify] to 3.3.3 to fix CVE-2026-0540. Remove on next redocusaurus bump | [webpack] to 5.105.4 to fix CVE-2025-68458 & CVE-2025-68157. Remove on @docusaurus 4x bump | [picomatch] to 2.3.2 to fix CVE-2026-33672 & CVE-2026-33671. Remove on @docusaurus 4x bump"
     },
     "onlyBuiltDependencies": [
       "core-js",

--- a/docs/endatix-docs/pnpm-lock.yaml
+++ b/docs/endatix-docs/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  node-forge: ^1.3.2
+  node-forge: ^1.4.0
   qs: ^6.14.2
   fast-xml-parser: ^5.5.7
   minimatch: ^3.1.4
@@ -4093,8 +4093,8 @@ packages:
       encoding:
         optional: true
 
-  node-forge@1.3.2:
-    resolution: {integrity: sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==}
+  node-forge@1.4.0:
+    resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
     engines: {node: '>= 6.13.0'}
 
   node-readfiles@0.2.0:
@@ -11251,7 +11251,7 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
-  node-forge@1.3.2: {}
+  node-forge@1.4.0: {}
 
   node-readfiles@0.2.0:
     dependencies:
@@ -12405,7 +12405,7 @@ snapshots:
   selfsigned@2.4.1:
     dependencies:
       '@types/node-forge': 1.3.14
-      node-forge: 1.3.2
+      node-forge: 1.4.0
 
   semver-diff@4.0.0:
     dependencies:


### PR DESCRIPTION
# chore: bump node-forge to 1.4.0

## Description
- bump node-forge to 1.4.0 to fix CVE-2026-33895, CVE-2026-33894, CVE-2026-33896 & CVE-2026-33891

## Related Issues
- closes https://github.com/endatix/endatix/issues/668
- addresses https://github.com/endatix/endatix/security/dependabot/77
- addresses https://github.com/endatix/endatix/security/dependabot/78
- addresses https://github.com/endatix/endatix/security/dependabot/79
- addresses https://github.com/endatix/endatix/security/dependabot/80

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Security fix

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
