### PR TITLE
feat: Added testing for date filters

### DIFF
--- a/tests/Endatix.Core.Tests/Specifications/SubmissionSpecificationExtensionsTests.cs
+++ b/tests/Endatix.Core.Tests/Specifications/SubmissionSpecificationExtensionsTests.cs
@@ -2,6 +2,7 @@ using Ardalis.Specification;
 using Endatix.Core.Entities;
 using Endatix.Core.Specifications;
 using Endatix.Core.Specifications.Parameters;
+using Endatix.Core.UseCases.Submissions;
 
 namespace Endatix.Core.Tests.Specifications;
 
@@ -26,12 +27,112 @@ public class SubmissionSpecificationExtensionsTests
         matchesOtherForm.Should().BeFalse();
     }
 
+    [Fact]
+    public void SubmissionsByFormIdSpec_CreatedAtRange_AppliesDateFilters()
+    {
+        // Arrange
+        var spec = new SubmissionsByFormIdSpec(
+            10,
+            new PagingParameters(1, 10),
+            new FilterParameters([
+                "createdAt>:2026-01-02T00:00:00.000Z",
+                "createdAt<2026-01-04T00:00:00.000Z"
+            ]));
+
+        // Act
+        var matchesBefore = Matches(spec, CreateSubmission(10, SubmissionStatus.New, createdAt: new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc)));
+        var matchesInside = Matches(spec, CreateSubmission(10, SubmissionStatus.New, createdAt: new DateTime(2026, 1, 3, 12, 0, 0, DateTimeKind.Utc)));
+        var matchesAfter = Matches(spec, CreateSubmission(10, SubmissionStatus.New, createdAt: new DateTime(2026, 1, 4, 0, 0, 0, DateTimeKind.Utc)));
+
+        // Assert
+        matchesBefore.Should().BeFalse();
+        matchesInside.Should().BeTrue();
+        matchesAfter.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SubmissionsByFormIdCountSpec_CreatedAtRange_AppliesDateFilters()
+    {
+        // Arrange
+        var spec = new SubmissionsByFormIdCountSpec(
+            10,
+            new FilterParameters([
+                "createdAt>:2026-01-02T00:00:00.000Z",
+                "createdAt<2026-01-04T00:00:00.000Z"
+            ]));
+
+        // Act
+        var matchesBefore = Matches(spec, CreateSubmission(10, SubmissionStatus.New, createdAt: new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc)));
+        var matchesInside = Matches(spec, CreateSubmission(10, SubmissionStatus.New, createdAt: new DateTime(2026, 1, 3, 12, 0, 0, DateTimeKind.Utc)));
+        var matchesAfter = Matches(spec, CreateSubmission(10, SubmissionStatus.New, createdAt: new DateTime(2026, 1, 4, 0, 0, 0, DateTimeKind.Utc)));
+
+        // Assert
+        matchesBefore.Should().BeFalse();
+        matchesInside.Should().BeTrue();
+        matchesAfter.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SubmissionsByFormIdSpec_CompletedAtRange_AppliesDateFiltersAndExcludesIncompleteSubmissions()
+    {
+        // Arrange
+        var spec = new SubmissionsByFormIdSpec(
+            10,
+            new PagingParameters(1, 10),
+            new FilterParameters([
+                "completedAt>:2026-01-02T00:00:00.000Z",
+                "completedAt<2026-01-04T00:00:00.000Z"
+            ]));
+
+        // Act
+        var matchesBefore = Matches(spec, CreateSubmission(10, SubmissionStatus.New, completedAt: new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc)));
+        var matchesInside = Matches(spec, CreateSubmission(10, SubmissionStatus.New, completedAt: new DateTime(2026, 1, 3, 12, 0, 0, DateTimeKind.Utc)));
+        var matchesIncomplete = Matches(spec, CreateSubmission(10, SubmissionStatus.New, isComplete: false));
+
+        // Assert
+        matchesBefore.Should().BeFalse();
+        matchesInside.Should().BeTrue();
+        matchesIncomplete.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SubmissionsByFormIdCountSpec_CompletedAtRange_AppliesDateFiltersAndExcludesIncompleteSubmissions()
+    {
+        // Arrange
+        var spec = new SubmissionsByFormIdCountSpec(
+            10,
+            new FilterParameters([
+                "completedAt>:2026-01-02T00:00:00.000Z",
+                "completedAt<2026-01-04T00:00:00.000Z"
+            ]));
+
+        // Act
+        var matchesBefore = Matches(spec, CreateSubmission(10, SubmissionStatus.New, completedAt: new DateTime(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc)));
+        var matchesInside = Matches(spec, CreateSubmission(10, SubmissionStatus.New, completedAt: new DateTime(2026, 1, 3, 12, 0, 0, DateTimeKind.Utc)));
+        var matchesIncomplete = Matches(spec, CreateSubmission(10, SubmissionStatus.New, isComplete: false));
+
+        // Assert
+        matchesBefore.Should().BeFalse();
+        matchesInside.Should().BeTrue();
+        matchesIncomplete.Should().BeFalse();
+    }
+
     private static bool Matches(ISpecification<Submission> spec, Submission submission)
     {
         return spec.WhereExpressions.All(where => where.FilterFunc(submission));
     }
 
-    private static Submission CreateSubmission(long formId, SubmissionStatus status)
+    private static bool Matches(ISpecification<Submission, SubmissionDto> spec, Submission submission)
+    {
+        return spec.WhereExpressions.All(where => where.FilterFunc(submission));
+    }
+
+    private static Submission CreateSubmission(
+        long formId,
+        SubmissionStatus status,
+        DateTime? createdAt = null,
+        DateTime? completedAt = null,
+        bool isComplete = true)
     {
         var formDefinition = new FormDefinition(SampleData.TENANT_ID);
         typeof(FormDefinition)
@@ -42,11 +143,22 @@ public class SubmissionSpecificationExtensionsTests
             SampleData.TENANT_ID,
             "{}",
             formId,
-            formDefinitionId: 1);
+            formDefinitionId: 1,
+            options: new SubmissionCreateOptions(IsComplete: isComplete));
 
         typeof(Submission)
             .GetProperty(nameof(Submission.FormDefinition))!
             .SetValue(submission, formDefinition);
+        typeof(Submission)
+            .GetProperty(nameof(Submission.CreatedAt))!
+            .SetValue(submission, createdAt ?? new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        if (completedAt.HasValue)
+        {
+            typeof(Submission)
+                .GetProperty(nameof(Submission.CompletedAt))!
+                .SetValue(submission, completedAt);
+        }
 
         submission.UpdateStatus(status);
 


### PR DESCRIPTION
## Description

Stacked PR: Added date filters in support of date filtering on the Hub.

- Adds regression coverage for submission specification filtering.
- Verifies createdAt and completedAt date range filters.
- Verifies completed-date filters exclude incomplete submissions with null CompletedAt.
- Verifies multiple status filters are applied together, including inclusive and exclusive criteria.

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above
