### PR TITLE
feat: Add form scoping for public data list endpoints

### DIFF
--- a/src/Endatix.Api/Endpoints/Access/Public/GetFormPublicAccess.cs
+++ b/src/Endatix.Api/Endpoints/Access/Public/GetFormPublicAccess.cs
@@ -1,7 +1,6 @@
 using Endatix.Api.Infrastructure;
 using Endatix.Core.Authorization.Access;
 using Endatix.Core.Infrastructure;
-using Endatix.Infrastructure.Caching;
 using Endatix.Infrastructure.Features.AccessControl;
 using FastEndpoints;
 using FluentValidation;

--- a/src/Endatix.Api/Endpoints/DataLists/GetChoiceDisplayValues.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/GetChoiceDisplayValues.cs
@@ -1,7 +1,9 @@
 using Endatix.Api.Common.FeatureFlags;
 using Endatix.Api.Infrastructure;
+using Endatix.Core.Authorization.Access;
 using Endatix.Core.UseCases.DataLists.Search;
 using Endatix.Framework.FeatureFlags;
+using Endatix.Infrastructure.Features.AccessControl;
 using FastEndpoints;
 using FluentValidation;
 using MediatR;
@@ -12,18 +14,21 @@ namespace Endatix.Api.Endpoints.DataLists;
 /// <summary>
 /// Public endpoint to get choice display values.
 /// </summary>
-public sealed class GetChoiceDisplayValues(IMediator mediator)
+public sealed class GetChoiceDisplayValues(
+    IMediator mediator,
+    IResourceAccessQuery<PublicFormAccessData, PublicFormAccessContext> publicFormAccessPolicy)
     : Endpoint<GetChoiceDisplayValuesRequest, Results<Ok<IReadOnlyCollection<DataListPublicChoiceModel>>, ProblemHttpResult>>
 {
     public override void Configure()
     {
-        Get(ApiRoutes.Public("data-lists/{dataListId}/display-values"));
+        Get(ApiRoutes.Public("forms/{formId}/data-lists/{dataListId}/display-values"));
         AllowAnonymous();
         FeatureFlag<EndpointFeatureGate>(FeatureFlags.DataLists);
         Summary(s =>
         {
             s.Summary = "Resolve data list display values";
-            s.Description = "Returns label/value pairs for provided values in a public data list.";
+            s.Description =
+                "Returns label/value pairs for stored values in a runtime form context. Access is evaluated like access/public/forms/{formId} (optional token + tokenType query parameters; same cached policy).";
         });
     }
 
@@ -31,6 +36,14 @@ public sealed class GetChoiceDisplayValues(IMediator mediator)
         GetChoiceDisplayValuesRequest request,
         CancellationToken ct)
     {
+        PublicFormAccessContext accessContext = new(request.FormId, request.Token, request.TokenType);
+        var accessDataResult = await publicFormAccessPolicy.GetAccessData(accessContext, ct).ConfigureAwait(false);
+
+        if (!accessDataResult.IsSuccess)
+        {
+            return accessDataResult.ToProblem();
+        }
+
         GetDataListChoiceDisplayValuesQuery query = new(request.DataListId, request.Values);
         var result = await mediator.Send(query, ct);
 
@@ -47,9 +60,24 @@ public sealed class GetChoiceDisplayValues(IMediator mediator)
 public sealed class GetChoiceDisplayValuesRequest
 {
     /// <summary>
+    /// The ID of the form that owns the runtime context for this data list.
+    /// </summary>
+    public long FormId { get; init; }
+
+    /// <summary>
     /// The ID of the data list.
     /// </summary>
     public long DataListId { get; init; }
+
+    /// <summary>
+    /// Optional access or submission token (same semantics as <c>access/public/forms/{formId}</c>).
+    /// </summary>
+    public string? Token { get; init; }
+
+    /// <summary>
+    /// Token type when <see cref="Token"/> is set.
+    /// </summary>
+    public SubmissionTokenType? TokenType { get; init; }
 
     /// <summary>
     /// The values to get display values for.
@@ -64,7 +92,19 @@ public sealed class GetChoiceDisplayValuesValidator : Validator<GetChoiceDisplay
 {
     public GetChoiceDisplayValuesValidator()
     {
+        RuleFor(x => x.FormId).GreaterThan(0);
         RuleFor(x => x.DataListId).GreaterThan(0);
+        RuleFor(x => x.Token)
+            .NotEmpty()
+            .When(x => x.Token is not null);
+        RuleFor(x => x.TokenType)
+            .NotNull()
+            .IsInEnum()
+            .When(x => !string.IsNullOrEmpty(x.Token));
+        RuleFor(x => x.TokenType)
+            .Null()
+            .When(x => string.IsNullOrEmpty(x.Token))
+            .WithMessage("Token must be provided when Token Type is specified.");
         RuleFor(x => x.Values)
             .NotNull()
             .Must(values => values.Count > 0)

--- a/src/Endatix.Api/Endpoints/DataLists/Search.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/Search.cs
@@ -1,7 +1,9 @@
 using Endatix.Api.Common.FeatureFlags;
 using Endatix.Api.Infrastructure;
+using Endatix.Core.Authorization.Access;
 using Endatix.Core.UseCases.DataLists.Search;
 using Endatix.Framework.FeatureFlags;
+using Endatix.Infrastructure.Features.AccessControl;
 using FastEndpoints;
 using FluentValidation;
 using MediatR;
@@ -13,23 +15,33 @@ namespace Endatix.Api.Endpoints.DataLists;
 /// Endpoint to search data list items.
 /// </summary>
 public sealed class Search(
-    IMediator mediator)
+    IMediator mediator,
+    IResourceAccessQuery<PublicFormAccessData, PublicFormAccessContext> publicFormAccessPolicy)
     : Endpoint<SearchDataListItemsRequest, Results<Ok<DataListPublicSearchResultModel>, ProblemHttpResult>>
 {
     public override void Configure()
     {
-        Get(ApiRoutes.Public("data-lists/{dataListId}/search"));
+        Get(ApiRoutes.Public("forms/{formId}/data-lists/{dataListId}/search"));
         AllowAnonymous();
         Summary(s =>
         {
             s.Summary = "Search data list items";
-            s.Description = "Searches public data list choices using simple text matching.";
+            s.Description =
+                "Searches data list choices in a runtime form context. Access is evaluated like access/public/forms/{formId} (public vs authenticated, optional token + tokenType query parameters; uses the same cached policy).";
         });
         FeatureFlag<EndpointFeatureGate>(FeatureFlags.DataLists);
     }
 
     public override async Task<Results<Ok<DataListPublicSearchResultModel>, ProblemHttpResult>> ExecuteAsync(SearchDataListItemsRequest request, CancellationToken ct)
     {
+        PublicFormAccessContext accessContext = new(request.FormId, request.Token, request.TokenType);
+        var accessDataResult = await publicFormAccessPolicy.GetAccessData(accessContext, ct).ConfigureAwait(false);
+
+        if (!accessDataResult.IsSuccess)
+        {
+            return accessDataResult.ToProblem();
+        }
+
         SearchDataListItemsQuery query = new(request.DataListId, request.Query, request.Skip, request.Take);
         var result = await mediator.Send(query, ct);
         return TypedResultsBuilder
@@ -44,11 +56,25 @@ public sealed class Search(
 /// </summary>
 public sealed class SearchDataListItemsRequest
 {
+    /// <summary>
+    /// The ID of the form that owns the runtime context for this data list.
+    /// </summary>
+    public long FormId { get; init; }
 
     /// <summary>
     /// The ID of the data list to search.
     /// </summary>
     public long DataListId { get; init; }
+
+    /// <summary>
+    /// Optional access or submission token (same semantics as <c>access/public/forms/{formId}</c>).
+    /// </summary>
+    public string? Token { get; init; }
+
+    /// <summary>
+    /// Token type when <see cref="Token"/> is set.
+    /// </summary>
+    public SubmissionTokenType? TokenType { get; init; }
 
     /// <summary>
     /// The query to search for.
@@ -74,7 +100,19 @@ public sealed class SearchDataListItemsValidator : Validator<SearchDataListItems
 {
     public SearchDataListItemsValidator()
     {
+        RuleFor(x => x.FormId).GreaterThan(0);
         RuleFor(x => x.DataListId).GreaterThan(0);
+        RuleFor(x => x.Token)
+            .NotEmpty()
+            .When(x => x.Token is not null);
+        RuleFor(x => x.TokenType)
+            .NotNull()
+            .IsInEnum()
+            .When(x => !string.IsNullOrEmpty(x.Token));
+        RuleFor(x => x.TokenType)
+            .Null()
+            .When(x => string.IsNullOrEmpty(x.Token))
+            .WithMessage("Token must be provided when Token Type is specified.");
         RuleFor(x => x.Skip).GreaterThanOrEqualTo(0);
         RuleFor(x => x.Take).GreaterThan(0).LessThanOrEqualTo(SearchDataListItemsQuery.MAX_TAKE);
     }

--- a/src/Endatix.Core/Specifications/DataListsSpecifications.cs
+++ b/src/Endatix.Core/Specifications/DataListsSpecifications.cs
@@ -76,7 +76,7 @@ public class DataListsSpecifications
     {
         public ByIdWithItemsByValuesSpec(long dataListId, IReadOnlyCollection<string> values)
         {
-            Query.Where(x => x.Id == dataListId);
+            Query.Where(x => x.Id == dataListId && x.IsActive);
 
             if (values.Count == 0)
             {

--- a/src/Endatix.Infrastructure/Caching/HybridCacheExtension.cs
+++ b/src/Endatix.Infrastructure/Caching/HybridCacheExtension.cs
@@ -115,13 +115,13 @@ internal static class HybridCacheExtensions
                         throw new FailedResultException<T>(result);
                     }
 
-                    return Cached<T>.Create(result.Value, utcNow, ttl);
+                    return new Cached<T>(result.Value, utcNow, ttl);
                 },
                 new HybridCacheEntryOptions { Expiration = ttl },
                 tags,
                 cancellationToken);
 
-            return Result.Success(cachedOrCreated);
+            return Result.Success<ICachedData<T>>(cachedOrCreated);
         }
         catch (FailedResultException<T> ex)
         {

--- a/src/Endatix.Infrastructure/Data/Repositories/DataListRepository.cs
+++ b/src/Endatix.Infrastructure/Data/Repositories/DataListRepository.cs
@@ -20,7 +20,7 @@ public sealed class DataListRepository(AppDbContext dbContext) : IDataListReposi
     {
         var dataListExists = await _dbContext.DataLists
             .AsNoTracking()
-            .AnyAsync(d => d.Id == dataListId, cancellationToken)
+            .AnyAsync(d => d.Id == dataListId && d.IsActive, cancellationToken)
             .ConfigureAwait(false);
 
         if (!dataListExists)

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/GetChoiceDisplayValuesTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/GetChoiceDisplayValuesTests.cs
@@ -1,6 +1,10 @@
 using Endatix.Api.Endpoints.DataLists;
+using Endatix.Core.Authorization.Access;
+using Endatix.Core.Infrastructure;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.DataLists.Search;
+using Endatix.Infrastructure.Caching;
+using Endatix.Infrastructure.Features.AccessControl;
 using FastEndpoints;
 using MediatR;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -10,22 +14,39 @@ namespace Endatix.Api.Tests.Endpoints.DataLists;
 public class GetChoiceDisplayValuesTests
 {
     private readonly IMediator _mediator;
+    private readonly IResourceAccessQuery<PublicFormAccessData, PublicFormAccessContext> _publicFormAccessPolicy;
     private readonly GetChoiceDisplayValues _endpoint;
 
     public GetChoiceDisplayValuesTests()
     {
         _mediator = Substitute.For<IMediator>();
-        _endpoint = Factory.Create<GetChoiceDisplayValues>(_mediator);
+        _publicFormAccessPolicy = Substitute.For<IResourceAccessQuery<PublicFormAccessData, PublicFormAccessContext>>();
+        ICachedData<PublicFormAccessData> cached = new Cached<PublicFormAccessData>(
+            PublicFormAccessData.CreatePublicForm(1),
+            DateTime.UtcNow,
+            TimeSpan.FromMinutes(10),
+            "etag-display");
+        _publicFormAccessPolicy
+            .GetAccessData(Arg.Any<PublicFormAccessContext>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success<ICachedData<PublicFormAccessData>>(cached));
+        _endpoint = Factory.Create<GetChoiceDisplayValues>(_mediator, _publicFormAccessPolicy);
     }
 
     [Fact]
     public async Task ExecuteAsync_MapsRequestToQuery()
     {
-        GetChoiceDisplayValuesRequest request = new() { DataListId = 11, Values = ["a", "b"] };
+        GetChoiceDisplayValuesRequest request = new() { FormId = 3, DataListId = 11, Values = ["a", "b"] };
         _mediator.Send(Arg.Any<GetDataListChoiceDisplayValuesQuery>(), Arg.Any<CancellationToken>())
             .Returns(Result.Success<IReadOnlyCollection<DataListChoiceDisplayValueDto>>([]));
 
         await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        await _publicFormAccessPolicy.Received(1).GetAccessData(
+            Arg.Is<PublicFormAccessContext>(c =>
+                c.FormId == request.FormId &&
+                c.Token == request.Token &&
+                c.TokenType == request.TokenType),
+            Arg.Any<CancellationToken>());
 
         await _mediator.Received(1).Send(
             Arg.Is<GetDataListChoiceDisplayValuesQuery>(x =>
@@ -37,7 +58,7 @@ public class GetChoiceDisplayValuesTests
     [Fact]
     public async Task ExecuteAsync_ReturnsPublicChoiceModels()
     {
-        GetChoiceDisplayValuesRequest request = new() { DataListId = 11, Values = ["1"] };
+        GetChoiceDisplayValuesRequest request = new() { FormId = 2, DataListId = 11, Values = ["1"] };
         _mediator.Send(Arg.Any<GetDataListChoiceDisplayValuesQuery>(), Arg.Any<CancellationToken>())
             .Returns(Result.Success<IReadOnlyCollection<DataListChoiceDisplayValueDto>>(
                 [new DataListChoiceDisplayValueDto("1", "United States")]));
@@ -45,5 +66,20 @@ public class GetChoiceDisplayValuesTests
         var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
         var ok = response.Result.Should().BeOfType<Ok<IReadOnlyCollection<DataListPublicChoiceModel>>>().Subject;
         ok.Value.Should().ContainSingle(x => x.Value == "1" && x.Label == "United States");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenAccessDenied_DoesNotCallMediator()
+    {
+        _publicFormAccessPolicy
+            .GetAccessData(Arg.Any<PublicFormAccessContext>(), Arg.Any<CancellationToken>())
+            .Returns(Result<ICachedData<PublicFormAccessData>>.NotFound("Form not found."));
+
+        GetChoiceDisplayValuesRequest request = new() { FormId = 1, DataListId = 22, Values = ["1"] };
+
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        response.Result.Should().BeOfType<ProblemHttpResult>();
+        await _mediator.DidNotReceive().Send(Arg.Any<GetDataListChoiceDisplayValuesQuery>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/SearchTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/SearchTests.cs
@@ -1,7 +1,11 @@
 using Endatix.Api.Endpoints.DataLists;
+using Endatix.Core.Authorization.Access;
+using Endatix.Core.Infrastructure;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.DataLists;
 using Endatix.Core.UseCases.DataLists.Search;
+using Endatix.Infrastructure.Caching;
+using Endatix.Infrastructure.Features.AccessControl;
 using FastEndpoints;
 using MediatR;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -11,12 +15,22 @@ namespace Endatix.Api.Tests.Endpoints.DataLists;
 public class SearchTests
 {
     private readonly IMediator _mediator;
+    private readonly IResourceAccessQuery<PublicFormAccessData, PublicFormAccessContext> _publicFormAccessPolicy;
     private readonly Search _endpoint;
 
     public SearchTests()
     {
         _mediator = Substitute.For<IMediator>();
-        _endpoint = Factory.Create<Search>(_mediator);
+        _publicFormAccessPolicy = Substitute.For<IResourceAccessQuery<PublicFormAccessData, PublicFormAccessContext>>();
+        ICachedData<PublicFormAccessData> cached = new Cached<PublicFormAccessData>(
+            PublicFormAccessData.CreatePublicForm(1),
+            DateTime.UtcNow,
+            TimeSpan.FromMinutes(10),
+            "etag-search");
+        _publicFormAccessPolicy
+            .GetAccessData(Arg.Any<PublicFormAccessContext>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success<ICachedData<PublicFormAccessData>>(cached));
+        _endpoint = Factory.Create<Search>(_mediator, _publicFormAccessPolicy);
     }
 
     [Fact]
@@ -24,6 +38,7 @@ public class SearchTests
     {
         var request = new SearchDataListItemsRequest
         {
+            FormId = 7,
             DataListId = 42,
             Query = "ab",
             Skip = 5,
@@ -41,6 +56,13 @@ public class SearchTests
 
         await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
 
+        await _publicFormAccessPolicy.Received(1).GetAccessData(
+            Arg.Is<PublicFormAccessContext>(c =>
+                c.FormId == request.FormId &&
+                c.Token == request.Token &&
+                c.TokenType == request.TokenType),
+            Arg.Any<CancellationToken>());
+
         await _mediator.Received(1).Send(
             Arg.Is<SearchDataListItemsQuery>(x =>
                 x.DataListId == request.DataListId &&
@@ -55,6 +77,7 @@ public class SearchTests
     {
         SearchDataListItemsRequest request = new()
         {
+            FormId = 1,
             DataListId = 42,
             Query = "ab",
             Skip = 0,
@@ -74,5 +97,27 @@ public class SearchTests
         var item = ok.Value.Items.Single();
         item.Label.Should().Be("Abc");
         item.Value.Should().Be("1");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenAccessDenied_DoesNotCallMediator()
+    {
+        _publicFormAccessPolicy
+            .GetAccessData(Arg.Any<PublicFormAccessContext>(), Arg.Any<CancellationToken>())
+            .Returns(Result<ICachedData<PublicFormAccessData>>.NotFound("Form not found."));
+
+        SearchDataListItemsRequest request = new()
+        {
+            FormId = 1,
+            DataListId = 99,
+            Query = "x",
+            Skip = 0,
+            Take = 10
+        };
+
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        response.Result.Should().BeOfType<ProblemHttpResult>();
+        await _mediator.DidNotReceive().Send(Arg.Any<SearchDataListItemsQuery>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Endatix.Infrastructure.Tests/Caching/HybridCacheExtensionTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Caching/HybridCacheExtensionTests.cs
@@ -175,16 +175,16 @@ public sealed class HybridCacheExtensionTests
         var key = "cached";
         var utcNow = new DateTime(2024, 01, 01, 0, 0, 0, DateTimeKind.Utc);
         var ttl = TimeSpan.FromMinutes(7);
-        var cachedEnvelope = Cached<DummyData>.Create(new DummyData { Id = 42 }, utcNow, ttl);
+        var cachedEnvelope = new Cached<DummyData>(new DummyData { Id = 42 }, utcNow, ttl);
 
         cache
-            .GetOrCreateAsync<ICachedData<DummyData>>(
+            .GetOrCreateAsync<Cached<DummyData>>(
                 Arg.Is<string>(k => k == key),
-                Arg.Any<Func<CancellationToken, ValueTask<ICachedData<DummyData>>>>(),
+                Arg.Any<Func<CancellationToken, ValueTask<Cached<DummyData>>>>(),
                 Arg.Any<HybridCacheEntryOptions?>(),
                 Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>())
-            .Returns(new ValueTask<ICachedData<DummyData>>(cachedEnvelope));
+            .Returns(new ValueTask<Cached<DummyData>>(cachedEnvelope));
 
         var factoryInvoked = false;
 
@@ -224,15 +224,15 @@ public sealed class HybridCacheExtensionTests
         var ttl = TimeSpan.FromMinutes(7);
 
         cache
-            .GetOrCreateAsync<ICachedData<DummyData>>(
+            .GetOrCreateAsync<Cached<DummyData>>(
                 Arg.Is<string>(k => k == key),
-                Arg.Any<Func<CancellationToken, ValueTask<ICachedData<DummyData>>>>(),
+                Arg.Any<Func<CancellationToken, ValueTask<Cached<DummyData>>>>(),
                 Arg.Any<HybridCacheEntryOptions?>(),
                 Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
-                var factory = callInfo.Arg<Func<CancellationToken, ValueTask<ICachedData<DummyData>>>>();
+                var factory = callInfo.Arg<Func<CancellationToken, ValueTask<Cached<DummyData>>>>();
                 var ct = callInfo.Arg<CancellationToken>();
                 return factory(ct);
             });

--- a/tests/Endatix.Infrastructure.Tests/Features/AccessControl/FormAccessPolicyTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/AccessControl/FormAccessPolicyTests.cs
@@ -26,15 +26,15 @@ public class FormAccessPolicyTests
         _dateTimeProvider.Now.Returns(DateTimeOffset.UtcNow);
 
         _cache
-            .GetOrCreateAsync<ICachedData<FormAccessData>>(
+            .GetOrCreateAsync<Cached<FormAccessData>>(
                 Arg.Any<string>(),
-                Arg.Any<Func<CancellationToken, ValueTask<ICachedData<FormAccessData>>>>(),
+                Arg.Any<Func<CancellationToken, ValueTask<Cached<FormAccessData>>>>(),
                 Arg.Any<HybridCacheEntryOptions?>(),
                 Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
-                var factory = callInfo.Arg<Func<CancellationToken, ValueTask<ICachedData<FormAccessData>>>>();
+                var factory = callInfo.Arg<Func<CancellationToken, ValueTask<Cached<FormAccessData>>>>();
                 var ct = callInfo.Arg<CancellationToken>();
                 return factory(ct);
             });
@@ -283,9 +283,9 @@ public class FormAccessPolicyTests
         await _policy.GetAccessData(context, TestContext.Current.CancellationToken);
 
         // Assert
-        await _cache.Received(1).GetOrCreateAsync<ICachedData<FormAccessData>>(
+        await _cache.Received(1).GetOrCreateAsync<Cached<FormAccessData>>(
             Arg.Is<string>(k => k == $"auth:form_mgmt:{formId}:user:{userId}"),
-            Arg.Any<Func<CancellationToken, ValueTask<ICachedData<FormAccessData>>>>(),
+            Arg.Any<Func<CancellationToken, ValueTask<Cached<FormAccessData>>>>(),
             Arg.Any<HybridCacheEntryOptions?>(),
             Arg.Any<IEnumerable<string>?>(),
             Arg.Any<CancellationToken>());
@@ -313,16 +313,16 @@ public class FormAccessPolicyTests
             FormId = formId.ToString(),
             Permissions = ResourcePermissions.Form.Sets.ViewForm.ToImmutableHashSet()
         };
-        var cachedEnvelope = Cached<FormAccessData>.Create(cachedData, _dateTimeProvider.Now.UtcDateTime, TimeSpan.FromMinutes(10));
+        var cachedEnvelope = (Cached<FormAccessData>)Cached<FormAccessData>.Create(cachedData, _dateTimeProvider.Now.UtcDateTime, TimeSpan.FromMinutes(10));
 
         _cache
-            .GetOrCreateAsync<ICachedData<FormAccessData>>(
+            .GetOrCreateAsync<Cached<FormAccessData>>(
                 Arg.Any<string>(),
-                Arg.Any<Func<CancellationToken, ValueTask<ICachedData<FormAccessData>>>>(),
+                Arg.Any<Func<CancellationToken, ValueTask<Cached<FormAccessData>>>>(),
                 Arg.Any<HybridCacheEntryOptions?>(),
                 Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>())
-            .Returns(new ValueTask<ICachedData<FormAccessData>>(cachedEnvelope));
+            .Returns(new ValueTask<Cached<FormAccessData>>(cachedEnvelope));
 
         // Act
         var result = await _policy.GetAccessData(context, TestContext.Current.CancellationToken);
@@ -358,9 +358,9 @@ public class FormAccessPolicyTests
         await _policy.GetAccessData(context, TestContext.Current.CancellationToken);
 
         // Assert
-        await _cache.Received(1).GetOrCreateAsync<ICachedData<FormAccessData>>(
+        await _cache.Received(1).GetOrCreateAsync<Cached<FormAccessData>>(
             Arg.Is<string>(k => k.StartsWith($"auth:form_mgmt:{formId}:")),
-            Arg.Any<Func<CancellationToken, ValueTask<ICachedData<FormAccessData>>>>(),
+            Arg.Any<Func<CancellationToken, ValueTask<Cached<FormAccessData>>>>(),
             Arg.Any<HybridCacheEntryOptions?>(),
             Arg.Any<IEnumerable<string>?>(),
             Arg.Any<CancellationToken>());

--- a/tests/Endatix.Infrastructure.Tests/Features/AccessControl/FormTemplateAccessPolicyTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/AccessControl/FormTemplateAccessPolicyTests.cs
@@ -25,15 +25,15 @@ public class FormTemplateAccessPolicyTests
         _dateTimeProvider.Now.Returns(DateTimeOffset.UtcNow);
 
         _cache
-            .GetOrCreateAsync<ICachedData<FormTemplateAccessData>>(
+            .GetOrCreateAsync<Cached<FormTemplateAccessData>>(
                 Arg.Any<string>(),
-                Arg.Any<Func<CancellationToken, ValueTask<ICachedData<FormTemplateAccessData>>>>(),
+                Arg.Any<Func<CancellationToken, ValueTask<Cached<FormTemplateAccessData>>>>(),
                 Arg.Any<HybridCacheEntryOptions?>(),
                 Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
-                var factory = callInfo.Arg<Func<CancellationToken, ValueTask<ICachedData<FormTemplateAccessData>>>>();
+                var factory = callInfo.Arg<Func<CancellationToken, ValueTask<Cached<FormTemplateAccessData>>>>();
                 var ct = callInfo.Arg<CancellationToken>();
                 return factory(ct);
             });
@@ -225,9 +225,9 @@ public class FormTemplateAccessPolicyTests
         await _policy.GetAccessData(context, TestContext.Current.CancellationToken);
 
         // Assert
-        await _cache.Received(1).GetOrCreateAsync<ICachedData<FormTemplateAccessData>>(
+        await _cache.Received(1).GetOrCreateAsync<Cached<FormTemplateAccessData>>(
             Arg.Is<string>(k => k == $"auth:tpl_mgmt:{templateId}:user:{userId}"),
-            Arg.Any<Func<CancellationToken, ValueTask<ICachedData<FormTemplateAccessData>>>>(),
+            Arg.Any<Func<CancellationToken, ValueTask<Cached<FormTemplateAccessData>>>>(),
             Arg.Any<HybridCacheEntryOptions?>(),
             Arg.Any<IEnumerable<string>?>(),
             Arg.Any<CancellationToken>());
@@ -258,15 +258,15 @@ public class FormTemplateAccessPolicyTests
         HybridCacheEntryOptions? capturedOptions = null;
 
         _cache
-            .GetOrCreateAsync<ICachedData<FormTemplateAccessData>>(
+            .GetOrCreateAsync<Cached<FormTemplateAccessData>>(
                 Arg.Any<string>(),
-                Arg.Any<Func<CancellationToken, ValueTask<ICachedData<FormTemplateAccessData>>>>(),
+                Arg.Any<Func<CancellationToken, ValueTask<Cached<FormTemplateAccessData>>>>(),
                 Arg.Do<HybridCacheEntryOptions?>(o => capturedOptions = o),
                 Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
-                var factory = callInfo.Arg<Func<CancellationToken, ValueTask<ICachedData<FormTemplateAccessData>>>>();
+                var factory = callInfo.Arg<Func<CancellationToken, ValueTask<Cached<FormTemplateAccessData>>>>();
                 return factory(callInfo.Arg<CancellationToken>());
             });
 

--- a/tests/Endatix.Infrastructure.Tests/Features/AccessControl/PublicFormAccessPolicyTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/AccessControl/PublicFormAccessPolicyTests.cs
@@ -101,15 +101,15 @@ public partial class PublicFormAccessPolicyTests
             .Returns(true);
 
         _cache
-            .GetOrCreateAsync<ICachedData<PublicFormAccessData>>(
+            .GetOrCreateAsync<Cached<PublicFormAccessData>>(
                 Arg.Any<string>(),
-                Arg.Any<Func<CancellationToken, ValueTask<ICachedData<PublicFormAccessData>>>>(),
+                Arg.Any<Func<CancellationToken, ValueTask<Cached<PublicFormAccessData>>>>(),
                 Arg.Any<HybridCacheEntryOptions?>(),
                 Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
-                var factory = callInfo.Arg<Func<CancellationToken, ValueTask<ICachedData<PublicFormAccessData>>>>();
+                var factory = callInfo.Arg<Func<CancellationToken, ValueTask<Cached<PublicFormAccessData>>>>();
                 var token = callInfo.Arg<CancellationToken>();
                 return factory(token);
             });
@@ -214,10 +214,9 @@ public partial class PublicFormAccessPolicyTests
         string? capturedCacheKey = null;
 
         _cache
-            .GetOrCreateAsync<object, ICachedData<PublicFormAccessData>>(
+            .GetOrCreateAsync<Cached<PublicFormAccessData>>(
                 Arg.Any<string>(),
-                Arg.Any<object>(),
-                Arg.Any<Func<object, CancellationToken, ValueTask<ICachedData<PublicFormAccessData>>>>(),
+                Arg.Any<Func<CancellationToken, ValueTask<Cached<PublicFormAccessData>>>>(),
                 Arg.Any<HybridCacheEntryOptions?>(),
                 Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>())
@@ -398,10 +397,9 @@ public partial class PublicFormAccessPolicyTests
         string? capturedCacheKey = null;
 
         _cache
-            .GetOrCreateAsync<object, ICachedData<PublicFormAccessData>>(
+            .GetOrCreateAsync<Cached<PublicFormAccessData>>(
                 Arg.Any<string>(),
-                Arg.Any<object>(),
-                Arg.Any<Func<object, CancellationToken, ValueTask<ICachedData<PublicFormAccessData>>>>(),
+                Arg.Any<Func<CancellationToken, ValueTask<Cached<PublicFormAccessData>>>>(),
                 Arg.Any<HybridCacheEntryOptions?>(),
                 Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>())
@@ -539,10 +537,9 @@ public partial class PublicFormAccessPolicyTests
         string? capturedCacheKey = null;
 
         _cache
-            .GetOrCreateAsync<object, ICachedData<PublicFormAccessData>>(
+            .GetOrCreateAsync<Cached<PublicFormAccessData>>(
                 Arg.Any<string>(),
-                Arg.Any<object>(),
-                Arg.Any<Func<object, CancellationToken, ValueTask<ICachedData<PublicFormAccessData>>>>(),
+                Arg.Any<Func<CancellationToken, ValueTask<Cached<PublicFormAccessData>>>>(),
                 Arg.Any<HybridCacheEntryOptions?>(),
                 Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>())
@@ -590,10 +587,9 @@ public partial class PublicFormAccessPolicyTests
         string? capturedCacheKey = null;
 
         _cache
-            .GetOrCreateAsync<object, ICachedData<PublicFormAccessData>>(
+            .GetOrCreateAsync<Cached<PublicFormAccessData>>(
                 Arg.Any<string>(),
-                Arg.Any<object>(),
-                Arg.Any<Func<object, CancellationToken, ValueTask<ICachedData<PublicFormAccessData>>>>(),
+                Arg.Any<Func<CancellationToken, ValueTask<Cached<PublicFormAccessData>>>>(),
                 Arg.Any<HybridCacheEntryOptions?>(),
                 Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>())
@@ -961,7 +957,7 @@ public partial class PublicFormAccessPolicyTests
             SubmissionPermissions = ResourcePermissions.Submission.Sets.CreateSubmission.ToImmutableHashSet(),
             ExpiresAt = DateTimeOffset.UtcNow.AddMinutes(10)
         };
-        var cachedEnvelope = Cached<PublicFormAccessData>.Create(cachedData, _dateTimeProvider.Now.UtcDateTime, TimeSpan.FromMinutes(10));
+        var cachedEnvelope = (Cached<PublicFormAccessData>)Cached<PublicFormAccessData>.Create(cachedData, _dateTimeProvider.Now.UtcDateTime, TimeSpan.FromMinutes(10));
         var context = new PublicFormAccessContext(formId);
 
         _cache
@@ -974,13 +970,13 @@ public partial class PublicFormAccessPolicyTests
             .Returns(new ValueTask<bool>(true));
 
         _cache
-            .GetOrCreateAsync<ICachedData<PublicFormAccessData>>(
+            .GetOrCreateAsync<Cached<PublicFormAccessData>>(
                 Arg.Is<string>(k => k.StartsWith("ac:form:")),
-                Arg.Any<Func<CancellationToken, ValueTask<ICachedData<PublicFormAccessData>>>>(),
+                Arg.Any<Func<CancellationToken, ValueTask<Cached<PublicFormAccessData>>>>(),
                 Arg.Any<HybridCacheEntryOptions?>(),
                 Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>())
-            .Returns(new ValueTask<ICachedData<PublicFormAccessData>>(cachedEnvelope));
+            .Returns(new ValueTask<Cached<PublicFormAccessData>>(cachedEnvelope));
 
         // Act
         var result = await _policy.GetAccessData(context, TestContext.Current.CancellationToken);
@@ -993,18 +989,12 @@ public partial class PublicFormAccessPolicyTests
     #endregion
 
     /// <summary>
-    /// Invokes the HybridCache factory used by <c>GetOrCreateCachedResultAsync</c> (stateful
-    /// <c>GetOrCreateAsync</c> overload). Handles either <see cref="Task{T}"/> or <see cref="ValueTask{T}"/> results.
+    /// Invokes the HybridCache factory used by <c>GetOrCreateCachedResultAsync</c>.
+    /// Handles either <see cref="Task{T}"/> or <see cref="ValueTask{T}"/> results.
     /// </summary>
-    private static ValueTask<ICachedData<PublicFormAccessData>> InvokeHybridCacheGetOrCreateFactory(CallInfo callInfo)
+    private static ValueTask<Cached<PublicFormAccessData>> InvokeHybridCacheGetOrCreateFactory(CallInfo callInfo)
     {
-        var factory = (Delegate)callInfo[2]!;
-        var invokeResult = factory.DynamicInvoke(callInfo[1], callInfo[5]);
-        return invokeResult switch
-        {
-            ValueTask<ICachedData<PublicFormAccessData>> vt => vt,
-            Task<ICachedData<PublicFormAccessData>> t => new ValueTask<ICachedData<PublicFormAccessData>>(t.GetAwaiter().GetResult()),
-            _ => throw new InvalidOperationException($"Unexpected factory result type: {invokeResult?.GetType().FullName}")
-        };
+        var factory = callInfo.Arg<Func<CancellationToken, ValueTask<Cached<PublicFormAccessData>>>>();
+        return factory(callInfo.Arg<CancellationToken>());
     }
 }

--- a/tests/Endatix.Infrastructure.Tests/Features/AccessControl/SubmissionAccessPolicyTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/AccessControl/SubmissionAccessPolicyTests.cs
@@ -35,15 +35,15 @@ public sealed class SubmissionAccessPolicyTests
     private void SetupCacheMiss()
     {
         _cache
-            .GetOrCreateAsync<ICachedData<SubmissionAccessData>>(
+            .GetOrCreateAsync<Cached<SubmissionAccessData>>(
                 Arg.Any<string>(),
-                Arg.Any<Func<CancellationToken, ValueTask<ICachedData<SubmissionAccessData>>>>(),
+                Arg.Any<Func<CancellationToken, ValueTask<Cached<SubmissionAccessData>>>>(),
                 Arg.Any<HybridCacheEntryOptions?>(),
                 Arg.Any<IEnumerable<string>?>(),
                 Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
-                var factory = callInfo.Arg<Func<CancellationToken, ValueTask<ICachedData<SubmissionAccessData>>>>();
+                var factory = callInfo.Arg<Func<CancellationToken, ValueTask<Cached<SubmissionAccessData>>>>();
                 var ct = callInfo.Arg<CancellationToken>();
                 return factory(ct);
             });
@@ -94,9 +94,9 @@ public sealed class SubmissionAccessPolicyTests
         result.Value.Data.SubmissionPermissions.Should().BeEquivalentTo(ResourcePermissions.Submission.Sets.EditSubmission);
         result.Value.ExpiresAt.Should().Be(expectedExpiresAt);
 
-        await _cache.Received(1).GetOrCreateAsync<ICachedData<SubmissionAccessData>>(
+        await _cache.Received(1).GetOrCreateAsync<Cached<SubmissionAccessData>>(
             expectedCacheKey,
-            Arg.Any<Func<CancellationToken, ValueTask<ICachedData<SubmissionAccessData>>>>(),
+            Arg.Any<Func<CancellationToken, ValueTask<Cached<SubmissionAccessData>>>>(),
             Arg.Is<HybridCacheEntryOptions>(o => o != null && o.Expiration == expectedTtl),
             Arg.Any<IEnumerable<string>?>(),
             Arg.Any<CancellationToken>());
@@ -141,9 +141,9 @@ public sealed class SubmissionAccessPolicyTests
         result.Value.Data.SubmissionPermissions.Should().BeEquivalentTo(ResourcePermissions.Submission.Sets.ViewOnly);
         result.Value.ExpiresAt.Should().Be(utcNow.Add(expectedTtl));
 
-        await _cache.Received(1).GetOrCreateAsync<ICachedData<SubmissionAccessData>>(
+        await _cache.Received(1).GetOrCreateAsync<Cached<SubmissionAccessData>>(
             expectedCacheKey,
-            Arg.Any<Func<CancellationToken, ValueTask<ICachedData<SubmissionAccessData>>>>(),
+            Arg.Any<Func<CancellationToken, ValueTask<Cached<SubmissionAccessData>>>>(),
             Arg.Is<HybridCacheEntryOptions>(o => o != null && o.Expiration == expectedTtl),
             Arg.Any<IEnumerable<string>?>(),
             Arg.Any<CancellationToken>());
@@ -188,9 +188,9 @@ public sealed class SubmissionAccessPolicyTests
         result.Value.Data.SubmissionPermissions.Should().BeEquivalentTo(ResourcePermissions.Submission.Sets.EditSubmission);
         result.Value.ExpiresAt.Should().Be(utcNow.Add(expectedTtl));
 
-        await _cache.Received(1).GetOrCreateAsync<ICachedData<SubmissionAccessData>>(
+        await _cache.Received(1).GetOrCreateAsync<Cached<SubmissionAccessData>>(
             expectedCacheKey,
-            Arg.Any<Func<CancellationToken, ValueTask<ICachedData<SubmissionAccessData>>>>(),
+            Arg.Any<Func<CancellationToken, ValueTask<Cached<SubmissionAccessData>>>>(),
             Arg.Is<HybridCacheEntryOptions>(o => o != null && o.Expiration == expectedTtl),
             Arg.Any<IEnumerable<string>?>(),
             Arg.Any<CancellationToken>());


### PR DESCRIPTION
# feat: Add form scoping for public data list endpoints

## Description
- Add Form scoping
       - Add `GET /api/public/forms/:formId/data-lists/:dataListId/search`
       - Add `GET /api/public/forms/:formId/data-lists/:dataListId/display-values`
- Add security layer based on reuing FormSubmission ReBAC until we have Form specific ReBAC

## Related Issues
- closes https://github.com/endatix/endatix/issues/705

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
