### PR TITLE
fix: Modify Delete form endpoint to return ProblemHttpResult for error paths

### DIFF
--- a/src/Endatix.Api/Endpoints/Forms/Delete.cs
+++ b/src/Endatix.Api/Endpoints/Forms/Delete.cs
@@ -4,13 +4,14 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.Forms.Delete;
 using Endatix.Core.Abstractions.Authorization;
+using Microsoft.AspNetCore.Http;
 
 namespace Endatix.Api.Endpoints.Forms;
 
 /// <summary>
 /// Endpoint for deleting a form.
 /// </summary>
-public class Delete(IMediator mediator) : Endpoint<DeleteFormRequest, Results<Ok<string>, BadRequest, NotFound>>
+public class Delete(IMediator mediator) : Endpoint<DeleteFormRequest, Results<Ok<string>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -23,14 +24,20 @@ public class Delete(IMediator mediator) : Endpoint<DeleteFormRequest, Results<Ok
         {
             s.Summary = "Delete a form";
             s.Description = "Deletes a form and all its definitions and submissions.";
+            s.ExampleRequest = new DeleteFormRequest { FormId = 1 };
+            s.ResponseExamples[204] = new { Message = "Form deleted successfully." };
             s.Responses[204] = "Form deleted successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form not found.";
         });
+        Description(builder => builder
+            .Produces<string>(200, "application/json")
+            .ProducesProblem(404)
+            .ProducesProblem(400));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<string>, BadRequest, NotFound>> ExecuteAsync(DeleteFormRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<string>, ProblemHttpResult>> ExecuteAsync(DeleteFormRequest request, CancellationToken cancellationToken)
     {
         var result = await mediator.Send(
             new DeleteFormCommand(request.FormId),
@@ -38,6 +45,6 @@ public class Delete(IMediator mediator) : Endpoint<DeleteFormRequest, Results<Ok
 
         return TypedResultsBuilder
             .MapResult(result, form => form.Id.ToString())
-            .SetTypedResults<Ok<string>, BadRequest, NotFound>();
+            .SetTypedResults<Ok<string>, ProblemHttpResult>();
     }
 }

--- a/tests/Endatix.Api.Tests/Endpoints/Forms/DeleteTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Forms/DeleteTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Entities;
@@ -20,26 +21,27 @@ public class DeleteTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_InvalidRequest_ReturnsBadRequest()
+    public async Task ExecuteAsync_InvalidRequest_ReturnsProblemDetails()
     {
         // Arrange
         var formId = 1L;
         var request = new DeleteFormRequest { FormId = formId };
         var result = Result.Invalid();
-        
+
         _mediator.Send(Arg.Any<DeleteFormCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);
 
         // Act
-        var response = await _endpoint.ExecuteAsync(request, default);
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]
-    public async Task ExecuteAsync_FormNotFound_ReturnsNotFound()
+    public async Task ExecuteAsync_FormNotFound_ReturnsProblemDetails()
     {
         // Arrange
         var formId = 1L;
@@ -50,11 +52,12 @@ public class DeleteTests
             .Returns(result);
 
         // Act
-        var response = await _endpoint.ExecuteAsync(request, default);
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]
@@ -70,7 +73,7 @@ public class DeleteTests
             .Returns(result);
 
         // Act
-        var response = await _endpoint.ExecuteAsync(request, default);
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
 
         // Assert
         var okResult = response.Result as Ok<string>;
@@ -84,7 +87,7 @@ public class DeleteTests
         // Arrange
         var request = new DeleteFormRequest { FormId = 123 };
         var result = Result.Success(new Form(SampleData.TENANT_ID, "Test Form"));
-        
+
         _mediator.Send(Arg.Any<DeleteFormCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);
 


### PR DESCRIPTION
# fix: Modify Delete form endpoint to return ProblemHttpResult for error paths

## Description
- Modify Delete form endpoint to return `ProblemHttpResult` for error paths
- Add additional endoint metadata for Swagger
- fix tests

## Related Issues
- closes https://github.com/endatix/endatix-hub/issues/658

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
