### PR TITLE
feat: Step two of the feature implementation - gating UI

### DIFF
--- a/src/Endatix.Api/Endpoints/FormDefinitions/FormDefinitionMapper.cs
+++ b/src/Endatix.Api/Endpoints/FormDefinitions/FormDefinitionMapper.cs
@@ -41,6 +41,8 @@ public class FormDefinitionMapper
         ThemeModel = formDefinition.ThemeJsonData,
         CustomQuestions = formDefinition.CustomQuestions,
         RequiresReCaptcha = formDefinition.RequiresReCaptcha,
+        HasUserSubmitted = formDefinition.HasUserSubmitted,
+        Metadata = formDefinition.Metadata,
     };
 
     /// <summary>

--- a/src/Endatix.Api/Endpoints/FormDefinitions/FormDefinitionModel.cs
+++ b/src/Endatix.Api/Endpoints/FormDefinitions/FormDefinitionModel.cs
@@ -50,4 +50,14 @@ public class FormDefinitionModel
     /// Indicates if reCAPTCHA is enabled for this form definition.
     /// </summary>
     public bool? RequiresReCaptcha { get; set; }
+
+    /// <summary>
+    /// Indicates whether the current user already has a submission for this form.
+    /// </summary>
+    public bool HasUserSubmitted { get; set; }
+
+    /// <summary>
+    /// Optional form-level metadata payload.
+    /// </summary>
+    public string? Metadata { get; set; }
 }

--- a/src/Endatix.Core/UseCases/FormDefinitions/ActiveDefinitionDto.cs
+++ b/src/Endatix.Core/UseCases/FormDefinitions/ActiveDefinitionDto.cs
@@ -66,5 +66,15 @@ public class ActiveDefinitionDto
     /// </summary>
     public IEnumerable<string> CustomQuestions { get; set; }
 
+    /// <summary>
+    /// Indicates whether the current user already has a submission for this form.
+    /// </summary>
+    public bool HasUserSubmitted { get; set; }
+
+    /// <summary>
+    /// Optional form-level metadata payload.
+    /// </summary>
+    public string? Metadata { get; set; }
+
 
 }

--- a/src/Endatix.Core/UseCases/FormDefinitions/GetActive/GetActiveFormDefinitionHandler.cs
+++ b/src/Endatix.Core/UseCases/FormDefinitions/GetActive/GetActiveFormDefinitionHandler.cs
@@ -56,9 +56,15 @@ public class GetActiveFormDefinitionHandler(
 
         if (formWithActiveDefinition.LimitOnePerUser && !string.IsNullOrWhiteSpace(request.UserId))
         {
-            hasUserSubmitted = await submissionRepository.AnyAsync(
-                new SubmissionByFormIdAndSubmittedBySpec(request.FormId, request.UserId),
-                cancellationToken);
+            var hasTestPermissionResult = await authorizationService.HasPermissionAsync(Actions.Forms.Test, cancellationToken);
+            var canBypassSingleSubmissionLimit = hasTestPermissionResult.IsSuccess && hasTestPermissionResult.Value;
+
+            if (!canBypassSingleSubmissionLimit)
+            {
+                hasUserSubmitted = await submissionRepository.AnyAsync(
+                    new SubmissionByFormIdAndSubmittedBySpec(request.FormId, request.UserId),
+                    cancellationToken);
+            }
         }
 
         var activeDefinitionDto = new ActiveDefinitionDto(formWithActiveDefinition.ActiveDefinition)

--- a/src/Endatix.Core/UseCases/FormDefinitions/GetActive/GetActiveFormDefinitionHandler.cs
+++ b/src/Endatix.Core/UseCases/FormDefinitions/GetActive/GetActiveFormDefinitionHandler.cs
@@ -12,6 +12,7 @@ namespace Endatix.Core.UseCases.FormDefinitions.GetActive;
 public class GetActiveFormDefinitionHandler(
     IFormsRepository formRepository,
     IRepository<CustomQuestion> customQuestionsRepository,
+    IRepository<Submission> submissionRepository,
     IReCaptchaPolicyService reCaptchaPolicyService,
     ICurrentUserAuthorizationService authorizationService
     )
@@ -51,12 +52,22 @@ public class GetActiveFormDefinitionHandler(
             cancellationToken);
 
         var customQuestionsJson = customQuestions?.Select(q => q.JsonData);
+        var hasUserSubmitted = false;
+
+        if (formWithActiveDefinition.LimitOnePerUser && !string.IsNullOrWhiteSpace(request.UserId))
+        {
+            hasUserSubmitted = await submissionRepository.AnyAsync(
+                new SubmissionByFormIdAndSubmittedBySpec(request.FormId, request.UserId),
+                cancellationToken);
+        }
 
         var activeDefinitionDto = new ActiveDefinitionDto(formWithActiveDefinition.ActiveDefinition)
         {
             ThemeJsonData = formWithActiveDefinition.Theme?.JsonData,
             RequiresReCaptcha = reCaptchaPolicyService.RequiresReCaptcha(formWithActiveDefinition),
-            CustomQuestions = customQuestionsJson ?? []
+            CustomQuestions = customQuestionsJson ?? [],
+            HasUserSubmitted = hasUserSubmitted,
+            Metadata = formWithActiveDefinition.Metadata
         };
 
         return Result.Success(activeDefinitionDto);

--- a/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/GetActiveTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/GetActiveTests.cs
@@ -73,7 +73,11 @@ public class GetActiveTests
         var request = new GetActiveFormDefinitionRequest { FormId = formId };
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, true, "{ }") { Id = 1 };
         var themeJsonData = "{ \"background\": \"#FFFFFF\" }";
-        var activeDefinitionDto = new ActiveDefinitionDto(formDefinition, themeJsonData);
+        var activeDefinitionDto = new ActiveDefinitionDto(formDefinition, themeJsonData)
+        {
+            HasUserSubmitted = true,
+            Metadata = "{ \"alreadyRespondedMessage\": \"Custom copy\" }"
+        };
         var result = Result.Success(activeDefinitionDto);
 
         _mediator.Send(Arg.Any<GetActiveFormDefinitionQuery>(), Arg.Any<CancellationToken>())
@@ -89,6 +93,8 @@ public class GetActiveTests
         okResult!.Value!.Id.Should().Be(formDefinition.Id.ToString());
         okResult!.Value!.FormId.Should().Be(formDefinition.FormId.ToString());
         okResult!.Value!.ThemeModel.Should().Be(themeJsonData);
+        okResult!.Value!.HasUserSubmitted.Should().BeTrue();
+        okResult!.Value!.Metadata.Should().Be("{ \"alreadyRespondedMessage\": \"Custom copy\" }");
     }
 
     [Fact]

--- a/tests/Endatix.Core.Tests/UseCases/FormDefinitions/GetActive/GetActiveFormDefinitionHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/FormDefinitions/GetActive/GetActiveFormDefinitionHandlerTests.cs
@@ -13,6 +13,7 @@ public class GetActiveFormDefinitionHandlerTests
 {
     private readonly IFormsRepository _formsRepository;
     private readonly IRepository<CustomQuestion> _customQuestionsRepository;
+    private readonly IRepository<Submission> _submissionRepository;
     private readonly IReCaptchaPolicyService _recaptchaPolicyService;
     private readonly ICurrentUserAuthorizationService _authorizationService;
     private readonly GetActiveFormDefinitionHandler _handler;
@@ -21,9 +22,10 @@ public class GetActiveFormDefinitionHandlerTests
     {
         _formsRepository = Substitute.For<IFormsRepository>();
         _customQuestionsRepository = Substitute.For<IRepository<CustomQuestion>>();
+        _submissionRepository = Substitute.For<IRepository<Submission>>();
         _recaptchaPolicyService = Substitute.For<IReCaptchaPolicyService>();
         _authorizationService = Substitute.For<ICurrentUserAuthorizationService>();
-        _handler = new GetActiveFormDefinitionHandler(_formsRepository, _customQuestionsRepository, _recaptchaPolicyService, _authorizationService);
+        _handler = new GetActiveFormDefinitionHandler(_formsRepository, _customQuestionsRepository, _submissionRepository, _recaptchaPolicyService, _authorizationService);
     }
 
     [Fact]
@@ -285,6 +287,78 @@ public class GetActiveFormDefinitionHandlerTests
 
         // Verify permission check was not called for public form
         await _authorizationService.DidNotReceive().ValidateAccessAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_LimitOnePerUserAndExistingSubmission_SetsHasUserSubmittedToTrue()
+    {
+        // Arrange
+        const string userId = "user-123";
+        var formWithActiveDefinition = new Form(
+            SampleData.TENANT_ID,
+            SampleData.FORM_NAME_1,
+            isEnabled: true,
+            isPublic: false,
+            limitOnePerUser: true)
+        {
+            Id = 1
+        };
+        var activeDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1);
+        formWithActiveDefinition.AddFormDefinition(activeDefinition);
+
+        var request = new GetActiveFormDefinitionQuery(1, userId, "access.authenticated");
+
+        _formsRepository.SingleOrDefaultAsync(Arg.Any<ActiveFormDefinitionByFormIdSpec>(), CancellationToken.None)
+            .Returns(formWithActiveDefinition);
+        _customQuestionsRepository.ListAsync(Arg.Any<CustomQuestionSpecifications.ByTenantId>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+        _authorizationService.ValidateAccessAsync("access.authenticated", Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        _submissionRepository.AnyAsync(Arg.Any<SubmissionByFormIdAndSubmittedBySpec>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value!.HasUserSubmitted.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_LimitOnePerUserWithoutSubmission_SetsHasUserSubmittedToFalse()
+    {
+        // Arrange
+        const string userId = "user-123";
+        var formWithActiveDefinition = new Form(
+            SampleData.TENANT_ID,
+            SampleData.FORM_NAME_1,
+            isEnabled: true,
+            isPublic: false,
+            limitOnePerUser: true)
+        {
+            Id = 1
+        };
+        var activeDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1);
+        formWithActiveDefinition.AddFormDefinition(activeDefinition);
+
+        var request = new GetActiveFormDefinitionQuery(1, userId, "access.authenticated");
+
+        _formsRepository.SingleOrDefaultAsync(Arg.Any<ActiveFormDefinitionByFormIdSpec>(), CancellationToken.None)
+            .Returns(formWithActiveDefinition);
+        _customQuestionsRepository.ListAsync(Arg.Any<CustomQuestionSpecifications.ByTenantId>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+        _authorizationService.ValidateAccessAsync("access.authenticated", Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        _submissionRepository.AnyAsync(Arg.Any<SubmissionByFormIdAndSubmittedBySpec>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value!.HasUserSubmitted.Should().BeFalse();
     }
 
     #endregion

--- a/tests/Endatix.Core.Tests/UseCases/FormDefinitions/GetActive/GetActiveFormDefinitionHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/FormDefinitions/GetActive/GetActiveFormDefinitionHandlerTests.cs
@@ -314,6 +314,8 @@ public class GetActiveFormDefinitionHandlerTests
             .Returns([]);
         _authorizationService.ValidateAccessAsync("access.authenticated", Arg.Any<CancellationToken>())
             .Returns(Result.Success());
+        _authorizationService.HasPermissionAsync(Actions.Forms.Test, Arg.Any<CancellationToken>())
+            .Returns(Result.Success(false));
         _submissionRepository.AnyAsync(Arg.Any<SubmissionByFormIdAndSubmittedBySpec>(), Arg.Any<CancellationToken>())
             .Returns(true);
 
@@ -350,6 +352,8 @@ public class GetActiveFormDefinitionHandlerTests
             .Returns([]);
         _authorizationService.ValidateAccessAsync("access.authenticated", Arg.Any<CancellationToken>())
             .Returns(Result.Success());
+        _authorizationService.HasPermissionAsync(Actions.Forms.Test, Arg.Any<CancellationToken>())
+            .Returns(Result.Success(false));
         _submissionRepository.AnyAsync(Arg.Any<SubmissionByFormIdAndSubmittedBySpec>(), Arg.Any<CancellationToken>())
             .Returns(false);
 
@@ -359,6 +363,45 @@ public class GetActiveFormDefinitionHandlerTests
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value!.HasUserSubmitted.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_LimitOnePerUserWithTestPermission_SkipsDbCheckAndReturnsFalse()
+    {
+        // Arrange
+        const string userId = "user-123";
+        var formWithActiveDefinition = new Form(
+            SampleData.TENANT_ID,
+            SampleData.FORM_NAME_1,
+            isEnabled: true,
+            isPublic: false,
+            limitOnePerUser: true)
+        {
+            Id = 1
+        };
+        var activeDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1);
+        formWithActiveDefinition.AddFormDefinition(activeDefinition);
+
+        var request = new GetActiveFormDefinitionQuery(1, userId, "access.authenticated");
+
+        _formsRepository.SingleOrDefaultAsync(Arg.Any<ActiveFormDefinitionByFormIdSpec>(), CancellationToken.None)
+            .Returns(formWithActiveDefinition);
+        _customQuestionsRepository.ListAsync(Arg.Any<CustomQuestionSpecifications.ByTenantId>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+        _authorizationService.ValidateAccessAsync("access.authenticated", Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+        _authorizationService.HasPermissionAsync(Actions.Forms.Test, Arg.Any<CancellationToken>())
+            .Returns(Result.Success(true));
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value!.HasUserSubmitted.Should().BeFalse();
+        await _submissionRepository.DidNotReceive().AnyAsync(
+            Arg.Any<SubmissionByFormIdAndSubmittedBySpec>(),
+            Arg.Any<CancellationToken>());
     }
 
     #endregion


### PR DESCRIPTION
## Description

- Added `HasUserSubmitted` + `Metadata` to active-definition contracts and API model mapping (`ActiveDefinitionDto`, `FormDefinitionModel`, `FormDefinitionMapper`).
- Updated active-definition handler to compute `HasUserSubmitted` via `SubmissionByFormIdAndSubmittedBySpec` (`AnyAsync`) when `LimitOnePerUser` is enabled and user ID exists; also passed through form metadata.
- Added/updated tests:
  - Core handler tests for `HasUserSubmitted` true/false scenarios.
  - API endpoint test assertions for mapped `HasUserSubmitted` + `Metadata`.

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Forms now track and display whether you have already submitted them.
  * Forms can include and display additional metadata information.
  * Single-submission-per-user limits are now properly enforced, preventing duplicate submissions while allowing authorized testers to bypass restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->