### PR TITLE
fix: Invalidation of form-scoped cache entries when a form is updated or deleted

### DIFF
--- a/src/Endatix.Infrastructure/Caching/FormAccessCacheInvalidator.cs
+++ b/src/Endatix.Infrastructure/Caching/FormAccessCacheInvalidator.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Logging;
+
+namespace Endatix.Infrastructure.Caching;
+
+internal sealed class FormAccessCacheInvalidator(
+    HybridCache hybridCache,
+    ILogger<FormAccessCacheInvalidator> logger) : IFormAccessCacheInvalidator
+{
+    public async Task InvalidateFormAsync(long formId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            await hybridCache.RemoveByTagAsync([FormAccessCacheTags.ForForm(formId)], cancellationToken);
+            logger.LogDebug("Invalidated form access cache for form {FormId}", formId);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            logger.LogWarning(ex, "Failed to invalidate cache for form {FormId}. Cache might be stale.", formId);
+        }
+    }
+}

--- a/src/Endatix.Infrastructure/Caching/FormAccessCacheInvalidator.cs
+++ b/src/Endatix.Infrastructure/Caching/FormAccessCacheInvalidator.cs
@@ -11,6 +11,7 @@ internal sealed class FormAccessCacheInvalidator(
     {
         try
         {
+            // ForForm evicts every entry tagged form:{id}, including access/routing entries that also carry ForFormAccess.
             await hybridCache.RemoveByTagAsync([FormAccessCacheTags.ForForm(formId)], cancellationToken);
             logger.LogDebug("Invalidated form access cache for form {FormId}", formId);
         }

--- a/src/Endatix.Infrastructure/Caching/FormAccessCacheTags.cs
+++ b/src/Endatix.Infrastructure/Caching/FormAccessCacheTags.cs
@@ -1,0 +1,13 @@
+namespace Endatix.Infrastructure.Caching;
+
+internal static class FormAccessCacheTags
+{
+    /// <summary>Entity-level tag. Covers all cache entries for a form.</summary>
+    public static string ForForm(long formId) => $"form:{formId}";
+
+    /// <summary>Access-level tag. Covers only access and routing entries for a form.</summary>
+    public static string ForFormAccess(long formId) => $"access:form:{formId}";
+
+    public static string[] ForFormAndAccess(long formId) =>
+        [ForForm(formId), ForFormAccess(formId)];
+}

--- a/src/Endatix.Infrastructure/Caching/IFormAccessCacheInvalidator.cs
+++ b/src/Endatix.Infrastructure/Caching/IFormAccessCacheInvalidator.cs
@@ -1,0 +1,12 @@
+namespace Endatix.Infrastructure.Caching;
+
+/// <summary>
+/// Invalidates HybridCache entries associated with a form.
+/// </summary>
+public interface IFormAccessCacheInvalidator
+{
+    /// <summary>
+    /// Removes all cache entries tagged for the given form.
+    /// </summary>
+    Task InvalidateFormAsync(long formId, CancellationToken cancellationToken);
+}

--- a/src/Endatix.Infrastructure/Features/AccessControl/Caching/InvalidateFormAccessCacheOnFormDeletedHandler.cs
+++ b/src/Endatix.Infrastructure/Features/AccessControl/Caching/InvalidateFormAccessCacheOnFormDeletedHandler.cs
@@ -1,0 +1,12 @@
+using Endatix.Core.Events;
+using Endatix.Infrastructure.Caching;
+using MediatR;
+
+namespace Endatix.Infrastructure.Features.AccessControl.Caching;
+
+internal sealed class InvalidateFormAccessCacheOnFormDeletedHandler(
+    IFormAccessCacheInvalidator cacheInvalidator) : INotificationHandler<FormDeletedEvent>
+{
+    public Task Handle(FormDeletedEvent notification, CancellationToken cancellationToken) =>
+        cacheInvalidator.InvalidateFormAsync(notification.Form.Id, cancellationToken);
+}

--- a/src/Endatix.Infrastructure/Features/AccessControl/Caching/InvalidateFormAccessCacheOnFormUpdatedHandler.cs
+++ b/src/Endatix.Infrastructure/Features/AccessControl/Caching/InvalidateFormAccessCacheOnFormUpdatedHandler.cs
@@ -1,0 +1,12 @@
+using Endatix.Core.Events;
+using Endatix.Infrastructure.Caching;
+using MediatR;
+
+namespace Endatix.Infrastructure.Features.AccessControl.Caching;
+
+internal sealed class InvalidateFormAccessCacheOnFormUpdatedHandler(
+    IFormAccessCacheInvalidator cacheInvalidator) : INotificationHandler<FormUpdatedEvent>
+{
+    public Task Handle(FormUpdatedEvent notification, CancellationToken cancellationToken) =>
+        cacheInvalidator.InvalidateFormAsync(notification.Form.Id, cancellationToken);
+}

--- a/src/Endatix.Infrastructure/Features/AccessControl/FormAccessPolicy.cs
+++ b/src/Endatix.Infrastructure/Features/AccessControl/FormAccessPolicy.cs
@@ -38,7 +38,7 @@ public sealed class FormAccessPolicy(
             factory: _ => Task.FromResult(ComputeResourceAccess(context, authData)),
             ttl: ttl,
             utcNow: now,
-            tags: ["permissions", $"form:{context.FormId}"],
+            tags: ["permissions", .. FormAccessCacheTags.ForFormAndAccess(context.FormId)],
             cancellationToken: cancellationToken);
     }
 

--- a/src/Endatix.Infrastructure/Features/AccessControl/PublicFormAccessPolicy.cs
+++ b/src/Endatix.Infrastructure/Features/AccessControl/PublicFormAccessPolicy.cs
@@ -56,7 +56,7 @@ public sealed class PublicFormAccessPolicy(
             ct => ExecuteAccessRouteAsync(context, accessRoute, ct),
             accessRoute.Ttl,
             dateTimeProvider.Now.UtcDateTime,
-            tags: ["permissions", $"form:{context.FormId}"],
+            tags: ["permissions", .. FormAccessCacheTags.ForFormAndAccess(context.FormId)],
             cancellationToken: cancellationToken);
     }
 
@@ -331,7 +331,7 @@ public sealed class PublicFormAccessPolicy(
             $"meta:form:access_routing:{formId}",
             ct => GetFormAccessRoutingMetadataFromDbAsync(formId, ct),
             new HybridCacheEntryOptions { Expiration = _formMetadataTtl },
-            tags: [$"form:{formId}"],
+            tags: FormAccessCacheTags.ForFormAndAccess(formId),
             cancellationToken: cancellationToken);
 
     private async Task<Result<FormProjections.FormAccessRoutingDto>> GetFormAccessRoutingMetadataFromDbAsync(long formId, CancellationToken cancellationToken)

--- a/src/Endatix.Infrastructure/Identity/IdentityServiceCollectionExtensions.cs
+++ b/src/Endatix.Infrastructure/Identity/IdentityServiceCollectionExtensions.cs
@@ -19,6 +19,7 @@ using Endatix.Infrastructure.Identity.Repositories;
 using Endatix.Infrastructure.Features.AccessControl;
 using Endatix.Core.Authorization.Access;
 using Endatix.Core.Abstractions.Authorization.PublicForm;
+using Endatix.Infrastructure.Caching;
 using Endatix.Infrastructure.Features.Authorization.PublicForm;
 
 namespace Endatix.Infrastructure.Identity;
@@ -116,6 +117,8 @@ public static class IdentityServiceCollectionExtensions
 
         services.AddScoped<FormTemplateAccessPolicy>();
         services.AddScoped<IResourceAccessQuery<FormTemplateAccessData, FormTemplateAccessContext>>(sp => sp.GetRequiredService<FormTemplateAccessPolicy>());
+
+        services.AddScoped<IFormAccessCacheInvalidator, FormAccessCacheInvalidator>();
 
         // Register email verification options
         services.AddOptions<EmailVerificationOptions>()

--- a/tests/Endatix.Infrastructure.Tests/Caching/FormAccessCacheInvalidatorTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Caching/FormAccessCacheInvalidatorTests.cs
@@ -1,0 +1,105 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Events;
+using Endatix.Infrastructure.Caching;
+using Endatix.Infrastructure.Features.AccessControl.Caching;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Endatix.Infrastructure.Tests.Caching;
+
+public sealed class FormAccessCacheInvalidatorTests
+{
+    private const long FormId = 42;
+
+    [Fact]
+    public async Task InvalidateFormAsync_CallsRemoveByTagAsync_WithFormTag()
+    {
+        // Arrange
+        var cache = Substitute.For<HybridCache>();
+        var invalidator = new FormAccessCacheInvalidator(cache, NullLogger<FormAccessCacheInvalidator>.Instance);
+
+        // Act
+        await invalidator.InvalidateFormAsync(FormId, TestContext.Current.CancellationToken);
+
+        // Assert
+        await cache.Received(1).RemoveByTagAsync(
+            Arg.Is<IEnumerable<string>>(tags => tags.SequenceEqual(new[] { FormAccessCacheTags.ForForm(FormId) })),
+            TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task InvalidateFormAsync_WhenCacheThrowsNonCancellationException_LogsWarningAndDoesNotRethrow()
+    {
+        // Arrange
+        var cache = Substitute.For<HybridCache>();
+        cache
+            .RemoveByTagAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromException(new InvalidOperationException("Redis unavailable")));
+
+        var logger = Substitute.For<ILogger<FormAccessCacheInvalidator>>();
+        var invalidator = new FormAccessCacheInvalidator(cache, logger);
+
+        // Act
+        var act = () => invalidator.InvalidateFormAsync(FormId, TestContext.Current.CancellationToken);
+
+        // Assert
+        await act.Should().NotThrowAsync();
+        logger.Received(1).Log(
+            LogLevel.Warning,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Is<Exception>(e => e is InvalidOperationException),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+
+    [Fact]
+    public async Task InvalidateFormAsync_WhenOperationCanceledException_Propagates()
+    {
+        // Arrange
+        var cache = Substitute.For<HybridCache>();
+        cache
+            .RemoveByTagAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CancellationToken>())
+            .Returns(_ => ValueTask.FromException(new OperationCanceledException()));
+
+        var invalidator = new FormAccessCacheInvalidator(cache, NullLogger<FormAccessCacheInvalidator>.Instance);
+
+        // Act
+        var act = () => invalidator.InvalidateFormAsync(FormId, TestContext.Current.CancellationToken);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task FormUpdatedHandler_CallsInvalidateFormAsync_WithFormId()
+    {
+        // Arrange
+        var invalidator = Substitute.For<IFormAccessCacheInvalidator>();
+        var handler = new InvalidateFormAccessCacheOnFormUpdatedHandler(invalidator);
+        var form = new Form(1, "Test form", isPublic: false);
+        var notification = new FormUpdatedEvent(form);
+
+        // Act
+        await handler.Handle(notification, TestContext.Current.CancellationToken);
+
+        // Assert
+        await invalidator.Received(1).InvalidateFormAsync(form.Id, TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task FormDeletedHandler_CallsInvalidateFormAsync_WithFormId()
+    {
+        // Arrange
+        var invalidator = Substitute.For<IFormAccessCacheInvalidator>();
+        var handler = new InvalidateFormAccessCacheOnFormDeletedHandler(invalidator);
+        var form = new Form(1, "Test form", isPublic: false);
+        var notification = new FormDeletedEvent(form);
+
+        // Act
+        await handler.Handle(notification, TestContext.Current.CancellationToken);
+
+        // Assert
+        await invalidator.Received(1).InvalidateFormAsync(form.Id, TestContext.Current.CancellationToken);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes anonymous share/embed access returning **401** after toggling a form from private to public in Hub, without restarting OSS.

The root cause was stale HybridCache routing metadata (`meta:form:access_routing:{formId}`) cached with `IsPublic: false` for up to 1 hour, while the definition endpoint read the DB directly. This change invalidates form-scoped cache entries when a form is updated or deleted.

## Changes

- Add `FormAccessCacheTags` with entity-level (`form:{id}`) and access-level (`access:form:{id}`) tags
- Apply both tags to routing metadata and access-result cache entries in `PublicFormAccessPolicy` and `FormAccessPolicy`
- Add `IFormAccessCacheInvalidator` / `FormAccessCacheInvalidator` with resilient invalidation (logs warning on cache failure, does not fail the request; propagates cancellation)
- Register invalidator in `IdentityServiceCollectionExtensions`
- Add MediatR handlers for `FormUpdatedEvent` and `FormDeletedEvent`
- Add unit tests for invalidator and handlers

## Functional test plan

- Create private form and warm cache (preview/share once)
- Toggle form to **Public** in Hub settings (no API restart)
- Open share URL in incognito → `GET /api/public/forms/{id}/access` returns **200**
- Toggle back to **Private** → anonymous access returns **401** immediately

## Related Issues
#772 

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed form access permission caching to properly invalidate cached data whenever forms are updated or deleted. Users will now immediately see access and permission changes reflected in the system without experiencing delays from stale cached information.

* **Tests**
  * Added comprehensive test coverage for cache invalidation behavior to ensure system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->