### PR TITLE
fix: Add duplicate name error code to data list creation

### DIFF
--- a/src/Endatix.Api/Endpoints/DataLists/Create.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/Create.cs
@@ -1,9 +1,7 @@
-using Endatix.Api.Common.FeatureFlags;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.Abstractions.Authorization;
 using Endatix.Core.Entities;
 using Endatix.Core.UseCases.DataLists.Create;
-using Endatix.Framework.FeatureFlags;
 using Endatix.Infrastructure.Data.Config;
 using FastEndpoints;
 using FluentValidation;

--- a/src/Endatix.Core/UseCases/DataLists/Create/CreateDataListHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Create/CreateDataListHandler.cs
@@ -14,6 +14,8 @@ public sealed class CreateDataListHandler(
     IValueNormalizer valueNormalizer,
     IUniqueConstraintViolationChecker uniqueConstraintViolationChecker) : ICommandHandler<CreateDataListCommand, Result<DataList>>
 {
+    public const string DuplicateNameErrorCode = "data_list_name_already_exists";
+
     public async Task<Result<DataList>> Handle(CreateDataListCommand request, CancellationToken cancellationToken)
     {
         if (tenantContext.TenantId <= 0)
@@ -65,6 +67,7 @@ public sealed class CreateDataListHandler(
     private static ValidationError CreateDuplicateNameValidationError(string name) => new()
     {
         Identifier = nameof(CreateDataListCommand.Name),
-        ErrorMessage = $"A data list with the name '{name}' already exists."
+        ErrorMessage = $"A data list with the name '{name}' already exists.",
+        ErrorCode = DuplicateNameErrorCode
     };
 }

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/Create/CreateDataListHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/Create/CreateDataListHandlerTests.cs
@@ -55,6 +55,9 @@ public class CreateDataListHandlerTests
             TestContext.Current.CancellationToken);
 
         result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().Contain(error =>
+            error.Identifier == nameof(CreateDataListCommand.Name) &&
+            error.ErrorCode == CreateDataListHandler.DuplicateNameErrorCode);
         await _repository.DidNotReceive().AddAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>());
     }
 
@@ -74,6 +77,8 @@ public class CreateDataListHandlerTests
             TestContext.Current.CancellationToken);
 
         result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().Contain(error =>
+            error.ErrorCode == CreateDataListHandler.DuplicateNameErrorCode);
     }
 
     [Fact]


### PR DESCRIPTION
# fix: Add duplicate name error code to data list creation

## Description
- Adds error code propagation on duplicate name to make error handling language agnostic and easy

## Related Issues
- related to https://github.com/endatix/endatix-hub/issues/650

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
<img width="1200" height="358" alt="image" src="https://github.com/user-attachments/assets/a028cc45-be3f-4bf5-b7bf-e62dfea494e4" />
