### PR TITLE
feat: Add NSGs to Bicep template and generate-quickstart-secrets.mjs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 **/bin/
 **/obj/
 **/publish/
+**/*.csproj.lscache
 
 # Compiled Java class files
 *.class

--- a/samples/deployment-scripts/azure/README.md
+++ b/samples/deployment-scripts/azure/README.md
@@ -35,7 +35,8 @@ git clone git@github.com:endatix/endatix.git endatix-api
 git clone git@github.com:endatix/endatix-hub.git
 ```
 
-**Monorepo (this repository):** API sources live under `oss/`, Hub under `hub/`. Run the wizard from `oss/samples/deployment-scripts/azure/`; it will look for `hub/.env.production` four levels up.
+>[!NOTE] On Using Monorepo
+> If you use this repository as **monorepo:** API sources will live under `oss/`, Hub under `hub/`. Run the wizard from `oss/samples/deployment-scripts/azure/`; it will look for `hub/.env.production` four levels up.
 
 ## Quickstart wizard
 
@@ -56,12 +57,13 @@ node ./generate-quickstart-secrets.mjs
 
 The wizard does **not** call Azure itself. It:
 
-1. Helps you choose or name a resource group (`rg-{project}-{environment}-us` when creating a new one).
-2. Writes **`parameters.production.bicepparam`** (secrets + **Resource name overrides** block at the top).
-3. Prints **`az group create`** (if needed) and **`az deployment group create`** — run those in **another terminal**, still from this `azure/` folder (paths are relative to here).
-4. Waits until you press Enter after infrastructure finishes.
-5. Reads **`deployment-outputs.json`** (created by the deploy command’s output redirect) and writes **`.env.production`** into your Hub repo root.
-6. Prints Hub and API build/deploy commands (API zip + `az webapp deploy`; Hub **`swa deploy`** when using Static Web Apps).
+1. Asks for a **naming convention** (see below) and shows example resource names.
+2. Helps you choose or name a resource group (`rg-{project}-{environment}-us` when creating a new one).
+3. Writes **`parameters.production.bicepparam`** (secrets + **Resource name overrides** block at the top).
+4. Prints **`az group create`** (if needed) and **`az deployment group create`** — run those in **another terminal**, still from this `azure/` folder (paths are relative to here).
+5. Waits until you press Enter after infrastructure finishes.
+6. Reads **`deployment-outputs.json`** (created by the deploy command’s output redirect) and writes **`.env.production`** into your Hub repo root.
+7. Prints Hub and API build/deploy commands (API zip + `az webapp deploy`; Hub **`swa deploy`** when using Static Web Apps).
 
 **Before you deploy infrastructure:** open `parameters.production.bicepparam` and adjust the **Resource name overrides** block or other parameters if needed ([Resource name overrides](#resource-name-overrides), [Key parameters](#key-parameters-quick-reference)).
 
@@ -130,30 +132,47 @@ Edit [parameters.bicepparam](./parameters.bicepparam) before running the wizard,
 | **Private storage** | `storageIsPrivate = true` |
 | **PostgreSQL high availability** | `enablePostgresqlHA = true` |
 | **Failure anomaly alerts** | `enableFailureAnomalyAlerts = true` (see template notes on provider registration) |
-| **Naming / tags** | `resourcePrefix`, `project`, `environment`, `companyName`, `workloadName`, `regionAbbreviation` |
+| **Naming convention** | `namingConvention`: `quickstart`, `caf`, or `manual` — [Naming convention](#naming-convention) |
+| **CAF segments** | `companyName`, `workloadName`, `regionAbbreviation`, `environment` |
+| **Tags / storage suffix** | `resourcePrefix`, `project` (`resourcePrefix` is not used for App Service / Hub auto names) |
 | **Per-resource name overrides** | `*Override` params — [Resource name overrides](#resource-name-overrides) |
 | **Git deploy from GitHub (optional)** | `hubRepositoryUrl`, `apiRepositoryUrl`, `branch`, `apiDeploymentBranch` |
 
+## Naming convention
+
+All resources use **[CAF-style](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-naming)** auto names unless a per-resource `*Override` is set:
+
+**Pattern:** `{abbr}-{companyName}-{workloadName}-{regionAbbreviation}-{environment}` (optional `-{role}` for NSGs, VPN, etc.)
+
+**Storage:** `st` + company + workload + region + env (no dashes, max 24 characters).
+
+The wizard sets `namingConvention` and CAF segments in **`parameters.production.bicepparam`**:
+
+| Mode | Wizard behavior | Segment defaults |
+|------|-----------------|------------------|
+| **quickstart** (default) | No extra prompts; prints name preview | `companyName` = `project`, `workloadName` = `endatix`, `regionAbbreviation` = `weu` |
+| **caf** | Prompts for company, workload, region, environment | Your inputs |
+| **manual** | Skips naming prompts | Edit `*Override` params in the generated file before deploy |
+
+**Example** (quickstart with `project=endatix`, `environment=sandbox`): API → `app-endatix-endatix-weu-sandbox`, Hub (SWA) → `stapp-endatix-endatix-weu-sandbox`, storage → `stendatixendatixweusan` (truncated to 24 chars).
+
+> [!Note]
+> This replaces the older `{resourcePrefix}{project}-api` style. `resourcePrefix` remains for tagging only.
+
 ## Resource name overrides
 
-**Compute / data plane (default):** `{resourcePrefix}{project}-{suffix}` (e.g. `test-endatix-api` with prefix `test-`).
+The wizard injects an overrides block with empty values and `// auto:` comments showing the **actual** names for your chosen mode and segments.
 
-**Managed VNet resources:** `{abbr}-{companyName}-{workloadName}-{regionAbbreviation}-{environment}` from `parameters.bicepparam` (defaults: `endatix` / `endatix` / `weu` / your `environment` value).
-
-The wizard injects an overrides block into **`parameters.production.bicepparam`** (empty values + `// auto:` hints). Deploying without the wizard: copy `parameters.bicepparam`, add the optional `*Override` parameters, or run the wizard once and reuse the block.
-
-**CAF-style examples** below use fictitious segments `acme` / `datanium` / `eus` / `test` (same as `// override e.g.` hints in `generate-quickstart-secrets.mjs`):
-
-| Override param | Resource type | Default name | CAF-style example |
-|----------------|---------------|--------------|-------------------|
-| `apiAppNameOverride` | App Service (API) | `{prefix}{project}-api` | `app-acme-datanium-eus-test` |
-| `hubAppNameOverride` | Static Web App / Web App | `{prefix}{project}-hub` | `stapp-acme-datanium-eus-test` |
-| `appServicePlanNameOverride` | App Service Plan | `{prefix}{project}-serviceplan` | `plan-acme-datanium-eus-test` |
-| `appInsightsNameOverride` | Application Insights | `{prefix}{project}-appinsights` | `appi-acme-datanium-eus-test` |
-| `logAnalyticsWorkspaceNameOverride` | Log Analytics Workspace | `{prefix}{project}-appinsights-ws` | `log-acme-datanium-eus-test` |
-| `postgresqlServerNameOverride` | PostgreSQL Flexible Server | `{prefix}{project}-postgresql` | `psql-acme-datanium-eus-test` |
-| `storageAccountNameOverride` | Storage Account | `{prefix}{project}{hash}` (truncated) | `stacmedataniumeustest` |
-| `vnetNameOverride` | VNet (managed only) | `vnet-{company}-{workload}-{region}-{env}` | `vnet-acme-datanium-eus-test` |
+| Override param | Resource type | CAF auto name (empty override) |
+|----------------|---------------|--------------------------------|
+| `apiAppNameOverride` | App Service (API) | `app-{company}-{workload}-{region}-{env}` |
+| `hubAppNameOverride` | Static Web App / Web App | `stapp-...` (SWA) or `app-...` (web-app mode) |
+| `appServicePlanNameOverride` | App Service Plan | `plan-...` |
+| `appInsightsNameOverride` | Application Insights | `appi-...` |
+| `logAnalyticsWorkspaceNameOverride` | Log Analytics Workspace | `log-...` |
+| `postgresqlServerNameOverride` | PostgreSQL Flexible Server | `psql-...` |
+| `storageAccountNameOverride` | Storage Account | `st{company}{workload}{region}{env}` |
+| `vnetNameOverride` | VNet (managed only) | `vnet-...` |
 
 When managed VNet is enabled, these are also created (no separate override params in v1):
 

--- a/samples/deployment-scripts/azure/README.md
+++ b/samples/deployment-scripts/azure/README.md
@@ -1,33 +1,33 @@
 # Endatix Azure Deployment (Quickstart)
 
-Use this guide to get Endatix running quickly on Azure so you can see it in action. This script provisions the required Azure resources and configures Endatix environment variables and secrets for the Azure App Services hosting model (non-containerized). If you want the containerized deployment model instead, use the [Install Endatix via Docker guide](https://docs.endatix.com/docs/getting-started/quick-start/#install-via-docker-container).
+Use this guide to get Endatix running quickly on Azure so you can see it in action. This folder contains a Bicep template and an interactive wizard that generate secrets, provision infrastructure, and print the commands to deploy the **Endatix API** (App Service) and **Endatix Hub** (Static Web Apps by default).
+
+For a containerized deployment instead, see the [Install Endatix via Docker guide](https://docs.endatix.com/docs/getting-started/quick-start/#install-via-docker-container).
 
 > [!Note]
-> `parameters.bicepparam` is a bicep parameters template used to generate your bespoke Azure runtime configuration. You don't need to modify this file unless you want to change the base biceparam structure. As a typical flow, the CLI tool will generate your customized `parameters.production.bicepparam`, which includes an injected **Resource name overrides** block (with `// auto:` hints derived from your `resourcePrefix` and `project`). Edit that block before deploying if you want custom Azure resource names. Use the generated file to provision, deploy and configure your ready-to-test Endatix solution.
+> **`parameters.bicepparam`** is the base template. You normally do not edit it for a one-off deploy. Run **`generate-quickstart-secrets.mjs`** to create **`parameters.production.bicepparam`** (secure secrets + an injected **Resource name overrides** block with `// auto:` hints). Deploy with that generated file.
 
 ## Prerequisites
 
-To follow this guide, you will need the ensure the following are intalled
+Install and sign in before you start:
 
-- **Azure CLI (`az`)** - the Azure Command-Line Interface to get you connected to Azure and provision the needed resources [[documentation link](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)]
-- **SWA CLI (`swa`)** - Static Web Apps (SWA) CLI to execute your deployment for Azure Static Sites. [[documentation link](https://azure.github.io/static-web-apps-cli/docs/use/install)]
+- **Azure CLI (`az`)** — install and run `az login` ([install docs](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest))
+- **SWA CLI (`swa`)** — required when `hubDeploymentMode` is `'static-site'` (default) ([install docs](https://azure.github.io/static-web-apps-cli/docs/use/install))
+- **.NET 10 SDK** — build and publish the Endatix API
+- **Node.js 22 + pnpm 10** — build the Endatix Hub
 
-...and from the Endatix System requirements:
+### Directory layout
 
-- **.NET 10 SDK** to build and publish the Endatix API
-- **Node.js 22 + pnpm 10** - to build your Endatix Hub application
+The wizard resolves Hub paths automatically when repos sit next to each other:
 
-### Directory Structure
+**Separate clones (documented quickstart layout):**
 
-Before you start, ensure the following directory structure, so that the scripts are able to correctly resolve paths for the Endatix Hub and Endatix API source codes. 
-
-```bash
+```text
 endatix/
-├── endatix-api/      # cloned from github.com:endatix/endatix.git
-├── endatix-hub/      # cloned from github.com:endatix/endatix-hub.git
+├── endatix-api/    # github.com/endatix/endatix
+│   └── samples/deployment-scripts/azure/   ← run the wizard here
+└── endatix-hub/
 ```
-
-To do so, execute the commands below
 
 ```bash
 mkdir endatix && cd endatix
@@ -35,95 +35,148 @@ git clone git@github.com:endatix/endatix.git endatix-api
 git clone git@github.com:endatix/endatix-hub.git
 ```
 
-## Using the Quickstart Interactice CLI
+**Monorepo (this repository):** API sources live under `oss/`, Hub under `hub/`. Run the wizard from `oss/samples/deployment-scripts/azure/`; it will look for `hub/.env.production` four levels up.
 
-We have provided an interactive script that streamlines the deployment process. It will guide you. To use it:
+## Quickstart wizard
 
-1. Open your terminal and cd into the Azure deployment scripts folder (same folder as this README):
-
-```bash
-cd endatix-api/samples/deployment-scripts/azure
-```
-
-1. Run the interactive Quickstart Wizard and follow the instructions:
+From the Azure scripts folder:
 
 ```bash
+cd endatix-api/samples/deployment-scripts/azure   # or oss/samples/deployment-scripts/azure in the monorepo
 node ./generate-quickstart-secrets.mjs
 ```
 
-The CLI won't provision any Azure resource, but instead will guide you step-by-step:
+**CLI flags** (optional):
 
-1. It will assist you in selecting or creating an Azure Resource Group.
-2. It natively generates secure configs, passwords and secrets into a local file (`parameters.production.bicepparam`).
-3. **(Optional) Open `parameters.production.bicepparam` and adjust the "Resource name overrides" block at the top** if you want custom resource names (for example, to match the [Azure CAF resource abbreviations](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations)). See [Resource name overrides](#resource-name-overrides) below. Leave any value empty to keep the auto-generated default.
-4. It will provide the exact `az deployment group create` command to provision your Azure resources.
-5. While the script runs, it waits for you to complete the deployment in another terminal window.
-6. Once complete, it reads the Azure outputs to automatically map runtime URLs and automatically creates `.env.production` in your `endatix-hub` directory.
-7. Finally, the script will output the exact commands you need to correctly build and deploy both the Hub and the API from your `endatix` root directory.
-8. The entire process should take 5-10 minutes
+| Flag | Effect |
+|------|--------|
+| *(none)* | If `parameters.production.bicepparam` exists, prompt to Overwrite / Reuse (read-only) / Cancel |
+| `--force` | Regenerate secrets and overrides without prompting |
+| `--read-only` | Skip secret generation; reuse existing `parameters.production.bicepparam` |
+
+The wizard does **not** call Azure itself. It:
+
+1. Helps you choose or name a resource group (`rg-{project}-{environment}-us` when creating a new one).
+2. Writes **`parameters.production.bicepparam`** (secrets + **Resource name overrides** block at the top).
+3. Prints **`az group create`** (if needed) and **`az deployment group create`** — run those in **another terminal**, still from this `azure/` folder (paths are relative to here).
+4. Waits until you press Enter after infrastructure finishes.
+5. Reads **`deployment-outputs.json`** (created by the deploy command’s output redirect) and writes **`.env.production`** into your Hub repo root.
+6. Prints Hub and API build/deploy commands (API zip + `az webapp deploy`; Hub **`swa deploy`** when using Static Web Apps).
+
+**Before you deploy infrastructure:** open `parameters.production.bicepparam` and adjust the **Resource name overrides** block or other parameters if needed ([Resource name overrides](#resource-name-overrides), [Key parameters](#key-parameters-quick-reference)).
+
+**Typical timing:** about **5–10 minutes** for the default stack (no managed VNet). If you enable **managed private networking**, the VPN gateway alone can take **30–45 minutes** and adds significant cost.
+
+### Files produced locally
+
+| File | Purpose |
+|------|---------|
+| `parameters.production.bicepparam` | Parameters for `az deployment group create` |
+| `deployment-outputs.json` | Template outputs (`hubBaseUrl`, `apiAppName`, etc.) — keep this file; the wizard reads it after deploy |
+| `{hub}/.env.production` | Hub build-time env (API URL, session secret, public flags) |
+
+Example infrastructure command (also printed by the wizard):
+
+```bash
+az deployment group create \
+  --resource-group rg-endatix-sandbox-us \
+  --parameters parameters.production.bicepparam \
+  --mode Complete \
+  --query properties.outputs -o json > deployment-outputs.json
+```
+
+### Build and deploy applications
+
+Run these after infrastructure succeeds. Paths assume the **separate-clone** layout; adjust `cd` targets for the monorepo (`oss/`, `hub/`).
+
+**Hub (default `hubDeploymentMode = 'static-site'`):**
+
+1. `cd` into **endatix-hub** (ensure `.env.production` is in the repo root).
+2. `pnpm build:standalone`
+3. Deploy with the `swa deploy ...` command from the wizard (run from a directory where `.next/standalone` is available — typically the Hub root after build).
+
+**API:**
+
+1. `cd` into **endatix-api** (repository root containing `src/Endatix.WebHost`).
+2. `dotnet publish src/Endatix.WebHost -c Release -o ./publish`
+3. Zip `publish/` → `endatix-api.zip` (wizard prints Windows or Unix command).
+4. `az webapp deploy ...` (wizard prints resource group and app name from outputs).
+
+> [!Important]
+> The wizard’s Hub deploy step uses **`swa deploy`** only. If you set **`hubDeploymentMode = 'web-app'`**, provision with Bicep but deploy the Hub with **`az webapp deploy`** (zip of the standalone build) instead — see [deploy-endatix-to-azure.yml](./deploy-endatix-to-azure.yml) for a CI example.
 
 ## What gets provisioned (high level)
 
-The Bicep template deploys into **your** resource group. It's meant to be simple, affordable, evaluation-ready setup, but it can be easily tunned to be production ready. By default you will get:
+The Bicep template deploys into **your** resource group. Default settings target a simple, evaluation-ready stack:
 
 - **Application Insights** (and linked Log Analytics workspace where applicable)
-- **Storage account** plus **containers** and **blob** configuration. BLOBs can be public or private depending on `storageIsPrivate`
-- **PostgreSQL Flexible Server** (database for the API)
-- **Endatix API** — **App Service (Linux Web App)** on a shared **App Service plan**
-- **Endatix Hub** — either **Azure Static Web Apps** or a second **App Service Web App**, depending on `hubDeploymentMode`
-- **VNet** [Optional] when `enablePostgresqlPrivateNetwork` is set to true, the template will secure the PostgreSQL with **managed VNet** (or integration with your VNet) for closer to production-ready recommended network level security.
+- **Storage account** plus containers and blob configuration (`storageIsPrivate` controls public vs private blob access)
+- **PostgreSQL Flexible Server** (API database)
+- **Endatix API** — Linux **App Service** on a shared **App Service plan**
+- **Endatix Hub** — **Azure Static Web Apps** (`static-site`) or a second **App Service** (`web-app`), per `hubDeploymentMode`
+- **Managed VNet (optional)** — when `enablePostgresqlPrivateNetwork = true` and `vnetResourceId` is empty: VNet with `snet-app`, `snet-db`, `GatewaySubnet`, NSGs, **VPN gateway** (`VpnGw2AZ`), and gateway public IP
 
-For exact resource types, naming, and conditional branches, see `[endatix-azure.template.bicep](./endatix-azure.template.bicep)` and the modules it references under `[modules/](./modules/)`.
+For resource types, naming, and branches, see [endatix-azure.template.bicep](./endatix-azure.template.bicep) and [modules/](./modules/).
 
 ## Key parameters (quick reference)
 
-Edit values in `[parameters.bicepparam](./parameters.bicepparam)` (or the generated `parameters.production.bicepparam` from the wizard). Parameter names and defaults are defined in the template; see `[endatix-azure.template.bicep](./endatix-azure.template.bicep)` for full descriptions and constraints.
+Edit [parameters.bicepparam](./parameters.bicepparam) before running the wizard, or edit the generated **`parameters.production.bicepparam`** afterward. Full descriptions are in the Bicep template.
 
-
-| What you want                               | Parameter(s) to change                                                                                                                                                                                                                                                                                                  |
-| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Hub on Static Web Apps vs App Service**   | `hubDeploymentMode`: `'static-site'` (default, fastest for evaluation) or `'web-app'`                                                                                                                                                                                                                                   |
-| **Private PostgreSQL + networking**         | `enablePostgresqlPrivateNetwork` — set `true` for private access. **Managed VNet:** leave `vnetResourceId` empty; template creates `{resourcePrefix}endatix-vnet`. **Your VNet:** set `vnetResourceId`, `postgresSubnetName`, and either `apiVirtualNetworkSubnetId` (full subnet ARM ID) or `apiIntegrationSubnetName` |
-| **Private storage (no public blob access)** | `storageIsPrivate` — set `true`                                                                                                                                                                                                                                                                                         |
-| **PostgreSQL high availability**            | `enablePostgresqlHA` — set `true`                                                                                                                                                                                                                                                                                       |
-| **Failure anomaly alerts**                  | `enableFailureAnomalyAlerts` — set `true` (requires provider registration; see template description)                                                                                                                                                                                                                    |
-| **Naming / tags**                           | `resourcePrefix`, `project`, `environment`                                                                                                                                                                                                                                                                              |
-| **Per-resource name overrides**             | `apiAppNameOverride`, `hubAppNameOverride`, `appServicePlanNameOverride`, `appInsightsNameOverride`, `logAnalyticsWorkspaceNameOverride`, `postgresqlServerNameOverride`, `storageAccountNameOverride`, `vnetNameOverride` — see [Resource name overrides](#resource-name-overrides)                                    |
-| **Git deploy from GitHub (optional)**       | `hubRepositoryUrl`, `apiRepositoryUrl`, `branch`, `apiDeploymentBranch`                                                                                                                                                                                                                                                 |
-
+| What you want | Parameter(s) |
+|---------------|----------------|
+| **Hub on Static Web Apps vs App Service** | `hubDeploymentMode`: `'static-site'` (default) or `'web-app'` |
+| **Private PostgreSQL + networking** | `enablePostgresqlPrivateNetwork = true`. **Managed VNet:** leave `vnetResourceId` empty. **Your VNet:** set `vnetResourceId`, `postgresSubnetName`, and `apiVirtualNetworkSubnetId` or `apiIntegrationSubnetName` |
+| **Managed VNet IP addressing** | `vnetAddressPrefix` (e.g. `10.70.0.0/16` test, `10.71.0.0/16` prod); `vpnAddressPoolPrefix` for point-to-site clients (e.g. `10.0.1.0/24` test) |
+| **Private storage** | `storageIsPrivate = true` |
+| **PostgreSQL high availability** | `enablePostgresqlHA = true` |
+| **Failure anomaly alerts** | `enableFailureAnomalyAlerts = true` (see template notes on provider registration) |
+| **Naming / tags** | `resourcePrefix`, `project`, `environment`, `companyName`, `workloadName`, `regionAbbreviation` |
+| **Per-resource name overrides** | `*Override` params — [Resource name overrides](#resource-name-overrides) |
+| **Git deploy from GitHub (optional)** | `hubRepositoryUrl`, `apiRepositoryUrl`, `branch`, `apiDeploymentBranch` |
 
 ## Resource name overrides
 
-By default, every resource is named using the `{resourcePrefix}{project}-{type}` convention (for example `wetest-endatix-api`). If you need different names — for example to follow the [Azure CAF resource abbreviations](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations) using a `{type}-{company}-{workload}-{region}-{env}` format — edit the **Resource name overrides** block.
+**Compute / data plane (default):** `{resourcePrefix}{project}-{suffix}` (e.g. `test-endatix-api` with prefix `test-`).
 
-For the quickstart wizard, that block is **injected into `parameters.production.bicepparam`** when secrets are generated (empty values + inline `// auto:` hints match your chosen prefix and project). If you deploy **without** the wizard, copy `[parameters.bicepparam](./parameters.bicepparam)` and add the optional `*Override` parameters yourself (same names as below); omitted overrides default to empty in the template.
+**Managed VNet resources:** `{abbr}-{companyName}-{workloadName}-{regionAbbreviation}-{environment}` from `parameters.bicepparam` (defaults: `endatix` / `endatix` / `weu` / your `environment` value).
 
-Set any of the following:
+The wizard injects an overrides block into **`parameters.production.bicepparam`** (empty values + `// auto:` hints). Deploying without the wizard: copy `parameters.bicepparam`, add the optional `*Override` parameters, or run the wizard once and reuse the block.
 
-| Override param                        | Resource type                | Default name                          | CAF-style example                              |
-| ------------------------------------- | ---------------------------- | ------------------------------------- | ---------------------------------------------- |
-| `apiAppNameOverride`                  | App Service (API)            | `{prefix}{project}-api`               | `app-fairtrade-surveytools-weu-test`           |
-| `hubAppNameOverride`                  | Static Web App / Web App     | `{prefix}{project}-hub`               | `stapp-fairtrade-surveytools-weu-test`         |
-| `appServicePlanNameOverride`          | App Service Plan             | `{prefix}{project}-serviceplan`       | `plan-fairtrade-surveytools-weu-test`          |
-| `appInsightsNameOverride`             | Application Insights         | `{prefix}{project}-appinsights`       | `appi-fairtrade-surveytools-weu-test`          |
-| `logAnalyticsWorkspaceNameOverride`   | Log Analytics Workspace      | `{prefix}{project}-appinsights-ws`    | `log-fairtrade-surveytools-weu-test`           |
-| `postgresqlServerNameOverride`        | PostgreSQL Flexible Server   | `{prefix}{project}-postgresql`        | `psql-fairtrade-surveytools-weu-test`          |
-| `storageAccountNameOverride`          | Storage Account              | `{prefix}{project}{hash}` (truncated) | `stfairtrsurveyweutest`                        |
-| `vnetNameOverride`                    | VNet (managed only)          | `{prefix}{project}-vnet`              | `vnet-fairtrade-surveytools-weu-test`          |
+**CAF-style examples** below use fictitious segments `acme` / `datanium` / `eus` / `test` (same as `// override e.g.` hints in `generate-quickstart-secrets.mjs`):
 
-Notes:
+| Override param | Resource type | Default name | CAF-style example |
+|----------------|---------------|--------------|-------------------|
+| `apiAppNameOverride` | App Service (API) | `{prefix}{project}-api` | `app-acme-datanium-eus-test` |
+| `hubAppNameOverride` | Static Web App / Web App | `{prefix}{project}-hub` | `stapp-acme-datanium-eus-test` |
+| `appServicePlanNameOverride` | App Service Plan | `{prefix}{project}-serviceplan` | `plan-acme-datanium-eus-test` |
+| `appInsightsNameOverride` | Application Insights | `{prefix}{project}-appinsights` | `appi-acme-datanium-eus-test` |
+| `logAnalyticsWorkspaceNameOverride` | Log Analytics Workspace | `{prefix}{project}-appinsights-ws` | `log-acme-datanium-eus-test` |
+| `postgresqlServerNameOverride` | PostgreSQL Flexible Server | `{prefix}{project}-postgresql` | `psql-acme-datanium-eus-test` |
+| `storageAccountNameOverride` | Storage Account | `{prefix}{project}{hash}` (truncated) | `stacmedataniumeustest` |
+| `vnetNameOverride` | VNet (managed only) | `vnet-{company}-{workload}-{region}-{env}` | `vnet-acme-datanium-eus-test` |
 
-- Leave any value empty (`''`) to keep the auto-generated default.
-- **Storage account names must be 3-24 characters, lowercase alphanumeric only — no dashes.** Plan abbreviations accordingly (the example above shortens `fairtrade` and `surveytools` to fit).
-- These overrides take effect on the next `az deployment group create`. If you have already deployed with auto-generated names, changing them will provision new resources alongside the old ones — delete the old resources or your old resource group first.
+When managed VNet is enabled, these are also created (no separate override params in v1):
 
+| Resource | Default name pattern | Example |
+|----------|----------------------|---------|
+| App NSG | `nsg-{company}-{workload}-{region}-{env}-app` | `nsg-acme-datanium-eus-test-app` |
+| DB NSG | `nsg-{company}-{workload}-{region}-{env}-db` | `nsg-acme-datanium-eus-test-db` |
+| VPN Gateway | `vgw-{company}-{workload}-{region}-{env}-01` | `vgw-acme-datanium-eus-test-01` |
+| Gateway Public IP | `pip-{company}-{workload}-{region}-{env}-vgw-01` | `pip-acme-datanium-eus-test-vgw-01` |
 
-## Optional: Generate ARM JSON From Bicep
+**Notes:**
 
-If you need the compiled ARM template for troubleshooting or other tooling:
+- Leave any override empty (`''`) to keep the auto-generated default.
+- **Storage account names:** 3–24 characters, lowercase alphanumeric only, **no dashes**. The example is `st` + `acme` + `datanium` + `eus` + `test`.
+- Changing overrides after deploy creates **new** resources; remove the old ones or use a new resource group.
+
+## Optional: GitHub Actions sample
+
+[deploy-endatix-to-azure.yml](./deploy-endatix-to-azure.yml) shows OIDC-based API and Hub deployment for CI. It complements this interactive quickstart; configure repository variables and secrets as documented in that file.
+
+## Optional: compile Bicep to ARM JSON
 
 ```bash
 cd endatix-api/samples/deployment-scripts/azure
 az bicep build --file endatix-azure.template.bicep
 ```
-

--- a/samples/deployment-scripts/azure/__tests__/azure-naming.test.mjs
+++ b/samples/deployment-scripts/azure/__tests__/azure-naming.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildNamingPreview,
+  buildResourceNameOverridesBlock,
+  cafName,
+  cafStorageAccountName,
+  hubCafAbbreviation,
+  normalizeEnvironmentSegment,
+  normalizeRegionAbbreviation,
+  quickstartSegments,
+} from "../lib/azure-naming.mjs";
+
+const acmeSegments = {
+  company: "acme",
+  workload: "datanium",
+  region: "eus",
+  env: "test",
+};
+
+test("cafName builds CAF pattern with optional role", () => {
+  assert.equal(cafName("app", acmeSegments), "app-acme-datanium-eus-test");
+  assert.equal(
+    cafName("nsg", acmeSegments, "app"),
+    "nsg-acme-datanium-eus-test-app",
+  );
+  assert.equal(
+    cafName("pip", acmeSegments, "vgw-01"),
+    "pip-acme-datanium-eus-test-vgw-01",
+  );
+});
+
+test("cafStorageAccountName concatenates without dashes and truncates to 24 chars", () => {
+  assert.equal(cafStorageAccountName(acmeSegments), "stacmedataniumeustest");
+  const longEnv = {
+    ...acmeSegments,
+    company: "verylongcompanyname",
+    workload: "verylongworkloadname",
+    env: "production",
+  };
+  assert.equal(cafStorageAccountName(longEnv).length, 24);
+});
+
+test("hubCafAbbreviation depends on hub deployment mode", () => {
+  assert.equal(hubCafAbbreviation("static-site"), "stapp");
+  assert.equal(hubCafAbbreviation("web-app"), "app");
+});
+
+test("buildNamingPreview uses stapp for static-site and app for web-app hub", () => {
+  const staticPreview = buildNamingPreview({
+    convention: "caf",
+    segments: acmeSegments,
+    hubDeploymentMode: "static-site",
+  });
+  const webPreview = buildNamingPreview({
+    convention: "caf",
+    segments: acmeSegments,
+    hubDeploymentMode: "web-app",
+  });
+
+  const staticHub = staticPreview.find((row) => row.key === "hub");
+  const webHub = webPreview.find((row) => row.key === "hub");
+
+  assert.equal(staticHub?.example, "stapp-acme-datanium-eus-test");
+  assert.equal(webHub?.example, "app-acme-datanium-eus-test");
+});
+
+test("quickstartSegments uses project as company with default workload and region", () => {
+  const segments = quickstartSegments("MyProject", "sandbox");
+  assert.equal(segments.company, "myproject");
+  assert.equal(segments.workload, "endatix");
+  assert.equal(segments.region, "weu");
+  assert.equal(segments.env, "sandbox");
+});
+
+test("normalizeRegionAbbreviation strips invalid chars and caps length", () => {
+  assert.equal(normalizeRegionAbbreviation("WEU"), "weu");
+  assert.equal(normalizeRegionAbbreviation("east-us-2"), "eastus");
+  assert.equal(normalizeRegionAbbreviation(""), "weu");
+});
+
+test("normalizeEnvironmentSegment lowercases and hyphenates", () => {
+  assert.equal(normalizeEnvironmentSegment("Sandbox"), "sandbox");
+  assert.equal(normalizeEnvironmentSegment("  prod env  "), "prod-env");
+});
+
+test("buildResourceNameOverridesBlock includes auto hints and segment comment", () => {
+  const block = buildResourceNameOverridesBlock({
+    convention: "quickstart",
+    segments: quickstartSegments("endatix", "sandbox"),
+    hubDeploymentMode: "static-site",
+  });
+
+  assert.match(block, /Naming mode: quickstart/);
+  assert.match(block, /param apiAppNameOverride = ''/);
+  assert.match(block, /\/\/ auto: app-endatix-endatix-weu-sandbox/);
+  assert.match(block, /\/\/ auto: stapp-endatix-endatix-weu-sandbox/);
+  assert.match(block, /Managed VNet also creates:/);
+});

--- a/samples/deployment-scripts/azure/__tests__/azure-naming.test.mjs
+++ b/samples/deployment-scripts/azure/__tests__/azure-naming.test.mjs
@@ -9,6 +9,8 @@ import {
   normalizeEnvironmentSegment,
   normalizeRegionAbbreviation,
   quickstartSegments,
+  trimLeadingHyphens,
+  trimTrailingHyphens,
 } from "../lib/azure-naming.mjs";
 
 const acmeSegments = {
@@ -82,6 +84,18 @@ test("normalizeRegionAbbreviation strips invalid chars and caps length", () => {
 test("normalizeEnvironmentSegment lowercases and hyphenates", () => {
   assert.equal(normalizeEnvironmentSegment("Sandbox"), "sandbox");
   assert.equal(normalizeEnvironmentSegment("  prod env  "), "prod-env");
+});
+
+test("trimTrailingHyphens removes only trailing hyphens", () => {
+  assert.equal(trimTrailingHyphens("abc---"), "abc");
+  assert.equal(trimTrailingHyphens("abc-def-"), "abc-def");
+  assert.equal(trimTrailingHyphens("---"), "");
+  assert.equal(trimTrailingHyphens("abc"), "abc");
+});
+
+test("normalizeEnvironmentSegment drops leading and trailing hyphens after normalization", () => {
+  assert.equal(normalizeEnvironmentSegment("  --prod-- env---  "), "prod-env");
+  assert.equal(normalizeEnvironmentSegment("---DEV---"), "dev");
 });
 
 test("buildResourceNameOverridesBlock includes auto hints and segment comment", () => {

--- a/samples/deployment-scripts/azure/endatix-azure.template.bicep
+++ b/samples/deployment-scripts/azure/endatix-azure.template.bicep
@@ -105,6 +105,14 @@ param workloadName string = 'endatix'
 @description('Azure region abbreviation for CAF-style resource names (e.g. weu, eus)')
 param regionAbbreviation string = 'weu'
 
+@allowed([
+  'quickstart'
+  'caf'
+  'manual'
+])
+@description('Naming mode for the quickstart wizard (all auto names use CAF segments unless *Override is set)')
+param namingConvention string = 'quickstart'
+
 @description('When enablePostgresqlPrivateNetwork and vnetResourceId is set: PostgreSQL delegated subnet name inside that VNet')
 param postgresSubnetName string = ''
 
@@ -128,66 +136,64 @@ param enableFailureAnomalyAlerts bool = false
 param hubDeploymentMode string = 'static-site'
 
 // --- Resource name overrides (optional) ---
-// Leave any of these empty to use the auto-generated {prefix}{project}-{type} convention.
-// Recommended convention for custom names: {type}-{company}-{workload}-{region}-{env}
-// using Azure abbreviations (https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations).
+// Leave empty for CAF auto names: {abbr}-{companyName}-{workloadName}-{regionAbbreviation}-{environment}[-{role}]
 
-@description('Override: API App Service name. Leave empty to use {prefix}{project}-api')
+@description('Override: API App Service name. Leave empty for CAF auto name (app-...)')
 param apiAppNameOverride string = ''
 
-@description('Override: Hub App name (Static Web App or Web App). Leave empty to use {prefix}{project}-hub')
+@description('Override: Hub App name. Leave empty for CAF auto name (stapp- or app- by hubDeploymentMode)')
 param hubAppNameOverride string = ''
 
-@description('Override: App Service Plan name. Leave empty to use {prefix}{project}-serviceplan')
+@description('Override: App Service Plan name. Leave empty for CAF auto name (plan-...)')
 param appServicePlanNameOverride string = ''
 
-@description('Override: Application Insights name. Leave empty to use {prefix}{project}-appinsights')
+@description('Override: Application Insights name. Leave empty for CAF auto name (appi-...)')
 param appInsightsNameOverride string = ''
 
-@description('Override: Log Analytics Workspace name. Leave empty to use {prefix}{project}-appinsights-ws')
+@description('Override: Log Analytics Workspace name. Leave empty for CAF auto name (log-...)')
 param logAnalyticsWorkspaceNameOverride string = ''
 
-@description('Override: PostgreSQL Flexible Server name. Leave empty to use {prefix}{project}-postgresql')
+@description('Override: PostgreSQL Flexible Server name. Leave empty for CAF auto name (psql-...)')
 param postgresqlServerNameOverride string = ''
 
-@description('Override: Storage Account name (3-24 chars, lowercase alphanumeric only). Leave empty for auto-generated.')
+@description('Override: Storage Account name (3-24 chars, lowercase alphanumeric only). Leave empty for CAF auto name (st+segments)')
 param storageAccountNameOverride string = ''
 
-@description('Override: VNet name (only used when managed VNet is enabled). Leave empty for CAF default vnet-{company}-{workload}-{region}-{env}')
+@description('Override: VNet name (managed VNet only). Leave empty for CAF auto name (vnet-...)')
 param vnetNameOverride string = ''
 
-func cafName(string abbr, string role) string =>
-  empty(role)
-    ? '${abbr}-${companyName}-${workloadName}-${regionAbbreviation}-${environment}'
-    : '${abbr}-${companyName}-${workloadName}-${regionAbbreviation}-${environment}-${role}'
+var cafNameSuffix = '${companyName}-${workloadName}-${regionAbbreviation}-${environment}'
 
-// Resource naming variables
-var projectLower = toLower(project)
-var projectServiceToken = replace(replace(replace(replace(projectLower, ' ', '-'), '_', '-'), '.', '-'), '--', '-')
-var projectStorageToken = replace(replace(replace(replace(projectLower, '-', ''), '_', ''), '.', ''), ' ', '')
-var prefixServiceToken = toLower(resourcePrefix)
-var prefixStorageToken = replace(prefixServiceToken, '-', '')
-var defaultStorageSuffix = take(uniqueString(subscription().id, resourceGroup().id, resourcePrefix), 8)
+func cafName(abbr string, suffix string, role string) string =>
+  empty(role) ? '${abbr}-${suffix}' : '${abbr}-${suffix}-${role}'
 
-var endatixAppInsightsName = !empty(appInsightsNameOverride) ? appInsightsNameOverride : '${prefixServiceToken}${projectServiceToken}-appinsights'
-var endatixLogAnalyticsWsName = !empty(logAnalyticsWorkspaceNameOverride) ? logAnalyticsWorkspaceNameOverride : '${prefixServiceToken}${projectServiceToken}-appinsights-ws'
-var endatixHubName = !empty(hubAppNameOverride) ? hubAppNameOverride : '${prefixServiceToken}${projectServiceToken}-hub'
-var endatixApiName = !empty(apiAppNameOverride) ? apiAppNameOverride : '${prefixServiceToken}${projectServiceToken}-api'
-var endatixServicePlanName = !empty(appServicePlanNameOverride) ? appServicePlanNameOverride : '${prefixServiceToken}${projectServiceToken}-serviceplan'
-var endatixVnetName = !empty(vnetNameOverride) ? vnetNameOverride : cafName('vnet', '')
+func stripDashes(value string) string => replace(replace(value, '-', ''), '_', '')
+
+func cafStorageAccountName(company string, workload string, region string, env string) string =>
+  take('st${stripDashes(company)}${stripDashes(workload)}${region}${stripDashes(env)}', 24)
+
+func resolveResourceName(override string, abbr string, suffix string, role string) string =>
+  !empty(override) ? override : cafName(abbr, suffix, role)
+
+var hubCafAbbr = hubDeploymentMode == 'static-site' ? 'stapp' : 'app'
+
+var endatixAppInsightsName = resolveResourceName(appInsightsNameOverride, 'appi', cafNameSuffix, '')
+var endatixLogAnalyticsWsName = resolveResourceName(logAnalyticsWorkspaceNameOverride, 'log', cafNameSuffix, '')
+var endatixHubName = resolveResourceName(hubAppNameOverride, hubCafAbbr, cafNameSuffix, '')
+var endatixApiName = resolveResourceName(apiAppNameOverride, 'app', cafNameSuffix, '')
+var endatixServicePlanName = resolveResourceName(appServicePlanNameOverride, 'plan', cafNameSuffix, '')
+var endatixVnetName = resolveResourceName(vnetNameOverride, 'vnet', cafNameSuffix, '')
 var appSubnetPrefix = cidrSubnet(vnetAddressPrefix, 24, 0)
 var dbSubnetPrefix = cidrSubnet(vnetAddressPrefix, 24, 1)
 var gatewaySubnetPrefix = cidrSubnet(vnetAddressPrefix, 24, 3)
-var appNsgName = cafName('nsg', 'app')
-var dbNsgName = cafName('nsg', 'db')
-var vgwName = cafName('vgw', '01')
-var vgwPipName = cafName('pip', 'vgw-01')
+var appNsgName = cafName('nsg', cafNameSuffix, 'app')
+var dbNsgName = cafName('nsg', cafNameSuffix, 'db')
+var vgwName = cafName('vgw', cafNameSuffix, '01')
+var vgwPipName = cafName('pip', cafNameSuffix, 'vgw-01')
 var endatixStorageAccountName = !empty(storageAccountNameOverride)
   ? storageAccountNameOverride
-  : (projectStorageToken == 'endatix'
-      ? '${prefixStorageToken}${projectStorageToken}${defaultStorageSuffix}'
-      : take('${prefixStorageToken}${projectStorageToken}', 24))
-var endatixPostgresqlServerName = !empty(postgresqlServerNameOverride) ? postgresqlServerNameOverride : '${prefixServiceToken}${projectServiceToken}-postgresql'
+  : cafStorageAccountName(companyName, workloadName, regionAbbreviation, environment)
+var endatixPostgresqlServerName = resolveResourceName(postgresqlServerNameOverride, 'psql', cafNameSuffix, '')
 var deployManagedVnet = enablePostgresqlPrivateNetwork && vnetResourceId == ''
 var storageHostName = '${endatixStorageAccountName}.blob.${az.environment().suffixes.storage}'
 var resolvedHubDefaultHostName = hubDeploymentMode == 'static-site'

--- a/samples/deployment-scripts/azure/endatix-azure.template.bicep
+++ b/samples/deployment-scripts/azure/endatix-azure.template.bicep
@@ -1,10 +1,4 @@
 /* ********* Parameters ********** */
-
-@minLength(1)
-@maxLength(10)
-@description('Prefix for all resource names (e.g., "prod-", "dev-", "uat-")')
-param resourcePrefix string = 'temp-'
-
 @description('Azure region for deploying resources')
 param location string = resourceGroup().location
 
@@ -104,14 +98,6 @@ param workloadName string = 'endatix'
 
 @description('Azure region abbreviation for CAF-style resource names (e.g. weu, eus)')
 param regionAbbreviation string = 'weu'
-
-@allowed([
-  'quickstart'
-  'caf'
-  'manual'
-])
-@description('Naming mode for the quickstart wizard (all auto names use CAF segments unless *Override is set)')
-param namingConvention string = 'quickstart'
 
 @description('When enablePostgresqlPrivateNetwork and vnetResourceId is set: PostgreSQL delegated subnet name inside that VNet')
 param postgresSubnetName string = ''

--- a/samples/deployment-scripts/azure/endatix-azure.template.bicep
+++ b/samples/deployment-scripts/azure/endatix-azure.template.bicep
@@ -87,8 +87,23 @@ param enablePostgresqlHA bool = false
 @description('Enable private network access (VNet integration) for PostgreSQL')
 param enablePostgresqlPrivateNetwork bool = false
 
-@description('Existing VNet resource ID. Leave empty with enablePostgresqlPrivateNetwork to create a managed VNet (snet-app, snet-db, snet-pe).')
+@description('Existing VNet resource ID. Leave empty with enablePostgresqlPrivateNetwork to create a managed VNet (snet-app, snet-db, GatewaySubnet).')
 param vnetResourceId string = ''
+
+@description('Managed VNet address space (app/db/gateway subnets are derived via cidrSubnet). Example prod: 10.71.0.0/16')
+param vnetAddressPrefix string = '10.70.0.0/16'
+
+@description('Point-to-site VPN client address pool (separate from VNet space). Example prod: 10.0.2.0/24')
+param vpnAddressPoolPrefix string = '10.0.1.0/24'
+
+@description('Company segment for CAF-style resource names (e.g. acme)')
+param companyName string = project
+
+@description('Workload segment for CAF-style resource names (e.g. endatix)')
+param workloadName string = 'endatix'
+
+@description('Azure region abbreviation for CAF-style resource names (e.g. weu, eus)')
+param regionAbbreviation string = 'weu'
 
 @description('When enablePostgresqlPrivateNetwork and vnetResourceId is set: PostgreSQL delegated subnet name inside that VNet')
 param postgresSubnetName string = ''
@@ -138,8 +153,13 @@ param postgresqlServerNameOverride string = ''
 @description('Override: Storage Account name (3-24 chars, lowercase alphanumeric only). Leave empty for auto-generated.')
 param storageAccountNameOverride string = ''
 
-@description('Override: VNet name (only used when managed VNet is enabled). Leave empty to use {prefix}{project}-vnet')
+@description('Override: VNet name (only used when managed VNet is enabled). Leave empty for CAF default vnet-{company}-{workload}-{region}-{env}')
 param vnetNameOverride string = ''
+
+func cafName(string abbr, string role) string =>
+  empty(role)
+    ? '${abbr}-${companyName}-${workloadName}-${regionAbbreviation}-${environment}'
+    : '${abbr}-${companyName}-${workloadName}-${regionAbbreviation}-${environment}-${role}'
 
 // Resource naming variables
 var projectLower = toLower(project)
@@ -154,7 +174,14 @@ var endatixLogAnalyticsWsName = !empty(logAnalyticsWorkspaceNameOverride) ? logA
 var endatixHubName = !empty(hubAppNameOverride) ? hubAppNameOverride : '${prefixServiceToken}${projectServiceToken}-hub'
 var endatixApiName = !empty(apiAppNameOverride) ? apiAppNameOverride : '${prefixServiceToken}${projectServiceToken}-api'
 var endatixServicePlanName = !empty(appServicePlanNameOverride) ? appServicePlanNameOverride : '${prefixServiceToken}${projectServiceToken}-serviceplan'
-var endatixVnetName = !empty(vnetNameOverride) ? vnetNameOverride : '${prefixServiceToken}${projectServiceToken}-vnet'
+var endatixVnetName = !empty(vnetNameOverride) ? vnetNameOverride : cafName('vnet', '')
+var appSubnetPrefix = cidrSubnet(vnetAddressPrefix, 24, 0)
+var dbSubnetPrefix = cidrSubnet(vnetAddressPrefix, 24, 1)
+var gatewaySubnetPrefix = cidrSubnet(vnetAddressPrefix, 24, 3)
+var appNsgName = cafName('nsg', 'app')
+var dbNsgName = cafName('nsg', 'db')
+var vgwName = cafName('vgw', '01')
+var vgwPipName = cafName('pip', 'vgw-01')
 var endatixStorageAccountName = !empty(storageAccountNameOverride)
   ? storageAccountNameOverride
   : (projectStorageToken == 'endatix'
@@ -277,8 +304,17 @@ module vnetModule './modules/vnet.module.bicep' = if (deployManagedVnet) {
   name: 'vnetModule'
   params: {
     location: location
-    vnetName: endatixVnetName
     tags: tags
+    vnetName: endatixVnetName
+    vnetAddressPrefix: vnetAddressPrefix
+    appSubnetPrefix: appSubnetPrefix
+    dbSubnetPrefix: dbSubnetPrefix
+    gatewaySubnetPrefix: gatewaySubnetPrefix
+    vpnAddressPoolPrefix: vpnAddressPoolPrefix
+    appNsgName: appNsgName
+    dbNsgName: dbNsgName
+    vgwName: vgwName
+    vgwPublicIpName: vgwPipName
   }
 }
 

--- a/samples/deployment-scripts/azure/generate-quickstart-secrets.mjs
+++ b/samples/deployment-scripts/azure/generate-quickstart-secrets.mjs
@@ -70,11 +70,44 @@ function deriveResourceGroupName(environmentName, projectName = "endatix") {
 
 const RESOURCE_OVERRIDES_MARKER = "// --- Resource name overrides ---";
 
-function buildResourceNameOverridesBlock({ resourcePrefixRaw, project }) {
+/** Fictitious CAF segments for override comments and README (not deployed defaults). */
+const CAF_EXAMPLE_NAMING = {
+  company: "acme",
+  workload: "datanium",
+  region: "eus",
+  env: "test",
+};
+
+function cafExampleName(abbr, role = "") {
+  const { company, workload, region, env } = CAF_EXAMPLE_NAMING;
+  return role
+    ? `${abbr}-${company}-${workload}-${region}-${env}-${role}`
+    : `${abbr}-${company}-${workload}-${region}-${env}`;
+}
+
+function cafExampleStorageAccountName() {
+  const { company, workload, region, env } = CAF_EXAMPLE_NAMING;
+  return `st${company}${workload}${region}${env}`;
+}
+
+function buildResourceNameOverridesBlock({
+  resourcePrefixRaw,
+  project,
+  environment = "dev",
+}) {
   const prefixServiceToken = resourcePrefixRaw.toLowerCase();
   const projectNormalized = normalizeProjectName(project);
   const auto = (suffix) =>
     `${prefixServiceToken}${projectNormalized}-${suffix}`;
+
+  const company = projectNormalized;
+  const workload = "endatix";
+  const region = "weu";
+  const env = (environment ?? "dev").toLowerCase();
+  const caf = (abbr, role = "") =>
+    role
+      ? `${abbr}-${company}-${workload}-${region}-${env}-${role}`
+      : `${abbr}-${company}-${workload}-${region}-${env}`;
 
   const prefixStorageToken = prefixServiceToken.replaceAll("-", "");
   const projectStorageToken = projectNormalized
@@ -92,14 +125,16 @@ function buildResourceNameOverridesBlock({ resourcePrefixRaw, project }) {
     "// Recommended convention for custom names: {type}-{company}-{workload}-{region}-{env}",
     "// Azure abbreviations: https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations",
     "// -------------------------------------------------------------------",
-    `param apiAppNameOverride = ''                  // auto: ${auto("api")} or override e.g. app-acme-datanium-eus-test`,
-    `param hubAppNameOverride = ''                  // auto: ${auto("hub")} or override e.g. stapp-acme-datanium-eus-test`,
-    `param appServicePlanNameOverride = ''          // auto: ${auto("serviceplan")} or override e.g. plan-acme-datanium-eus-test`,
-    `param appInsightsNameOverride = ''             // auto: ${auto("appinsights")} or override e.g. appi-acme-datanium-eus-test`,
-    `param logAnalyticsWorkspaceNameOverride = ''   // auto: ${auto("appinsights-ws")} or override e.g. log-acme-datanium-eus-test`,
-    `param postgresqlServerNameOverride = ''        // auto: ${auto("postgresql")} or override e.g. psql-acme-datanium-eus-test`,
-    `param storageAccountNameOverride = ''          // auto: ${storageAutoHint} or override e.g. stacmedataniumeustest (3-24 chars, lowercase alphanumeric only, no dashes)`,
-    `param vnetNameOverride = ''                    // auto: ${auto("vnet")} or override e.g. vnet-acme-datanium-eus-test (if VNet is enabled)`,
+    "// CAF/network params (companyName, workloadName, regionAbbreviation, vnetAddressPrefix,",
+    "// vpnAddressPoolPrefix) are in parameters.bicepparam — edit there for prod IP examples.",
+    `param apiAppNameOverride = ''                  // auto: ${auto("api")} or override e.g. ${cafExampleName("app")}`,
+    `param hubAppNameOverride = ''                  // auto: ${auto("hub")} or override e.g. ${cafExampleName("stapp")}`,
+    `param appServicePlanNameOverride = ''          // auto: ${auto("serviceplan")} or override e.g. ${cafExampleName("plan")}`,
+    `param appInsightsNameOverride = ''             // auto: ${auto("appinsights")} or override e.g. ${cafExampleName("appi")}`,
+    `param logAnalyticsWorkspaceNameOverride = ''   // auto: ${auto("appinsights-ws")} or override e.g. ${cafExampleName("log")}`,
+    `param postgresqlServerNameOverride = ''        // auto: ${auto("postgresql")} or override e.g. ${cafExampleName("psql")}`,
+    `param storageAccountNameOverride = ''          // auto: ${storageAutoHint} or override e.g. ${cafExampleStorageAccountName()} (3-24 chars, lowercase alphanumeric only, no dashes)`,
+    `param vnetNameOverride = ''                    // auto: ${caf("vnet")} (managed VNet only); NSGs: ${cafExampleName("nsg", "app")}, ${cafExampleName("nsg", "db")}`,
     "",
   ].join("\n");
 }
@@ -265,6 +300,7 @@ async function ensureLocalParameters({
   projectOverride,
   configuredResourcePrefix,
   effectiveProject,
+  environmentName,
 }) {
   if (skipSecretGen) {
     console.log(
@@ -303,6 +339,7 @@ async function ensureLocalParameters({
   const overridesBlock = buildResourceNameOverridesBlock({
     resourcePrefixRaw: configuredResourcePrefix,
     project: effectiveProject,
+    environment: environmentName,
   });
   const localParametersBicep = injectResourceNameOverrides(
     replacedBicep,
@@ -348,6 +385,7 @@ async function interactiveWizard() {
     projectOverride,
     configuredResourcePrefix,
     effectiveProject: effectiveProject || projectName,
+    environmentName,
   });
 
   console.log(`\n${infoText("=== Step 1: Provision Infrastructure ===")}`);

--- a/samples/deployment-scripts/azure/generate-quickstart-secrets.mjs
+++ b/samples/deployment-scripts/azure/generate-quickstart-secrets.mjs
@@ -21,6 +21,17 @@ import {
   randomSigningKey,
 } from "../../../scripts/lib/secret-generation.mjs";
 import { normalizeProjectName } from "../../../scripts/lib/project-name-utils.mjs";
+import {
+  buildNamingPreview,
+  buildResourceNameOverridesBlock,
+  DEFAULT_REGION,
+  DEFAULT_WORKLOAD,
+  formatNamingPreviewTable,
+  normalizeEnvironmentSegment,
+  normalizeNamingSegment,
+  normalizeRegionAbbreviation,
+  quickstartSegments,
+} from "./lib/azure-naming.mjs";
 import { readDeploymentOutputsFromFile } from "./lib/deployment-outputs.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -70,73 +81,132 @@ function deriveResourceGroupName(environmentName, projectName = "endatix") {
 
 const RESOURCE_OVERRIDES_MARKER = "// --- Resource name overrides ---";
 
-/** Fictitious CAF segments for override comments and README (not deployed defaults). */
-const CAF_EXAMPLE_NAMING = {
-  company: "acme",
-  workload: "datanium",
-  region: "eus",
-  env: "test",
-};
-
-function cafExampleName(abbr, role = "") {
-  const { company, workload, region, env } = CAF_EXAMPLE_NAMING;
-  return role
-    ? `${abbr}-${company}-${workload}-${region}-${env}-${role}`
-    : `${abbr}-${company}-${workload}-${region}-${env}`;
+function printNamingPreview(convention, segments, hubDeploymentMode) {
+  const preview = buildNamingPreview({
+    convention,
+    segments,
+    hubDeploymentMode,
+  });
+  console.log(
+    `\n${infoText("Resource names (CAF auto; pattern {abbr}-{company}-{workload}-{region}-{env}):")}`,
+  );
+  console.log(formatNamingPreviewTable(preview));
 }
 
-function cafExampleStorageAccountName() {
-  const { company, workload, region, env } = CAF_EXAMPLE_NAMING;
-  return `st${company}${workload}${region}${env}`;
+function loadNamingFromParameters(content) {
+  return {
+    convention:
+      readStringParamFromBicepParam(content, "namingConvention") ??
+      "quickstart",
+    segments: {
+      company: normalizeNamingSegment(
+        readStringParamFromBicepParam(content, "companyName") ?? "endatix",
+      ),
+      workload: normalizeNamingSegment(
+        readStringParamFromBicepParam(content, "workloadName") ??
+          DEFAULT_WORKLOAD,
+      ),
+      region: normalizeRegionAbbreviation(
+        readStringParamFromBicepParam(content, "regionAbbreviation") ??
+          DEFAULT_REGION,
+      ),
+      env: normalizeEnvironmentSegment(
+        readStringParamFromBicepParam(content, "environment") ?? "dev",
+      ),
+    },
+    hubDeploymentMode:
+      readStringParamFromBicepParam(content, "hubDeploymentMode") ??
+      "static-site",
+  };
 }
 
-function buildResourceNameOverridesBlock({
-  resourcePrefixRaw,
-  project,
-  environment = "dev",
-}) {
-  const prefixServiceToken = resourcePrefixRaw.toLowerCase();
-  const projectNormalized = normalizeProjectName(project);
-  const auto = (suffix) =>
-    `${prefixServiceToken}${projectNormalized}-${suffix}`;
+async function resolveNamingConvention(
+  baseBicepParameters,
+  skipSecretGen,
+  effectiveProject,
+  environmentName,
+) {
+  const hubDeploymentMode =
+    readStringParamFromBicepParam(baseBicepParameters, "hubDeploymentMode") ??
+    "static-site";
 
-  const company = projectNormalized;
-  const workload = "endatix";
-  const region = "weu";
-  const env = (environment ?? "dev").toLowerCase();
-  const caf = (abbr, role = "") =>
-    role
-      ? `${abbr}-${company}-${workload}-${region}-${env}-${role}`
-      : `${abbr}-${company}-${workload}-${region}-${env}`;
+  if (skipSecretGen) {
+    const source = (await fileExists(localParametersPath))
+      ? await readFile(localParametersPath, "utf8")
+      : baseBicepParameters;
+    const loaded = loadNamingFromParameters(source);
+    console.log(
+      `\n${infoText("Naming:")} reusing ${loaded.convention} mode from existing parameters.`,
+    );
+    return { ...loaded, hubDeploymentMode };
+  }
 
-  const prefixStorageToken = prefixServiceToken.replaceAll("-", "");
-  const projectStorageToken = projectNormalized
-    .replaceAll("-", "")
-    .replaceAll("_", "")
-    .replaceAll(".", "")
-    .replaceAll(" ", "");
-  const storageBase = `${prefixStorageToken}${projectStorageToken}`;
-  const storageAutoHint = `projectStorageToken=='endatix' ? storageBase+defaultStorageSuffix (here ${storageBase}+8-char hash; defaultStorageSuffix uses resourcePrefix) : take(storageBase,24), storageBase=${storageBase} from resourcePrefix & project, no hash`;
+  console.log(
+    `\n${infoText("Naming convention")} — all auto names use CAF unless you set *Override in the generated file.`,
+  );
+  console.log(
+    "  [Q]uickstart — CAF with defaults (company=project, workload=endatix, region=weu)",
+  );
+  console.log("  [C]AF — prompt for company, workload, region, environment");
+  console.log(
+    "  [M]anual — skip naming prompts; edit *Override params before deploy",
+  );
+  const choice = (await question("❯ Choose naming mode [Q/c/m] (default Q): "))
+    .trim()
+    .toLowerCase();
 
-  return [
-    "",
-    RESOURCE_OVERRIDES_MARKER,
-    "// Leave any of these empty to use the auto-generated name (shown in comments below).",
-    "// Recommended convention for custom names: {type}-{company}-{workload}-{region}-{env}",
-    "// Azure abbreviations: https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations",
-    "// -------------------------------------------------------------------",
-    "// CAF/network params (companyName, workloadName, regionAbbreviation, vnetAddressPrefix,",
-    "// vpnAddressPoolPrefix) are in parameters.bicepparam — edit there for prod IP examples.",
-    `param apiAppNameOverride = ''                  // auto: ${auto("api")} or override e.g. ${cafExampleName("app")}`,
-    `param hubAppNameOverride = ''                  // auto: ${auto("hub")} or override e.g. ${cafExampleName("stapp")}`,
-    `param appServicePlanNameOverride = ''          // auto: ${auto("serviceplan")} or override e.g. ${cafExampleName("plan")}`,
-    `param appInsightsNameOverride = ''             // auto: ${auto("appinsights")} or override e.g. ${cafExampleName("appi")}`,
-    `param logAnalyticsWorkspaceNameOverride = ''   // auto: ${auto("appinsights-ws")} or override e.g. ${cafExampleName("log")}`,
-    `param postgresqlServerNameOverride = ''        // auto: ${auto("postgresql")} or override e.g. ${cafExampleName("psql")}`,
-    `param storageAccountNameOverride = ''          // auto: ${storageAutoHint} or override e.g. ${cafExampleStorageAccountName()} (3-24 chars, lowercase alphanumeric only, no dashes)`,
-    `param vnetNameOverride = ''                    // auto: ${caf("vnet")} (managed VNet only); NSGs: ${cafExampleName("nsg", "app")}, ${cafExampleName("nsg", "db")}`,
-    "",
-  ].join("\n");
+  let convention = "quickstart";
+  if (choice.startsWith("c")) {
+    convention = "caf";
+  } else if (choice.startsWith("m")) {
+    convention = "manual";
+  }
+
+  let segments;
+  if (convention === "caf") {
+    const defaultCompany =
+      readStringParamFromBicepParam(baseBicepParameters, "companyName") ??
+      effectiveProject;
+    const defaultWorkload =
+      readStringParamFromBicepParam(baseBicepParameters, "workloadName") ??
+      DEFAULT_WORKLOAD;
+    const defaultRegion =
+      readStringParamFromBicepParam(
+        baseBicepParameters,
+        "regionAbbreviation",
+      ) ?? DEFAULT_REGION;
+
+    const companyInput = await question(
+      `❯ Company segment (companyName) [${defaultCompany}]: `,
+    );
+    const workloadInput = await question(
+      `❯ Workload segment (workloadName) [${defaultWorkload}]: `,
+    );
+    const regionInput = await question(
+      `❯ Region abbreviation (e.g. weu, eus) [${defaultRegion}]: `,
+    );
+    const envInput = await question(
+      `❯ Environment segment [${environmentName}]: `,
+    );
+
+    segments = {
+      company: normalizeNamingSegment(companyInput.trim() || defaultCompany),
+      workload: normalizeNamingSegment(workloadInput.trim() || defaultWorkload),
+      region: normalizeRegionAbbreviation(regionInput.trim() || defaultRegion),
+      env: normalizeEnvironmentSegment(envInput.trim() || environmentName),
+    };
+  } else if (convention === "manual") {
+    console.log(
+      `\n${tipText("Manual mode:")} set *NameOverride values in parameters.production.bicepparam before deploy. Empty overrides still use CAF from segment params below.`,
+    );
+    segments = quickstartSegments(effectiveProject, environmentName);
+  } else {
+    segments = quickstartSegments(effectiveProject, environmentName);
+  }
+
+  printNamingPreview(convention, segments, hubDeploymentMode);
+
+  return { convention, segments, hubDeploymentMode };
 }
 
 function injectResourceNameOverrides(content, block) {
@@ -198,9 +268,6 @@ async function resolveSecretGenerationMode() {
 
 async function loadDeploymentConfig() {
   const baseBicepParameters = await readFile(bicepParametersPath, "utf8");
-  const configuredPrefix =
-    readStringParamFromBicepParam(baseBicepParameters, "resourcePrefix") ??
-    "eval-";
   const environmentName =
     readStringParamFromBicepParam(baseBicepParameters, "environment") ?? "temp";
   const projectName =
@@ -208,7 +275,6 @@ async function loadDeploymentConfig() {
 
   return {
     baseBicepParameters,
-    configuredResourcePrefix: configuredPrefix,
     environmentName,
     projectName: normalizeProjectName(projectName),
   };
@@ -298,9 +364,11 @@ async function ensureLocalParameters({
   baseBicepParameters,
   skipSecretGen,
   projectOverride,
-  configuredResourcePrefix,
   effectiveProject,
   environmentName,
+  namingConvention,
+  namingSegments,
+  hubDeploymentMode,
 }) {
   if (skipSecretGen) {
     console.log(
@@ -331,15 +399,23 @@ async function ensureLocalParameters({
     generatedReplacements.push(["project", projectOverride]);
   }
 
+  generatedReplacements.push(
+    ["namingConvention", namingConvention],
+    ["companyName", namingSegments.company],
+    ["workloadName", namingSegments.workload],
+    ["regionAbbreviation", namingSegments.region],
+    ["environment", namingSegments.env],
+  );
+
   const replacedBicep = applyStringParamReplacements(
     baseBicepParameters,
     generatedReplacements,
   );
 
   const overridesBlock = buildResourceNameOverridesBlock({
-    resourcePrefixRaw: configuredResourcePrefix,
-    project: effectiveProject,
-    environment: environmentName,
+    convention: namingConvention,
+    segments: namingSegments,
+    hubDeploymentMode,
   });
   const localParametersBicep = injectResourceNameOverrides(
     replacedBicep,
@@ -351,7 +427,7 @@ async function ensureLocalParameters({
     `\n\u2705 Generated secure parameters dynamically in: ${path.basename(localParametersPath)}`,
   );
   console.log(
-    `\n${tipText("Tip:")} Review the "Resource name overrides" block at the top of ${path.basename(localParametersPath)} if you want custom (e.g. CAF-style) resource names.`,
+    `\n${tipText("Tip:")} Review the "Resource name overrides" block at the top of ${path.basename(localParametersPath)} to set custom per-resource names.`,
   );
 }
 
@@ -366,26 +442,32 @@ async function interactiveWizard() {
   );
 
   const { skipSecretGen } = await resolveSecretGenerationMode();
-  const {
-    baseBicepParameters,
-    configuredResourcePrefix,
-    environmentName,
-    projectName,
-  } = await loadDeploymentConfig();
+  const { baseBicepParameters, environmentName, projectName } =
+    await loadDeploymentConfig();
   const { effectiveProject, projectOverride } =
     await resolveProjectForCurrentRun(baseBicepParameters, skipSecretGen);
+  const resolvedProject = effectiveProject || projectName;
+  const { convention, segments, hubDeploymentMode } =
+    await resolveNamingConvention(
+      baseBicepParameters,
+      skipSecretGen,
+      resolvedProject,
+      environmentName,
+    );
   const { resourceGroupName, createRgCmd } = await resolveResourceGroupInfo(
     environmentName,
-    effectiveProject || projectName,
+    resolvedProject,
   );
 
   await ensureLocalParameters({
     baseBicepParameters,
     skipSecretGen,
     projectOverride,
-    configuredResourcePrefix,
-    effectiveProject: effectiveProject || projectName,
-    environmentName,
+    effectiveProject: resolvedProject,
+    environmentName: segments.env,
+    namingConvention: convention,
+    namingSegments: segments,
+    hubDeploymentMode,
   });
 
   console.log(`\n${infoText("=== Step 1: Provision Infrastructure ===")}`);

--- a/samples/deployment-scripts/azure/lib/azure-naming.mjs
+++ b/samples/deployment-scripts/azure/lib/azure-naming.mjs
@@ -24,7 +24,8 @@ export function normalizeEnvironmentSegment(value) {
       .trim()
       .toLowerCase()
       .replaceAll(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "") || "dev"
+      .replace(/^-+/, "")
+      .replace(/-+$/, "") || "dev"
   );
 }
 

--- a/samples/deployment-scripts/azure/lib/azure-naming.mjs
+++ b/samples/deployment-scripts/azure/lib/azure-naming.mjs
@@ -18,15 +18,32 @@ export function normalizeRegionAbbreviation(value) {
   return raw.slice(0, 6) || DEFAULT_REGION;
 }
 
+
+// Remove leading hyphens to avoid issues with Azure resource names (e.g., App Service names can't start with a dash).
+export function trimLeadingHyphens(value) {
+  let start = 0;
+  while (start < value.length && value[start] === "-") {
+    start += 1;
+  }
+  return value.slice(start);
+}
+
+// Remove trailing hyphens to avoid issues with Azure resource names (e.g., NSG names can't end with a dash).
+export function trimTrailingHyphens(value) {
+  let end = value.length;
+  while (end > 0 && value[end - 1] === "-") {
+    end -= 1;
+  }
+  return value.slice(0, end);
+}
+
 export function normalizeEnvironmentSegment(value) {
-  return (
-    String(value ?? "dev")
-      .trim()
-      .toLowerCase()
-      .replaceAll(/[^a-z0-9]+/g, "-")
-      .replace(/^-+/, "")
-      .replace(/-+$/, "") || "dev"
-  );
+  const normalized = String(value ?? "dev")
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, "-");
+
+  return trimTrailingHyphens(trimLeadingHyphens(normalized)) || "dev";
 }
 
 /**

--- a/samples/deployment-scripts/azure/lib/azure-naming.mjs
+++ b/samples/deployment-scripts/azure/lib/azure-naming.mjs
@@ -1,0 +1,214 @@
+import { normalizeProjectName } from "../../../../scripts/lib/project-name-utils.mjs";
+
+export const NAMING_CONVENTIONS = ["quickstart", "caf", "manual"];
+
+export const DEFAULT_WORKLOAD = "endatix";
+export const DEFAULT_REGION = "weu";
+
+/** CAF pattern: {abbr}-{company}-{workload}-{region}-{env}[-{role}] */
+export function normalizeNamingSegment(value) {
+  return normalizeProjectName(value);
+}
+
+export function normalizeRegionAbbreviation(value) {
+  const raw = String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]/g, "");
+  return raw.slice(0, 6) || DEFAULT_REGION;
+}
+
+export function normalizeEnvironmentSegment(value) {
+  return (
+    String(value ?? "dev")
+      .trim()
+      .toLowerCase()
+      .replaceAll(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "dev"
+  );
+}
+
+/**
+ * @param {object} segments
+ * @param {string} segments.company
+ * @param {string} segments.workload
+ * @param {string} segments.region
+ * @param {string} segments.env
+ */
+export function cafName(abbr, segments, role = "") {
+  const company = normalizeNamingSegment(segments.company);
+  const workload = normalizeNamingSegment(segments.workload);
+  const region = normalizeRegionAbbreviation(segments.region);
+  const env = normalizeEnvironmentSegment(segments.env);
+  const base = `${abbr}-${company}-${workload}-${region}-${env}`;
+  return role ? `${base}-${role}` : base;
+}
+
+/**
+ * @param {object} segments
+ */
+export function cafStorageAccountName(segments) {
+  const company = normalizeNamingSegment(segments.company).replaceAll("-", "");
+  const workload = normalizeNamingSegment(segments.workload).replaceAll(
+    "-",
+    "",
+  );
+  const region = normalizeRegionAbbreviation(segments.region);
+  const env = normalizeEnvironmentSegment(segments.env).replaceAll("-", "");
+  const name = `st${company}${workload}${region}${env}`;
+  return name.slice(0, 24);
+}
+
+/**
+ * @param {'static-site' | 'web-app'} hubDeploymentMode
+ */
+export function hubCafAbbreviation(hubDeploymentMode) {
+  return hubDeploymentMode === "web-app" ? "app" : "stapp";
+}
+
+/**
+ * @param {object} options
+ * @param {'static-site' | 'web-app'} options.hubDeploymentMode
+ */
+export function getResourceNameSpecs({
+  hubDeploymentMode = "static-site",
+} = {}) {
+  const hubAbbr = hubCafAbbreviation(hubDeploymentMode);
+  return [
+    { key: "api", label: "API (App Service)", abbr: "app", role: "" },
+    { key: "hub", label: "Hub (SWA / Web App)", abbr: hubAbbr, role: "" },
+    { key: "plan", label: "App Service plan", abbr: "plan", role: "" },
+    { key: "appi", label: "Application Insights", abbr: "appi", role: "" },
+    { key: "log", label: "Log Analytics workspace", abbr: "log", role: "" },
+    { key: "psql", label: "PostgreSQL server", abbr: "psql", role: "" },
+    {
+      key: "storage",
+      label: "Storage account",
+      abbr: "st",
+      role: "",
+      isStorage: true,
+    },
+    { key: "vnet", label: "VNet (managed)", abbr: "vnet", role: "" },
+    { key: "nsgApp", label: "App NSG (managed)", abbr: "nsg", role: "app" },
+    { key: "nsgDb", label: "DB NSG (managed)", abbr: "nsg", role: "db" },
+    { key: "vgw", label: "VPN gateway (managed)", abbr: "vgw", role: "01" },
+    {
+      key: "pip",
+      label: "Gateway public IP (managed)",
+      abbr: "pip",
+      role: "vgw-01",
+    },
+  ];
+}
+
+/**
+ * @param {object} options
+ * @param {'quickstart' | 'caf' | 'manual'} options.convention
+ * @param {object} options.segments
+ * @param {'static-site' | 'web-app'} [options.hubDeploymentMode]
+ */
+export function buildNamingPreview({
+  convention,
+  segments,
+  hubDeploymentMode = "static-site",
+}) {
+  const specs = getResourceNameSpecs({ hubDeploymentMode });
+  return specs.map((spec) => ({
+    key: spec.key,
+    label: spec.label,
+    example: spec.isStorage
+      ? cafStorageAccountName(segments)
+      : cafName(spec.abbr, segments, spec.role),
+    convention,
+  }));
+}
+
+export function formatNamingPreviewTable(previewRows) {
+  const maxLabel = Math.max(...previewRows.map((r) => r.label.length), 5);
+  return previewRows
+    .map((row) => `  ${row.label.padEnd(maxLabel)}  ${row.example}`)
+    .join("\n");
+}
+
+const OVERRIDE_PARAM_BY_KEY = {
+  api: "apiAppNameOverride",
+  hub: "hubAppNameOverride",
+  plan: "appServicePlanNameOverride",
+  appi: "appInsightsNameOverride",
+  log: "logAnalyticsWorkspaceNameOverride",
+  psql: "postgresqlServerNameOverride",
+  storage: "storageAccountNameOverride",
+  vnet: "vnetNameOverride",
+};
+
+/**
+ * @param {object} options
+ * @param {'quickstart' | 'caf' | 'manual'} options.convention
+ * @param {object} options.segments
+ * @param {'static-site' | 'web-app'} [options.hubDeploymentMode]
+ */
+export function buildResourceNameOverridesBlock({
+  convention,
+  segments,
+  hubDeploymentMode = "static-site",
+}) {
+  const preview = buildNamingPreview({
+    convention,
+    segments,
+    hubDeploymentMode,
+  });
+  const previewByKey = Object.fromEntries(preview.map((row) => [row.key, row]));
+
+  const conventionNote =
+    convention === "manual"
+      ? "// Manual: set any *Override below; empty values use CAF auto names from segment params in this file."
+      : `// Naming mode: ${convention} — pattern {abbr}-{company}-{workload}-{region}-{env}`;
+
+  const segmentLine = `// Segments: company=${normalizeNamingSegment(segments.company)}, workload=${normalizeNamingSegment(segments.workload)}, region=${normalizeRegionAbbreviation(segments.region)}, env=${normalizeEnvironmentSegment(segments.env)}`;
+
+  const overrideLines = [
+    "api",
+    "hub",
+    "plan",
+    "appi",
+    "log",
+    "psql",
+    "storage",
+  ].map((key) => {
+    const param = OVERRIDE_PARAM_BY_KEY[key];
+    const example = previewByKey[key]?.example ?? "";
+    const pad = Math.max(28 - param.length, 1);
+    const storageNote =
+      key === "storage"
+        ? " (3-24 chars, lowercase alphanumeric, no dashes)"
+        : "";
+    return `param ${param} = ''${" ".repeat(pad)}// auto: ${example}${storageNote}`;
+  });
+
+  const networkHint = `// Managed VNet also creates: ${previewByKey.nsgApp?.example}, ${previewByKey.nsgDb?.example}, ${previewByKey.vgw?.example}, ${previewByKey.pip?.example}`;
+
+  return [
+    "",
+    "// --- Resource name overrides ---",
+    conventionNote,
+    segmentLine,
+    "// Azure abbreviations: https://learn.microsoft.com/azure/cloud-adoption-framework/ready/azure-best-practices/resource-abbreviations",
+    "// -------------------------------------------------------------------",
+    ...overrideLines,
+    `param vnetNameOverride = ''${" ".repeat(22)}// auto: ${previewByKey.vnet?.example} (managed VNet only)`,
+    networkHint,
+    "",
+  ].join("\n");
+}
+
+/**
+ * Quickstart segments: company = project, default workload/region.
+ */
+export function quickstartSegments(project, environment) {
+  return {
+    company: normalizeNamingSegment(project),
+    workload: DEFAULT_WORKLOAD,
+    region: DEFAULT_REGION,
+    env: normalizeEnvironmentSegment(environment),
+  };
+}

--- a/samples/deployment-scripts/azure/modules/vnet.module.bicep
+++ b/samples/deployment-scripts/azure/modules/vnet.module.bicep
@@ -216,15 +216,15 @@ resource vnet 'Microsoft.Network/virtualNetworks@2024-05-01' = {
 resource vgwPublicIp 'Microsoft.Network/publicIPAddresses@2024-05-01' = {
   name: vgwPublicIpName
   location: location
-  tags: tags
-  sku: {
-    name: 'Standard'
-  }
   zones: [
     '1'
     '2'
     '3'
   ]
+  sku: {
+    name: 'Standard'
+  }
+  tags: tags
   properties: {
     publicIPAllocationMethod: 'Static'
   }

--- a/samples/deployment-scripts/azure/modules/vnet.module.bicep
+++ b/samples/deployment-scripts/azure/modules/vnet.module.bicep
@@ -1,71 +1,274 @@
 /*
-Endatix managed Virtual Network for private PostgreSQL + App Service integration.
-
-Deploys snet-app (Microsoft.Web/serverFarms), snet-db (PostgreSQL flexible server),
-and snet-pe (reserved for private endpoints).
+Managed VNet for Endatix private PostgreSQL and API VNet integration.
+Includes NSGs, subnets, VPN gateway, and public IP for point-to-site VPN.
 */
 
-@description('Azure region for deployment')
 param location string
-
-@description('Virtual network name')
-param vnetName string
-
-@description('Azure resource tags')
 param tags object
+param vnetName string
+param vnetAddressPrefix string
+param appSubnetPrefix string
+param dbSubnetPrefix string
+param gatewaySubnetPrefix string
+param vpnAddressPoolPrefix string
+param appNsgName string
+param dbNsgName string
+param vgwName string
+param vgwPublicIpName string
 
-resource vnet 'Microsoft.Network/virtualNetworks@2025-05-01' = {
+resource appNsg 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
+  name: appNsgName
+  location: location
+  tags: tags
+  properties: {
+    securityRules: [
+      {
+        name: 'AllowPostgresToDbSubnet'
+        properties: {
+          priority: 100
+          direction: 'Outbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '5432'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: dbSubnetPrefix
+        }
+      }
+      {
+        name: 'AllowHttpsToStorage'
+        properties: {
+          priority: 110
+          direction: 'Outbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '443'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: 'Storage'
+        }
+      }
+      {
+        name: 'AllowHttpsToInternet'
+        properties: {
+          priority: 120
+          direction: 'Outbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '443'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: 'Internet'
+        }
+      }
+      {
+        name: 'DenyOutboundVirtualNetwork'
+        properties: {
+          priority: 4000
+          direction: 'Outbound'
+          access: 'Deny'
+          protocol: '*'
+          sourcePortRange: '*'
+          destinationPortRange: '*'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: 'VirtualNetwork'
+        }
+      }
+    ]
+  }
+}
+
+resource dbNsg 'Microsoft.Network/networkSecurityGroups@2024-05-01' = {
+  name: dbNsgName
+  location: location
+  tags: tags
+  properties: {
+    securityRules: [
+      {
+        name: 'AllowPostgresFromAppSubnet'
+        properties: {
+          priority: 100
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '5432'
+          sourceAddressPrefix: appSubnetPrefix
+          destinationAddressPrefix: '*'
+        }
+      }
+      {
+        name: 'AllowPostgresFromVpnPool'
+        properties: {
+          priority: 110
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: 'Tcp'
+          sourcePortRange: '*'
+          destinationPortRange: '5432'
+          sourceAddressPrefix: vpnAddressPoolPrefix
+          destinationAddressPrefix: '*'
+        }
+      }
+      {
+        name: 'AllowAzureLoadBalancer'
+        properties: {
+          priority: 3900
+          direction: 'Inbound'
+          access: 'Allow'
+          protocol: '*'
+          sourcePortRange: '*'
+          destinationPortRange: '*'
+          sourceAddressPrefix: 'AzureLoadBalancer'
+          destinationAddressPrefix: '*'
+        }
+      }
+      {
+        name: 'DenyInboundVirtualNetwork'
+        properties: {
+          priority: 4000
+          direction: 'Inbound'
+          access: 'Deny'
+          protocol: '*'
+          sourcePortRange: '*'
+          destinationPortRange: '*'
+          sourceAddressPrefix: 'VirtualNetwork'
+          destinationAddressPrefix: '*'
+        }
+      }
+      {
+        name: 'DenyOutboundInternet'
+        properties: {
+          priority: 100
+          direction: 'Outbound'
+          access: 'Deny'
+          protocol: '*'
+          sourcePortRange: '*'
+          destinationPortRange: '*'
+          sourceAddressPrefix: '*'
+          destinationAddressPrefix: 'Internet'
+        }
+      }
+    ]
+  }
+}
+
+resource vnet 'Microsoft.Network/virtualNetworks@2024-05-01' = {
   name: vnetName
   location: location
   tags: tags
   properties: {
     addressSpace: {
-      addressPrefixes: ['10.70.0.0/16']
+      addressPrefixes: [
+        vnetAddressPrefix
+      ]
+    }
+    subnets: [
+      {
+        name: 'snet-app'
+        properties: {
+          addressPrefix: appSubnetPrefix
+          networkSecurityGroup: {
+            id: appNsg.id
+          }
+          serviceEndpoints: [
+            {
+              service: 'Microsoft.Storage'
+            }
+          ]
+          delegations: [
+            {
+              name: 'app-service-delegation'
+              properties: {
+                serviceName: 'Microsoft.Web/serverFarms'
+              }
+            }
+          ]
+        }
+      }
+      {
+        name: 'snet-db'
+        properties: {
+          addressPrefix: dbSubnetPrefix
+          networkSecurityGroup: {
+            id: dbNsg.id
+          }
+          delegations: [
+            {
+              name: 'postgresql-delegation'
+              properties: {
+                serviceName: 'Microsoft.DBforPostgreSQL/flexibleServers'
+              }
+            }
+          ]
+        }
+      }
+      {
+        name: 'GatewaySubnet'
+        properties: {
+          addressPrefix: gatewaySubnetPrefix
+        }
+      }
+    ]
+  }
+}
+
+resource vgwPublicIp 'Microsoft.Network/publicIPAddresses@2024-05-01' = {
+  name: vgwPublicIpName
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard'
+  }
+  zones: [
+    '1'
+    '2'
+    '3'
+  ]
+  properties: {
+    publicIPAllocationMethod: 'Static'
+  }
+}
+
+resource vgw 'Microsoft.Network/virtualNetworkGateways@2024-05-01' = {
+  name: vgwName
+  location: location
+  tags: tags
+  dependsOn: [
+    vnet
+    vgwPublicIp
+  ]
+  properties: {
+    ipConfigurations: [
+      {
+        name: 'vnetGatewayConfig'
+        properties: {
+          privateIPAllocationMethod: 'Dynamic'
+          subnet: {
+            id: '${vnet.id}/subnets/GatewaySubnet'
+          }
+          publicIPAddress: {
+            id: vgwPublicIp.id
+          }
+        }
+      }
+    ]
+    sku: {
+      name: 'VpnGw2AZ'
+      tier: 'VpnGw2AZ'
+    }
+    gatewayType: 'Vpn'
+    vpnType: 'RouteBased'
+    vpnClientConfiguration: {
+      vpnClientAddressPool: {
+        addressPrefixes: [
+          vpnAddressPoolPrefix
+        ]
+      }
     }
   }
 }
 
-resource subnetApp 'Microsoft.Network/virtualNetworks/subnets@2025-05-01' = {
-  parent: vnet
-  name: 'snet-app'
-  properties: {
-    addressPrefix: '10.70.0.0/24'
-    delegations: [
-      {
-        name: 'app-service-delegation'
-        properties: {
-          serviceName: 'Microsoft.Web/serverFarms'
-        }
-      }
-    ]
-  }
-}
-
-resource subnetDb 'Microsoft.Network/virtualNetworks/subnets@2025-05-01' = {
-  parent: vnet
-  name: 'snet-db'
-  properties: {
-    addressPrefix: '10.70.1.0/24'
-    delegations: [
-      {
-        name: 'postgresql-flex-delegation'
-        properties: {
-          serviceName: 'Microsoft.DBforPostgreSQL/flexibleServers'
-        }
-      }
-    ]
-  }
-}
-
-resource subnetPe 'Microsoft.Network/virtualNetworks/subnets@2025-05-01' = {
-  parent: vnet
-  name: 'snet-pe'
-  properties: {
-    addressPrefix: '10.70.2.0/24'
-    privateEndpointNetworkPolicies: 'Disabled'
-  }
-}
-
 output vnetId string = vnet.id
-output appSubnetId string = subnetApp.id
-output postgresSubnetId string = subnetDb.id
+output appSubnetId string = '${vnet.id}/subnets/snet-app'
+output postgresSubnetId string = '${vnet.id}/subnets/snet-db'

--- a/samples/deployment-scripts/azure/modules/vnet.module.bicep
+++ b/samples/deployment-scripts/azure/modules/vnet.module.bicep
@@ -234,10 +234,6 @@ resource vgw 'Microsoft.Network/virtualNetworkGateways@2024-05-01' = {
   name: vgwName
   location: location
   tags: tags
-  dependsOn: [
-    vnet
-    vgwPublicIp
-  ]
   properties: {
     ipConfigurations: [
       {

--- a/samples/deployment-scripts/azure/parameters.bicepparam
+++ b/samples/deployment-scripts/azure/parameters.bicepparam
@@ -1,19 +1,26 @@
 using './endatix-azure.template.bicep'
 
 // Quickstart note:
-// Keep deployment outputs persisted locally - do not delete deployment-outputs.json.
-// Example infra deployment command:
-// az deployment group create --resource-group rg-endatix-sandbox-us --parameters parameters.deploy.bicepparam --mode Complete --query properties.outputs -o json > deployment-outputs.json
-// The build-env step reads this file:
-// node ./generate-quickstart-secrets.mjs build-env --outputs-file ./deployment-outputs.json
+// 1) Run: node ./generate-quickstart-secrets.mjs  (creates parameters.production.bicepparam)
+// 2) Deploy from this folder; keep deployment-outputs.json for the wizard's second phase:
+//    az deployment group create --resource-group rg-endatix-sandbox-us --parameters parameters.production.bicepparam --mode Complete --query properties.outputs -o json > deployment-outputs.json
 //
-// Resource name overrides: not declared here. When you run generate-quickstart-secrets.mjs, it injects
-// an optional "Resource name overrides" block (with accurate // auto: hints) into parameters.production.bicepparam.
-// Deploying without the wizard? Copy this file and add the optional *Override params — see README "Resource name overrides".
+// Resource name overrides are not declared here. The wizard injects that block into parameters.production.bicepparam.
+// Deploying without the wizard? Copy this file to parameters.production.bicepparam and add *Override params — see README.
 
 param resourcePrefix = 'test-'
 param project = 'endatix'
 param environment = 'sandbox'
+
+// CAF naming segments (used for managed VNet resources when private network is enabled)
+param companyName = 'endatix'
+param workloadName = 'endatix'
+param regionAbbreviation = 'weu'
+
+// Managed VNet address space (subnets derived automatically). Prod example: 10.71.0.0/16
+param vnetAddressPrefix = '10.70.0.0/16'
+// Point-to-site VPN pool (separate from VNet). Prod example: 10.0.2.0/24
+param vpnAddressPoolPrefix = '10.0.1.0/24'
 param hubDeploymentMode = 'static-site'
 param branch = 'main'
 param hubRepositoryUrl = ''
@@ -45,7 +52,7 @@ param enablePostgresqlHA = false
 // --- PostgreSQL + VNet (see README "What gets provisioned" / "Key parameters") ---
 // Quickstart default: private network off — leave all of the following empty / false.
 // Managed VNet: set enablePostgresqlPrivateNetwork = true; keep vnetResourceId empty
-//   (template creates {resourcePrefix}endatix-vnet with snet-app, snet-db, snet-pe).
+//   (template creates CAF-named VNet with snet-app, snet-db, GatewaySubnet, NSGs, VPN gateway).
 // BYO VNet: enablePostgresqlPrivateNetwork = true; set vnetResourceId + postgresSubnetName;
 //   set apiVirtualNetworkSubnetId OR apiIntegrationSubnetName for the API Web App subnet.
 param enablePostgresqlPrivateNetwork = false

--- a/samples/deployment-scripts/azure/parameters.bicepparam
+++ b/samples/deployment-scripts/azure/parameters.bicepparam
@@ -9,14 +9,12 @@ using './endatix-azure.template.bicep'
 // Deploying without the wizard? Copy this file to parameters.production.bicepparam and add *Override params — see README.
 
 // --- Naming convention (wizard) ---
-param namingConvention = 'quickstart'
 
 // --- Naming: CAF segments (quickstart: company=project, workload=endatix, region=weu) ---
 param companyName = 'endatix'
 param workloadName = 'endatix'
 param regionAbbreviation = 'weu'
 param environment = 'sandbox'
-param resourcePrefix = 'test-'
 param project = 'endatix'
 
 // Managed VNet address space (subnets derived automatically). Prod example: 10.71.0.0/16

--- a/samples/deployment-scripts/azure/parameters.bicepparam
+++ b/samples/deployment-scripts/azure/parameters.bicepparam
@@ -8,14 +8,16 @@ using './endatix-azure.template.bicep'
 // Resource name overrides are not declared here. The wizard injects that block into parameters.production.bicepparam.
 // Deploying without the wizard? Copy this file to parameters.production.bicepparam and add *Override params — see README.
 
-param resourcePrefix = 'test-'
-param project = 'endatix'
-param environment = 'sandbox'
+// --- Naming convention (wizard) ---
+param namingConvention = 'quickstart'
 
-// CAF naming segments (used for managed VNet resources when private network is enabled)
+// --- Naming: CAF segments (quickstart: company=project, workload=endatix, region=weu) ---
 param companyName = 'endatix'
 param workloadName = 'endatix'
 param regionAbbreviation = 'weu'
+param environment = 'sandbox'
+param resourcePrefix = 'test-'
+param project = 'endatix'
 
 // Managed VNet address space (subnets derived automatically). Prod example: 10.71.0.0/16
 param vnetAddressPrefix = '10.70.0.0/16'


### PR DESCRIPTION
# feat: Add NSGs to Bicep template and generate-quickstart-secrets.mjs

## Description
- Adds Azure NSGs to the VNET setup
- Adds more options to naming conventions and naming of Azur resources
- Adds control over IP address space when VNET is defined
- Improves readme

## Related Issues
- closes https://github.com/endatix/endatix/issues/749

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
