### PR TITLE
fix: add logic to detect status quo folder moves

### DIFF
--- a/src/Endatix.Api/Endpoints/FormTemplates/Create.cs
+++ b/src/Endatix.Api/Endpoints/FormTemplates/Create.cs
@@ -38,7 +38,7 @@ public class Create(IMediator mediator) : Endpoint<CreateFormTemplateRequest, Re
         var result = await mediator.Send(createCommand, ct);
 
         return TypedResultsBuilder
-            .MapResult(result, FormTemplateMapper.Map<CreateFormTemplateResponse>)
+            .MapResult(result, formTemplate => formTemplate.ToFormTemplateModel<CreateFormTemplateResponse>())
             .SetTypedResults<Created<CreateFormTemplateResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/FormTemplates/FormTemplateMapper.cs
+++ b/src/Endatix.Api/Endpoints/FormTemplates/FormTemplateMapper.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using Endatix.Core.Entities;
 using Endatix.Core.UseCases.FormTemplates;
 
@@ -17,7 +14,7 @@ public static class FormTemplateMapper
     /// <typeparam name="T">The type of the form template API model, which inherits FormTemplateModel.</typeparam>
     /// <param name="formTemplate">The form template entity.</param>
     /// <returns>The mapped form template API model.</returns>
-    public static T Map<T>(FormTemplate formTemplate) where T : FormTemplateModel, new() => new T
+    public static T ToFormTemplateModel<T>(this FormTemplate formTemplate) where T : FormTemplateModel, new() => new T
     {
         Id = formTemplate.Id.ToString(),
         Name = formTemplate.Name,

--- a/src/Endatix.Api/Endpoints/FormTemplates/GetById.cs
+++ b/src/Endatix.Api/Endpoints/FormTemplates/GetById.cs
@@ -37,7 +37,7 @@ public class GetById(IMediator mediator) : Endpoint<GetFormTemplateByIdRequest, 
             cancellationToken);
 
         return TypedResultsBuilder
-            .MapResult(result, FormTemplateMapper.Map<FormTemplateModel>)
+            .MapResult(result, formTemplate => formTemplate.ToFormTemplateModel<FormTemplateModel>())
             .SetTypedResults<Ok<FormTemplateModel>, BadRequest, NotFound>();
     }
 }

--- a/src/Endatix.Api/Endpoints/FormTemplates/PartialUpdate.cs
+++ b/src/Endatix.Api/Endpoints/FormTemplates/PartialUpdate.cs
@@ -11,7 +11,7 @@ namespace Endatix.Api.Endpoints.FormTemplates;
 /// <summary>
 /// Endpoint for partially updating a form template.
 /// </summary>
-public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateFormTemplateRequest, Results<Ok<PartialUpdateFormTemplateResponse>, BadRequest, NotFound>>
+public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateFormTemplateRequest, Results<Ok<PartialUpdateFormTemplateResponse>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -31,7 +31,7 @@ public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateFormTempl
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<PartialUpdateFormTemplateResponse>, BadRequest, NotFound>> ExecuteAsync(PartialUpdateFormTemplateRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<PartialUpdateFormTemplateResponse>, ProblemHttpResult>> ExecuteAsync(PartialUpdateFormTemplateRequest request, CancellationToken ct)
     {
         var folderId = request.FolderId.ParseToLong();
 
@@ -41,10 +41,13 @@ public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateFormTempl
                 ClearFolderId = request.ClearFolderId,
                 FolderId = folderId,
             },
-            cancellationToken);
+            ct);
 
         return TypedResultsBuilder
-            .MapResult(result, FormTemplateMapper.Map<PartialUpdateFormTemplateResponse>)
-            .SetTypedResults<Ok<PartialUpdateFormTemplateResponse>, BadRequest, NotFound>();
+         .MapResult(
+            result,
+            formTemplate => formTemplate.ToFormTemplateModel<PartialUpdateFormTemplateResponse>()
+        )
+        .SetTypedResults<Ok<PartialUpdateFormTemplateResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Core/UseCases/Folders/FolderAssignmentPolicy.cs
+++ b/src/Endatix.Core/UseCases/Folders/FolderAssignmentPolicy.cs
@@ -15,7 +15,8 @@ public sealed class FolderAssignmentPolicy(
     IRepository<Folder> folderRepository,
     ITenantContext tenantContext)
 {
-    private const string IMMUTABLE_FOLDER_MOVE_ERROR = "Items in immutable folders cannot be moved or cleared.";
+    private const string IMMUTABLE_FOLDER_MOVE_ERROR = "Items in locked folders cannot be moved or cleared.";
+    private const string NO_OP_FOLDER_MOVE_ERROR = "Folder assignment is unchanged.";
 
     /// <summary>
     /// Ensures the folder assignment is valid for the current tenant.
@@ -105,6 +106,11 @@ public sealed class FolderAssignmentPolicy(
             return validation;
         }
 
+        if (IsStatusQuoFolderMove(currentFolderId, requestedFolderId))
+        {
+            return Result.Invalid(CreateStatusQuoFolderMoveValidationError());
+        }
+
         if (!applyMove(requestedFolderId))
         {
             return Result.Error(cannotMoveMessage);
@@ -112,5 +118,20 @@ public sealed class FolderAssignmentPolicy(
 
         return Result.Success();
     }
+
+    /// <summary>
+    /// True when current and requested are the same positive folder id (status quo folder move).
+    /// Excludes null/null — full replace may omit folder id without intending a PATCH no-op.
+    /// </summary>
+    private static bool IsStatusQuoFolderMove(long? currentFolderId, long? requestedFolderId) =>
+        currentFolderId is long currentId and > 0 &&
+        requestedFolderId is long requestedId and > 0 &&
+        currentId == requestedId;
+
+    private static ValidationError CreateStatusQuoFolderMoveValidationError() => new(
+                identifier: "folderId",
+                errorMessage: NO_OP_FOLDER_MOVE_ERROR,
+                errorCode: "FOLDER_ASSIGNMENT_UNCHANGED",
+                severity: ValidationSeverity.Error);
 }
 

--- a/src/Endatix.Core/UseCases/Forms/List/ListFormsHandler.cs
+++ b/src/Endatix.Core/UseCases/Forms/List/ListFormsHandler.cs
@@ -1,4 +1,4 @@
-﻿using Endatix.Core.Abstractions.Repositories;
+using Endatix.Core.Abstractions.Repositories;
 using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;

--- a/src/Endatix.Core/UseCases/Forms/List/ListFormsHandler.cs
+++ b/src/Endatix.Core/UseCases/Forms/List/ListFormsHandler.cs
@@ -6,17 +6,28 @@ using Endatix.Core.Specifications.Parameters;
 
 namespace Endatix.Core.UseCases.Forms.List;
 
-public class ListFormsHandler(IFormsRepository repository) : IQueryHandler<ListFormsQuery, Result<IEnumerable<FormDto>>>
+/// <summary>
+/// Handler for listing forms.
+/// </summary>
+public sealed class ListFormsHandler(IFormsRepository repository) : IQueryHandler<ListFormsQuery, Result<IEnumerable<FormDto>>>
 {
+    /// <inheritdoc/>
     public async Task<Result<IEnumerable<FormDto>>> Handle(ListFormsQuery request, CancellationToken cancellationToken)
     {
-        var pagingParams = new PagingParameters(request.Page, request.PageSize);
-        var filterParams = CreateFilterParameters(request.FilterExpressions, request.FolderId);
+        try
+        {
+            var pagingParams = new PagingParameters(request.Page, request.PageSize);
+            var filterParams = CreateFilterParameters(request.FilterExpressions, request.FolderId);
 
-        var spec = new FormsWithSubmissionsCountSpec(pagingParams, filterParams);
-        IEnumerable<FormDto> forms = await repository.ListAsync(spec, cancellationToken);
+            var spec = new FormsWithSubmissionsCountSpec(pagingParams, filterParams);
+            IEnumerable<FormDto> forms = await repository.ListAsync(spec, cancellationToken);
 
-        return Result.Success(forms);
+            return Result.Success(forms);
+        }
+        catch (Exception ex)
+        {
+            return Result.Error($"Error listing forms: {ex.Message}");
+        }
     }
 
     private static FilterParameters CreateFilterParameters(IEnumerable<string>? filterExpressions, long? folderId)

--- a/src/Endatix.Core/UseCases/Forms/Update/UpdateFormHandler.cs
+++ b/src/Endatix.Core/UseCases/Forms/Update/UpdateFormHandler.cs
@@ -1,4 +1,4 @@
-﻿using Endatix.Core.Entities;
+using Endatix.Core.Entities;
 using Endatix.Core.Events;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Messaging;

--- a/tests/Endatix.Api.Tests/Endpoints/FormTemplates/PartialUpdateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/FormTemplates/PartialUpdateTests.cs
@@ -20,7 +20,7 @@ public class PartialUpdateTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_InvalidRequest_ReturnsBadRequest()
+    public async Task ExecuteAsync_InvalidRequest_ReturnsProblemResult()
     {
         // Arrange
         var formTemplateId = 1L;
@@ -31,15 +31,16 @@ public class PartialUpdateTests
             .Returns(result);
 
         // Act
-        var response = await _endpoint.ExecuteAsync(request, default);
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.ProblemDetails.Status.Should().Be(400);
     }
 
     [Fact]
-    public async Task ExecuteAsync_FormTemplateNotFound_ReturnsNotFound()
+    public async Task ExecuteAsync_FormTemplateNotFound_ReturnsProblemResult()
     {
         // Arrange
         var formTemplateId = 1L;
@@ -56,11 +57,12 @@ public class PartialUpdateTests
             .Returns(result);
 
         // Act
-        var response = await _endpoint.ExecuteAsync(request, default);
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.ProblemDetails.Status.Should().Be(404);
     }
 
     [Fact]

--- a/tests/Endatix.Core.Tests/UseCases/Folders/FolderAssignmentPolicyTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Folders/FolderAssignmentPolicyTests.cs
@@ -53,7 +53,7 @@ public class FolderAssignmentPolicyTests
         var result = await _helper.EnsureFolderMoveValidAsync(10, 11, CancellationToken.None);
 
         result.Status.Should().Be(ResultStatus.Conflict);
-        result.Errors.Should().ContainSingle(e => e.Contains("immutable folders", StringComparison.OrdinalIgnoreCase));
+        result.Errors.Should().ContainSingle(e => e.Contains("locked folders", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]
@@ -213,5 +213,28 @@ public class FolderAssignmentPolicyTests
             cancellationToken: CancellationToken.None);
 
         result.Status.Should().Be(ResultStatus.Ok);
+    }
+
+    [Fact]
+    public async Task EnsureAndApplyFolderMoveAsync_WhenFolderUnchanged_ReturnsInvalidAndDoesNotApply()
+    {
+        var applyCalled = false;
+
+        var result = await _helper.EnsureAndApplyFolderMoveAsync(
+            currentFolderId: 10,
+            requestedFolderId: 10,
+            applyMove: _ =>
+            {
+                applyCalled = true;
+                return true;
+            },
+            cannotMoveMessage: "cannot move",
+            cancellationToken: CancellationToken.None);
+
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().ContainSingle(error =>
+            error.Identifier == "folderId" &&
+            error.ErrorMessage.Contains("unchanged", StringComparison.OrdinalIgnoreCase));
+        applyCalled.Should().BeFalse();
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/FormTemplates/PartialUpdate/PartialUpdateFormTemplateHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/FormTemplates/PartialUpdate/PartialUpdateFormTemplateHandlerTests.cs
@@ -141,6 +141,6 @@ public class PartialUpdateFormTemplateHandlerTests
 
         // Assert
         result.Status.Should().Be(ResultStatus.Conflict);
-        result.Errors.Should().ContainSingle(e => e.Contains("immutable", StringComparison.OrdinalIgnoreCase));
+        result.Errors.Should().ContainSingle(e => e.Contains("locked folders", StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/Forms/PartialUpdate/PartialUpdateFormHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/PartialUpdate/PartialUpdateFormHandlerTests.cs
@@ -480,6 +480,6 @@ public class PartialUpdateFormHandlerTests
 
         // Assert
         result.Status.Should().Be(ResultStatus.Conflict);
-        result.Errors.Should().ContainSingle(e => e.Contains("immutable", StringComparison.OrdinalIgnoreCase));
+        result.Errors.Should().ContainSingle(e => e.Contains("locked folders", StringComparison.OrdinalIgnoreCase));
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/Forms/Update/UpdateFormHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/Update/UpdateFormHandlerTests.cs
@@ -346,6 +346,6 @@ public class UpdateFormHandlerTests
 
         // Assert
         result.Status.Should().Be(ResultStatus.Conflict);
-        result.Errors.Should().ContainSingle(e => e.Contains("immutable", StringComparison.OrdinalIgnoreCase));
+        result.Errors.Should().ContainSingle(e => e.Contains("locked folders", StringComparison.OrdinalIgnoreCase));
     }
 }


### PR DESCRIPTION
# fix: add logic to detect status quo folder moves

## Description
- Add logic to detect status quo folder moves (folder changes with same folderId - current and requested)
- Use problem details for update responses
- Update error message for status quo folder move
- Fix mappers
- Update tests

## Related Issues
- closes https://github.com/endatix/endatix/issues/731

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added validation to prevent reassigning form templates to their current folder.

* **Bug Fixes**
  * Improved error handling on form template endpoints with standardized error responses.

* **Refactor**
  * Updated error messaging terminology for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->