### PR TITLE
chore: bump path-to-regexp to 0.1.13

### DIFF
--- a/docs/endatix-docs/package.json
+++ b/docs/endatix-docs/package.json
@@ -61,10 +61,11 @@
       "lodash-es": "^4.18.0",
       "dompurify": "^3.3.3",
       "webpack": "^5.105.4",
-      "picomatch": "^2.3.2"
+      "picomatch": "^2.3.2",
+      "path-to-regexp": "^0.1.13"
     },
     "comments": {
-      "overrides": "[node-forge] to version 1.4.0 to fix CVE-2026-33895, CVE-2026-33894, CVE-2026-33896 & CVE-2026-33891. Remove on @docusaurus 4x bump | [qs] to 6.14.1 to fix GHSA-6rw7-vpxm-498p & CVE-2026-2391. Remove on @docusaurus 4x bump | [fast-xml-parser] to 5.5.7 to fix CVE-2026-2512, CVE-2026-25896, CVE-2026-27942, CVE-2026-33036 & CVE-2026-33349. Remove on next redocusaurus bump | [minimatch] to 3.1.4 to fix multiple CVEs. Remove on @docusaurus 4x bump | [serialize-javascript] to 7.0.4 to fix CVE-2020-7660. Remove on @docusaurus 4x bump | [svgo] to 3.3.3 to fix CVE-2026-29074. Remove on @docusaurus 4x bump | [lodash] to 4.18.0 to fix CVE-2025-13465, CVE-2026-2950 & CVE-2026-4800. Remove on @docusaurus 4x bump | [lodash-es] to 4.18.0 to fix CVE-2025-13465, CVE-2026-4800 & CVE-2026-2950. Remove on @docusaurus 4x bump | [dompurify] to 3.3.3 to fix CVE-2026-0540. Remove on next redocusaurus bump | [webpack] to 5.105.4 to fix CVE-2025-68458 & CVE-2025-68157. Remove on @docusaurus 4x bump | [picomatch] to 2.3.2 to fix CVE-2026-33672 & CVE-2026-33671. Remove on @docusaurus 4x bump"
+      "overrides": "[node-forge] to version 1.4.0 to fix CVE-2026-33895, CVE-2026-33894, CVE-2026-33896 & CVE-2026-33891. Remove on @docusaurus 4x bump | [qs] to 6.14.1 to fix GHSA-6rw7-vpxm-498p & CVE-2026-2391. Remove on @docusaurus 4x bump | [fast-xml-parser] to 5.5.7 to fix CVE-2026-2512, CVE-2026-25896, CVE-2026-27942, CVE-2026-33036 & CVE-2026-33349. Remove on next redocusaurus bump | [minimatch] to 3.1.4 to fix multiple CVEs. Remove on @docusaurus 4x bump | [serialize-javascript] to 7.0.4 to fix CVE-2020-7660. Remove on @docusaurus 4x bump | [svgo] to 3.3.3 to fix CVE-2026-29074. Remove on @docusaurus 4x bump | [lodash] to 4.18.0 to fix CVE-2025-13465, CVE-2026-2950 & CVE-2026-4800. Remove on @docusaurus 4x bump | [lodash-es] to 4.18.0 to fix CVE-2025-13465, CVE-2026-4800 & CVE-2026-2950. Remove on @docusaurus 4x bump | [dompurify] to 3.3.3 to fix CVE-2026-0540. Remove on next redocusaurus bump | [webpack] to 5.105.4 to fix CVE-2025-68458 & CVE-2025-68157. Remove on @docusaurus 4x bump | [picomatch] to 2.3.2 to fix CVE-2026-33672 & CVE-2026-33671. Remove on @docusaurus 4x bump | [path-to-regexp] to 0.1.13 to fix CVE-2026-4867. Remove on @docusaurus 4x bump"
     },
     "onlyBuiltDependencies": [
       "core-js",

--- a/docs/endatix-docs/pnpm-lock.yaml
+++ b/docs/endatix-docs/pnpm-lock.yaml
@@ -16,6 +16,7 @@ overrides:
   dompurify: ^3.3.3
   webpack: ^5.105.4
   picomatch: ^2.3.2
+  path-to-regexp: ^0.1.13
 
 importers:
 
@@ -3530,9 +3531,6 @@ packages:
     resolution: {integrity: sha512-/kppl+R+LO5VmhYSEWARUFjodS25D68gvj8W7z0I7OWhUla5xWu8KL6CtB2V0R6yqhnRgbcaREMr4EEM6htLPQ==}
     engines: {node: '>=12'}
 
-  isarray@0.0.1:
-    resolution: {integrity: sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==}
-
   isarray@1.0.0:
     resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
 
@@ -4289,14 +4287,8 @@ packages:
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
-  path-to-regexp@0.1.12:
-    resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
-
-  path-to-regexp@1.9.0:
-    resolution: {integrity: sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==}
-
-  path-to-regexp@3.3.0:
-    resolution: {integrity: sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==}
+  path-to-regexp@0.1.13:
+    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -9821,7 +9813,7 @@ snapshots:
       methods: 1.1.2
       on-finished: 2.4.1
       parseurl: 1.3.3
-      path-to-regexp: 0.1.12
+      path-to-regexp: 0.1.13
       proxy-addr: 2.0.7
       qs: 6.15.0
       range-parser: 1.2.1
@@ -10422,8 +10414,6 @@ snapshots:
       is-inside-container: 1.0.0
 
   is-yarn-global@0.4.1: {}
-
-  isarray@0.0.1: {}
 
   isarray@1.0.0: {}
 
@@ -11460,13 +11450,7 @@ snapshots:
 
   path-parse@1.0.7: {}
 
-  path-to-regexp@0.1.12: {}
-
-  path-to-regexp@1.9.0:
-    dependencies:
-      isarray: 0.0.1
-
-  path-to-regexp@3.3.0: {}
+  path-to-regexp@0.1.13: {}
 
   path-type@4.0.0: {}
 
@@ -12069,7 +12053,7 @@ snapshots:
       history: 4.10.1
       hoist-non-react-statics: 3.3.2
       loose-envify: 1.4.0
-      path-to-regexp: 1.9.0
+      path-to-regexp: 0.1.13
       prop-types: 15.8.1
       react: 19.1.1
       react-is: 16.13.1
@@ -12442,7 +12426,7 @@ snapshots:
       mime-types: 2.1.18
       minimatch: 3.1.5
       path-is-inside: 1.0.2
-      path-to-regexp: 3.3.0
+      path-to-regexp: 0.1.13
       range-parser: 1.2.0
 
   serve-index@1.9.1:


### PR DESCRIPTION
# bump path-to-regexp to 0.1.13

## Description
bump path-to-regexp to 0.1.13 to fix CVE-2026-4867

## Related Issues
- closes https://github.com/endatix/endatix/issues/670

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Security fix

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
