### PR TITLE
fix(helm): Add Helm chart for Endatix API deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,8 +136,10 @@ jobs:
 
   # Build validation on PRs; canary release on main — publishes only after ALL
   # tests above pass. docker-image makes the shared workflow log into GHCR and
-  # export DOCKER_IMAGE to the release scripts; canaries stay on GHCR only, the
-  # Docker Hub mirror is stable-only (release-publish.sh).
+  # export DOCKER_IMAGE to the release scripts; canaries stay on GHCR only.
+  # Promoted releases mirror to Docker Hub — both stable AND maintenance (an
+  # older line's hotfix still ships publicly); only stable moves the `latest`
+  # tag, so a maintenance release never drags it backwards (release-publish.sh).
   # No secrets are passed: the shared workflow uses the implicit GITHUB_TOKEN
   # and fetches everything else via Infisical (OIDC, hence id-token).
   pipeline:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,9 @@ jobs:
             --filter "Category!=Keycloak&DbSpecific!=PostgreSql"
 
   # Build validation on PRs; canary release on main — publishes only after ALL
-  # tests above pass. No docker-image: this repo ships NuGet packages only.
+  # tests above pass. docker-image makes the shared workflow log into GHCR and
+  # export DOCKER_IMAGE to the release scripts; canaries stay on GHCR only, the
+  # Docker Hub mirror is stable-only (release-publish.sh).
   # No secrets are passed: the shared workflow uses the implicit GITHUB_TOKEN
   # and fetches everything else via Infisical (OIDC, hence id-token).
   pipeline:
@@ -143,8 +145,9 @@ jobs:
     needs: [unit-tests, integration-tests, integration-tests-sqlserver]
     permissions:
       contents: read # release writes use the App token inside the shared workflow
-      packages: write # GitHub Packages push
+      packages: write # GitHub Packages push + GHCR image push
       id-token: write # OIDC for Infisical inside the shared workflow
     uses: endatix/release-workflows/.github/workflows/canary.yml@cca02534258a68b196f9295afe9fd855ad9eee83 # v1
     with:
+      docker-image: ghcr.io/endatix/endatix-api
       dotnet-version: "10.x" # global.json rolls forward within 10.0.x

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -23,7 +23,8 @@ jobs:
       id-token: write # OIDC for Infisical (fetch-secrets)
     uses: endatix/release-workflows/.github/workflows/release-artifacts.yml@cca02534258a68b196f9295afe9fd855ad9eee83 # v1
     with:
-      promotion: rebuild
-      fetch-secrets: true # ENDATIX_NUGET_ORG_USERNAME via Infisical (prod)
+      docker-image: ghcr.io/endatix/endatix-api
+      promotion: rebuild # NuGet versions are baked in — the image is rebuilt at the tag too
+      fetch-secrets: true # ENDATIX_NUGET_ORG_USERNAME + ENDATIX_DOCKERHUB_* via Infisical (prod)
       nuget-login: true # OIDC trusted publishing → short-lived NUGET_API_KEY
       dotnet-version: "10.x"

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: endatix-api
+description: Endatix API — .NET 10 form management backend
+type: application
+version: 0.1.0
+appVersion: 0.1.0

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{/*
+Release-qualified resource name, shared by every resource in this chart so two
+releases can coexist in one namespace without colliding. Truncated to 63 chars
+for the DNS label limit; if the release name already contains the chart name
+(e.g. `helm install endatix-api ./helm`) it is not repeated.
+*/}}
+{{- define "endatix-api.fullname" -}}
+{{- if contains .Chart.Name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Selector labels. These must be release-specific: without the instance label the
+Service of one release would also match the pods of another. Used verbatim in
+the Deployment selector, the pod template, and the Service selector — a
+Deployment's selector is immutable, so all three must stay in sync.
+*/}}
+{{- define "endatix-api.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,19 +1,31 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ include "endatix-api.fullname" . }}
   labels:
-    app: {{ .Chart.Name }}
+    {{- include "endatix-api.selectorLabels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ .Chart.Name }}
+      {{- include "endatix-api.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        app: {{ .Chart.Name }}
+        {{- include "endatix-api.selectorLabels" . | nindent 8 }}
     spec:
+      # The API only talks to Postgres — it never calls the Kubernetes API, so
+      # mounting a service-account token would just park a live credential in
+      # the pod for an attacker to find.
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        # 1654 is the non-root `app` user baked into the .NET runtime image;
+        # SDK container publish already sets it, this asserts it at admission.
+        runAsUser: 1654
+        fsGroup: 1654
+        seccompProfile:
+          type: RuntimeDefault
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -26,6 +38,12 @@ spec:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+            - ALL
         ports:
         - containerPort: 8080
         env:
@@ -37,34 +55,45 @@ spec:
         - name: HTTP_PORTS
           value: "8080"
 
-        # Database
+        # Database — see values.yaml for the two supported secret shapes.
+        {{- if .Values.db.connectionStringKey }}
+        - name: ConnectionStrings__DefaultConnection
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.db.secretName }}
+              key: {{ .Values.db.connectionStringKey }}
+        {{- else }}
+        # Composed with $(VAR) interpolation, which Kubernetes expands using
+        # env vars defined EARLIER in this same list — so these five must stay
+        # above ConnectionStrings__DefaultConnection.
         - name: DB_HOST
           valueFrom:
             secretKeyRef:
               name: {{ .Values.db.secretName }}
-              key: host
+              key: {{ .Values.db.keys.host }}
         - name: DB_PORT
           valueFrom:
             secretKeyRef:
               name: {{ .Values.db.secretName }}
-              key: port
+              key: {{ .Values.db.keys.port }}
         - name: DB_USER
           valueFrom:
             secretKeyRef:
               name: {{ .Values.db.secretName }}
-              key: user
+              key: {{ .Values.db.keys.user }}
         - name: DB_PASSWORD
           valueFrom:
             secretKeyRef:
               name: {{ .Values.db.secretName }}
-              key: password
+              key: {{ .Values.db.keys.password }}
         - name: DB_NAME
           valueFrom:
             secretKeyRef:
               name: {{ .Values.db.secretName }}
-              key: dbname
+              key: {{ .Values.db.keys.dbname }}
         - name: ConnectionStrings__DefaultConnection
           value: "Host=$(DB_HOST);Port=$(DB_PORT);Username=$(DB_USER);Password=$(DB_PASSWORD);Database=$(DB_NAME)"
+        {{- end }}
         - name: ConnectionStrings__DefaultConnection_DbProvider
           value: {{ .Values.db.provider | quote }}
 
@@ -80,6 +109,10 @@ spec:
           value: {{ .Values.auth.refreshExpiryInDays | quote }}
         - name: Endatix__Auth__Providers__EndatixJwt__Issuer
           value: {{ .Values.auth.issuer | quote }}
+        {{- range $i, $audience := .Values.auth.audiences }}
+        - name: Endatix__Auth__Providers__EndatixJwt__Audiences__{{ $i }}
+          value: {{ $audience | quote }}
+        {{- end }}
 
         # Initial admin user (seeded on first startup)
         - name: Endatix__Data__InitialUser__Email
@@ -141,3 +174,12 @@ spec:
             port: 8080
           initialDelaySeconds: 30
           periodSeconds: 30
+        # The only writable path. Startup and /health do not need it, but
+        # ASP.NET Core spills oversized request bodies to Path.GetTempPath()
+        # and the runtime puts its diagnostic socket there.
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,143 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        ports:
+        - containerPort: 8080
+        env:
+        # ASP.NET Core
+        - name: ASPNETCORE_ENVIRONMENT
+          value: {{ .Values.aspnetcore.environment | quote }}
+        - name: ASPNETCORE_FORWARDEDHEADERS_ENABLED
+          value: {{ .Values.aspnetcore.forwardedHeadersEnabled | quote }}
+        - name: HTTP_PORTS
+          value: "8080"
+
+        # Database
+        - name: DB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.db.secretName }}
+              key: host
+        - name: DB_PORT
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.db.secretName }}
+              key: port
+        - name: DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.db.secretName }}
+              key: user
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.db.secretName }}
+              key: password
+        - name: DB_NAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.db.secretName }}
+              key: dbname
+        - name: ConnectionStrings__DefaultConnection
+          value: "Host=$(DB_HOST);Port=$(DB_PORT);Username=$(DB_USER);Password=$(DB_PASSWORD);Database=$(DB_NAME)"
+        - name: ConnectionStrings__DefaultConnection_DbProvider
+          value: {{ .Values.db.provider | quote }}
+
+        # Auth
+        - name: Endatix__Auth__Providers__EndatixJwt__SigningKey
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.auth.secretName }}
+              key: signing-key
+        - name: Endatix__Auth__Providers__EndatixJwt__AccessExpiryInMinutes
+          value: {{ .Values.auth.accessExpiryInMinutes | quote }}
+        - name: Endatix__Auth__Providers__EndatixJwt__RefreshExpiryInDays
+          value: {{ .Values.auth.refreshExpiryInDays | quote }}
+        - name: Endatix__Auth__Providers__EndatixJwt__Issuer
+          value: {{ .Values.auth.issuer | quote }}
+
+        # Initial admin user (seeded on first startup)
+        - name: Endatix__Data__InitialUser__Email
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.initialUser.secretName }}
+              key: email
+        - name: Endatix__Data__InitialUser__Password
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.initialUser.secretName }}
+              key: password
+
+        # Data
+        - name: Endatix__Data__EnableAutoMigrations
+          value: {{ .Values.data.enableAutoMigrations | quote }}
+        - name: Endatix__Data__SeedSampleData
+          value: {{ .Values.data.seedSampleData | quote }}
+        - name: Endatix__Data__SeedSampleForms
+          value: {{ .Values.data.seedSampleForms | quote }}
+
+        # CORS
+        - name: Endatix__Cors__DefaultPolicyName
+          value: {{ .Values.cors.policyName | quote }}
+
+        {{- if .Values.hub.baseUrl }}
+        # Hub
+        - name: Endatix__Hub__HubBaseUrl
+          value: {{ .Values.hub.baseUrl | quote }}
+        {{- end }}
+
+        {{- if .Values.otel.enabled }}
+        # OpenTelemetry
+        - name: OTEL_SERVICE_NAME
+          value: {{ .Values.otel.serviceName | quote }}
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: {{ .Values.otel.endpoint | quote }}
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: {{ .Values.otel.protocol | quote }}
+        - name: OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES
+          value: "true"
+        - name: OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES
+          value: "true"
+        - name: OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY
+          value: "in_memory"
+        {{- end }}
+
+        resources:
+          {{- toYaml .Values.resources | nindent 10 }}
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+          initialDelaySeconds: 30
+          periodSeconds: 30

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,11 +1,13 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Chart.Name }}
+  name: {{ include "endatix-api.fullname" . }}
+  labels:
+    {{- include "endatix-api.selectorLabels" . | nindent 4 }}
 spec:
   type: ClusterIP
   selector:
-    app: {{ .Chart.Name }}
+    {{- include "endatix-api.selectorLabels" . | nindent 4 }}
   ports:
   - port: 80
     targetPort: 8080

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ .Chart.Name }}
+  ports:
+  - port: 80
+    targetPort: 8080

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,60 @@
+replicaCount: 1
+
+image:
+  repository: endatix/endatix-api
+  pullPolicy: Always
+  # tag defaults to chart appVersion
+
+imagePullSecrets: []
+
+db:
+  # Name of an existing secret with key: connection-string
+  # Example: Host=pg-host;Port=5432;Username=postgres;Password=xxx;Database=endatix
+  secretName: endatix-db-secret
+  provider: postgresql
+
+auth:
+  # Name of an existing secret with key: signing-key
+  secretName: endatix-auth-secret
+  accessExpiryInMinutes: 90
+  refreshExpiryInDays: 7
+  issuer: endatix-api
+  audiences:
+    - endatix-hub
+    - endatix-client
+
+initialUser:
+  # Name of an existing secret with keys: email, password
+  # Only used on first startup to seed the admin account
+  secretName: endatix-initial-user-secret
+
+data:
+  enableAutoMigrations: true
+  seedSampleData: false
+  seedSampleForms: false
+
+hub:
+  # Base URL of the Endatix Hub frontend, used for email links etc.
+  baseUrl: ""
+
+cors:
+  policyName: AllowAll
+
+aspnetcore:
+  environment: Production
+  forwardedHeadersEnabled: "true"
+
+otel:
+  enabled: false
+  endpoint: ""
+  protocol: grpc
+  serviceName: endatix-api
+
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    memory: 512Mi
+
+nodeSelector: {}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -8,10 +8,28 @@ image:
 imagePullSecrets: []
 
 db:
-  # Name of an existing secret with key: connection-string
-  # Example: Host=pg-host;Port=5432;Username=postgres;Password=xxx;Database=endatix
+  # Name of an existing secret holding the database credentials.
   secretName: endatix-db-secret
   provider: postgresql
+
+  # Two supported secret shapes:
+  #
+  # A) One key holding the whole connection string. Set connectionStringKey to
+  #    that key's name; the `keys` map below is then ignored.
+  #    Example value: Host=pg-host;Port=5432;Username=postgres;Password=xxx;Database=endatix
+  #    CloudNativePG publishes exactly this as `uri`.
+  # connectionStringKey: connection-string
+  #
+  # B) Individual keys, composed into the connection string at pod start. This
+  #    is the default, and the shape most database operators emit. The key
+  #    names are configurable because they differ between operators — e.g.
+  #    CloudNativePG uses `username`, not `user`.
+  keys:
+    host: host
+    port: port
+    user: user
+    password: password
+    dbname: dbname
 
 auth:
   # Name of an existing secret with key: signing-key
@@ -19,6 +37,10 @@ auth:
   accessExpiryInMinutes: 90
   refreshExpiryInDays: 7
   issuer: endatix-api
+  # Rendered as indexed env vars (Audiences__0, Audiences__1, ...). Env vars
+  # layer over the image's appsettings.json rather than replacing the array, so
+  # listing FEWER audiences than it ships (endatix-hub, endatix-client) leaves
+  # the surplus trailing entry in effect. Override by index, or keep >= 2.
   audiences:
     - endatix-hub
     - endatix-client

--- a/scripts/release-prepare.sh
+++ b/scripts/release-prepare.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 # Consumer contract for endatix/release-workflows (prepare half):
-# build every NuGet package stamped with the given version.
-# Called by the shared pipeline for PR validation (version 0.0.0-ci),
-# canary releases, and stable rebuilds.
+# build every NuGet package AND the Endatix.WebHost container image, all
+# stamped with the given version. Called by the shared pipeline for PR
+# validation (version 0.0.0-ci), canary releases, and stable rebuilds.
+# Builds only — nothing is pushed here (PR validation has no registry login).
 #
 # Usage: scripts/release-prepare.sh <version>
+# Expects env vars (exported by the shared workflows):
+#   DOCKER_IMAGE  container image name, from the caller's docker-image input
 set -euo pipefail
 
 VERSION="${1:?usage: release-prepare.sh <version>}"
+: "${DOCKER_IMAGE:?DOCKER_IMAGE env var is required (is docker-image set on the caller workflow?)}"
 
 # Clean so the publish step only ever sees packages stamped with THIS version.
 rm -rf build/packages/nuget
@@ -18,3 +22,18 @@ dotnet build -c Release --no-restore -p:Version="${VERSION}"
 
 echo "──── Packing NuGet packages at version ${VERSION} ────"
 dotnet pack -c Release --no-build -p:Version="${VERSION}" -o build/packages/nuget
+
+# Container image via the .NET SDK (/t:PublishContainer) — no Dockerfile.
+# One single-arch image per architecture, each loaded into the local Docker
+# daemon: a daemon cannot hold a manifest list, so release-publish.sh stitches
+# the per-arch tags into the multi-arch manifest once they reach a registry.
+# Each --arch is its own RID-specific compile, so --no-build does not apply.
+for arch in "x64:amd64" "arm64:arm64"; do
+  echo "──── Building container image for linux-${arch%%:*} at version ${VERSION} ────"
+  dotnet publish src/Endatix.WebHost/Endatix.WebHost.csproj \
+    -c Release --os linux --arch "${arch%%:*}" \
+    -p:Version="${VERSION}" \
+    /t:PublishContainer \
+    -p:ContainerRepository="${DOCKER_IMAGE}" \
+    -p:ContainerImageTag="${VERSION}-${arch##*:}"
+done

--- a/scripts/release-publish.sh
+++ b/scripts/release-publish.sh
@@ -1,24 +1,55 @@
 #!/usr/bin/env bash
 # Consumer contract for endatix/release-workflows (publish half):
-# push the packages produced by release-prepare.sh.
+# push the artifacts produced by release-prepare.sh.
 #
-# Channel split (RELEASE_CHANNEL, set by the shared workflows):
-#   canary → GitHub Packages ONLY. nuget.org is public and immutable —
-#            per-push canaries must never land there.
-#   stable → GitHub Packages + nuget.org.
+# Channels (RELEASE_CHANNEL, set by the shared workflows):
+#   canary       push to main             prerelease build
+#   hotfix       push to hotfix/X.Y.x     prerelease build on a maintenance line
+#   stable       promoted release, and the newest version overall
+#   maintenance  promoted release on an older line (a newer stable exists)
+#
+# Prereleases stay on the internal feeds — nuget.org and Docker Hub are public
+# and immutable, so per-push builds must never land there. BOTH promoted
+# channels publish to the public registries; only `stable` may move floating
+# pointers (docker `latest` — nuget.org sorts by semver on its own), so a hotfix
+# for an older line ships without dragging `latest` backwards.
+#
+#   channel              GitHub Packages + GHCR   nuget.org + Docker Hub   latest
+#   canary / hotfix               yes                      no               no
+#   maintenance                   yes                      yes              no
+#   stable                        yes                      yes              yes
 #
 # Usage: scripts/release-publish.sh <version>
 # Expects env vars (exported by the shared workflows):
 #   NUGET_SOURCE       GitHub NuGet feed (nuget.pkg.github.com/endatix)
 #   GH_PACKAGES_TOKEN  job token with packages:write
+#   DOCKER_IMAGE       GHCR image name, from the caller's docker-image input
+#                      (the shared workflows do the ghcr.io login)
 #   NUGET_API_KEY      short-lived nuget.org key minted per run via OIDC
-#                      trusted publishing (NuGet/login) — stable only
+#                      trusted publishing (NuGet/login) — promoted releases only
+#   ENDATIX_DOCKERHUB_USERNAME / ENDATIX_DOCKERHUB_TOKEN
+#                      Docker Hub credentials via Infisical (fetch-secrets:
+#                      true on the caller) — promoted releases only
 set -euo pipefail
 
 VERSION="${1:?usage: release-publish.sh <version>}"
 CHANNEL="${RELEASE_CHANNEL:-stable}"
 : "${NUGET_SOURCE:?NUGET_SOURCE env var is required}"
 : "${GH_PACKAGES_TOKEN:?GH_PACKAGES_TOKEN env var is required}"
+: "${DOCKER_IMAGE:?DOCKER_IMAGE env var is required (is docker-image set on the caller workflow?)}"
+
+# Public mirror for promoted releases. Not an input on the shared workflows
+# (they model a single image) — mirroring is this repo's own publish concern.
+DOCKERHUB_IMAGE="docker.io/endatix/endatix-api"
+
+# Fail loud on an unrecognised channel: silently publishing nothing is a far
+# worse outcome for a release than a red run.
+case "$CHANNEL" in
+  stable) PUBLISH_PUBLIC=true; MOVE_LATEST=true ;;
+  maintenance) PUBLISH_PUBLIC=true; MOVE_LATEST=false ;;
+  canary | hotfix) PUBLISH_PUBLIC=false; MOVE_LATEST=false ;;
+  *) echo "::error::Unknown RELEASE_CHANNEL '${CHANNEL}' — release-workflows contract changed?" >&2; exit 1 ;;
+esac
 
 echo "──── Publishing ${VERSION} (${CHANNEL} channel) ────"
 
@@ -30,11 +61,42 @@ dotnet nuget push "build/packages/nuget/*.${VERSION}.nupkg" \
   -s "$NUGET_SOURCE" \
   --skip-duplicate
 
-if [[ "$CHANNEL" = "stable" ]]; then
-  : "${NUGET_API_KEY:?NUGET_API_KEY env var is required for stable releases (minted by NuGet/login — is nuget-login: true set?)}"
+if [[ "$PUBLISH_PUBLIC" = true ]]; then
+  : "${NUGET_API_KEY:?NUGET_API_KEY env var is required for promoted releases (minted by NuGet/login — is nuget-login: true set?)}"
   echo "──── Pushing NuGet packages to nuget.org ────"
   dotnet nuget push "build/packages/nuget/*.${VERSION}.nupkg" \
     -k "$NUGET_API_KEY" \
     -s https://api.nuget.org/v3/index.json \
     --skip-duplicate
+fi
+
+# The per-arch tags are what release-prepare.sh built and loaded into the local
+# daemon; the plain version tag is a manifest list stitched from them once they
+# are in the registry, so `docker pull` resolves the right platform.
+echo "──── Pushing container image to ${DOCKER_IMAGE} ────"
+docker push "${DOCKER_IMAGE}:${VERSION}-amd64"
+docker push "${DOCKER_IMAGE}:${VERSION}-arm64"
+docker buildx imagetools create \
+  -t "${DOCKER_IMAGE}:${VERSION}" \
+  "${DOCKER_IMAGE}:${VERSION}-amd64" \
+  "${DOCKER_IMAGE}:${VERSION}-arm64"
+
+if [[ "$MOVE_LATEST" = true ]]; then
+  echo "──── Moving ${DOCKER_IMAGE}:latest to ${VERSION} ────"
+  docker buildx imagetools create -t "${DOCKER_IMAGE}:latest" "${DOCKER_IMAGE}:${VERSION}"
+fi
+
+if [[ "$PUBLISH_PUBLIC" = true ]]; then
+  : "${ENDATIX_DOCKERHUB_USERNAME:?ENDATIX_DOCKERHUB_USERNAME env var is required for promoted releases (Infisical prod — is fetch-secrets: true set?)}"
+  : "${ENDATIX_DOCKERHUB_TOKEN:?ENDATIX_DOCKERHUB_TOKEN env var is required for promoted releases (Infisical prod — is fetch-secrets: true set?)}"
+
+  # Mirror by copying the manifest — same digests as GHCR, no rebuild.
+  DOCKERHUB_TAGS=(-t "${DOCKERHUB_IMAGE}:${VERSION}")
+  if [[ "$MOVE_LATEST" = true ]]; then
+    DOCKERHUB_TAGS+=(-t "${DOCKERHUB_IMAGE}:latest")
+  fi
+
+  echo "──── Mirroring container image to ${DOCKERHUB_IMAGE} ────"
+  echo "$ENDATIX_DOCKERHUB_TOKEN" | docker login docker.io -u "$ENDATIX_DOCKERHUB_USERNAME" --password-stdin
+  docker buildx imagetools create "${DOCKERHUB_TAGS[@]}" "${DOCKER_IMAGE}:${VERSION}"
 fi


### PR DESCRIPTION
# Add Helm chart for Endatix API deployment

## Description
Adds a first Helm chart (endatix-api, v0.1.0) to streamline Kubernetes deployment of the Endatix API (.NET 10 form-management backend). Previously the API had no packaged deploy path; this gives a single helm install with all configuration driven from values.yaml and secrets.

###What's included

- Chart.yaml — chart metadata, endatix-api v0.1.0 / appVersion 0.1.0
- templates/deployment.yaml — the Deployment, wiring all Endatix config through env vars
- templates/service.yaml — ClusterIP Service, port 80 → container 8080
- values.yaml — tunable defaults (image, replicas, resources, auth, data, CORS, OTel)

### Key design points
- Secrets by reference — DB credentials, JWT signing key, and the seed admin user are pulled from existing K8s secrets (endatix-db-secret, endatix-auth-secret, endatix-initial-user-secret); nothing sensitive lives in the chart.
- Database — connection string assembled from secret keys (host/port/user/password/dbname); PostgreSQL provider; auto-migrations on by default, sample seeding off.
- Auth — JWT with 90-min access / 7-day refresh, issuer endatix-api.
- Health — readiness + liveness probes on /health (port 8080).
- Runtime — Production env, forwarded-headers enabled (proxy-aware), HTTP_PORTS=8080, configurable resource requests/limits.
- OpenTelemetry — fully scaffolded but gated behind otel.enabled (off by default).
- Optional — imagePullSecrets, nodeSelector, and hub.baseUrl render only when set.

### Notes for reviewers
- The commit is labeled fix(helm) but is all-new files — feat(helm) would be more accurate.
- Doc/template mismatch: values.yaml comments describe the DB secret as a single connection-string key, but deployment.yaml actually reads discrete keys (host, port, user, password, dbname). Worth reconciling the comment before merge so operators create the secret correctly.
- cors.policyName defaults to AllowAll — fine for dev, should be tightened for production.
- No Ingress template yet; access is ClusterIP-only for now.

## Related Issues
- closes https://github.com/endatix/endatix/issues/893

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [ ] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Helm chart support for deploying the API to Kubernetes.
  * Added configurable service, database, authentication, health checks, resources, CORS, and telemetry settings.
  * Added multi-architecture container image builds and publishing.
* **Release Improvements**
  * Updated release workflows to target the API container image explicitly.
  * Added channel-based publishing rules for package and container releases.
  * Added optional Docker Hub mirroring for public releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->