### PR TITLE
feat: Ability to override resource names in the for the Azure bicepparams

### DIFF
--- a/samples/deployment-scripts/azure/README.md
+++ b/samples/deployment-scripts/azure/README.md
@@ -3,7 +3,7 @@
 Use this guide to get Endatix running quickly on Azure so you can see it in action. This script provisions the required Azure resources and configures Endatix environment variables and secrets for the Azure App Services hosting model (non-containerized). If you want the containerized deployment model instead, use the [Install Endatix via Docker guide](https://docs.endatix.com/docs/getting-started/quick-start/#install-via-docker-container).
 
 > [!Note]
-> `parameters.bicepparam` is a bicep parameters template used to generate your bespoke Azure runtime configuration. You don't need to modify this file unless you want to change the base biceparam structure. As a typical flow, the CLI tool will generate your customized `parameters.production.bicepparam`, which you can use to provision, deploy and configure your ready-to-test Endatix solution
+> `parameters.bicepparam` is a bicep parameters template used to generate your bespoke Azure runtime configuration. You don't need to modify this file unless you want to change the base biceparam structure. As a typical flow, the CLI tool will generate your customized `parameters.production.bicepparam`, which includes an injected **Resource name overrides** block (with `// auto:` hints derived from your `resourcePrefix` and `project`). Edit that block before deploying if you want custom Azure resource names. Use the generated file to provision, deploy and configure your ready-to-test Endatix solution.
 
 ## Prerequisites
 
@@ -55,11 +55,12 @@ The CLI won't provision any Azure resource, but instead will guide you step-by-s
 
 1. It will assist you in selecting or creating an Azure Resource Group.
 2. It natively generates secure configs, passwords and secrets into a local file (`parameters.production.bicepparam`).
-3. It will provide the exact `az deployment group create` command to provision your Azure resources.
-4. While the script runs, it waits for you to complete the deployment in another terminal window.
-5. Once complete, it reads the Azure outputs to automatically map runtime URLs and automatically creates `.env.production` in your `endatix-hub` directory.
-6. Finally, the script will output the exact commands you need to correctly build and deploy both the Hub and the API from your `endatix` root directory.
-7. The entire process should take 5-10 minutes
+3. **(Optional) Open `parameters.production.bicepparam` and adjust the "Resource name overrides" block at the top** if you want custom resource names (for example, to match the [Azure CAF resource abbreviations](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations)). See [Resource name overrides](#resource-name-overrides) below. Leave any value empty to keep the auto-generated default.
+4. It will provide the exact `az deployment group create` command to provision your Azure resources.
+5. While the script runs, it waits for you to complete the deployment in another terminal window.
+6. Once complete, it reads the Azure outputs to automatically map runtime URLs and automatically creates `.env.production` in your `endatix-hub` directory.
+7. Finally, the script will output the exact commands you need to correctly build and deploy both the Hub and the API from your `endatix` root directory.
+8. The entire process should take 5-10 minutes
 
 ## What gets provisioned (high level)
 
@@ -87,7 +88,34 @@ Edit values in `[parameters.bicepparam](./parameters.bicepparam)` (or the genera
 | **PostgreSQL high availability**            | `enablePostgresqlHA` — set `true`                                                                                                                                                                                                                                                                                       |
 | **Failure anomaly alerts**                  | `enableFailureAnomalyAlerts` — set `true` (requires provider registration; see template description)                                                                                                                                                                                                                    |
 | **Naming / tags**                           | `resourcePrefix`, `project`, `environment`                                                                                                                                                                                                                                                                              |
+| **Per-resource name overrides**             | `apiAppNameOverride`, `hubAppNameOverride`, `appServicePlanNameOverride`, `appInsightsNameOverride`, `logAnalyticsWorkspaceNameOverride`, `postgresqlServerNameOverride`, `storageAccountNameOverride`, `vnetNameOverride` — see [Resource name overrides](#resource-name-overrides)                                    |
 | **Git deploy from GitHub (optional)**       | `hubRepositoryUrl`, `apiRepositoryUrl`, `branch`, `apiDeploymentBranch`                                                                                                                                                                                                                                                 |
+
+
+## Resource name overrides
+
+By default, every resource is named using the `{resourcePrefix}{project}-{type}` convention (for example `wetest-endatix-api`). If you need different names — for example to follow the [Azure CAF resource abbreviations](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations) using a `{type}-{company}-{workload}-{region}-{env}` format — edit the **Resource name overrides** block.
+
+For the quickstart wizard, that block is **injected into `parameters.production.bicepparam`** when secrets are generated (empty values + inline `// auto:` hints match your chosen prefix and project). If you deploy **without** the wizard, copy `[parameters.bicepparam](./parameters.bicepparam)` and add the optional `*Override` parameters yourself (same names as below); omitted overrides default to empty in the template.
+
+Set any of the following:
+
+| Override param                        | Resource type                | Default name                          | CAF-style example                              |
+| ------------------------------------- | ---------------------------- | ------------------------------------- | ---------------------------------------------- |
+| `apiAppNameOverride`                  | App Service (API)            | `{prefix}{project}-api`               | `app-fairtrade-surveytools-weu-test`           |
+| `hubAppNameOverride`                  | Static Web App / Web App     | `{prefix}{project}-hub`               | `stapp-fairtrade-surveytools-weu-test`         |
+| `appServicePlanNameOverride`          | App Service Plan             | `{prefix}{project}-serviceplan`       | `plan-fairtrade-surveytools-weu-test`          |
+| `appInsightsNameOverride`             | Application Insights         | `{prefix}{project}-appinsights`       | `appi-fairtrade-surveytools-weu-test`          |
+| `logAnalyticsWorkspaceNameOverride`   | Log Analytics Workspace      | `{prefix}{project}-appinsights-ws`    | `log-fairtrade-surveytools-weu-test`           |
+| `postgresqlServerNameOverride`        | PostgreSQL Flexible Server   | `{prefix}{project}-postgresql`        | `psql-fairtrade-surveytools-weu-test`          |
+| `storageAccountNameOverride`          | Storage Account              | `{prefix}{project}{hash}` (truncated) | `stfairtrsurveyweutest`                        |
+| `vnetNameOverride`                    | VNet (managed only)          | `{prefix}{project}-vnet`              | `vnet-fairtrade-surveytools-weu-test`          |
+
+Notes:
+
+- Leave any value empty (`''`) to keep the auto-generated default.
+- **Storage account names must be 3-24 characters, lowercase alphanumeric only — no dashes.** Plan abbreviations accordingly (the example above shortens `fairtrade` and `surveytools` to fit).
+- These overrides take effect on the next `az deployment group create`. If you have already deployed with auto-generated names, changing them will provision new resources alongside the old ones — delete the old resources or your old resource group first.
 
 
 ## Optional: Generate ARM JSON From Bicep

--- a/samples/deployment-scripts/azure/endatix-azure.template.bicep
+++ b/samples/deployment-scripts/azure/endatix-azure.template.bicep
@@ -112,6 +112,35 @@ param enableFailureAnomalyAlerts bool = false
 @description('The deployment mode for the Endatix Hub frontend (recommended: static-site for fastest evaluation; use web-app if you explicitly want App Service hosting)')
 param hubDeploymentMode string = 'static-site'
 
+// --- Resource name overrides (optional) ---
+// Leave any of these empty to use the auto-generated {prefix}{project}-{type} convention.
+// Recommended convention for custom names: {type}-{company}-{workload}-{region}-{env}
+// using Azure abbreviations (https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations).
+
+@description('Override: API App Service name. Leave empty to use {prefix}{project}-api')
+param apiAppNameOverride string = ''
+
+@description('Override: Hub App name (Static Web App or Web App). Leave empty to use {prefix}{project}-hub')
+param hubAppNameOverride string = ''
+
+@description('Override: App Service Plan name. Leave empty to use {prefix}{project}-serviceplan')
+param appServicePlanNameOverride string = ''
+
+@description('Override: Application Insights name. Leave empty to use {prefix}{project}-appinsights')
+param appInsightsNameOverride string = ''
+
+@description('Override: Log Analytics Workspace name. Leave empty to use {prefix}{project}-appinsights-ws')
+param logAnalyticsWorkspaceNameOverride string = ''
+
+@description('Override: PostgreSQL Flexible Server name. Leave empty to use {prefix}{project}-postgresql')
+param postgresqlServerNameOverride string = ''
+
+@description('Override: Storage Account name (3-24 chars, lowercase alphanumeric only). Leave empty for auto-generated.')
+param storageAccountNameOverride string = ''
+
+@description('Override: VNet name (only used when managed VNet is enabled). Leave empty to use {prefix}{project}-vnet')
+param vnetNameOverride string = ''
+
 // Resource naming variables
 var projectLower = toLower(project)
 var projectServiceToken = replace(replace(replace(replace(projectLower, ' ', '-'), '_', '-'), '.', '-'), '--', '-')
@@ -120,14 +149,18 @@ var prefixServiceToken = toLower(resourcePrefix)
 var prefixStorageToken = replace(prefixServiceToken, '-', '')
 var defaultStorageSuffix = take(uniqueString(subscription().id, resourceGroup().id, resourcePrefix), 8)
 
-var endatixAppInsightsName = '${prefixServiceToken}${projectServiceToken}-appinsights'
-var endatixHubName = '${prefixServiceToken}${projectServiceToken}-hub'
-var endatixApiName = '${prefixServiceToken}${projectServiceToken}-api'
-var endatixServicePlanName = '${prefixServiceToken}${projectServiceToken}-serviceplan'
-var endatixVnetName = '${prefixServiceToken}${projectServiceToken}-vnet'
-var endatixStorageAccountName = projectStorageToken == 'endatix'
-  ? '${prefixStorageToken}${projectStorageToken}${defaultStorageSuffix}'
-  : take('${prefixStorageToken}${projectStorageToken}', 24)
+var endatixAppInsightsName = !empty(appInsightsNameOverride) ? appInsightsNameOverride : '${prefixServiceToken}${projectServiceToken}-appinsights'
+var endatixLogAnalyticsWsName = !empty(logAnalyticsWorkspaceNameOverride) ? logAnalyticsWorkspaceNameOverride : '${prefixServiceToken}${projectServiceToken}-appinsights-ws'
+var endatixHubName = !empty(hubAppNameOverride) ? hubAppNameOverride : '${prefixServiceToken}${projectServiceToken}-hub'
+var endatixApiName = !empty(apiAppNameOverride) ? apiAppNameOverride : '${prefixServiceToken}${projectServiceToken}-api'
+var endatixServicePlanName = !empty(appServicePlanNameOverride) ? appServicePlanNameOverride : '${prefixServiceToken}${projectServiceToken}-serviceplan'
+var endatixVnetName = !empty(vnetNameOverride) ? vnetNameOverride : '${prefixServiceToken}${projectServiceToken}-vnet'
+var endatixStorageAccountName = !empty(storageAccountNameOverride)
+  ? storageAccountNameOverride
+  : (projectStorageToken == 'endatix'
+      ? '${prefixStorageToken}${projectStorageToken}${defaultStorageSuffix}'
+      : take('${prefixStorageToken}${projectStorageToken}', 24))
+var endatixPostgresqlServerName = !empty(postgresqlServerNameOverride) ? postgresqlServerNameOverride : '${prefixServiceToken}${projectServiceToken}-postgresql'
 var deployManagedVnet = enablePostgresqlPrivateNetwork && vnetResourceId == ''
 var storageHostName = '${endatixStorageAccountName}.blob.${az.environment().suffixes.storage}'
 var resolvedHubDefaultHostName = hubDeploymentMode == 'static-site'
@@ -222,7 +255,7 @@ module appInsights './modules/app-insights.module.bicep' = {
   params: {
     location: location
     tags: tags
-    workspaceName: '${prefixServiceToken}${projectServiceToken}-appinsights-ws'
+    workspaceName: endatixLogAnalyticsWsName
     appInsightsName: endatixAppInsightsName
     enableFailureAnomalyAlerts: enableFailureAnomalyAlerts
   }
@@ -346,8 +379,7 @@ module postgresqlModule './modules/postgres.module.bicep' = {
   name: 'postgresqlModule'
   params: {
     location: location
-    resourcePrefix: resourcePrefix
-    project: projectServiceToken
+    serverName: endatixPostgresqlServerName
     tags: tags
     postgresAdminUsername: postgresAdminUsername
     postgresAdminPassword: postgresAdminPassword

--- a/samples/deployment-scripts/azure/generate-quickstart-secrets.mjs
+++ b/samples/deployment-scripts/azure/generate-quickstart-secrets.mjs
@@ -72,6 +72,42 @@ function normalizeResourcePrefix(resourcePrefix) {
   return resourcePrefix.endsWith("-") ? resourcePrefix : `${resourcePrefix}-`;
 }
 
+const RESOURCE_OVERRIDES_MARKER = "// --- Resource name overrides ---";
+
+function buildResourceNameOverridesBlock({ resourcePrefix, project }) {
+  const auto = (suffix) => `${resourcePrefix}${project}-${suffix}`;
+  const storageBase = `${resourcePrefix.replaceAll("-", "")}${project.replaceAll("-", "")}`;
+
+  return [
+    "",
+    RESOURCE_OVERRIDES_MARKER,
+    "// Leave any of these empty to use the auto-generated name (shown in comments below).",
+    "// Recommended convention for custom names: {type}-{company}-{workload}-{region}-{env}",
+    "// Azure abbreviations: https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations",
+    "// Storage account name: 3-24 chars, lowercase alphanumeric only (no dashes).",
+    "// -------------------------------------------------------------------",
+    `param apiAppNameOverride = ''                  // auto: ${auto("api")}          (e.g. app-acme-datanium-eus-test)`,
+    `param hubAppNameOverride = ''                  // auto: ${auto("hub")}          (e.g. stapp-acme-datanium-eus-test)`,
+    `param appServicePlanNameOverride = ''          // auto: ${auto("serviceplan")}  (e.g. plan-acme-datanium-eus-test)`,
+    `param appInsightsNameOverride = ''             // auto: ${auto("appinsights")}  (e.g. appi-acme-datanium-eus-test)`,
+    `param logAnalyticsWorkspaceNameOverride = ''   // auto: ${auto("appinsights-ws")} (e.g. log-acme-datanium-eus-test)`,
+    `param postgresqlServerNameOverride = ''        // auto: ${auto("postgresql")}   (e.g. psql-acme-datanium-eus-test)`,
+    `param storageAccountNameOverride = ''          // auto: ${storageBase}{hash} (3-24 chars, lowercase alnum; e.g. stacmedataniumeustest)`,
+    `param vnetNameOverride = ''                    // auto: ${auto("vnet")}         (only used when managed VNet is enabled)`,
+    "",
+  ].join("\n");
+}
+
+function injectResourceNameOverrides(content, block) {
+  const lines = content.split("\n");
+  const firstParamIdx = lines.findIndex((line) => /^param\s+/.test(line));
+  if (firstParamIdx === -1) {
+    return `${content}\n${block}`;
+  }
+  lines.splice(firstParamIdx, 0, block);
+  return lines.join("\n");
+}
+
 const rl = createInterface({
   input: process.stdin,
   output: process.stdout,
@@ -217,11 +253,13 @@ async function resolveProjectForCurrentRun(baseBicepParameters, skipSecretGen) {
   };
 }
 
-async function ensureLocalParameters(
+async function ensureLocalParameters({
   baseBicepParameters,
   skipSecretGen,
   projectOverride,
-) {
+  resourcePrefix,
+  effectiveProject,
+}) {
   if (skipSecretGen) {
     console.log(
       `\n\u2705 Reusing values from: ${path.basename(localParametersPath)}`,
@@ -251,14 +289,26 @@ async function ensureLocalParameters(
     generatedReplacements.push(["project", projectOverride]);
   }
 
-  const localParametersBicep = applyStringParamReplacements(
+  const replacedBicep = applyStringParamReplacements(
     baseBicepParameters,
     generatedReplacements,
+  );
+
+  const overridesBlock = buildResourceNameOverridesBlock({
+    resourcePrefix,
+    project: effectiveProject,
+  });
+  const localParametersBicep = injectResourceNameOverrides(
+    replacedBicep,
+    overridesBlock,
   );
 
   await writeFile(localParametersPath, localParametersBicep, "utf8");
   console.log(
     `\n\u2705 Generated secure parameters dynamically in: ${path.basename(localParametersPath)}`,
+  );
+  console.log(
+    `\n${tipText("Tip:")} Review the "Resource name overrides" block at the top of ${path.basename(localParametersPath)} if you want custom (e.g. CAF-style) resource names.`,
   );
 }
 
@@ -273,7 +323,7 @@ async function interactiveWizard() {
   );
 
   const { skipSecretGen } = await resolveSecretGenerationMode();
-  const { baseBicepParameters, environmentName, projectName } =
+  const { baseBicepParameters, resourcePrefix, environmentName, projectName } =
     await loadDeploymentConfig();
   const { effectiveProject, projectOverride } =
     await resolveProjectForCurrentRun(baseBicepParameters, skipSecretGen);
@@ -282,11 +332,13 @@ async function interactiveWizard() {
     effectiveProject || projectName,
   );
 
-  await ensureLocalParameters(
+  await ensureLocalParameters({
     baseBicepParameters,
     skipSecretGen,
     projectOverride,
-  );
+    resourcePrefix,
+    effectiveProject: effectiveProject || projectName,
+  });
 
   console.log(`\n${infoText("=== Step 1: Provision Infrastructure ===")}`);
 

--- a/samples/deployment-scripts/azure/generate-quickstart-secrets.mjs
+++ b/samples/deployment-scripts/azure/generate-quickstart-secrets.mjs
@@ -68,15 +68,22 @@ function deriveResourceGroupName(environmentName, projectName = "endatix") {
   return `rg-${normalizedProject}-${normalizedEnv}-us`;
 }
 
-function normalizeResourcePrefix(resourcePrefix) {
-  return resourcePrefix.endsWith("-") ? resourcePrefix : `${resourcePrefix}-`;
-}
-
 const RESOURCE_OVERRIDES_MARKER = "// --- Resource name overrides ---";
 
-function buildResourceNameOverridesBlock({ resourcePrefix, project }) {
-  const auto = (suffix) => `${resourcePrefix}${project}-${suffix}`;
-  const storageBase = `${resourcePrefix.replaceAll("-", "")}${project.replaceAll("-", "")}`;
+function buildResourceNameOverridesBlock({ resourcePrefixRaw, project }) {
+  const prefixServiceToken = resourcePrefixRaw.toLowerCase();
+  const projectNormalized = normalizeProjectName(project);
+  const auto = (suffix) =>
+    `${prefixServiceToken}${projectNormalized}-${suffix}`;
+
+  const prefixStorageToken = prefixServiceToken.replaceAll("-", "");
+  const projectStorageToken = projectNormalized
+    .replaceAll("-", "")
+    .replaceAll("_", "")
+    .replaceAll(".", "")
+    .replaceAll(" ", "");
+  const storageBase = `${prefixStorageToken}${projectStorageToken}`;
+  const storageAutoHint = `projectStorageToken=='endatix' ? storageBase+defaultStorageSuffix (here ${storageBase}+8-char hash; defaultStorageSuffix uses resourcePrefix) : take(storageBase,24), storageBase=${storageBase} from resourcePrefix & project, no hash`;
 
   return [
     "",
@@ -84,16 +91,15 @@ function buildResourceNameOverridesBlock({ resourcePrefix, project }) {
     "// Leave any of these empty to use the auto-generated name (shown in comments below).",
     "// Recommended convention for custom names: {type}-{company}-{workload}-{region}-{env}",
     "// Azure abbreviations: https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations",
-    "// Storage account name: 3-24 chars, lowercase alphanumeric only (no dashes).",
     "// -------------------------------------------------------------------",
-    `param apiAppNameOverride = ''                  // auto: ${auto("api")}          (e.g. app-acme-datanium-eus-test)`,
-    `param hubAppNameOverride = ''                  // auto: ${auto("hub")}          (e.g. stapp-acme-datanium-eus-test)`,
-    `param appServicePlanNameOverride = ''          // auto: ${auto("serviceplan")}  (e.g. plan-acme-datanium-eus-test)`,
-    `param appInsightsNameOverride = ''             // auto: ${auto("appinsights")}  (e.g. appi-acme-datanium-eus-test)`,
-    `param logAnalyticsWorkspaceNameOverride = ''   // auto: ${auto("appinsights-ws")} (e.g. log-acme-datanium-eus-test)`,
-    `param postgresqlServerNameOverride = ''        // auto: ${auto("postgresql")}   (e.g. psql-acme-datanium-eus-test)`,
-    `param storageAccountNameOverride = ''          // auto: ${storageBase}{hash} (3-24 chars, lowercase alnum; e.g. stacmedataniumeustest)`,
-    `param vnetNameOverride = ''                    // auto: ${auto("vnet")}         (only used when managed VNet is enabled)`,
+    `param apiAppNameOverride = ''                  // auto: ${auto("api")} or override e.g. app-acme-datanium-eus-test`,
+    `param hubAppNameOverride = ''                  // auto: ${auto("hub")} or override e.g. stapp-acme-datanium-eus-test`,
+    `param appServicePlanNameOverride = ''          // auto: ${auto("serviceplan")} or override e.g. plan-acme-datanium-eus-test`,
+    `param appInsightsNameOverride = ''             // auto: ${auto("appinsights")} or override e.g. appi-acme-datanium-eus-test`,
+    `param logAnalyticsWorkspaceNameOverride = ''   // auto: ${auto("appinsights-ws")} or override e.g. log-acme-datanium-eus-test`,
+    `param postgresqlServerNameOverride = ''        // auto: ${auto("postgresql")} or override e.g. psql-acme-datanium-eus-test`,
+    `param storageAccountNameOverride = ''          // auto: ${storageAutoHint} or override e.g. stacmedataniumeustest (3-24 chars, lowercase alphanumeric only, no dashes)`,
+    `param vnetNameOverride = ''                    // auto: ${auto("vnet")} or override e.g. vnet-acme-datanium-eus-test (if VNet is enabled)`,
     "",
   ].join("\n");
 }
@@ -167,7 +173,7 @@ async function loadDeploymentConfig() {
 
   return {
     baseBicepParameters,
-    resourcePrefix: normalizeResourcePrefix(configuredPrefix),
+    configuredResourcePrefix: configuredPrefix,
     environmentName,
     projectName: normalizeProjectName(projectName),
   };
@@ -257,7 +263,7 @@ async function ensureLocalParameters({
   baseBicepParameters,
   skipSecretGen,
   projectOverride,
-  resourcePrefix,
+  configuredResourcePrefix,
   effectiveProject,
 }) {
   if (skipSecretGen) {
@@ -295,7 +301,7 @@ async function ensureLocalParameters({
   );
 
   const overridesBlock = buildResourceNameOverridesBlock({
-    resourcePrefix,
+    resourcePrefixRaw: configuredResourcePrefix,
     project: effectiveProject,
   });
   const localParametersBicep = injectResourceNameOverrides(
@@ -323,8 +329,12 @@ async function interactiveWizard() {
   );
 
   const { skipSecretGen } = await resolveSecretGenerationMode();
-  const { baseBicepParameters, resourcePrefix, environmentName, projectName } =
-    await loadDeploymentConfig();
+  const {
+    baseBicepParameters,
+    configuredResourcePrefix,
+    environmentName,
+    projectName,
+  } = await loadDeploymentConfig();
   const { effectiveProject, projectOverride } =
     await resolveProjectForCurrentRun(baseBicepParameters, skipSecretGen);
   const { resourceGroupName, createRgCmd } = await resolveResourceGroupInfo(
@@ -336,7 +346,7 @@ async function interactiveWizard() {
     baseBicepParameters,
     skipSecretGen,
     projectOverride,
-    resourcePrefix,
+    configuredResourcePrefix,
     effectiveProject: effectiveProject || projectName,
   });
 

--- a/samples/deployment-scripts/azure/modules/postgres.module.bicep
+++ b/samples/deployment-scripts/azure/modules/postgres.module.bicep
@@ -5,10 +5,8 @@ This module deploys a PostgreSQL Flexible Server with database and security conf
 */
 
 param location string
-@description('Resource prefix for naming resources')
-param resourcePrefix string = 'temp-'
-@description('Project token for naming resources')
-param project string = 'endatix'
+@description('PostgreSQL Flexible Server resource name')
+param serverName string
 param tags object
 
 @secure()
@@ -48,7 +46,7 @@ param postgresDelegatedSubnetResourceId string = ''
 
 // PostgreSQL Flexible Server
 resource postgresql 'Microsoft.DBforPostgreSQL/flexibleServers@2026-01-01-preview' = {
-  name: '${resourcePrefix}${project}-postgresql'
+  name: serverName
   location: location
   sku: {
     name: 'Standard_D2ds_v5'

--- a/samples/deployment-scripts/azure/parameters.bicepparam
+++ b/samples/deployment-scripts/azure/parameters.bicepparam
@@ -6,6 +6,10 @@ using './endatix-azure.template.bicep'
 // az deployment group create --resource-group rg-endatix-sandbox-us --parameters parameters.deploy.bicepparam --mode Complete --query properties.outputs -o json > deployment-outputs.json
 // The build-env step reads this file:
 // node ./generate-quickstart-secrets.mjs build-env --outputs-file ./deployment-outputs.json
+//
+// Resource name overrides: not declared here. When you run generate-quickstart-secrets.mjs, it injects
+// an optional "Resource name overrides" block (with accurate // auto: hints) into parameters.production.bicepparam.
+// Deploying without the wizard? Copy this file and add the optional *Override params — see README "Resource name overrides".
 
 param resourcePrefix = 'test-'
 param project = 'endatix'


### PR DESCRIPTION
# feat: Ability to override resource names in the for the Azure bicepparams

## Description
- Adding ability to override provisioned resource names via individual params for each resource name
- Update readme

## Related Issues
- closes https://github.com/endatix/endatix/issues/733

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Tooling for Devs

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added resource naming customization for Azure deployments, allowing users to override default names for API app, Hub app, App Service plan, Application Insights, Log Analytics, PostgreSQL, Storage account, and VNet.
  * Automated quickstart wizard now generates resource naming override parameters.

* **Documentation**
  * Expanded Azure deployment README with clearer guidance on resource naming configuration and customization options.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/endatix/endatix/pull/734)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->