### PR TITLE
feat: Add LimitOnePerUser to the ActiveFormDefinitionDto

### DIFF
--- a/docs/endatix-docs/docs/developers/hub/embed-events.mdx
+++ b/docs/endatix-docs/docs/developers/hub/embed-events.mdx
@@ -1,0 +1,292 @@
+---
+title: Embedded form events
+description: Listen to Endatix Hub embedded form events and integrate them safely with your website.
+---
+
+# Embedded form events
+
+Endatix Hub forms can be embedded in any page with the embed script. The script creates an iframe, resizes it automatically, and exposes lifecycle events on the host page so your application can react when a form loads, completes, or fails to submit.
+
+For prefilled forms and access-token workflows, see [Form Prefilling and Sharing](/docs/guides/form-prefilling).
+
+## Basic embed
+
+Use the embed snippet from the Hub share dialog or add the script directly:
+
+```html
+<script
+  src="https://app.endatix.com/embed/v1/embed.js"
+  data-form-id="1442869143157080064"
+></script>
+```
+
+For access-token embeds, include `data-token`:
+
+```html
+<script
+  src="https://app.endatix.com/embed/v1/embed.js"
+  data-form-id="1442869143157080064"
+  data-token="ACCESS_TOKEN"
+></script>
+```
+
+The script inserts an iframe immediately after the script tag. Each embed receives a unique `embedId`, so multiple forms can live on the same page without cross-handling events.
+
+## Listening to events
+
+Events are dispatched as browser `CustomEvent`s on both the embed container and `window`. The examples below listen on `window`, which is the simplest option for most integrations.
+
+```javascript
+window.addEventListener("endatix:form-loaded", (event) => {
+  console.log("Form loaded", event.detail);
+});
+
+window.addEventListener("endatix:form-complete", (event) => {
+  console.log("Form completed", event.detail);
+});
+
+window.addEventListener("endatix:form-error", (event) => {
+  console.error("Form failed", event.detail.error);
+});
+```
+
+Every host event includes:
+
+```ts
+type EndatixEmbedEventBase = {
+  formId: string;
+  embedId: string;
+};
+```
+
+Use `embedId` when a page embeds the same form more than once or embeds multiple forms.
+
+### `CustomEvent` vs `postMessage`
+
+Prefer the `endatix:*` `CustomEvent`s shown above for host-page integrations. The embed script validates the iframe source, Hub origin, and per-embed id before it dispatches those events.
+
+Only listen to raw `message` events if you are building your own embed wrapper. In that case, your code must perform the same origin, source, event type, `embedId`, and payload validation before trusting the message.
+
+### Debugging locally
+
+During local development, it can be useful to log both the public host events and the raw iframe messages handled by the embed script. Use the [basic embed sample](https://github.com/endatix/endatix/tree/main/samples/form-embedding/basic-embed) for a complete plain HTML page with local diagnostics.
+
+Treat raw `message` logs as diagnostics only. Production integrations should prefer the validated `CustomEvent`s.
+
+## Event reference
+
+### `endatix:form-loaded`
+
+Fires after the SurveyJS form has rendered inside the iframe.
+
+```ts
+type FormLoadedDetail = {
+  formId: string;
+  embedId: string;
+  definitionId?: string;
+  limitOnePerUser?: boolean;
+  requiresReCaptcha?: boolean;
+  metadata?: string;
+  title?: string;
+};
+```
+
+Example:
+
+```javascript
+window.addEventListener("endatix:form-loaded", (event) => {
+  const { formId, title, limitOnePerUser } = event.detail;
+
+  analytics.track("Endatix Form Loaded", {
+    formId,
+    title,
+    limitOnePerUser,
+  });
+
+  document.querySelector("#form-loading")?.remove();
+});
+```
+
+### `endatix:form-complete`
+
+Fires after Endatix confirms the submission was saved successfully.
+
+```ts
+type FormCompleteDetail = {
+  formId: string;
+  embedId: string;
+  submissionId: string;
+  success: true;
+  isComplete?: boolean;
+  status?: string;
+  completedAt?: string;
+};
+```
+
+Example:
+
+```javascript
+window.addEventListener("endatix:form-complete", (event) => {
+  analytics.track("Endatix Form Completed", {
+    formId: event.detail.formId,
+    submissionId: event.detail.submissionId,
+    status: event.detail.status,
+  });
+
+  window.location.assign("/thank-you");
+});
+```
+
+### `endatix:form-error`
+
+Fires when final submission fails after the user completes the form, or when the embed cannot show the form because access is blocked by a public-form rule such as `limitOnePerUser`.
+
+```ts
+type FormErrorDetail = {
+  formId: string;
+  embedId: string;
+  success: false;
+  error: {
+    type?: string;
+    code?: string;
+    message: string;
+  };
+};
+```
+
+When a respondent has already submitted a single-response form, the embed sends:
+
+```ts
+{
+  success: false,
+  error: {
+    type: "access",
+    code: "already_responded",
+    message: "You have already submitted a response for this form.",
+  },
+}
+```
+
+Example:
+
+```javascript
+window.addEventListener("endatix:form-error", (event) => {
+  const errorBox = document.querySelector("#form-error");
+  if (!errorBox) return;
+
+  errorBox.textContent =
+    event.detail.error.message || "The form could not be submitted.";
+});
+```
+
+## Resize and navigation behavior
+
+The embed script handles these iframe messages internally:
+
+- `endatix:resize` updates the iframe height.
+- `endatix:scroll` scrolls the iframe into view after page navigation inside the form.
+- `endatix:navigate` moves the host page when a SurveyJS completion URL is configured and passes URL safety checks.
+
+You usually do not need to listen for these messages directly. Use the lifecycle events above for application logic.
+
+## Practical patterns
+
+### Enable surrounding UI after load
+
+```html
+<button id="continue-button" disabled>Continue</button>
+
+<script>
+  window.addEventListener("endatix:form-loaded", () => {
+    document.querySelector("#continue-button").disabled = false;
+  });
+</script>
+```
+
+### Route different embeds independently
+
+```javascript
+const handlersByEmbedId = new Map();
+
+window.addEventListener("endatix:form-loaded", (event) => {
+  handlersByEmbedId.set(event.detail.embedId, {
+    formId: event.detail.formId,
+  });
+});
+
+window.addEventListener("endatix:form-complete", (event) => {
+  const embed = handlersByEmbedId.get(event.detail.embedId);
+  if (!embed) return;
+
+  console.log(`Embedded form ${embed.formId} completed`);
+});
+```
+
+### Track completion without collecting answers
+
+Embed events intentionally do not include respondent answers. Track identifiers and status only:
+
+```javascript
+window.addEventListener("endatix:form-complete", (event) => {
+  analytics.track("Lead Form Submitted", {
+    formId: event.detail.formId,
+    submissionId: event.detail.submissionId,
+    completedAt: event.detail.completedAt,
+  });
+});
+```
+
+## Security guidance
+
+The embed script validates iframe messages before acting on them. It checks the iframe source, the Hub origin, and the per-embed id. The iframe also sends messages back to the exact parent origin passed by the embed script.
+
+For production embeds:
+
+- Serve both the host page and Endatix Hub over HTTPS.
+- Generate short-lived access tokens on your backend when embedding prefilled or editable submissions.
+- Do not place long-lived tokens in static HTML, CMS content, or public source code.
+- Do not rely on client events as authorization. Endatix API submission endpoints remain the final authority for permissions, expiry, and `limitOnePerUser` rules.
+- Avoid putting sensitive respondent data in host-page analytics. Embed events expose form and submission identifiers, not answer payloads.
+- Prefer a per-form or per-tenant allowed embed origin list when available. That lets Hub enforce `frame-ancestors` and reject unexpected host origins.
+
+If you build custom `message` listeners around the iframe, validate all of the following before trusting a message:
+
+- `event.origin` is your Hub origin.
+- `event.source` is the embedded iframe's `contentWindow`.
+- `event.data.type` is an expected `endatix:*` event.
+- `event.data.embedId` matches the iframe instance you created.
+- Payload fields have the expected types.
+
+## Troubleshooting
+
+### Events do not fire
+
+- Confirm the script URL is reachable and uses the same Hub deployment that serves the iframe.
+- Confirm the browser console does not show blocked script, mixed-content, or CSP errors.
+- If you configure a custom `frame-ancestors` policy, include every host origin that should embed Hub forms.
+- Make sure listeners are registered before the user can complete the form.
+- If multiple embeds are on one page, inspect `event.detail.embedId` instead of only `formId`.
+
+### The iframe does not resize
+
+- Verify the embedded page can post messages to the parent page. Browser extensions or strict sandboxing can block message delivery.
+- Check for CSS on the host page that overrides iframe height or overflow.
+- Confirm the form is not inside a hidden container when it loads. Hidden parents can produce incorrect initial measurements.
+
+### Submission completion does not redirect
+
+- If you configured a SurveyJS completion URL, confirm it uses `http`, `https`, or a safe relative path.
+- Protocol-relative URLs such as `//example.com/path` and unsafe protocols such as `javascript:` are blocked.
+- For custom redirects, listen to `endatix:form-complete` and call `window.location.assign(...)` from your host page.
+
+### Token or permission errors
+
+- Access-token embeds need permissions to view and edit the submission.
+- Expired tokens must be regenerated.
+- If the form is private, confirm the access token or Hub session grants the expected public form access.
+- See [Form Prefilling and Sharing](/docs/guides/form-prefilling) for token creation and permission examples.
+
+### Local development origin mismatch
+
+- Use one consistent origin for the host page and the script. For example, avoid mixing `localhost`, `127.0.0.1`, and HTTPS tunnels unless you expect separate origins.
+- If testing from a static HTML file, prefer serving it from a local web server instead of opening it with `file://`.

--- a/docs/endatix-docs/docs/developers/hub/embed-events.mdx
+++ b/docs/endatix-docs/docs/developers/hub/embed-events.mdx
@@ -69,9 +69,9 @@ Only listen to raw `message` events if you are building your own embed wrapper. 
 
 ### Debugging locally
 
-During local development, it can be useful to log both the public host events and the raw iframe messages handled by the embed script. Use the [basic embed sample](https://github.com/endatix/endatix/tree/main/samples/form-embedding/basic-embed) for a complete plain HTML page with local diagnostics.
+During local development, it can be useful to log the validated public host events dispatched by the embed script. Use the [basic embed sample](https://github.com/endatix/endatix/tree/main/samples/form-embedding/basic-embed) for a complete plain HTML page with event logging.
 
-Treat raw `message` logs as diagnostics only. Production integrations should prefer the validated `CustomEvent`s.
+Production integrations should prefer the validated `CustomEvent`s.
 
 ## Event reference
 

--- a/docs/endatix-docs/sidebars.ts
+++ b/docs/endatix-docs/sidebars.ts
@@ -138,6 +138,7 @@ const sidebars: SidebarsConfig = {
       collapsed: true,
       items: [
         "developers/hub/index",
+        "developers/hub/embed-events",
         "developers/hub/azure-storage",
         "developers/hub/rustfs-storage",
         "developers/hub/maintenance-mode",

--- a/samples/form-embedding/basic-embed/README.md
+++ b/samples/form-embedding/basic-embed/README.md
@@ -1,0 +1,17 @@
+# Basic Endatix Hub Embed
+
+This sample shows how to embed an Endatix Hub form in a plain HTML page and log the public embed lifecycle events.
+
+## Usage
+
+1. Start Endatix Hub locally so the embed script is available at `http://localhost:3000/embed/v1/embed.js`.
+2. Replace `data-form-id` in `index.html` with your form id.
+3. Serve this folder with any static file server, for example:
+
+   ```bash
+   python3 -m http.server 8080
+   ```
+
+4. Open `http://localhost:8080` in your browser.
+
+Prefer the `CustomEvent` logs for application integrations. The raw `postMessage` log is included only for local diagnostics.

--- a/samples/form-embedding/basic-embed/README.md
+++ b/samples/form-embedding/basic-embed/README.md
@@ -4,14 +4,15 @@ This sample shows how to embed an Endatix Hub form in a plain HTML page and log 
 
 ## Usage
 
-1. Start Endatix Hub locally so the embed script is available at `http://localhost:3000/embed/v1/embed.js`.
+1. Start Endatix Hub locally so the embed script is available.
 2. Replace `data-form-id` in `index.html` with your form id.
-3. Serve this folder with any static file server, for example:
+3. If you serve this sample from a different origin than Hub, replace `/embed/v1/embed.js` with the trusted Hub embed script URL, for example `http://localhost:3000/embed/v1/embed.js`.
+4. Serve this folder with any static file server, for example:
 
    ```bash
    python3 -m http.server 8080
    ```
 
-4. Open `http://localhost:8080` in your browser.
+5. Open `http://localhost:8080` in your browser.
 
 Prefer the `CustomEvent` logs for application integrations. The raw `postMessage` log is included only for local diagnostics.

--- a/samples/form-embedding/basic-embed/README.md
+++ b/samples/form-embedding/basic-embed/README.md
@@ -15,4 +15,4 @@ This sample shows how to embed an Endatix Hub form in a plain HTML page and log 
 
 5. Open `http://localhost:8080` in your browser.
 
-Prefer the `CustomEvent` logs for application integrations. The raw `postMessage` log is included only for local diagnostics.
+Prefer the `CustomEvent` logs for application integrations. The embed script validates iframe messages before it dispatches these events.

--- a/samples/form-embedding/basic-embed/index.html
+++ b/samples/form-embedding/basic-embed/index.html
@@ -98,9 +98,10 @@
             </p>
         </section>
 
-        <!-- Replace {{ADD_FORM_ID_HERE}} with the form ID you want to embed -->
+        <!-- Replace {{ADD_FORM_ID_HERE}} with the form ID you want to embed. -->
+        <!-- Replace the same-origin src with your trusted Hub embed script URL e.g. http://localhost:3000/embed/v1/embed.js -->
         <section class="panel">
-            <script src="http://localhost:3000/embed/v1/embed.js" data-form-id="{{ADD_FORM_ID_HERE}}"></script>
+            <script src="/embed/v1/embed.js" data-form-id="{{ADD_FORM_ID_HERE}}"></script>
         </section>
 
         <section class="panel">

--- a/samples/form-embedding/basic-embed/index.html
+++ b/samples/form-embedding/basic-embed/index.html
@@ -1,0 +1,113 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Endatix Basic Embed</title>
+    <style>
+        body {
+            margin: 0;
+            padding: 2rem;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            color: #172033;
+            background: #f8fafc;
+        }
+
+        main {
+            max-width: 72rem;
+            margin: 0 auto;
+        }
+
+        .panel {
+            margin-bottom: 1.5rem;
+            padding: 1rem;
+            border: 1px solid #d4dce8;
+            border-radius: 0.75rem;
+            background: #fff;
+        }
+
+        .log {
+            height: 24rem;
+            overflow: auto;
+            padding: 1rem;
+            border-radius: 0.5rem;
+            background: #0f172a;
+            color: #dbeafe;
+            font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+            font-size: 0.8125rem;
+            line-height: 1.5;
+            white-space: pre-wrap;
+        }
+
+        .log-entry {
+            padding: 0.35rem 0;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+        }
+
+        .muted {
+            color: #64748b;
+        }
+    </style>
+    <script>
+        (function setupEndatixEmbedDiagnostics() {
+            const endatixEventTypes = [
+                "endatix:form-loaded",
+                "endatix:form-complete",
+                "endatix:form-error",
+            ];
+
+            function getLogElement() {
+                return document.getElementById("embed-event-log");
+            }
+
+            function writeLog(label, payload) {
+                const logElement = getLogElement();
+                if (!logElement) {
+                    return;
+                }
+
+                const entry = document.createElement("div");
+                entry.className = "log-entry";
+                entry.textContent = [
+                    new Date().toISOString(),
+                    label,
+                    JSON.stringify(payload, null, 2),
+                ].join("\n");
+
+                logElement.appendChild(entry);
+                logElement.scrollTop = logElement.scrollHeight;
+                console.log(`[Endatix embed diagnostics] ${label}`, payload);
+            }
+
+            endatixEventTypes.forEach(function registerEndatixEvent(type) {
+                window.addEventListener(type, function onEndatixEvent(event) {
+                    writeLog(`CustomEvent ${type}`, event.detail);
+                });
+            });
+        })();
+    </script>
+</head>
+
+<body>
+    <main>
+        <section class="panel">
+            <h1>Endatix Basic Embed</h1>
+            <p class="muted">
+                This local page embeds an Endatix Hub form and logs the public lifecycle events
+            </p>
+        </section>
+
+        <!-- Replace {{ADD_FORM_ID_HERE}} with the form ID you want to embed -->
+        <section class="panel">
+            <script src="http://localhost:3000/embed/v1/embed.js" data-form-id="{{ADD_FORM_ID_HERE}}"></script>
+        </section>
+
+        <section class="panel">
+            <h2>Event log</h2>
+            <div id="embed-event-log" class="log" aria-live="polite"></div>
+        </section>
+    </main>
+</body>
+
+</html>

--- a/samples/form-embedding/basic-embed/index.html
+++ b/samples/form-embedding/basic-embed/index.html
@@ -50,7 +50,7 @@
         }
     </style>
     <script>
-        (function setupEndatixEmbedDiagnostics() {
+        (function setupEndatixEmbedEventLog() {
             const endatixEventTypes = [
                 "endatix:form-loaded",
                 "endatix:form-complete",
@@ -77,11 +77,11 @@
 
                 logElement.appendChild(entry);
                 logElement.scrollTop = logElement.scrollHeight;
-                console.log(`[Endatix embed diagnostics] ${label}`, payload);
+                console.log(`[Endatix embed] ${label}`, payload);
             }
 
             endatixEventTypes.forEach(function registerEndatixEvent(type) {
-                window.addEventListener(type, function onEndatixEvent(event) {
+                globalThis.window.addEventListener(type, function onEndatixEvent(event) {
                     writeLog(`CustomEvent ${type}`, event.detail);
                 });
             });

--- a/src/Endatix.Api/Endpoints/FormDefinitions/FormDefinitionMapper.cs
+++ b/src/Endatix.Api/Endpoints/FormDefinitions/FormDefinitionMapper.cs
@@ -41,6 +41,7 @@ public class FormDefinitionMapper
         ThemeModel = formDefinition.ThemeJsonData,
         CustomQuestions = formDefinition.CustomQuestions,
         RequiresReCaptcha = formDefinition.RequiresReCaptcha,
+        LimitOnePerUser = formDefinition.LimitOnePerUser,
         HasUserSubmitted = formDefinition.HasUserSubmitted,
         Metadata = formDefinition.Metadata,
     };

--- a/src/Endatix.Api/Endpoints/FormDefinitions/FormDefinitionModel.cs
+++ b/src/Endatix.Api/Endpoints/FormDefinitions/FormDefinitionModel.cs
@@ -52,6 +52,11 @@ public class FormDefinitionModel
     public bool? RequiresReCaptcha { get; set; }
 
     /// <summary>
+    /// Indicates whether one response per user is enforced for the form.
+    /// </summary>
+    public bool LimitOnePerUser { get; set; }
+
+    /// <summary>
     /// Indicates whether the current user already has a submission for this form.
     /// </summary>
     public bool HasUserSubmitted { get; set; }

--- a/src/Endatix.Core/UseCases/FormDefinitions/ActiveDefinitionDto.cs
+++ b/src/Endatix.Core/UseCases/FormDefinitions/ActiveDefinitionDto.cs
@@ -36,6 +36,11 @@ public class ActiveDefinitionDto
     public bool? RequiresReCaptcha { get; init; }
 
     /// <summary>
+    /// Indicates whether one response per user is enforced for the form.
+    /// </summary>
+    public bool LimitOnePerUser { get; init; }
+
+    /// <summary>
     /// Indicates whether this form definition is in draft status.
     /// </summary>
     public bool IsDraft { get; set; }

--- a/src/Endatix.Core/UseCases/FormDefinitions/GetActive/GetActiveFormDefinitionHandler.cs
+++ b/src/Endatix.Core/UseCases/FormDefinitions/GetActive/GetActiveFormDefinitionHandler.cs
@@ -71,6 +71,7 @@ public class GetActiveFormDefinitionHandler(
         {
             ThemeJsonData = formWithActiveDefinition.Theme?.JsonData,
             RequiresReCaptcha = reCaptchaPolicyService.RequiresReCaptcha(formWithActiveDefinition),
+            LimitOnePerUser = formWithActiveDefinition.LimitOnePerUser,
             CustomQuestions = customQuestionsJson ?? [],
             HasUserSubmitted = hasUserSubmitted,
             Metadata = formWithActiveDefinition.Metadata

--- a/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/GetActiveTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/GetActiveTests.cs
@@ -75,6 +75,7 @@ public class GetActiveTests
         var themeJsonData = "{ \"background\": \"#FFFFFF\" }";
         var activeDefinitionDto = new ActiveDefinitionDto(formDefinition, themeJsonData)
         {
+            LimitOnePerUser = true,
             HasUserSubmitted = true,
             Metadata = "{ \"alreadyRespondedMessage\": \"Custom copy\" }"
         };
@@ -93,6 +94,7 @@ public class GetActiveTests
         okResult!.Value!.Id.Should().Be(formDefinition.Id.ToString());
         okResult!.Value!.FormId.Should().Be(formDefinition.FormId.ToString());
         okResult!.Value!.ThemeModel.Should().Be(themeJsonData);
+        okResult!.Value!.LimitOnePerUser.Should().BeTrue();
         okResult!.Value!.HasUserSubmitted.Should().BeTrue();
         okResult!.Value!.Metadata.Should().Be("{ \"alreadyRespondedMessage\": \"Custom copy\" }");
     }

--- a/tests/Endatix.Core.Tests/UseCases/FormDefinitions/GetActive/GetActiveFormDefinitionHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/FormDefinitions/GetActive/GetActiveFormDefinitionHandlerTests.cs
@@ -77,6 +77,7 @@ public class GetActiveFormDefinitionHandlerTests
         result.Value.Should().NotBeNull();
         result.Value.Id.Should().Be(activeDefinition.Id);
         result.Value.CustomQuestions.Should().BeEmpty();
+        result.Value.LimitOnePerUser.Should().BeFalse();
     }
 
     [Fact]
@@ -325,6 +326,7 @@ public class GetActiveFormDefinitionHandlerTests
         // Assert
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value!.HasUserSubmitted.Should().BeTrue();
+        result.Value!.LimitOnePerUser.Should().BeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
# feat: Add LimitOnePerUser to the ActiveFormDefinitionDto

## Description
- Extend the `ActiveFormDefinitionDto` to support `LimitOnePerUser`
- Add docs on embedding events
- Adds basic embed sample with included events output for local debugging

## Related Issues
- closes https://github.com/endatix/endatix-hub/issues/646

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Exposed `LimitOnePerUser` property in form definition API to indicate one-response-per-user enforcement.

* **Documentation**
  * Added comprehensive guide for embedding forms with lifecycle event handling and security best practices.
  * Added sample HTML implementation demonstrating form embedding with event listeners and troubleshooting guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/endatix/endatix/pull/754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->