### PR TITLE
chore: Add SQL Script to replace blob hostnames in the database

### DIFF
--- a/src/Endatix.Persistence.PostgreSql/Scripts/Tools/ReplaceBlobHostnames.sql
+++ b/src/Endatix.Persistence.PostgreSql/Scripts/Tools/ReplaceBlobHostnames.sql
@@ -1,0 +1,98 @@
+-- This function replaces hostnames in JSONB columns across multiple tables. It can be used to update blob storage hostnames in the database.
+-- Parameters:
+-- - source_host: The hostname to be replaced.
+-- - destination_host: The new hostname to replace with.
+-- - dry_run: If true, the function will perform the updates but will raise an exception at the end to prevent committing the changes. Set to false to apply the changes permanently.
+-- Example usage:
+--BEGIN;
+--
+--SELECT *
+--FROM public.replace_blob_hostnames(
+--    'https://old-hostname.blob.core.windows.net/',
+--    'https://new-hostname.blob.core.windows.net/',
+--    true
+--);
+--
+
+ROLLBACK;
+CREATE OR REPLACE FUNCTION public.replace_blob_hostnames(
+    source_host text,
+    destination_host text,
+    dry_run boolean DEFAULT true
+)
+RETURNS TABLE (
+    table_name text,
+    affected_rows integer
+)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    affected_count integer;
+BEGIN
+
+    -- FormDefinitions
+    UPDATE public."FormDefinitions"
+    SET "JsonData" = replace(
+        "JsonData"::text,
+        source_host,
+        destination_host
+    )::jsonb
+    WHERE "JsonData"::text ILIKE '%' || source_host || '%';
+
+    GET DIAGNOSTICS affected_count = ROW_COUNT;
+
+    table_name := 'FormDefinitions';
+    affected_rows := affected_count;
+    RETURN NEXT;
+
+    -- Submissions
+    UPDATE public."Submissions"
+    SET "JsonData" = replace(
+        "JsonData"::text,
+        source_host,
+        destination_host
+    )::jsonb
+    WHERE "JsonData"::text ILIKE '%' || source_host || '%';
+
+    GET DIAGNOSTICS affected_count = ROW_COUNT;
+
+    table_name := 'Submissions';
+    affected_rows := affected_count;
+    RETURN NEXT;
+
+    -- SubmissionVersions
+    UPDATE public."SubmissionVersions"
+    SET "JsonData" = replace(
+        "JsonData"::text,
+        source_host,
+        destination_host
+    )::jsonb
+    WHERE "JsonData"::text ILIKE '%' || source_host || '%';
+
+    GET DIAGNOSTICS affected_count = ROW_COUNT;
+
+    table_name := 'SubmissionVersions';
+    affected_rows := affected_count;
+    RETURN NEXT;
+
+    -- FormTemplates
+    UPDATE public."FormTemplates"
+    SET "JsonData" = replace(
+        "JsonData"::text,
+        source_host,
+        destination_host
+    )::jsonb
+    WHERE "JsonData"::text ILIKE '%' || source_host || '%';
+
+    GET DIAGNOSTICS affected_count = ROW_COUNT;
+
+    table_name := 'FormTemplates';
+    affected_rows := affected_count;
+    RETURN NEXT;
+
+    IF dry_run THEN
+        RAISE EXCEPTION 'Dry run rollback';
+    END IF;
+
+END;
+$$;

--- a/src/Endatix.Persistence.SqlServer/Scripts/Tools/ReplaceBlobHostnames.sql
+++ b/src/Endatix.Persistence.SqlServer/Scripts/Tools/ReplaceBlobHostnames.sql
@@ -1,0 +1,104 @@
+-- This function replaces hostnames in JSONB columns across multiple tables. It can be used to update blob storage hostnames in the database.
+-- Parameters:
+-- - source_host: The hostname to be replaced.
+-- - destination_host: The new hostname to replace with.
+-- - dry_run: If true, the function will perform the updates but will raise an exception at the end to prevent committing the changes. Set to false to apply the changes permanently.
+-- Example usage:
+-- EXEC dbo.ReplaceBlobHostnames
+--    @SourceHost = 'https://old-hostname.blob.core.windows.net/',
+--    @DestinationHost = 'https://new-hostname.blob.core.windows.net/',
+--    @DryRun = 1;
+
+CREATE OR ALTER PROCEDURE dbo.ReplaceBlobHostnames
+(
+    @SourceHost NVARCHAR(500),
+    @DestinationHost NVARCHAR(500),
+    @DryRun BIT = 1
+)
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    DECLARE @Results TABLE
+    (
+        TableName NVARCHAR(200),
+        AffectedRows INT
+    );
+
+    BEGIN TRANSACTION;
+
+    BEGIN TRY
+
+        -- FormDefinitions
+        UPDATE dbo.FormDefinitions
+        SET JsonData = REPLACE(
+            CAST(JsonData AS NVARCHAR(MAX)),
+            @SourceHost,
+            @DestinationHost
+        )
+        WHERE CAST(JsonData AS NVARCHAR(MAX)) LIKE '%' + @SourceHost + '%';
+
+        INSERT INTO @Results
+        VALUES ('FormDefinitions', @@ROWCOUNT);
+
+        -- Submissions
+        UPDATE dbo.Submissions
+        SET JsonData = REPLACE(
+            CAST(JsonData AS NVARCHAR(MAX)),
+            @SourceHost,
+            @DestinationHost
+        )
+        WHERE CAST(JsonData AS NVARCHAR(MAX)) LIKE '%' + @SourceHost + '%';
+
+        INSERT INTO @Results
+        VALUES ('Submissions', @@ROWCOUNT);
+
+        -- SubmissionVersions
+        UPDATE dbo.SubmissionVersions
+        SET JsonData = REPLACE(
+            CAST(JsonData AS NVARCHAR(MAX)),
+            @SourceHost,
+            @DestinationHost
+        )
+        WHERE CAST(JsonData AS NVARCHAR(MAX)) LIKE '%' + @SourceHost + '%';
+
+        INSERT INTO @Results
+        VALUES ('SubmissionVersions', @@ROWCOUNT);
+
+        -- FormTemplates
+        UPDATE dbo.FormTemplates
+        SET JsonData = REPLACE(
+            CAST(JsonData AS NVARCHAR(MAX)),
+            @SourceHost,
+            @DestinationHost
+        )
+        WHERE CAST(JsonData AS NVARCHAR(MAX)) LIKE '%' + @SourceHost + '%';
+
+        INSERT INTO @Results
+        VALUES ('FormTemplates', @@ROWCOUNT);
+
+        -- Return structured result
+        SELECT
+            TableName,
+            AffectedRows
+        FROM @Results;
+
+        IF @DryRun = 1
+        BEGIN
+            ROLLBACK TRANSACTION;
+        END
+        ELSE
+        BEGIN
+            COMMIT TRANSACTION;
+        END
+
+    END TRY
+    BEGIN CATCH
+
+        IF @@TRANCOUNT > 0
+            ROLLBACK TRANSACTION;
+
+        THROW;
+
+    END CATCH
+END


### PR DESCRIPTION
# chore: Add SQL Script to replace blob hostnames in the database

## Description
Adds PostgreSQL and MS SQL scripts to migrate BLOB Urls in the DB post migration of BLOB storage. Supports dry run, so we can add to the UI easily with report before via dry run and after on execution

Usage (for PostgreSQL)
```SQL
BEGIN;

SELECT *
FROM public.replace_blob_hostnames(
    'https://old-hostname.blob.core.windows.net/',
    'https://new-hostname.blob.core.windows.net/',
    true
);

ROLLBACK;
```

## Related Issues
N/A

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Tooling

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
