### PR TITLE
fix: "get form by id" endpoint doesn't return submissions count

### DIFF
--- a/src/Endatix.Api/Endpoints/Forms/FormMapper.cs
+++ b/src/Endatix.Api/Endpoints/Forms/FormMapper.cs
@@ -74,10 +74,10 @@ public static class FormMapperExtensions
 
     public static IEnumerable<FormModel> ToFormModelList(this IEnumerable<FormDto> forms)
     {
-        return forms.Select(formDto => formDto.ToFormModel());
+        return forms.Select(formDto => formDto.ToFormModel(includeWebHookSettings: false));
     }
 
-    public static FormModel ToFormModel(this FormDto formDto) => new FormModel()
+    public static FormModel ToFormModel(this FormDto formDto, bool includeWebHookSettings = true) => new FormModel()
     {
         Id = formDto.Id,
         Name = formDto.Name,
@@ -90,6 +90,8 @@ public static class FormMapperExtensions
         ModifiedAt = formDto.ModifiedAt,
         SubmissionsCount = formDto.SubmissionsCount,
         WebHookSettingsJson = formDto.WebHookSettingsJson,
-        WebHookSettings = FormMapper.ParseJsonString(formDto.WebHookSettingsJson)
+        WebHookSettings = includeWebHookSettings
+            ? FormMapper.ParseJsonString(formDto.WebHookSettingsJson)
+            : null
     };
 }

--- a/src/Endatix.Api/Endpoints/Forms/GetById.cs
+++ b/src/Endatix.Api/Endpoints/Forms/GetById.cs
@@ -37,7 +37,7 @@ public class GetById(IMediator mediator) : Endpoint<GetFormByIdRequest, Results<
             cancellationToken);
 
         return TypedResultsBuilder
-            .MapResult(result, form => form.ToFormModel())
+            .MapResult(result, form => form.ToFormModel(includeWebHookSettings: true))
             .SetTypedResults<Ok<FormModel>, BadRequest, NotFound>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Forms/GetById.cs
+++ b/src/Endatix.Api/Endpoints/Forms/GetById.cs
@@ -37,7 +37,7 @@ public class GetById(IMediator mediator) : Endpoint<GetFormByIdRequest, Results<
             cancellationToken);
 
         return TypedResultsBuilder
-            .MapResult(result, FormMapper.Map<FormModel>)
+            .MapResult(result, form => form.ToFormModel())
             .SetTypedResults<Ok<FormModel>, BadRequest, NotFound>();
     }
 }

--- a/src/Endatix.Core/Specifications/FormByIdWithSubmissionsCountSpec.cs
+++ b/src/Endatix.Core/Specifications/FormByIdWithSubmissionsCountSpec.cs
@@ -1,0 +1,31 @@
+using Ardalis.Specification;
+using Endatix.Core.Entities;
+using Endatix.Core.UseCases.Forms;
+
+namespace Endatix.Core.Specifications;
+
+public sealed class FormByIdWithSubmissionsCountSpec : Specification<Form, FormDto>
+{
+    public FormByIdWithSubmissionsCountSpec(long formId)
+    {
+        Query
+            .Where(form => form.Id == formId)
+            .AsNoTracking();
+
+        Query.Select(form =>
+            new FormDto()
+            {
+                Id = form.Id.ToString(),
+                Name = form.Name,
+                Description = form.Description,
+                IsEnabled = form.IsEnabled,
+                IsPublic = form.IsPublic,
+                ThemeId = form.ThemeId.HasValue ? form.ThemeId.Value.ToString() : null,
+                ActiveDefinitionId = form.ActiveDefinitionId.HasValue ? form.ActiveDefinitionId.Value.ToString() : null,
+                CreatedAt = form.CreatedAt,
+                ModifiedAt = form.ModifiedAt,
+                SubmissionsCount = form.FormDefinitions.SelectMany(fd => fd.Submissions).Count(),
+                WebHookSettingsJson = form.WebHookSettingsJson
+            });
+    }
+}

--- a/src/Endatix.Core/Specifications/FormByIdWithSubmissionsCountSpec.cs
+++ b/src/Endatix.Core/Specifications/FormByIdWithSubmissionsCountSpec.cs
@@ -4,7 +4,7 @@ using Endatix.Core.UseCases.Forms;
 
 namespace Endatix.Core.Specifications;
 
-public sealed class FormByIdWithSubmissionsCountSpec : Specification<Form, FormDto>
+public sealed class FormByIdWithSubmissionsCountSpec : SingleResultSpecification<Form, FormDto>
 {
     public FormByIdWithSubmissionsCountSpec(long formId)
     {

--- a/src/Endatix.Core/Specifications/FormByIdWithSubmissionsCountSpec.cs
+++ b/src/Endatix.Core/Specifications/FormByIdWithSubmissionsCountSpec.cs
@@ -23,7 +23,7 @@ public sealed class FormByIdWithSubmissionsCountSpec : Specification<Form, FormD
                 ActiveDefinitionId = form.ActiveDefinitionId.HasValue ? form.ActiveDefinitionId.Value.ToString() : null,
                 CreatedAt = form.CreatedAt,
                 ModifiedAt = form.ModifiedAt,
-                SubmissionsCount = form.FormDefinitions.SelectMany(fd => fd.Submissions).Count(),
+                SubmissionsCount = form.FormDefinitions.SelectMany(fd => fd.Submissions).Count(s => !s.IsDeleted),
                 WebHookSettingsJson = form.WebHookSettingsJson
             });
     }

--- a/src/Endatix.Core/Specifications/FormByIdWithSubmissionsCountSpec.cs
+++ b/src/Endatix.Core/Specifications/FormByIdWithSubmissionsCountSpec.cs
@@ -9,8 +9,7 @@ public sealed class FormByIdWithSubmissionsCountSpec : Specification<Form, FormD
     public FormByIdWithSubmissionsCountSpec(long formId)
     {
         Query
-            .Where(form => form.Id == formId)
-            .AsNoTracking();
+            .Where(form => form.Id == formId);
 
         Query.Select(form =>
             new FormDto()

--- a/src/Endatix.Core/Specifications/FormByIdWithSubmissionsCountSpec.cs
+++ b/src/Endatix.Core/Specifications/FormByIdWithSubmissionsCountSpec.cs
@@ -11,20 +11,6 @@ public sealed class FormByIdWithSubmissionsCountSpec : Specification<Form, FormD
         Query
             .Where(form => form.Id == formId);
 
-        Query.Select(form =>
-            new FormDto()
-            {
-                Id = form.Id.ToString(),
-                Name = form.Name,
-                Description = form.Description,
-                IsEnabled = form.IsEnabled,
-                IsPublic = form.IsPublic,
-                ThemeId = form.ThemeId.HasValue ? form.ThemeId.Value.ToString() : null,
-                ActiveDefinitionId = form.ActiveDefinitionId.HasValue ? form.ActiveDefinitionId.Value.ToString() : null,
-                CreatedAt = form.CreatedAt,
-                ModifiedAt = form.ModifiedAt,
-                SubmissionsCount = form.FormDefinitions.SelectMany(fd => fd.Submissions).Count(s => !s.IsDeleted),
-                WebHookSettingsJson = form.WebHookSettingsJson
-            });
+        Query.Select(FormProjections.ToFormDtoWithSubmissionsCount);
     }
 }

--- a/src/Endatix.Core/Specifications/FormSpecifications.FormProjections.cs
+++ b/src/Endatix.Core/Specifications/FormSpecifications.FormProjections.cs
@@ -1,5 +1,7 @@
+using System.Linq.Expressions;
 using Ardalis.Specification;
 using Endatix.Core.Entities;
+using Endatix.Core.UseCases.Forms;
 
 namespace Endatix.Core.Specifications;
 
@@ -8,6 +10,25 @@ namespace Endatix.Core.Specifications;
 /// </summary>
 public static class FormProjections
 {
+    /// <summary>
+    /// Maps a form to <see cref="FormDto"/> with submission statistics.
+    /// Keep this as an expression so EF can translate it to SQL in specifications.
+    /// </summary>
+    public static readonly Expression<Func<Form, FormDto>> ToFormDtoWithSubmissionsCount = form => new FormDto
+    {
+        Id = form.Id.ToString(),
+        Name = form.Name,
+        Description = form.Description,
+        IsEnabled = form.IsEnabled,
+        IsPublic = form.IsPublic,
+        ThemeId = form.ThemeId.HasValue ? form.ThemeId.Value.ToString() : null,
+        ActiveDefinitionId = form.ActiveDefinitionId.HasValue ? form.ActiveDefinitionId.Value.ToString() : null,
+        CreatedAt = form.CreatedAt,
+        ModifiedAt = form.ModifiedAt,
+        SubmissionsCount = form.FormDefinitions.SelectMany(fd => fd.Submissions).Count(s => !s.IsDeleted),
+        WebHookSettingsJson = form.WebHookSettingsJson
+    };
+
     /// <summary>
     /// Permission focused projection to get the IsPublic property of a form with its id
     /// </summary>

--- a/src/Endatix.Core/Specifications/FormSpecifications.FormProjections.cs
+++ b/src/Endatix.Core/Specifications/FormSpecifications.FormProjections.cs
@@ -25,7 +25,7 @@ public static class FormProjections
         ActiveDefinitionId = form.ActiveDefinitionId.HasValue ? form.ActiveDefinitionId.Value.ToString() : null,
         CreatedAt = form.CreatedAt,
         ModifiedAt = form.ModifiedAt,
-        SubmissionsCount = form.FormDefinitions.SelectMany(fd => fd.Submissions).Count(s => !s.IsDeleted),
+        SubmissionsCount = form.FormDefinitions.SelectMany(fd => fd.Submissions).Count(),
         WebHookSettingsJson = form.WebHookSettingsJson
     };
 

--- a/src/Endatix.Core/Specifications/FormsWithSubmissionsCountSpec.cs
+++ b/src/Endatix.Core/Specifications/FormsWithSubmissionsCountSpec.cs
@@ -16,19 +16,7 @@ public sealed class FormsWithSubmissionsCountSpec : Specification<Form, FormDto>
             .Paginate(pagingParams)
             .AsNoTracking();
 
-        Query.Select(form =>
-            new FormDto()
-            {
-                Id = form.Id.ToString(),
-                Name = form.Name,
-                Description = form.Description,
-                IsEnabled = form.IsEnabled,
-                IsPublic = form.IsPublic,
-                ActiveDefinitionId = form.ActiveDefinitionId.HasValue ? form.ActiveDefinitionId.Value.ToString() : null,
-                CreatedAt = form.CreatedAt,
-                ModifiedAt = form.ModifiedAt,
-                SubmissionsCount = form.FormDefinitions.SelectMany(fd => fd.Submissions).Count()
-            });
+        Query.Select(FormProjections.ToFormDtoWithSubmissionsCount);
     }
 }
 

--- a/src/Endatix.Core/UseCases/Forms/GetById/GetFormByIdHandler.cs
+++ b/src/Endatix.Core/UseCases/Forms/GetById/GetFormByIdHandler.cs
@@ -11,7 +11,7 @@ public class GetFormByIdHandler(IFormsRepository repository) : IQueryHandler<Get
     public async Task<Result<FormDto>> Handle(GetFormByIdQuery request, CancellationToken cancellationToken)
     {
         var spec = new FormByIdWithSubmissionsCountSpec(request.FormId);
-        var form = (await repository.ListAsync(spec, cancellationToken)).FirstOrDefault();
+        var form = await repository.FirstOrDefaultAsync(spec, cancellationToken);
         if (form == null)
         {
             return Result.NotFound("Form not found.");

--- a/src/Endatix.Core/UseCases/Forms/GetById/GetFormByIdHandler.cs
+++ b/src/Endatix.Core/UseCases/Forms/GetById/GetFormByIdHandler.cs
@@ -1,15 +1,17 @@
-﻿using Endatix.Core.Entities;
+﻿using Endatix.Core.Abstractions.Repositories;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
 
 namespace Endatix.Core.UseCases.Forms.GetById;
 
-public class GetFormByIdHandler(IRepository<Form> repository) : IQueryHandler<GetFormByIdQuery, Result<Form>>
+public class GetFormByIdHandler(IFormsRepository repository) : IQueryHandler<GetFormByIdQuery, Result<FormDto>>
 {
-    public async Task<Result<Form>> Handle(GetFormByIdQuery request, CancellationToken cancellationToken)
+    public async Task<Result<FormDto>> Handle(GetFormByIdQuery request, CancellationToken cancellationToken)
     {
-        var form = await repository.GetByIdAsync(request.FormId, cancellationToken);
+        var spec = new FormByIdWithSubmissionsCountSpec(request.FormId);
+        var form = (await repository.ListAsync(spec, cancellationToken)).FirstOrDefault();
         if (form == null)
         {
             return Result.NotFound("Form not found.");

--- a/src/Endatix.Core/UseCases/Forms/GetById/GetFormByIdQuery.cs
+++ b/src/Endatix.Core/UseCases/Forms/GetById/GetFormByIdQuery.cs
@@ -1,14 +1,14 @@
 ﻿using Ardalis.GuardClauses;
-using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.Forms;
 
 namespace Endatix.Core.UseCases.Forms.GetById;
 
 /// <summary>
 /// Query for getting a form by ID.
 /// </summary>
-public record GetFormByIdQuery : IQuery<Result<Form>>
+public record GetFormByIdQuery : IQuery<Result<FormDto>>
 {
     public long FormId { get; init; }
 

--- a/tests/Endatix.Api.Tests/Endpoints/Forms/GetByIdTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Forms/GetByIdTests.cs
@@ -2,9 +2,9 @@ using FastEndpoints;
 using MediatR;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
-using Endatix.Core.Entities;
 using Endatix.Api.Endpoints.Forms;
 using Endatix.Core.UseCases.Forms.GetById;
+using Endatix.Core.UseCases.Forms;
 
 namespace Endatix.Api.Tests.Endpoints.Forms;
 
@@ -63,7 +63,7 @@ public class GetByIdTests
         // Arrange
         var formId = 1L;
         var request = new GetFormByIdRequest { FormId = formId };
-        var form = new Form(SampleData.TENANT_ID, "Test Form") { Id = formId };
+        var form = new FormDto { Id = formId.ToString(), Name = "Test Form", SubmissionsCount = 5 };
         var result = Result.Success(form);
 
         _mediator.Send(Arg.Any<GetFormByIdQuery>(), Arg.Any<CancellationToken>())
@@ -76,8 +76,31 @@ public class GetByIdTests
         var okResult = response.Result as Ok<FormModel>;
         okResult.Should().NotBeNull();
         okResult!.Value.Should().NotBeNull();
-        okResult!.Value!.Id.Should().Be(formId.ToString());
+        okResult!.Value!.Id.Should().Be(form.Id);
         okResult!.Value!.Name.Should().Be(form.Name);
+        okResult!.Value!.SubmissionsCount.Should().Be(5);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ValidRequestWithNoSubmissions_ReturnsZeroSubmissionsCount()
+    {
+        // Arrange
+        var formId = 1L;
+        var request = new GetFormByIdRequest { FormId = formId };
+        var form = new FormDto { Id = formId.ToString(), Name = "Test Form", SubmissionsCount = 0 };
+        var result = Result.Success(form);
+
+        _mediator.Send(Arg.Any<GetFormByIdQuery>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, default);
+
+        // Assert
+        var okResult = response.Result as Ok<FormModel>;
+        okResult.Should().NotBeNull();
+        okResult!.Value.Should().NotBeNull();
+        okResult!.Value!.SubmissionsCount.Should().Be(0);
     }
 
     [Fact]
@@ -85,7 +108,7 @@ public class GetByIdTests
     {
         // Arrange
         var request = new GetFormByIdRequest { FormId = 123 };
-        var result = Result.Success(new Form(SampleData.TENANT_ID, "Test Form"));
+        var result = Result.Success(new FormDto { Id = "123", Name = "Test Form", SubmissionsCount = 0 });
         
         _mediator.Send(Arg.Any<GetFormByIdQuery>(), Arg.Any<CancellationToken>())
             .Returns(result);

--- a/tests/Endatix.Api.Tests/Endpoints/Forms/ListTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Forms/ListTests.cs
@@ -44,8 +44,8 @@ public class ListTests
         var request = new FormsListRequest { Page = 1, PageSize = 10 };
         var forms = new List<FormDto> 
         { 
-            new() { Id = "1", Name = "Form 1" },
-            new() { Id = "2", Name = "Form 2" }
+            new() { Id = "1", Name = "Form 1", SubmissionsCount = 4 },
+            new() { Id = "2", Name = "Form 2", SubmissionsCount = 0 }
         };
         var result = Result.Success(forms.AsEnumerable());
 
@@ -60,6 +60,8 @@ public class ListTests
         okResult.Should().NotBeNull();
         okResult!.Value.Should().NotBeNull();
         okResult!.Value!.Count().Should().Be(2);
+        okResult!.Value!.First().SubmissionsCount.Should().Be(4);
+        okResult!.Value!.Last().SubmissionsCount.Should().Be(0);
     }
 
     [Fact]

--- a/tests/Endatix.Core.Tests/UseCases/Forms/GetById/GetFormByIdHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/GetById/GetFormByIdHandlerTests.cs
@@ -23,8 +23,8 @@ public class GetFormByIdHandlerTests
     {
         // Arrange
         var request = new GetFormByIdQuery(1);
-        _repository.ListAsync(Arg.Any<FormByIdWithSubmissionsCountSpec>(), Arg.Any<CancellationToken>())
-                   .Returns([]);
+        _repository.FirstOrDefaultAsync(Arg.Any<FormByIdWithSubmissionsCountSpec>(), Arg.Any<CancellationToken>())
+                   .Returns((FormDto?)null);
 
         // Act
         var result = await _handler.Handle(request, CancellationToken.None);
@@ -41,8 +41,8 @@ public class GetFormByIdHandlerTests
         // Arrange
         var form = new FormDto { Id = "1", Name = SampleData.FORM_NAME_1, SubmissionsCount = 0 };
         var request = new GetFormByIdQuery(1);
-        _repository.ListAsync(Arg.Any<FormByIdWithSubmissionsCountSpec>(), Arg.Any<CancellationToken>())
-                   .Returns([form]);
+        _repository.FirstOrDefaultAsync(Arg.Any<FormByIdWithSubmissionsCountSpec>(), Arg.Any<CancellationToken>())
+                   .Returns(form);
 
         // Act
         var result = await _handler.Handle(request, CancellationToken.None);

--- a/tests/Endatix.Core.Tests/UseCases/Forms/GetById/GetFormByIdHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/GetById/GetFormByIdHandlerTests.cs
@@ -1,18 +1,20 @@
-using Endatix.Core.Entities;
+using Endatix.Core.Abstractions.Repositories;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
 using Endatix.Core.UseCases.Forms.GetById;
+using Endatix.Core.UseCases.Forms;
 
 namespace Endatix.Core.Tests.UseCases.Forms.GetById;
 
 public class GetFormByIdHandlerTests
 {
-    private readonly IRepository<Form> _repository;
+    private readonly IFormsRepository _repository;
     private readonly GetFormByIdHandler _handler;
 
     public GetFormByIdHandlerTests()
     {
-        _repository = Substitute.For<IRepository<Form>>();
+        _repository = Substitute.For<IFormsRepository>();
         _handler = new GetFormByIdHandler(_repository);
     }
 
@@ -20,10 +22,9 @@ public class GetFormByIdHandlerTests
     public async Task Handle_FormNotFound_ReturnsNotFoundResult()
     {
         // Arrange
-        Form? notFoundForm = null;
         var request = new GetFormByIdQuery(1);
-        _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
-                   .Returns(notFoundForm);
+        _repository.ListAsync(Arg.Any<FormByIdWithSubmissionsCountSpec>(), Arg.Any<CancellationToken>())
+                   .Returns([]);
 
         // Act
         var result = await _handler.Handle(request, CancellationToken.None);
@@ -38,10 +39,10 @@ public class GetFormByIdHandlerTests
     public async Task Handle_ValidRequest_ReturnsForm()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1 };
+        var form = new FormDto { Id = "1", Name = SampleData.FORM_NAME_1, SubmissionsCount = 0 };
         var request = new GetFormByIdQuery(1);
-        _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
-                   .Returns(form);
+        _repository.ListAsync(Arg.Any<FormByIdWithSubmissionsCountSpec>(), Arg.Any<CancellationToken>())
+                   .Returns([form]);
 
         // Act
         var result = await _handler.Handle(request, CancellationToken.None);

--- a/tests/Endatix.Core.Tests/UseCases/Forms/List/ListFormsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/List/ListFormsHandlerTests.cs
@@ -25,12 +25,14 @@ public class ListFormsHandlerTests
             new(){
                 Name = "Form 1",
                 Description = "Description 1",
-                IsEnabled = true
+                IsEnabled = true,
+                SubmissionsCount = 3
             },
             new(){
                 Name = "Form 1",
                 Description = "Description 2",
                 IsEnabled = true,
+                SubmissionsCount = 0
             }
         };
         var request = new ListFormsQuery(1, 10, ["name:form1"]);
@@ -55,12 +57,14 @@ public class ListFormsHandlerTests
             new(){
                 Name = "Form 1",
                 Description = "Description 1",
-                IsEnabled = true
+                IsEnabled = true,
+                SubmissionsCount = 2
             },
             new(){
                 Name = "Form 1",
                 Description = "Description 2",
                 IsEnabled = true,
+                SubmissionsCount = 0
             }
         };
         var request = new ListFormsQuery(1, 10, null);


### PR DESCRIPTION
## Description
Fixes GET form/{id} was not returning the submissions count

Addresses https://github.com/endatix/endatix-hub/issues/559

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

