### PR TITLE
feat: Add Test email + Email settings api endpoints and handlers

### DIFF
--- a/src/Endatix.Api/Endpoints/Admin/Email/GetEmailSettings.cs
+++ b/src/Endatix.Api/Endpoints/Admin/Email/GetEmailSettings.cs
@@ -1,0 +1,45 @@
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Endatix.Api.Infrastructure;
+using Endatix.Core.Abstractions.Authorization;
+using Endatix.Core.UseCases.Email.GetSettings;
+
+namespace Endatix.Api.Endpoints.Admin.Email;
+
+/// <summary>
+/// Endpoint for retrieving the active email settings.
+/// </summary>
+public class GetEmailSettings(IMediator mediator)
+    : EndpointWithoutRequest<Results<Ok<EmailSettingsDto>, ProblemHttpResult>>
+{
+    /// <summary>
+    /// Configures the endpoint.
+    /// </summary>
+    public override void Configure()
+    {
+        Get("/admin/email/settings");
+        Policies(SystemRole.PlatformAdmin.Name);
+        Summary(s =>
+        {
+            s.Summary = "Get email settings";
+            s.Description = "Returns the active email provider settings.";
+            s.Responses[200] = "Email settings retrieved successfully.";
+            s.Responses[400] = "Invalid request or tenant context.";
+        });
+        Description(builder => builder
+            .Produces<EmailSettingsDto>(200, "application/json")
+            .ProducesProblem(400));
+    }
+
+    /// <inheritdoc/>
+    public override async Task<Results<Ok<EmailSettingsDto>, ProblemHttpResult>> ExecuteAsync(CancellationToken ct)
+    {
+        var query = new GetEmailSettingsQuery();
+        var result = await mediator.Send(query, ct);
+
+        return TypedResultsBuilder.FromResult(result)
+            .SetTypedResults<Ok<EmailSettingsDto>, ProblemHttpResult>();
+    }
+}

--- a/src/Endatix.Api/Endpoints/Admin/Email/ListTemplates.cs
+++ b/src/Endatix.Api/Endpoints/Admin/Email/ListTemplates.cs
@@ -27,11 +27,11 @@ public class ListTemplates(IMediator mediator)
             s.Summary = "List email templates";
             s.Description = "Returns all registered email templates.";
             s.Responses[200] = "Email templates retrieved successfully.";
-            s.Responses[400] = "Invalid request or tenant context.";
+            s.Responses[401] = "Unauthenticated - valid credentials required.";
+            s.Responses[403] = "Forbidden - insufficient privileges (PlatformAdmin required).";
         });
         Description(builder => builder
-            .Produces<IEnumerable<EmailTemplateSummaryDto>>(200, "application/json")
-            .ProducesProblem(400));
+            .Produces<IEnumerable<EmailTemplateSummaryDto>>(200, "application/json"));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Admin/Email/ListTemplates.cs
+++ b/src/Endatix.Api/Endpoints/Admin/Email/ListTemplates.cs
@@ -1,0 +1,46 @@
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Endatix.Api.Infrastructure;
+using Endatix.Core.UseCases.Email.Dtos;
+using Endatix.Core.UseCases.Email.ListTemplates;
+using Endatix.Core.Abstractions.Authorization;
+
+namespace Endatix.Api.Endpoints.Admin.Email;
+
+/// <summary>
+/// Endpoint for listing registered email templates.
+/// </summary>
+public class ListTemplates(IMediator mediator)
+    : EndpointWithoutRequest<Results<Ok<IEnumerable<EmailTemplateSummaryDto>>, ProblemHttpResult>>
+{
+    /// <summary>
+    /// Configures the endpoint.
+    /// </summary>
+    public override void Configure()
+    {
+        Get("/admin/email/templates");
+        Policies(SystemRole.PlatformAdmin.Name);
+        Summary(s =>
+        {
+            s.Summary = "List email templates";
+            s.Description = "Returns all registered email templates.";
+            s.Responses[200] = "Email templates retrieved successfully.";
+            s.Responses[400] = "Invalid request or tenant context.";
+        });
+        Description(builder => builder
+            .Produces<IEnumerable<EmailTemplateSummaryDto>>(200, "application/json")
+            .ProducesProblem(400));
+    }
+
+    /// <inheritdoc/>
+    public override async Task<Results<Ok<IEnumerable<EmailTemplateSummaryDto>>, ProblemHttpResult>> ExecuteAsync(CancellationToken ct)
+    {
+        var query = new ListEmailTemplatesQuery();
+        var result = await mediator.Send(query, ct);
+
+        return TypedResultsBuilder.FromResult(result)
+            .SetTypedResults<Ok<IEnumerable<EmailTemplateSummaryDto>>, ProblemHttpResult>();
+    }
+}

--- a/src/Endatix.Api/Endpoints/Admin/Email/SendTestEmail.cs
+++ b/src/Endatix.Api/Endpoints/Admin/Email/SendTestEmail.cs
@@ -1,0 +1,72 @@
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Endatix.Api.Infrastructure;
+using Endatix.Core.UseCases.Email.SendTestEmail;
+using Endatix.Core.Abstractions.Authorization;
+using FluentValidation;
+
+namespace Endatix.Api.Endpoints.Admin.Email;
+
+/// <summary>
+/// Endpoint for sending a test email to verify email provider configuration.
+/// </summary>
+public class SendTestEmail(IMediator mediator)
+    : Endpoint<SendTestEmailRequest, Results<Ok<string>, ProblemHttpResult>>
+{
+    /// <summary>
+    /// Configures the endpoint.
+    /// </summary>
+    public override void Configure()
+    {
+        Post("/admin/email/test");
+        Policies(SystemRole.PlatformAdmin.Name);
+        Summary(s =>
+        {
+            s.Summary = "Send test email";
+            s.Description = "Sends a test email to verify email provider configuration.";
+            s.ExampleRequest = new SendTestEmailRequest("admin@example.com", null);
+            s.ResponseExamples[200] = "Test email sent successfully.";
+            s.Responses[200] = "Test email sent successfully.";
+            s.Responses[400] = "Invalid input data.";
+        });
+        Description(builder => builder
+            .Produces<string>(200, "application/json")
+            .ProducesProblem(400));
+    }
+
+    /// <inheritdoc/>
+    public override async Task<Results<Ok<string>, ProblemHttpResult>> ExecuteAsync(SendTestEmailRequest request, CancellationToken ct)
+    {
+        var command = new SendTestEmailCommand(request.ToEmail, request.TemplateId);
+        var result = await mediator.Send(command, ct);
+
+        return TypedResultsBuilder
+            .MapResult(result, _ => "Test email sent successfully.")
+            .SetTypedResults<Ok<string>, ProblemHttpResult>();
+    }
+}
+
+/// <summary>
+/// Validator for the SendTestEmailRequest used in the email test sending process.
+/// </summary>
+public class SendTestEmailValidator : Validator<SendTestEmailRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of the SendTestEmailValidator class.
+    /// </summary>
+    public SendTestEmailValidator()
+    {
+        RuleFor(x => x.ToEmail)
+            .NotEmpty()
+            .EmailAddress();
+    }
+}
+
+/// <summary>
+/// Request model for sending a test email.
+/// </summary>
+/// <param name="ToEmail">The email address to send the test email to.</param>
+/// <param name="TemplateId">The ID of the email template to send.</param>
+public record SendTestEmailRequest(string ToEmail, string? TemplateId = null);

--- a/src/Endatix.Core/Features/Email/IEmailSender.cs
+++ b/src/Endatix.Core/Features/Email/IEmailSender.cs
@@ -9,6 +9,16 @@ namespace Endatix.Core.Features.Email;
 public interface IEmailSender
 {
     /// <summary>
+    /// The display name of the configured email provider.
+    /// </summary>
+    string ProviderName { get; }
+
+    /// <summary>
+    /// Whether this email sender has enough configuration to send email.
+    /// </summary>
+    bool IsConfigured { get; }
+
+    /// <summary>
     /// Send email async passing the body of the email
     /// </summary>
     /// <param name="email">Email model of type <see cref="EmailWithBody"/> </param>

--- a/src/Endatix.Core/UseCases/Email/Dtos/EmailTemplateSummaryDto.cs
+++ b/src/Endatix.Core/UseCases/Email/Dtos/EmailTemplateSummaryDto.cs
@@ -1,0 +1,10 @@
+namespace Endatix.Core.UseCases.Email.Dtos;
+
+/// <summary>
+/// DTO for a summary of an email template.
+/// </summary>
+/// <param name="Id">The ID of the email template.</param>
+/// <param name="Name">The name of the email template.</param>
+/// <param name="Subject">The subject of the email template.</param>
+/// <param name="FromAddress">The from address of the email template.</param>
+public record EmailTemplateSummaryDto(long Id, string Name, string Subject, string FromAddress);

--- a/src/Endatix.Core/UseCases/Email/GetSettings/EmailSettingsDto.cs
+++ b/src/Endatix.Core/UseCases/Email/GetSettings/EmailSettingsDto.cs
@@ -1,0 +1,8 @@
+namespace Endatix.Core.UseCases.Email.GetSettings;
+
+/// <summary>
+/// DTO for the active email sender settings.
+/// </summary>
+/// <param name="ProviderName">The name of the active email provider.</param>
+/// <param name="IsConfigured">Whether the active email provider is configured.</param>
+public record EmailSettingsDto(string ProviderName, bool IsConfigured);

--- a/src/Endatix.Core/UseCases/Email/GetSettings/GetEmailSettingsHandler.cs
+++ b/src/Endatix.Core/UseCases/Email/GetSettings/GetEmailSettingsHandler.cs
@@ -1,0 +1,26 @@
+using Endatix.Core.Features.Email;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.Email.GetSettings;
+
+/// <summary>
+/// Handler for the GetEmailSettingsQuery.
+/// </summary>
+/// <param name="emailSender">The email sender.</param>
+public class GetEmailSettingsHandler(
+    IEmailSender emailSender
+) : IQueryHandler<GetEmailSettingsQuery, Result<EmailSettingsDto>>
+{
+    /// <summary>
+    /// Handles the GetEmailSettingsQuery.
+    /// </summary>
+    /// <param name="request">The GetEmailSettingsQuery.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The result.</returns>
+    public Task<Result<EmailSettingsDto>> Handle(GetEmailSettingsQuery request, CancellationToken cancellationToken)
+    {
+        var settings = new EmailSettingsDto(emailSender.ProviderName, emailSender.IsConfigured);
+        return Task.FromResult(Result.Success(settings));
+    }
+}

--- a/src/Endatix.Core/UseCases/Email/GetSettings/GetEmailSettingsQuery.cs
+++ b/src/Endatix.Core/UseCases/Email/GetSettings/GetEmailSettingsQuery.cs
@@ -1,0 +1,10 @@
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.Email.GetSettings;
+
+/// <summary>
+/// Query to get email settings.
+/// </summary>
+/// <returns>The result.</returns>
+public record GetEmailSettingsQuery() : IQuery<Result<EmailSettingsDto>>;

--- a/src/Endatix.Core/UseCases/Email/ListTemplates/ListEmailTemplatesHandler.cs
+++ b/src/Endatix.Core/UseCases/Email/ListTemplates/ListEmailTemplatesHandler.cs
@@ -24,7 +24,10 @@ public class ListEmailTemplatesHandler(
     {
         var templates = await repository.ListAsync(cancellationToken);
 
-        var dtos = templates.Select(t => new EmailTemplateSummaryDto(t.Id, t.Name, t.Subject, t.FromAddress));
+        var dtos = templates
+        .Select(t => new EmailTemplateSummaryDto(t.Id, t.Name, t.Subject, t.FromAddress))
+        .ToList()
+        .AsEnumerable();
 
         return Result.Success(dtos);
     }

--- a/src/Endatix.Core/UseCases/Email/ListTemplates/ListEmailTemplatesHandler.cs
+++ b/src/Endatix.Core/UseCases/Email/ListTemplates/ListEmailTemplatesHandler.cs
@@ -1,0 +1,31 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.Email.Dtos;
+
+namespace Endatix.Core.UseCases.Email.ListTemplates;
+
+/// <summary>
+/// Handler for the ListEmailTemplatesQuery.
+/// </summary>
+/// <param name="repository">The repository.</param>
+public class ListEmailTemplatesHandler(
+    IRepository<EmailTemplate> repository
+) : IQueryHandler<ListEmailTemplatesQuery, Result<IEnumerable<EmailTemplateSummaryDto>>>
+{
+    /// <summary>
+    /// Handles the ListEmailTemplatesQuery.
+    /// </summary>
+    /// <param name="request">The ListEmailTemplatesQuery.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The result.</returns>
+    public async Task<Result<IEnumerable<EmailTemplateSummaryDto>>> Handle(ListEmailTemplatesQuery request, CancellationToken cancellationToken)
+    {
+        var templates = await repository.ListAsync(cancellationToken);
+
+        var dtos = templates.Select(t => new EmailTemplateSummaryDto(t.Id, t.Name, t.Subject, t.FromAddress));
+
+        return Result.Success(dtos);
+    }
+}

--- a/src/Endatix.Core/UseCases/Email/ListTemplates/ListEmailTemplatesQuery.cs
+++ b/src/Endatix.Core/UseCases/Email/ListTemplates/ListEmailTemplatesQuery.cs
@@ -1,0 +1,11 @@
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.Email.Dtos;
+
+namespace Endatix.Core.UseCases.Email.ListTemplates;
+
+/// <summary>
+/// Query to list email templates.
+/// </summary>
+/// <returns>The result.</returns>
+public record ListEmailTemplatesQuery() : IQuery<Result<IEnumerable<EmailTemplateSummaryDto>>>;

--- a/src/Endatix.Core/UseCases/Email/SendTestEmail/SendTestEmailCommand.cs
+++ b/src/Endatix.Core/UseCases/Email/SendTestEmail/SendTestEmailCommand.cs
@@ -1,0 +1,15 @@
+using Endatix.Core.Infrastructure.Logging;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.Email.SendTestEmail;
+
+/// <summary>
+/// Command to send a test email.
+/// </summary>
+/// <param name="ToEmail">The email address to send the test email to.</param>
+/// <param name="TemplateId">The ID of the email template to send.</param>
+public record SendTestEmailCommand(
+    [property: Sensitive(SensitivityType.Email)] string ToEmail,
+    string? TemplateId = null
+) : ICommand<Result>;

--- a/src/Endatix.Core/UseCases/Email/SendTestEmail/SendTestEmailHandler.cs
+++ b/src/Endatix.Core/UseCases/Email/SendTestEmail/SendTestEmailHandler.cs
@@ -1,0 +1,76 @@
+using Endatix.Core.Features.Email;
+using Endatix.Core.Infrastructure.Logging;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+using Microsoft.Extensions.Logging;
+
+namespace Endatix.Core.UseCases.Email.SendTestEmail;
+
+/// <summary>
+/// Handler for the SendTestEmailCommand.
+/// </summary>
+/// <param name="emailSender">The email sender.</param>
+/// <param name="logger">The logger.</param>
+public partial class SendTestEmailHandler(
+    IEmailSender emailSender,
+    ILogger<SendTestEmailHandler> logger
+) : ICommandHandler<SendTestEmailCommand, Result>
+{
+    /// <summary>
+    /// Handles the SendTestEmailCommand.
+    /// </summary>
+    /// <param name="request">The SendTestEmailCommand.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The result.</returns>
+    public async Task<Result> Handle(SendTestEmailCommand request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.ToEmail))
+        {
+            return Result.Invalid(new ValidationError("Email address cannot be empty."));
+        }
+
+        var fromAddress = "noreply@endatix.com";
+
+        if (request.TemplateId is not null)
+        {
+            var emailWithTemplate = new EmailWithTemplate
+            {
+                To = request.ToEmail,
+                From = fromAddress,
+                TemplateId = request.TemplateId,
+                Subject = "Test Email from Endatix",
+                Metadata = new Dictionary<string, object>
+                {
+                    { "name", "Admin Test User" },
+                    { "activationUrl", "https://endatix.com/test" }
+                }
+            };
+
+            await emailSender.SendEmailAsync(emailWithTemplate, cancellationToken);
+        }
+        else
+        {
+            var emailWithBody = new EmailWithBody
+            {
+                To = request.ToEmail,
+                From = fromAddress,
+                Subject = "Test Email from Endatix",
+                PlainTextBody = "This is a test email sent from the Endatix admin panel.",
+                HtmlBody = "<h1>Test Email</h1><p>This is a test email sent from the Endatix admin panel.</p>"
+            };
+
+            await emailSender.SendEmailAsync(emailWithBody, cancellationToken);
+        }
+
+        LogTestEmailSent(logger, SensitiveValue.Email(request.ToEmail));
+
+        return Result.SuccessWithMessage("Test email sent successfully.");
+    }
+
+    [LoggerMessage(
+        EventId = 52001,
+        Level = LogLevel.Information,
+        EventName = "TestEmailSent",
+        Message = "Test email sent successfully to {Email}")]
+    private static partial void LogTestEmailSent(ILogger logger, SensitiveValue email);
+}

--- a/src/Endatix.Core/UseCases/Email/SendTestEmail/SendTestEmailHandler.cs
+++ b/src/Endatix.Core/UseCases/Email/SendTestEmail/SendTestEmailHandler.cs
@@ -29,40 +29,52 @@ public partial class SendTestEmailHandler(
             return Result.Invalid(new ValidationError("Email address cannot be empty."));
         }
 
-        var fromAddress = "noreply@endatix.com";
-
-        if (request.TemplateId is not null)
+        if (!emailSender.IsConfigured)
         {
-            var emailWithTemplate = new EmailWithTemplate
+            return Result.Unavailable("Email provider is not configured.");
+        }
+
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(request.TemplateId))
             {
-                To = request.ToEmail,
-                From = fromAddress,
-                TemplateId = request.TemplateId,
-                Subject = "Test Email from Endatix",
-                Metadata = new Dictionary<string, object>
+                var emailWithTemplate = new EmailWithTemplate
                 {
-                    { "name", "Admin Test User" },
-                    { "activationUrl", "https://endatix.com/test" }
-                }
-            };
+                    To = request.ToEmail,
+                    TemplateId = request.TemplateId,
+                    Subject = "Test Email from Endatix",
+                    Metadata = new Dictionary<string, object>
+                    {
+                        { "name", "Admin Test User" },
+                        { "activationUrl", "https://endatix.com/test" }
+                    }
+                };
 
-            await emailSender.SendEmailAsync(emailWithTemplate, cancellationToken);
-        }
-        else
-        {
-            var emailWithBody = new EmailWithBody
+                await emailSender.SendEmailAsync(emailWithTemplate, cancellationToken);
+            }
+            else
             {
-                To = request.ToEmail,
-                From = fromAddress,
-                Subject = "Test Email from Endatix",
-                PlainTextBody = "This is a test email sent from the Endatix admin panel.",
-                HtmlBody = "<h1>Test Email</h1><p>This is a test email sent from the Endatix admin panel.</p>"
-            };
+                var emailWithBody = new EmailWithBody
+                {
+                    To = request.ToEmail,
+                    Subject = "Test Email from Endatix",
+                    PlainTextBody = "This is a test email sent from the Endatix admin panel.",
+                    HtmlBody = "<h1>Test Email</h1><p>This is a test email sent from the Endatix admin panel.</p>"
+                };
 
-            await emailSender.SendEmailAsync(emailWithBody, cancellationToken);
+                await emailSender.SendEmailAsync(emailWithBody, cancellationToken);
+            }
+        }
+        catch (Exception exception)
+        {
+            logger.LogError(exception, "Failed to send test email.");
+            return Result.Error("Failed to send test email.");
         }
 
-        LogTestEmailSent(logger, SensitiveValue.Email(request.ToEmail));
+        if (logger.IsEnabled(LogLevel.Information))
+        {
+            LogTestEmailSent(logger, SensitiveValue.Email(request.ToEmail));
+        }
 
         return Result.SuccessWithMessage("Test email sent successfully.");
     }

--- a/src/Endatix.Infrastructure/Email/FakeEmailSender.cs
+++ b/src/Endatix.Infrastructure/Email/FakeEmailSender.cs
@@ -14,6 +14,13 @@ namespace Endatix.Infrastructure.Email;
 /// <param name="logger"></param>
 public class FakeEmailSender(ILogger<FakeEmailSender> logger) : IEmailSender
 {
+    /// <inheritdoc />
+    public string ProviderName => "Fake";
+
+    /// <inheritdoc />
+    public bool IsConfigured => true;
+
+    /// <inheritdoc />
     public Task SendEmailAsync(EmailWithBody email, CancellationToken cancellationToken = default)
     {
         logger.LogInformation("Not actually sending an email to {To} from {From} with subject {Subject}", SensitiveValue.Email(email.To), email.From, email.Subject);

--- a/src/Endatix.Infrastructure/Email/MailgunEmailSender.cs
+++ b/src/Endatix.Infrastructure/Email/MailgunEmailSender.cs
@@ -49,6 +49,15 @@ public class MailgunEmailSender(
     }
 
     /// <inheritdoc />
+    public string ProviderName => "Mailgun";
+
+    /// <inheritdoc />
+    public bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(_settings.ApiKey) &&
+        !string.IsNullOrWhiteSpace(_settings.BaseUrl) &&
+        !string.IsNullOrWhiteSpace(_settings.Domain);
+
+    /// <inheritdoc />
     public async Task SendEmailAsync(EmailWithBody email, CancellationToken cancellationToken = default)
     {
         Guard.Against.Null(email);

--- a/src/Endatix.Infrastructure/Email/SendGridEmailSender.cs
+++ b/src/Endatix.Infrastructure/Email/SendGridEmailSender.cs
@@ -52,6 +52,12 @@ public class SendGridEmailSender(
     };
 
     /// <inheritdoc />
+    public string ProviderName => "SendGrid";
+
+    /// <inheritdoc />
+    public bool IsConfigured => !string.IsNullOrWhiteSpace(_settings.ApiKey);
+
+    /// <inheritdoc />
     public async Task SendEmailAsync(EmailWithBody email, CancellationToken cancellationToken = default)
     {
         Guard.Against.Null(email);

--- a/src/Endatix.Infrastructure/Email/SmtpEmailSender.cs
+++ b/src/Endatix.Infrastructure/Email/SmtpEmailSender.cs
@@ -47,6 +47,12 @@ public class SmtpEmailSender : IEmailSender, IHasConfigSection<SmtpSettings>, IP
         // SmtpClient is created per email for thread safety
     };
 
+    /// <inheritdoc />
+    public string ProviderName => "SMTP";
+
+    /// <inheritdoc />
+    public bool IsConfigured => !string.Equals(_settings.Host, "localhost", StringComparison.OrdinalIgnoreCase);
+
     public async Task SendEmailAsync(EmailWithBody email, CancellationToken cancellationToken = default)
     {
         Guard.Against.Null(email);

--- a/tests/Endatix.Core.Tests/UseCases/Email/GetSettings/GetEmailSettingsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Email/GetSettings/GetEmailSettingsHandlerTests.cs
@@ -21,4 +21,19 @@ public class GetEmailSettingsHandlerTests
         result.Value.ProviderName.Should().Be("SendGrid");
         result.Value.IsConfigured.Should().BeTrue();
     }
+
+    [Fact]
+    public async Task Handle_UnconfiguredSender_ReturnsProviderNameAndUnconfiguredStatus()
+    {
+        var emailSender = Substitute.For<IEmailSender>();
+        emailSender.ProviderName.Returns("Smtp");
+        emailSender.IsConfigured.Returns(false);
+        var sut = new GetEmailSettingsHandler(emailSender);
+
+        var result = await sut.Handle(new GetEmailSettingsQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ProviderName.Should().Be("Smtp");
+        result.Value.IsConfigured.Should().BeFalse();
+    }
 }

--- a/tests/Endatix.Core.Tests/UseCases/Email/GetSettings/GetEmailSettingsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Email/GetSettings/GetEmailSettingsHandlerTests.cs
@@ -1,0 +1,24 @@
+using Endatix.Core.Features.Email;
+using Endatix.Core.UseCases.Email.GetSettings;
+using FluentAssertions;
+using NSubstitute;
+
+namespace Endatix.Core.Tests.UseCases.Email.GetSettings;
+
+public class GetEmailSettingsHandlerTests
+{
+    [Fact]
+    public async Task Handle_ReturnsSettingsFromResolvedEmailSender()
+    {
+        var emailSender = Substitute.For<IEmailSender>();
+        emailSender.ProviderName.Returns("SendGrid");
+        emailSender.IsConfigured.Returns(true);
+        var sut = new GetEmailSettingsHandler(emailSender);
+
+        var result = await sut.Handle(new GetEmailSettingsQuery(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.ProviderName.Should().Be("SendGrid");
+        result.Value.IsConfigured.Should().BeTrue();
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/Email/SendTestEmail/SendTestEmailHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Email/SendTestEmail/SendTestEmailHandlerTests.cs
@@ -1,0 +1,105 @@
+using Endatix.Core.Features.Email;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.Email.SendTestEmail;
+using Microsoft.Extensions.Logging;
+
+namespace Endatix.Core.Tests.UseCases.Email.SendTestEmail;
+
+public class SendTestEmailHandlerTests
+{
+    private readonly IEmailSender _emailSender;
+    private readonly SendTestEmailHandler _sut;
+
+    public SendTestEmailHandlerTests()
+    {
+        _emailSender = Substitute.For<IEmailSender>();
+        _sut = new SendTestEmailHandler(
+            _emailSender,
+            Substitute.For<ILogger<SendTestEmailHandler>>());
+    }
+
+    [Fact]
+    public async Task Handle_UnconfiguredSenderForBodyEmail_ReturnsUnavailableWithoutSending()
+    {
+        _emailSender.IsConfigured.Returns(false);
+        var command = new SendTestEmailCommand("admin@example.com");
+
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        result.Status.Should().Be(ResultStatus.Unavailable);
+        result.Errors.Should().Contain("Email provider is not configured.");
+        await _emailSender.DidNotReceive().SendEmailAsync(
+            Arg.Any<EmailWithBody>(),
+            Arg.Any<CancellationToken>());
+        await _emailSender.DidNotReceive().SendEmailAsync(
+            Arg.Any<EmailWithTemplate>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_UnconfiguredSenderForTemplateEmail_ReturnsUnavailableWithoutSending()
+    {
+        _emailSender.IsConfigured.Returns(false);
+        var command = new SendTestEmailCommand("admin@example.com", "welcome-email");
+
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        result.Status.Should().Be(ResultStatus.Unavailable);
+        result.Errors.Should().Contain("Email provider is not configured.");
+        await _emailSender.DidNotReceive().SendEmailAsync(
+            Arg.Any<EmailWithBody>(),
+            Arg.Any<CancellationToken>());
+        await _emailSender.DidNotReceive().SendEmailAsync(
+            Arg.Any<EmailWithTemplate>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhitespaceTemplateId_SendsBodyEmail()
+    {
+        _emailSender.IsConfigured.Returns(true);
+        var command = new SendTestEmailCommand("admin@example.com", " ");
+
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        await _emailSender.Received(1).SendEmailAsync(
+            Arg.Any<EmailWithBody>(),
+            Arg.Any<CancellationToken>());
+        await _emailSender.DidNotReceive().SendEmailAsync(
+            Arg.Any<EmailWithTemplate>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_BodyEmailSendFails_ReturnsSafeError()
+    {
+        _emailSender.IsConfigured.Returns(true);
+        _emailSender
+            .SendEmailAsync(Arg.Any<EmailWithBody>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("SMTP auth failed"));
+        var command = new SendTestEmailCommand("admin@example.com");
+
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        result.Status.Should().Be(ResultStatus.Error);
+        result.Errors.Should().Contain("Failed to send test email.");
+        result.Errors.Should().NotContain(error => error.Contains("SMTP auth failed", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Handle_TemplateEmailSendFails_ReturnsSafeError()
+    {
+        _emailSender.IsConfigured.Returns(true);
+        _emailSender
+            .SendEmailAsync(Arg.Any<EmailWithTemplate>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new InvalidOperationException("HTTP provider failed"));
+        var command = new SendTestEmailCommand("admin@example.com", "welcome-email");
+
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        result.Status.Should().Be(ResultStatus.Error);
+        result.Errors.Should().Contain("Failed to send test email.");
+        result.Errors.Should().NotContain(error => error.Contains("HTTP provider failed", StringComparison.Ordinal));
+    }
+}

--- a/tests/Endatix.Infrastructure.Tests/Email/FakeEmailSenderTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Email/FakeEmailSenderTests.cs
@@ -1,0 +1,16 @@
+using Microsoft.Extensions.Logging;
+using Endatix.Infrastructure.Email;
+
+namespace Endatix.Infrastructure.Tests.Email;
+
+public class FakeEmailSenderTests
+{
+    [Fact]
+    public void ProviderMetadata_ReturnsConfiguredFakeProvider()
+    {
+        var sut = new FakeEmailSender(Substitute.For<ILogger<FakeEmailSender>>());
+
+        sut.ProviderName.Should().Be("Fake");
+        sut.IsConfigured.Should().BeTrue();
+    }
+}

--- a/tests/Endatix.Infrastructure.Tests/Email/MailgunEmailSenderTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Email/MailgunEmailSenderTests.cs
@@ -192,6 +192,13 @@ public class MailgunEmailSenderTests
     // -- SendEmailAsync(EmailWithBody) success tests --
 
     [Fact]
+    public void ProviderMetadata_ConfiguredSettings_ReturnsMailgun()
+    {
+        _sut.ProviderName.Should().Be("Mailgun");
+        _sut.IsConfigured.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task SendEmailWithBody_ValidEmail_SendsHttpPostWithCorrectContent()
     {
         var email = CreateValidEmailWithBody();

--- a/tests/Endatix.Infrastructure.Tests/Email/SendGridEmailSenderTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Email/SendGridEmailSenderTests.cs
@@ -140,6 +140,13 @@ public class SendGridEmailSenderTests
     // -- SendEmailAsync(EmailWithBody) success tests --
 
     [Fact]
+    public void ProviderMetadata_ConfiguredSettings_ReturnsSendGrid()
+    {
+        _sut.ProviderName.Should().Be("SendGrid");
+        _sut.IsConfigured.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task SendEmailWithBody_ValidEmail_SendsViaSendGrid()
     {
         _sendGridClient.SendEmailAsync(Arg.Any<SendGridMessage>(), Arg.Any<CancellationToken>())

--- a/tests/Endatix.Infrastructure.Tests/Email/SmtpEmailSenderTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Email/SmtpEmailSenderTests.cs
@@ -11,6 +11,22 @@ namespace Endatix.Infrastructure.Tests.Email;
 public class SmtpEmailSenderTests
 {
     [Fact]
+    public void ProviderMetadata_DefaultSettings_ReturnsUnconfiguredSmtp()
+    {
+        var sut = new SmtpEmailSender(
+            Substitute.For<ILogger<SmtpEmailSender>>(),
+            Options.Create(new SmtpSettings
+            {
+                Host = "localhost",
+                DefaultFromAddress = "noreply@example.com"
+            }),
+            new EmailTemplateRenderer(Substitute.For<IRepository<EmailTemplate>>()));
+
+        sut.ProviderName.Should().Be("SMTP");
+        sut.IsConfigured.Should().BeFalse();
+    }
+
+    [Fact]
     public async Task SendEmailWithTemplate_ExternalTemplate_StillUsesDatabaseTemplate()
     {
         var templateRepository = Substitute.For<IRepository<EmailTemplate>>();


### PR DESCRIPTION
# feat: Add Test email + Email settings api endpoints and handlers

## Description
- Add platform only endpoints
- Tests

## Related Issues
-  closes https://github.com/endatix/endatix/issues/763

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added admin API endpoints to view email provider settings and configuration status
  * Added admin API endpoint to list email templates with summary details
  * Added admin API endpoint to send test emails with optional template selection

* **Tests**
  * Added unit tests for email settings retrieval, template listing, and provider configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->