### PR TITLE
feat: Extend data lists list DTO with created/modified dates and item count

### DIFF
--- a/src/Endatix.Api/Endpoints/DataLists/Create.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/Create.cs
@@ -54,12 +54,8 @@ public sealed class Create(
         IsActive = dataList.IsActive,
         CreatedAt = dataList.CreatedAt,
         ModifiedAt = dataList.ModifiedAt,
-        ItemsCount = dataList.Items.Count,
-        Items = [.. dataList.Items.Select(d => new DataListItemModel(){
-            Id = d.Id,
-            Label = d.Label,
-            Value = d.Value
-        })]
+        ItemsCount = 0,
+        Items = []
     };
 }
 

--- a/src/Endatix.Api/Endpoints/DataLists/Create.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/Create.cs
@@ -17,8 +17,9 @@ namespace Endatix.Api.Endpoints.DataLists;
 /// </summary>
 public sealed class Create(
     IMediator mediator)
-    : Endpoint<CreateDataListRequest, Results<Created<DataListModel>, ProblemHttpResult>>
+    : Endpoint<CreateDataListRequest, Results<Created<DataListDetailsModel>, ProblemHttpResult>>
 {
+    /// <inheritdoc />
     public override void Configure()
     {
         Post("data-lists");
@@ -34,23 +35,31 @@ public sealed class Create(
         FeatureFlag<EndpointFeatureGate>(FeatureFlags.DataLists);
     }
 
-    public override async Task<Results<Created<DataListModel>, ProblemHttpResult>> ExecuteAsync(CreateDataListRequest request, CancellationToken ct)
+    /// <inheritdoc />
+    public override async Task<Results<Created<DataListDetailsModel>, ProblemHttpResult>> ExecuteAsync(CreateDataListRequest request, CancellationToken ct)
     {
         CreateDataListCommand command = new(request.Name!, request.Description);
 
         var result = await mediator.Send(command, ct);
         return TypedResultsBuilder
             .MapResult(result, MapCreatedModel)
-            .SetTypedResults<Created<DataListModel>, ProblemHttpResult>();
+            .SetTypedResults<Created<DataListDetailsModel>, ProblemHttpResult>();
     }
 
-    private static DataListModel MapCreatedModel(DataList dataList) => new()
+    private static DataListDetailsModel MapCreatedModel(DataList dataList) => new()
     {
         Id = dataList.Id,
         Name = dataList.Name,
         Description = dataList.Description,
         IsActive = dataList.IsActive,
-        Items = []
+        CreatedAt = dataList.CreatedAt,
+        ModifiedAt = dataList.ModifiedAt,
+        ItemsCount = dataList.Items.Count,
+        Items = [.. dataList.Items.Select(d => new DataListItemModel(){
+            Id = d.Id,
+            Label = d.Label,
+            Value = d.Value
+        })]
     };
 }
 
@@ -60,6 +69,9 @@ public sealed class Create(
 /// </summary>
 public sealed class CreateDataListValidator : Validator<CreateDataListRequest>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CreateDataListValidator"/> class.
+    /// </summary>
     public CreateDataListValidator()
     {
         RuleFor(x => x.Name)
@@ -87,5 +99,3 @@ public sealed class CreateDataListRequest
     /// </summary>
     public string? Description { get; init; }
 }
-
-

--- a/src/Endatix.Api/Endpoints/DataLists/DataListMapper.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/DataListMapper.cs
@@ -19,6 +19,25 @@ public static class DataListMapper
         Name = dto.Name,
         Description = dto.Description,
         IsActive = dto.IsActive,
+        CreatedAt = dto.CreatedAt,
+        ModifiedAt = dto.ModifiedAt,
+        ItemsCount = dto.ItemsCount
+    };
+
+    /// <summary>
+    /// Maps a data list DTO to a data list details model.
+    /// </summary>
+    /// <param name="dto">The data list DTO.</param>
+    /// <returns>The data list details model.</returns>
+    public static DataListDetailsModel MapDetails(DataListDto dto) => new()
+    {
+        Id = dto.Id,
+        Name = dto.Name,
+        Description = dto.Description,
+        IsActive = dto.IsActive,
+        CreatedAt = dto.CreatedAt,
+        ModifiedAt = dto.ModifiedAt,
+        ItemsCount = dto.ItemsCount,
         Items = [.. dto.Items.Select(Map)]
     };
 

--- a/src/Endatix.Api/Endpoints/DataLists/DataListModel.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/DataListModel.cs
@@ -4,7 +4,7 @@ namespace Endatix.Api.Endpoints.DataLists;
 /// <summary>
 /// Data list model.
 /// </summary>
-public sealed class DataListModel
+public class DataListModel
 {
     /// <summary>
     /// The id of the data list.
@@ -23,8 +23,32 @@ public sealed class DataListModel
     /// Whether the data list is active.
     /// </summary>
     public bool IsActive { get; init; }
+
     /// <summary>
-    /// The items of the data list.
+    /// The created at date of the data list.
+    /// </summary>
+    public DateTime CreatedAt { get; init; }
+
+    /// <summary>
+    /// The modified at date of the data list.
+    /// </summary>
+    public DateTime? ModifiedAt { get; init; }
+
+    /// <summary>
+    /// The optional count of items in the data list. 
+    /// This can be conditionally populated based on request parameters.
+    /// </summary>
+    public int ItemsCount { get; init; }
+}
+
+/// <summary>
+/// Data list details model used for the GetById endpoint.
+/// Inherits the base properties and includes the full Items collection.
+/// </summary>
+public sealed class DataListDetailsModel : DataListModel
+{
+    /// <summary>
+    /// The full items of the data list.
     /// </summary>
     public IReadOnlyCollection<DataListItemModel> Items { get; init; } = [];
 }
@@ -54,6 +78,13 @@ public sealed class DataListItemModel
 /// </summary>
 public sealed class DataListPublicChoiceModel
 {
+    /// <summary>
+    /// The label of the data list public choice.
+    /// </summary>
     public string Label { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The value of the data list public choice.
+    /// </summary>
     public string Value { get; init; } = string.Empty;
 }

--- a/src/Endatix.Api/Endpoints/DataLists/GetById.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/GetById.cs
@@ -16,8 +16,9 @@ namespace Endatix.Api.Endpoints.DataLists;
 public sealed class GetById(
     IMediator mediator
     )
-    : Endpoint<GetDataListRequest, Results<Ok<DataListModel>, ProblemHttpResult>>
+    : Endpoint<GetDataListRequest, Results<Ok<DataListDetailsModel>, ProblemHttpResult>>
 {
+    /// <inheritdoc />
     public override void Configure()
     {
         Get("data-lists/{dataListId}");
@@ -25,14 +26,15 @@ public sealed class GetById(
         FeatureFlag<EndpointFeatureGate>(FeatureFlags.DataLists);
     }
 
-    public override async Task<Results<Ok<DataListModel>, ProblemHttpResult>> ExecuteAsync(GetDataListRequest request, CancellationToken ct)
+    /// <inheritdoc />
+    public override async Task<Results<Ok<DataListDetailsModel>, ProblemHttpResult>> ExecuteAsync(GetDataListRequest request, CancellationToken ct)
     {
         GetDataListByIdQuery query = new(request.DataListId);
         var result = await mediator.Send(query, ct);
 
         return TypedResultsBuilder
-            .MapResult(result, DataListMapper.Map)
-            .SetTypedResults<Ok<DataListModel>, ProblemHttpResult>();
+            .MapResult(result, DataListMapper.MapDetails)
+            .SetTypedResults<Ok<DataListDetailsModel>, ProblemHttpResult>();
     }
 }
 
@@ -42,6 +44,9 @@ public sealed class GetById(
 /// </summary>
 public sealed class GetDataListValidator : Validator<GetDataListRequest>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GetDataListValidator"/> class.
+    /// </summary>
     public GetDataListValidator()
     {
         RuleFor(x => x.DataListId).GreaterThan(0);

--- a/src/Endatix.Api/Endpoints/DataLists/List.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/List.cs
@@ -25,7 +25,7 @@ public sealed class List(
     public override void Configure()
     {
         Get("data-lists");
-        Permissions(Actions.Forms.View);        
+        Permissions(Actions.Forms.View);
         FeatureFlag<EndpointFeatureGate>(FeatureFlags.DataLists);
     }
     /// <summary>
@@ -65,7 +65,10 @@ public sealed class DataListsListValidator : Validator<DataListsListRequest>
 /// </summary>
 public sealed class DataListsListRequest : IPagedRequest
 {
+    /// <inheritdoc />
     public int? Page { get; set; }
+
+    /// <inheritdoc />
     public int? PageSize { get; set; }
 }
 

--- a/src/Endatix.Api/Endpoints/DataLists/ReplaceItems.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/ReplaceItems.cs
@@ -42,7 +42,7 @@ public sealed class ReplaceItems(
             .SetTypedResults<Ok<DataListDetailsModel>, ProblemHttpResult>();
     }
 
-    private ReplaceDataListItemInput ToReplaceDataListItemInput(ReplaceDataListItemRequest request) => new(
+    private static ReplaceDataListItemInput ToReplaceDataListItemInput(ReplaceDataListItemRequest request) => new(
         request.Label ?? string.Empty,
         request.Value ?? string.Empty);
 

--- a/src/Endatix.Api/Endpoints/DataLists/ReplaceItems.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/ReplaceItems.cs
@@ -16,8 +16,11 @@ namespace Endatix.Api.Endpoints.DataLists;
 /// </summary>
 public sealed class ReplaceItems(
     IMediator mediator)
-    : Endpoint<ReplaceDataListItemsRequest, Results<Ok<DataListModel>, ProblemHttpResult>>
+    : Endpoint<ReplaceDataListItemsRequest, Results<Ok<DataListDetailsModel>, ProblemHttpResult>>
 {
+    /// <summary>
+    /// Configures the endpoint settings.
+    /// </summary>
     public override void Configure()
     {
         Put("data-lists/{dataListId}/items");
@@ -25,17 +28,24 @@ public sealed class ReplaceItems(
         FeatureFlag<EndpointFeatureGate>(FeatureFlags.DataLists);
     }
 
-    public override async Task<Results<Ok<DataListModel>, ProblemHttpResult>> ExecuteAsync(ReplaceDataListItemsRequest request, CancellationToken ct)
+    /// <inheritdoc />
+    public override async Task<Results<Ok<DataListDetailsModel>, ProblemHttpResult>> ExecuteAsync(ReplaceDataListItemsRequest request, CancellationToken ct)
     {
-        ReplaceDataListItemsCommand command = new(
+        var command = new ReplaceDataListItemsCommand(
             request.DataListId,
-            request.Items.Select(x => new ReplaceDataListItemInput(x.Label ?? string.Empty, x.Value ?? string.Empty)).ToArray());
+            [.. request.Items.Select(ToReplaceDataListItemInput)]);
 
         var result = await mediator.Send(command, ct);
+
         return TypedResultsBuilder
-            .MapResult(result, DataListMapper.Map)
-            .SetTypedResults<Ok<DataListModel>, ProblemHttpResult>();
+            .MapResult(result, DataListMapper.MapDetails)
+            .SetTypedResults<Ok<DataListDetailsModel>, ProblemHttpResult>();
     }
+
+    private ReplaceDataListItemInput ToReplaceDataListItemInput(ReplaceDataListItemRequest request) => new(
+        request.Label ?? string.Empty,
+        request.Value ?? string.Empty);
+
 }
 
 
@@ -44,6 +54,9 @@ public sealed class ReplaceItems(
 /// </summary>
 public sealed class ReplaceDataListItemsValidator : Validator<ReplaceDataListItemsRequest>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplaceDataListItemsValidator"/> class.
+    /// </summary>
     public ReplaceDataListItemsValidator()
     {
         RuleFor(x => x.DataListId).GreaterThan(0);
@@ -54,6 +67,7 @@ public sealed class ReplaceDataListItemsValidator : Validator<ReplaceDataListIte
             item.RuleFor(x => x.Label)
                 .NotEmpty()
                 .MaximumLength(DataSchemaConstants.MAX_NAME_LENGTH);
+
             item.RuleFor(x => x.Value)
                 .NotEmpty()
                 .MaximumLength(DataSchemaConstants.MAX_NAME_LENGTH);

--- a/src/Endatix.Api/Endpoints/DataLists/Search.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/Search.cs
@@ -37,6 +37,7 @@ public sealed class Search(
         FeatureFlag<EndpointFeatureGate>(FeatureFlags.DataLists);
     }
 
+    /// <inheritdoc />
     public override async Task<Results<Ok<Paged<DataListPublicChoiceModel>>, ProblemHttpResult>> ExecuteAsync(SearchDataListItemsRequest request, CancellationToken ct)
     {
         PublicFormAccessContext accessContext = new(request.FormId, request.Token, request.TokenType);

--- a/src/Endatix.Core/Specifications/DataListsSpecifications.cs
+++ b/src/Endatix.Core/Specifications/DataListsSpecifications.cs
@@ -23,26 +23,36 @@ public class DataListsSpecifications
         public ListSpec()
         {
             Query
-                .OrderByDescending(x => x.CreatedAt)
-                .AsNoTracking();
+                 .OrderByDescending(x => x.CreatedAt)
+                 .AsNoTracking();
         }
     }
 
     /// <summary>
-    /// Specification to get data lists with paging.
+    /// Specification to get paged data lists projected to DTO without loading all items.
     /// </summary>
-    public sealed class WithPagingSpec : Specification<DataList>
+    public sealed class ListWithPagingToDtoSpec : Specification<DataList, DataListDto>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="WithPagingSpec"/> class.
+        /// Initializes a new instance of the <see cref="ListWithPagingToDtoSpec"/> class.
         /// </summary>
         /// <param name="pagingParams">The paging parameters.</param>
-        public WithPagingSpec(PagingParameters pagingParams)
+        public ListWithPagingToDtoSpec(PagingParameters pagingParams)
         {
             Query
                 .OrderByDescending(x => x.CreatedAt)
                 .Paginate(pagingParams)
                 .AsNoTracking();
+
+            Query.Select(dataList => new DataListDto(
+                dataList.Id,
+                dataList.Name,
+                dataList.Description,
+                dataList.CreatedAt,
+                dataList.ModifiedAt,
+                dataList.IsActive,
+                dataList.Items.Count,
+                Array.Empty<DataListItemDto>()));
         }
     }
 
@@ -52,6 +62,10 @@ public class DataListsSpecifications
     /// </summary>
     public sealed class ByNameSpec : SingleResultSpecification<DataList>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ByNameSpec"/> class.
+        /// </summary>
+        /// <param name="name">The name of the data list.</param>
         public ByNameSpec(string name)
         {
             Query.Where(x => x.Name == name);
@@ -64,6 +78,10 @@ public class DataListsSpecifications
     /// </summary>
     public sealed class ExistsSpec : Specification<DataList>, ISingleResultSpecification<DataList>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ExistsSpec"/> class.
+        /// </summary>
+        /// <param name="dataListId">The ID of the data list.</param>
         public ExistsSpec(long dataListId)
         {
             Query.Where(x => x.Id == dataListId);
@@ -76,6 +94,10 @@ public class DataListsSpecifications
     /// </summary>
     public sealed class ByIdWithItemsSpec : Specification<DataList>, ISingleResultSpecification<DataList>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ByIdWithItemsSpec"/> class.
+        /// </summary>
+        /// <param name="dataListId">The ID of the data list.</param>
         public ByIdWithItemsSpec(long dataListId)
         {
             Query
@@ -90,6 +112,11 @@ public class DataListsSpecifications
     /// </summary>
     public sealed class ByIdWithItemsByValuesSpec : Specification<DataList>, ISingleResultSpecification<DataList>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ByIdWithItemsByValuesSpec"/> class.
+        /// </summary>
+        /// <param name="dataListId">The ID of the data list.</param>
+        /// <param name="values">The values to filter the data list items by.</param>
         public ByIdWithItemsByValuesSpec(long dataListId, IReadOnlyCollection<string> values)
         {
             Query.Where(x => x.Id == dataListId && x.IsActive);
@@ -109,6 +136,9 @@ public class DataListsSpecifications
     /// </summary>
     public sealed class ToDataListDtoSpec : SingleResultSpecification<DataList, DataListDto>
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ToDataListDtoSpec"/> class.
+        /// </summary>
         public ToDataListDtoSpec()
         {
             Query.Select(dataList =>
@@ -116,7 +146,10 @@ public class DataListsSpecifications
                                 dataList.Id,
                                 dataList.Name,
                                 dataList.Description,
+                                dataList.CreatedAt,
+                                dataList.ModifiedAt,
                                 dataList.IsActive,
+                                dataList.Items.Count,
                                 dataList.Items.Select(x => new DataListItemDto(x.Id, x.Label, x.Value)).ToArray())
                 );
         }

--- a/src/Endatix.Core/UseCases/DataLists/DataListDto.cs
+++ b/src/Endatix.Core/UseCases/DataLists/DataListDto.cs
@@ -7,7 +7,10 @@ public sealed record DataListDto(
     long Id,
     string Name,
     string? Description,
+    DateTime CreatedAt,
+    DateTime? ModifiedAt,
     bool IsActive,
+    int ItemsCount,
     IReadOnlyCollection<DataListItemDto> Items);
 
 /// <summary>

--- a/src/Endatix.Core/UseCases/DataLists/List/ListDataListsHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/List/ListDataListsHandler.cs
@@ -17,21 +17,14 @@ public sealed class ListDataListsHandler(IRepository<DataList> repository)
     public async Task<Result<Paged<DataListDto>>> Handle(ListDataListsQuery request, CancellationToken cancellationToken)
     {
         PagingParameters pagingParams = new(request.Page, request.PageSize);
-        var pagedSpec = new DataListsSpecifications.WithPagingSpec(pagingParams);
+        var pagedSpec = new DataListsSpecifications.ListWithPagingToDtoSpec(pagingParams);
         var listSpec = new DataListsSpecifications.ListSpec();
         var totalRecords = await repository.CountAsync(listSpec, cancellationToken);
 
 
-        var dataLists = totalRecords <= 0
-        ? Enumerable.Empty<DataList>()
+        var dataListDtos = totalRecords <= 0
+        ? Enumerable.Empty<DataListDto>()
         : await repository.ListAsync(pagedSpec, cancellationToken);
-
-        var dataListDtos = dataLists.Select(x => new DataListDto(
-            Id: x.Id,
-            Name: x.Name,
-            Description: x.Description,
-            IsActive: x.IsActive,
-            Items: []));
 
         var skip = (pagingParams.Page - 1) * pagingParams.PageSize;
         var paged = Paged<DataListDto>.FromSkipAndTake(

--- a/src/Endatix.Core/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsCommand.cs
+++ b/src/Endatix.Core/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsCommand.cs
@@ -4,18 +4,34 @@ using Endatix.Core.Infrastructure.Result;
 
 namespace Endatix.Core.UseCases.DataLists.ReplaceItems;
 
+/// <summary>
+/// Command to replace items in a data list.
+/// </summary>
 public sealed record ReplaceDataListItemsCommand : ICommand<Result<DataListDto>>
 {
+    /// <summary>
     public long DataListId { get; init; }
+    /// <summary>
+    /// The items to replace in the data list.
+    /// </summary>
     public IReadOnlyCollection<ReplaceDataListItemInput> Items { get; init; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplaceDataListItemsCommand"/> class.
+    /// </summary>
+    /// <param name="dataListId">The ID of the data list to replace items for.</param>
+    /// <param name="items">The items to replace in the data list.</param>
     public ReplaceDataListItemsCommand(long dataListId, IReadOnlyCollection<ReplaceDataListItemInput> items)
     {
         Guard.Against.NegativeOrZero(dataListId);
         Guard.Against.Null(items);
+
         DataListId = dataListId;
         Items = items;
     }
 }
 
+/// <summary>
+/// Input for replacing a single item in a data list.
+/// </summary>
 public sealed record ReplaceDataListItemInput(string Label, string Value);

--- a/src/Endatix.Core/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsHandler.cs
@@ -8,12 +8,16 @@ using MediatR;
 
 namespace Endatix.Core.UseCases.DataLists.ReplaceItems;
 
+/// <summary>
+/// Handler for replacing items in a data list.
+/// </summary>
 public sealed class ReplaceDataListItemsHandler(
     IRepository<DataList> repository,
     IMediator mediator
     )
     : ICommandHandler<ReplaceDataListItemsCommand, Result<DataListDto>>
 {
+    /// <inheritdoc />
     public async Task<Result<DataListDto>> Handle(ReplaceDataListItemsCommand request, CancellationToken cancellationToken)
     {
         var spec = new DataListsSpecifications.ByIdWithItemsSpec(request.DataListId);
@@ -53,7 +57,10 @@ public sealed class ReplaceDataListItemsHandler(
             dataList.Id,
             dataList.Name,
             dataList.Description,
+            dataList.CreatedAt,
+            dataList.ModifiedAt,
             dataList.IsActive,
-            dataList.Items.Select(x => new DataListItemDto(x.Id, x.Label, x.Value)).ToArray()));
+            dataList.Items.Count,
+            [.. dataList.Items.Select(x => new DataListItemDto(x.Id, x.Label, x.Value))]));
     }
 }

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/ListTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/ListTests.cs
@@ -29,7 +29,7 @@ public class ListTests
             totalPages: 1,
             items:
             [
-                new DataListDto(11, "Cities", null, true, [])
+                new DataListDto(11, "Cities", null, DateTime.UtcNow, null, true, 0, [])
             ]);
         var result = Result.Success(payload);
         _mediator.Send(Arg.Any<ListDataListsQuery>(), Arg.Any<CancellationToken>())
@@ -50,7 +50,7 @@ public class ListTests
     {
         DataListsListRequest request = new() { Page = 2, PageSize = 25 };
         _mediator.Send(Arg.Any<ListDataListsQuery>(), Arg.Any<CancellationToken>())
-            .Returns(Result.Success(new Paged<DataListDto>(1, 25, 0, 0, [])));
+            .Returns(Result.Success(new Paged<DataListDto>(1, 25, 0, 0, Array.Empty<DataListDto>())));
 
         await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
 

--- a/tests/Endatix.Core.Tests/Infrastructure/Result/PagedTests.cs
+++ b/tests/Endatix.Core.Tests/Infrastructure/Result/PagedTests.cs
@@ -121,7 +121,7 @@ public class PagedTests
     }
 
     [Fact]
-    public void FromPagedRequest_ValidInput_CreatesInstance()
+    public void FromSkipAndTake_ValidInput_CreatesInstance()
     {
         var items = new[] { "a", "b" };
 
@@ -135,7 +135,7 @@ public class PagedTests
     }
 
     [Fact]
-    public void FromPagedRequest_SecondPage_CreatesCorrectPage()
+    public void FromSkipAndTake_SecondPage_CreatesCorrectPage()
     {
         var items = new[] { "c", "d" };
 
@@ -147,7 +147,7 @@ public class PagedTests
     [Theory]
     [InlineData(-1, 10)]
     [InlineData(-5, 10)]
-    public void FromPagedRequest_InvalidSkip_ThrowsArgumentException(int skip, int take)
+    public void FromSkipAndTake_InvalidSkip_ThrowsArgumentException(int skip, int take)
     {
         var items = new[] { "a" };
 
@@ -157,7 +157,7 @@ public class PagedTests
     }
 
     [Fact]
-    public void FromPagedRequest_TakeIsZero_ThrowsArgumentException()
+    public void FromSkipAndTake_TakeIsZero_ThrowsArgumentException()
     {
         var items = new[] { "a" };
 
@@ -167,7 +167,7 @@ public class PagedTests
     }
 
     [Fact]
-    public void FromPagedRequest_TotalRecordsZero_ReturnsEmpty()
+    public void FromSkipAndTake_TotalRecordsZero_ReturnsEmpty()
     {
         var items = Array.Empty<string>();
 

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/Create/CreateDataListHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/Create/CreateDataListHandlerTests.cs
@@ -24,6 +24,23 @@ public class CreateDataListHandlerTests
     }
 
     [Fact]
+    public async Task Handle_ValidRequest_ReturnsCreated()
+    {
+        _tenantContext.TenantId.Returns(101);
+        _repository.SingleOrDefaultAsync(Arg.Any<DataListsSpecifications.ByNameSpec>(), Arg.Any<CancellationToken>())
+            .Returns((DataList?)null);
+        _repository.AddAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>())
+            .Returns(info => new DataList(101, info[0]?.ToString()!, "Test Description"));
+
+        var result = await _sut.Handle(
+            new CreateDataListCommand("Cities", "Test Description"),
+            TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.Created);
+        result.Value.Should().NotBeNull();
+    }
+
+    [Fact]
     public async Task Handle_DuplicateNameExists_ReturnsInvalid()
     {
         _tenantContext.TenantId.Returns(101);
@@ -54,5 +71,79 @@ public class CreateDataListHandlerTests
             TestContext.Current.CancellationToken);
 
         result.Status.Should().Be(ResultStatus.Invalid);
+    }
+
+    [Fact]
+    public async Task Handle_UnauthorizedTenant_ReturnsUnauthorized()
+    {
+        _tenantContext.TenantId.Returns(0);
+
+        var result = await _sut.Handle(
+            new CreateDataListCommand("Cities", null),
+            TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.Unauthorized);
+        await _repository.DidNotReceive().AddAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_NegativeTenantId_ReturnsUnauthorized()
+    {
+        _tenantContext.TenantId.Returns(-1);
+
+        var result = await _sut.Handle(
+            new CreateDataListCommand("Cities", null),
+            TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.Unauthorized);
+    }
+
+    [Fact]
+    public void Handle_CommandWithNullName_ThrowsArgumentException()
+    {
+        Action act = () => _ = new CreateDataListCommand(null!, "description");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Handle_CommandWithWhitespaceName_ThrowsArgumentException()
+    {
+        Action act = () => _ = new CreateDataListCommand("   ", "description");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task Handle_ValidCommand_SetsCorrectName()
+    {
+        _tenantContext.TenantId.Returns(101);
+        _repository.SingleOrDefaultAsync(Arg.Any<DataListsSpecifications.ByNameSpec>(), Arg.Any<CancellationToken>())
+            .Returns((DataList?)null);
+        _repository.AddAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>())
+            .Returns(new DataList(101, "Cities", "description"));
+
+        var result = await _sut.Handle(
+            new CreateDataListCommand("Cities", "description"),
+            TestContext.Current.CancellationToken);
+
+        result.Value!.Name.Should().Be("Cities");
+    }
+
+    [Fact]
+    public async Task Handle_ValidCommand_SetsCorrectTenantId()
+    {
+        const long tenantId = 101;
+        _tenantContext.TenantId.Returns(tenantId);
+        _repository.SingleOrDefaultAsync(Arg.Any<DataListsSpecifications.ByNameSpec>(), Arg.Any<CancellationToken>())
+            .Returns((DataList?)null);
+        _repository.AddAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>())
+            .Returns(info => new DataList(tenantId, "Cities"));
+
+        var result = await _sut.Handle(
+            new CreateDataListCommand("Cities", null),
+            TestContext.Current.CancellationToken);
+
+        result.Value!.TenantId.Should().Be(tenantId);
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsHandlerTests.cs
@@ -87,4 +87,102 @@ public class ReplaceDataListItemsHandlerTests
             Arg.Any<CancellationToken>()
         );
     }
+
+    [Fact]
+    public async Task Handle_EmptyLabel_ReturnsInvalid()
+    {
+        var dataList = new DataList(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        _repository.SingleOrDefaultAsync(Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(), Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        var result = await _sut.Handle(
+            new ReplaceDataListItemsCommand(1, [new("", "NYC")]),
+            TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().Contain(e => e.Identifier == "Label");
+    }
+
+    [Fact]
+    public async Task Handle_WhitespaceLabel_ReturnsInvalid()
+    {
+        var dataList = new DataList(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        _repository.SingleOrDefaultAsync(Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(), Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        var result = await _sut.Handle(
+            new ReplaceDataListItemsCommand(1, [new("   ", "NYC")]),
+            TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.Invalid);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyValue_ReturnsInvalid()
+    {
+        var dataList = new DataList(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        _repository.SingleOrDefaultAsync(Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(), Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        var result = await _sut.Handle(
+            new ReplaceDataListItemsCommand(1, [new("City", "")]),
+            TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().Contain(e => e.Identifier == "Value");
+    }
+
+    [Fact]
+    public async Task Handle_WhitespaceValue_ReturnsInvalid()
+    {
+        var dataList = new DataList(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        _repository.SingleOrDefaultAsync(Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(), Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        var result = await _sut.Handle(
+            new ReplaceDataListItemsCommand(1, [new("City", "   ")]),
+            TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.Invalid);
+    }
+
+    [Fact]
+    public void Handle_CommandWithNullItems_ThrowsArgumentNullException()
+    {
+        Action act = () => _ = new ReplaceDataListItemsCommand(1, null!);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Handle_CommandWithZeroId_ThrowsArgumentException()
+    {
+        Action act = () => _ = new ReplaceDataListItemsCommand(0, [new("City", "NYC")]);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Handle_CommandWithNegativeId_ThrowsArgumentException()
+    {
+        Action act = () => _ = new ReplaceDataListItemsCommand(-1, [new("City", "NYC")]);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public async Task Handle_EmptyItemsList_ReplacesWithEmptyCollection()
+    {
+        var dataList = new DataList(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        dataList.ReplaceItems([("LA", "Los Angeles")]);
+        _repository.SingleOrDefaultAsync(Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(), Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        var result = await _sut.Handle(
+            new ReplaceDataListItemsCommand(1, []),
+            TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value!.Items.Should().BeEmpty();
+    }
 }


### PR DESCRIPTION
#  feat: Extend data lists list DTO with created/modified dates and item count

## Description
- Adds CreatedAt, ModifiedAt and ItemsCount at the DataListModel
- Add List and Details variations to the list model
- Fixes specifications
- Updates tests
- Fixes code styling issues

## Related Issues
- closes https://github.com/endatix/endatix/issues/714

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [x] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
![Uploading image.png…]()

