### PR TITLE
feat(790): activate integration-event capture in ProcessEntities()

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,6 +36,7 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="$(EFCoreVersion)" />
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.4.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EFCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EFCoreVersion)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EFCoreVersion)" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(EFCoreVersion)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />

--- a/src/Endatix.Core/Entities/BaseEntity.cs
+++ b/src/Endatix.Core/Entities/BaseEntity.cs
@@ -1,8 +1,13 @@
 using System.ComponentModel.DataAnnotations.Schema;
+using Endatix.Core.Infrastructure.Domain;
 
 namespace Endatix.Core.Entities;
 
-public abstract class BaseEntity
+/// <summary>
+/// Base type for persisted entities. Inherits <see cref="HasDomainEventsBase"/> so aggregates can
+/// raise domain/integration events (via <c>RegisterDomainEvent</c>) that the outbox capture picks up.
+/// </summary>
+public abstract class BaseEntity : HasDomainEventsBase
 {
     [DatabaseGenerated(DatabaseGeneratedOption.None)]
     public virtual long Id { get; set; }

--- a/src/Endatix.Core/Entities/OutboxMessage.cs
+++ b/src/Endatix.Core/Entities/OutboxMessage.cs
@@ -27,7 +27,8 @@ public class OutboxMessage : BaseEntity, IAggregateRoot
     {
         Guard.Against.NullOrWhiteSpace(eventType);
         Guard.Against.NullOrWhiteSpace(payload);
-        Guard.Against.NegativeOrZero(tenantId);
+        // 0 == AuthConstants.DEFAULT_TENANT_ID (app-level / cross-tenant events) is valid; only negatives are not.
+        Guard.Against.Negative(tenantId);
         Guard.Against.NegativeOrZero(schemaVersion);
 
         EventType = eventType;

--- a/src/Endatix.Core/Infrastructure/Domain/HasDomainEventsBase.cs
+++ b/src/Endatix.Core/Infrastructure/Domain/HasDomainEventsBase.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Linq;
 
 namespace Endatix.Core.Infrastructure.Domain;
 
@@ -16,4 +17,14 @@ public abstract class HasDomainEventsBase
   /// (e.g. by the outbox capture in <c>AppDbContext.ProcessEntities</c>).
   /// </summary>
   public void ClearDomainEvents() => _domainEvents.Clear();
+
+  /// <summary>
+  /// Removes the specified domain events (e.g. the integration events captured to the outbox),
+  /// leaving any other registered events in place.
+  /// </summary>
+  public void RemoveDomainEvents(IEnumerable<DomainEventBase> domainEvents)
+  {
+    var toRemove = domainEvents.ToHashSet();
+    _domainEvents.RemoveAll(toRemove.Contains);
+  }
 }

--- a/src/Endatix.Core/Infrastructure/Domain/HasDomainEventsBase.cs
+++ b/src/Endatix.Core/Infrastructure/Domain/HasDomainEventsBase.cs
@@ -10,5 +10,10 @@ public abstract class HasDomainEventsBase
   public IEnumerable<DomainEventBase> DomainEvents => _domainEvents.AsReadOnly();
 
   protected void RegisterDomainEvent(DomainEventBase domainEvent) => _domainEvents.Add(domainEvent);
-  internal void ClearDomainEvents() => _domainEvents.Clear();
+
+  /// <summary>
+  /// Clears the registered domain events. Called after they have been captured/dispatched
+  /// (e.g. by the outbox capture in <c>AppDbContext.ProcessEntities</c>).
+  /// </summary>
+  public void ClearDomainEvents() => _domainEvents.Clear();
 }

--- a/src/Endatix.Infrastructure/Builders/InfrastructureDataBuilder.cs
+++ b/src/Endatix.Infrastructure/Builders/InfrastructureDataBuilder.cs
@@ -50,6 +50,7 @@ public class InfrastructureDataBuilder
         Services.AddSingleton<IIdGenerator<long>, SnowflakeIdGenerator>();
         Services.AddScoped<IUnitOfWork, AppUnitOfWork>();
         Services.AddSingleton<EfCoreValueGeneratorFactory>();
+        Services.AddSingleton<Endatix.Infrastructure.Features.Outbox.OutboxIntegrationEventDispatcher>();
         Services.AddScoped<EndatixSpecificationEvaluator>();
         Services.AddScoped(typeof(IRepository<>), typeof(EfRepository<>));
         Services.AddScoped<IValueNormalizer, ValueNormalizer>();

--- a/src/Endatix.Infrastructure/Data/AppDbContext.cs
+++ b/src/Endatix.Infrastructure/Data/AppDbContext.cs
@@ -274,7 +274,7 @@ public class AppDbContext : DbContext, ITenantDbContext
             return;
         }
 
-        var outboxMessages = _outboxDispatcher.Capture(entitiesWithEvents, GetTenantId());
+        var outboxMessages = _outboxDispatcher.Capture(entitiesWithEvents);
         foreach (var message in outboxMessages)
         {
             var entry = OutboxMessages.Add(message);

--- a/src/Endatix.Infrastructure/Data/AppDbContext.cs
+++ b/src/Endatix.Infrastructure/Data/AppDbContext.cs
@@ -7,6 +7,8 @@ using Endatix.Infrastructure.Data.Abstractions;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Endatix.Core.Exceptions;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Infrastructure.Features.Outbox;
 
 namespace Endatix.Infrastructure.Data;
 
@@ -20,17 +22,20 @@ public class AppDbContext : DbContext, ITenantDbContext
     private readonly IIdGenerator<long> _idGenerator;
     private readonly ITenantContext _tenantContext;
     private readonly EfCoreValueGeneratorFactory _valueGeneratorFactory;
+    private readonly OutboxIntegrationEventDispatcher _outboxDispatcher;
 
     protected AppDbContext() { }
     public AppDbContext(
         DbContextOptions<AppDbContext> options,
         IIdGenerator<long> idGenerator,
         ITenantContext tenantContext,
-        EfCoreValueGeneratorFactory valueGeneratorFactory) : base(options)
+        EfCoreValueGeneratorFactory valueGeneratorFactory,
+        OutboxIntegrationEventDispatcher outboxDispatcher) : base(options)
     {
         _idGenerator = idGenerator;
         _tenantContext = tenantContext;
         _valueGeneratorFactory = valueGeneratorFactory;
+        _outboxDispatcher = outboxDispatcher;
     }
 
     public DbSet<Form> Forms { get; set; }
@@ -75,6 +80,12 @@ public class AppDbContext : DbContext, ITenantDbContext
     protected override void OnModelCreating(ModelBuilder builder)
     {
         base.OnModelCreating(builder);
+
+        // Domain events live on entities (BaseEntity : HasDomainEventsBase) but are never persisted —
+        // they are captured to the outbox in ProcessEntities. Exclude the type from the model so EF
+        // doesn't try to map the [NotMapped] DomainEvents collection as a keyless/related entity.
+        builder.Ignore<DomainEventBase>();
+
         builder.ApplyEndatixQueryFilters(this);
         ConfigureEntityIdValueGenerators(builder);
 
@@ -235,6 +246,40 @@ public class AppDbContext : DbContext, ITenantDbContext
 
                     break;
             }
+        }
+
+        CaptureIntegrationEvents();
+    }
+
+    /// <summary>
+    /// Captures <see cref="IIntegrationEvent"/>s raised on tracked aggregates into <see cref="OutboxMessage"/>
+    /// rows in this same context, so they commit atomically with the aggregate. Runs after Id/timestamp
+    /// stamping (so the aggregates' Ids are set before payloads are materialized); the new outbox rows are
+    /// added afterwards, so their Id/CreatedAt are stamped explicitly here.
+    /// </summary>
+    private void CaptureIntegrationEvents()
+    {
+        if (_outboxDispatcher is null)
+        {
+            return;
+        }
+
+        var entitiesWithEvents = ChangeTracker.Entries<HasDomainEventsBase>()
+            .Select(entry => entry.Entity)
+            .Where(entity => entity.DomainEvents.Any())
+            .ToList();
+
+        if (entitiesWithEvents.Count == 0)
+        {
+            return;
+        }
+
+        var outboxMessages = _outboxDispatcher.Capture(entitiesWithEvents, GetTenantId());
+        foreach (var message in outboxMessages)
+        {
+            var entry = OutboxMessages.Add(message);
+            entry.CurrentValues[nameof(BaseEntity.Id)] = _idGenerator.CreateId();
+            entry.CurrentValues[nameof(BaseEntity.CreatedAt)] = DateTime.UtcNow;
         }
     }
 

--- a/src/Endatix.Infrastructure/Features/Outbox/OutboxIntegrationEventDispatcher.cs
+++ b/src/Endatix.Infrastructure/Features/Outbox/OutboxIntegrationEventDispatcher.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Endatix.Core.Abstractions;
 using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Domain;
+using Endatix.Infrastructure.Identity.Authentication;
 
 namespace Endatix.Infrastructure.Features.Outbox;
 
@@ -23,12 +24,11 @@ public sealed class OutboxIntegrationEventDispatcher
 
     /// <summary>
     /// Builds an <see cref="OutboxMessage"/> for every <see cref="IIntegrationEvent"/> on the given
-    /// entities and clears their domain events. The caller is responsible for persisting the returned
-    /// rows (stamping <c>Id</c>/<c>CreatedAt</c> as it adds them).
+    /// entities and removes those events. The caller is responsible for persisting the returned rows
+    /// (stamping <c>Id</c>/<c>CreatedAt</c> as it adds them).
     /// </summary>
     /// <param name="entities">Tracked entities that may carry domain events.</param>
-    /// <param name="ambientTenantId">Fallback tenant id for events whose source is not tenant-owned.</param>
-    public IReadOnlyList<OutboxMessage> Capture(IEnumerable<HasDomainEventsBase> entities, long ambientTenantId)
+    public IReadOnlyList<OutboxMessage> Capture(IEnumerable<HasDomainEventsBase> entities)
     {
         var messages = new List<OutboxMessage>();
 
@@ -43,8 +43,9 @@ public sealed class OutboxIntegrationEventDispatcher
                 continue;
             }
 
-            // A tenant-owned aggregate carries the authoritative tenant; otherwise use the ambient one.
-            var tenantId = (entity as ITenantOwned)?.TenantId ?? ambientTenantId;
+            // Tenant is a pure function of the aggregate: a tenant-owned aggregate carries the
+            // authoritative tenant; a non-tenant-owned (global) aggregate's event is app-level.
+            var tenantId = (entity as ITenantOwned)?.TenantId ?? AuthConstants.DEFAULT_TENANT_ID;
 
             foreach (var domainEvent in integrationEvents)
             {

--- a/src/Endatix.Infrastructure/Features/Outbox/OutboxIntegrationEventDispatcher.cs
+++ b/src/Endatix.Infrastructure/Features/Outbox/OutboxIntegrationEventDispatcher.cs
@@ -1,0 +1,71 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Endatix.Core.Abstractions;
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
+
+namespace Endatix.Infrastructure.Features.Outbox;
+
+/// <summary>
+/// Turns the <see cref="IIntegrationEvent"/> domain events raised on tracked aggregates into
+/// <see cref="OutboxMessage"/> rows, so they are persisted atomically with the aggregate write
+/// (invoked from <c>AppDbContext.ProcessEntities</c> inside <c>SaveChanges</c>).
+/// </summary>
+/// <remarks>
+/// Capture is intentionally generic — it never switches on concrete event types, so adding a new
+/// integration event costs zero dispatcher/relay changes. Plain <see cref="DomainEventBase"/> events
+/// that are not <see cref="IIntegrationEvent"/> are ignored here (they stay in-process via MediatR).
+/// </remarks>
+public sealed class OutboxIntegrationEventDispatcher
+{
+    // Web defaults (camelCase) — payloads are opaque JSON to the relay; consumers own their shape.
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
+    /// <summary>
+    /// Builds an <see cref="OutboxMessage"/> for every <see cref="IIntegrationEvent"/> on the given
+    /// entities and clears their domain events. The caller is responsible for persisting the returned
+    /// rows (stamping <c>Id</c>/<c>CreatedAt</c> as it adds them).
+    /// </summary>
+    /// <param name="entities">Tracked entities that may carry domain events.</param>
+    /// <param name="ambientTenantId">Fallback tenant id for events whose source is not tenant-owned.</param>
+    public IReadOnlyList<OutboxMessage> Capture(IEnumerable<HasDomainEventsBase> entities, long ambientTenantId)
+    {
+        var messages = new List<OutboxMessage>();
+
+        foreach (var entity in entities)
+        {
+            var integrationEvents = entity.DomainEvents
+                .Where(domainEvent => domainEvent is IIntegrationEvent)
+                .ToList();
+
+            if (integrationEvents.Count == 0)
+            {
+                continue;
+            }
+
+            // A tenant-owned aggregate carries the authoritative tenant; otherwise use the ambient one.
+            var tenantId = (entity as ITenantOwned)?.TenantId ?? ambientTenantId;
+
+            foreach (var domainEvent in integrationEvents)
+            {
+                var integrationEvent = (IIntegrationEvent)domainEvent;
+
+                // Materialize the payload now, while the aggregate is still live (late-bound fields resolved).
+                var payloadDto = integrationEvent.GetPayload();
+                var payload = JsonSerializer.Serialize(payloadDto, payloadDto.GetType(), SerializerOptions);
+
+                messages.Add(new OutboxMessage(
+                    eventType: integrationEvent.EventType,
+                    payload: payload,
+                    tenantId: tenantId,
+                    occurredAt: domainEvent.DateOccurred,
+                    schemaVersion: integrationEvent.SchemaVersion,
+                    traceId: Activity.Current?.TraceId.ToString()));
+            }
+
+            entity.ClearDomainEvents();
+        }
+
+        return messages;
+    }
+}

--- a/src/Endatix.Infrastructure/Features/Outbox/OutboxIntegrationEventDispatcher.cs
+++ b/src/Endatix.Infrastructure/Features/Outbox/OutboxIntegrationEventDispatcher.cs
@@ -51,8 +51,12 @@ public sealed class OutboxIntegrationEventDispatcher
                 var integrationEvent = (IIntegrationEvent)domainEvent;
 
                 // Materialize the payload now, while the aggregate is still live (late-bound fields resolved).
+                // Serialize with the runtime type so derived properties are included; a null payload is
+                // stored as the JSON literal rather than aborting the whole SaveChanges.
                 var payloadDto = integrationEvent.GetPayload();
-                var payload = JsonSerializer.Serialize(payloadDto, payloadDto.GetType(), SerializerOptions);
+                var payload = payloadDto is null
+                    ? "null"
+                    : JsonSerializer.Serialize(payloadDto, payloadDto.GetType(), SerializerOptions);
 
                 messages.Add(new OutboxMessage(
                     eventType: integrationEvent.EventType,
@@ -63,7 +67,8 @@ public sealed class OutboxIntegrationEventDispatcher
                     traceId: Activity.Current?.TraceId.ToString()));
             }
 
-            entity.ClearDomainEvents();
+            // Remove only what we captured — any non-integration domain events stay in-process.
+            entity.RemoveDomainEvents(integrationEvents);
         }
 
         return messages;

--- a/tests/Endatix.Infrastructure.Tests/Endatix.Infrastructure.Tests.csproj
+++ b/tests/Endatix.Infrastructure.Tests/Endatix.Infrastructure.Tests.csproj
@@ -21,6 +21,10 @@
 
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Endatix.Infrastructure\Endatix.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\Endatix.Persistence.PostgreSql\Endatix.Persistence.PostgreSql.csproj" />
     <ProjectReference Include="..\..\src\Endatix.Persistence.SqlServer\Endatix.Persistence.SqlServer.csproj" />

--- a/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxCaptureIntegrationTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxCaptureIntegrationTests.cs
@@ -4,6 +4,7 @@ using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Infrastructure.Data;
 using Endatix.Infrastructure.Features.Outbox;
+using Endatix.Infrastructure.Identity.Authentication;
 using FluentAssertions;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -57,7 +58,8 @@ public sealed class OutboxCaptureIntegrationTests : IDisposable
 
         outbox.Should().ContainSingle();
         outbox[0].EventType.Should().Be("probe.created");
-        outbox[0].TenantId.Should().Be(AmbientTenantId);
+        // The probe is not tenant-owned → app-level event (DEFAULT_TENANT_ID), regardless of ambient context.
+        outbox[0].TenantId.Should().Be(AuthConstants.DEFAULT_TENANT_ID);
         outbox[0].Status.Should().Be(OutboxMessageStatus.Pending);
         outbox[0].Attempts.Should().Be(0);
         outbox[0].Id.Should().BeGreaterThan(0, "ProcessEntities stamps the outbox row's Id explicitly");

--- a/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxCaptureIntegrationTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxCaptureIntegrationTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Endatix.Core.Abstractions;
 using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Domain;
@@ -20,6 +21,8 @@ public sealed class OutboxCaptureIntegrationTests : IDisposable
     private const long AmbientTenantId = 42;
     private readonly SqliteConnection _connection;
     private readonly ITenantContext _tenantContext;
+    // One generator for the fixture: contexts share the DB connection, so Ids must be unique across them.
+    private readonly IncrementingIdGenerator _idGenerator = new();
 
     public OutboxCaptureIntegrationTests()
     {
@@ -58,7 +61,9 @@ public sealed class OutboxCaptureIntegrationTests : IDisposable
         outbox[0].Status.Should().Be(OutboxMessageStatus.Pending);
         outbox[0].Attempts.Should().Be(0);
         outbox[0].Id.Should().BeGreaterThan(0, "ProcessEntities stamps the outbox row's Id explicitly");
-        outbox[0].Payload.Should().Contain("555");
+
+        using var payload = JsonDocument.Parse(outbox[0].Payload);
+        payload.RootElement.GetProperty("formId").GetInt64().Should().Be(555);
     }
 
     [Fact]
@@ -90,16 +95,15 @@ public sealed class OutboxCaptureIntegrationTests : IDisposable
 
     private TestAppDbContext CreateContext()
     {
-        var idGenerator = new IncrementingIdGenerator();
         var options = new DbContextOptionsBuilder<AppDbContext>()
             .UseSqlite(_connection)
             .Options;
 
         return new TestAppDbContext(
             options,
-            idGenerator,
+            _idGenerator,
             _tenantContext,
-            new EfCoreValueGeneratorFactory(idGenerator),
+            new EfCoreValueGeneratorFactory(_idGenerator),
             new OutboxIntegrationEventDispatcher());
     }
 

--- a/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxCaptureIntegrationTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxCaptureIntegrationTests.cs
@@ -1,0 +1,159 @@
+using Endatix.Core.Abstractions;
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Infrastructure.Data;
+using Endatix.Infrastructure.Features.Outbox;
+using FluentAssertions;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using NSubstitute;
+
+namespace Endatix.Infrastructure.Tests.Features.Outbox;
+
+/// <summary>
+/// Proves the full Phase 2 capture path through a real <see cref="DbContext.SaveChanges()"/> against a
+/// SQLite database: integration events raised on an aggregate become OutboxMessage rows committed in the
+/// SAME transaction as the aggregate (and roll back together when the write fails).
+/// </summary>
+public sealed class OutboxCaptureIntegrationTests : IDisposable
+{
+    private const long AmbientTenantId = 42;
+    private readonly SqliteConnection _connection;
+    private readonly ITenantContext _tenantContext;
+
+    public OutboxCaptureIntegrationTests()
+    {
+        // A shared in-memory connection kept open for the test, so the schema survives across contexts.
+        _connection = new SqliteConnection("DataSource=:memory:");
+        _connection.Open();
+
+        _tenantContext = Substitute.For<ITenantContext>();
+        _tenantContext.TenantId.Returns(AmbientTenantId);
+    }
+
+    public void Dispose() => _connection.Dispose();
+
+    [Fact]
+    public async Task SaveChanges_WhenAggregateRaisesIntegrationEvent_CommitsOneOutboxRow()
+    {
+        // Arrange
+        using (var ctx = CreateContext())
+        {
+            await ctx.Database.EnsureCreatedAsync();
+            var probe = new OutboxCaptureProbe { Name = "alpha" };
+            probe.RaiseCreated(formId: 555);
+            ctx.Probes.Add(probe);
+
+            // Act
+            await ctx.SaveChangesAsync();
+        }
+
+        // Assert — a fresh context proves the row was committed, not merely tracked
+        using var verify = CreateContext();
+        var outbox = await verify.OutboxMessages.ToListAsync();
+
+        outbox.Should().ContainSingle();
+        outbox[0].EventType.Should().Be("probe.created");
+        outbox[0].TenantId.Should().Be(AmbientTenantId);
+        outbox[0].Status.Should().Be(OutboxMessageStatus.Pending);
+        outbox[0].Attempts.Should().Be(0);
+        outbox[0].Id.Should().BeGreaterThan(0, "ProcessEntities stamps the outbox row's Id explicitly");
+        outbox[0].Payload.Should().Contain("555");
+    }
+
+    [Fact]
+    public async Task SaveChanges_WhenTheAggregateWriteFails_RollsBackTheOutboxRowToo()
+    {
+        // Arrange — seed a row so a duplicate Name violates the unique index on the next write
+        using (var seed = CreateContext())
+        {
+            await seed.Database.EnsureCreatedAsync();
+            seed.Probes.Add(new OutboxCaptureProbe { Name = "dup" });
+            await seed.SaveChangesAsync();
+        }
+
+        using var ctx = CreateContext();
+        var probe = new OutboxCaptureProbe { Name = "dup" }; // duplicate → the INSERT will fail
+        probe.RaiseCreated(formId: 1);
+        ctx.Probes.Add(probe);
+
+        // Act — capture adds the outbox row, then base.SaveChanges throws on the unique violation
+        var act = async () => await ctx.SaveChangesAsync();
+
+        // Assert — the failed transaction left NO outbox row: capture is atomic with the aggregate write
+        await act.Should().ThrowAsync<DbUpdateException>();
+
+        using var verify = CreateContext();
+        (await verify.OutboxMessages.CountAsync()).Should().Be(0, "the captured row must roll back with the failed aggregate");
+        (await verify.Probes.CountAsync()).Should().Be(1, "only the seeded row should remain");
+    }
+
+    private TestAppDbContext CreateContext()
+    {
+        var idGenerator = new IncrementingIdGenerator();
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite(_connection)
+            .Options;
+
+        return new TestAppDbContext(
+            options,
+            idGenerator,
+            _tenantContext,
+            new EfCoreValueGeneratorFactory(idGenerator),
+            new OutboxIntegrationEventDispatcher());
+    }
+
+    private sealed class IncrementingIdGenerator : IIdGenerator<long>
+    {
+        private long _current = 1_000;
+        public long CreateId() => Interlocked.Increment(ref _current);
+    }
+}
+
+/// <summary>Test context that maps a probe entity alongside the real Endatix model.</summary>
+internal sealed class TestAppDbContext : AppDbContext
+{
+    public TestAppDbContext(
+        DbContextOptions<AppDbContext> options,
+        IIdGenerator<long> idGenerator,
+        ITenantContext tenantContext,
+        EfCoreValueGeneratorFactory valueGeneratorFactory,
+        OutboxIntegrationEventDispatcher outboxDispatcher)
+        : base(options, idGenerator, tenantContext, valueGeneratorFactory, outboxDispatcher)
+    {
+    }
+
+    public DbSet<OutboxCaptureProbe> Probes => Set<OutboxCaptureProbe>();
+
+    protected override void OnModelCreating(ModelBuilder builder)
+    {
+        base.OnModelCreating(builder);
+
+        builder.Entity<OutboxCaptureProbe>(entity =>
+        {
+            entity.ToTable("OutboxCaptureProbes");
+            entity.HasKey(probe => probe.Id);
+            entity.Property(probe => probe.Name).IsRequired();
+            entity.HasIndex(probe => probe.Name).IsUnique();
+        });
+    }
+}
+
+/// <summary>A minimal aggregate (not tenant-owned) that can raise an integration event for the test.</summary>
+internal sealed class OutboxCaptureProbe : BaseEntity
+{
+    public string Name { get; set; } = null!;
+
+    public void RaiseCreated(long formId) => RegisterDomainEvent(new ProbeCreatedEvent(formId));
+}
+
+internal sealed class ProbeCreatedEvent(long formId) : DomainEventBase, IIntegrationEvent
+{
+    private readonly ProbeCreatedPayload _payload = new(formId);
+
+    public string EventType => "probe.created";
+
+    public object GetPayload() => _payload;
+}
+
+internal sealed record ProbeCreatedPayload(long FormId);

--- a/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxIntegrationEventDispatcherTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxIntegrationEventDispatcherTests.cs
@@ -1,0 +1,120 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Infrastructure.Features.Outbox;
+using FluentAssertions;
+
+namespace Endatix.Infrastructure.Tests.Features.Outbox;
+
+public class OutboxIntegrationEventDispatcherTests
+{
+    private const long AmbientTenantId = 999;
+    private readonly OutboxIntegrationEventDispatcher _sut = new();
+
+    [Fact]
+    public void Capture_WithIntegrationEvent_BuildsOutboxMessageFromTheEvent()
+    {
+        // Arrange
+        var aggregate = new TestAggregate(tenantId: 42);
+        aggregate.RaiseIntegrationEvent(formId: 123, name: "Survey");
+
+        // Act
+        var messages = _sut.Capture([aggregate], AmbientTenantId);
+
+        // Assert
+        messages.Should().ContainSingle();
+        var message = messages[0];
+        message.EventType.Should().Be("test.created");
+        message.SchemaVersion.Should().Be(2);
+        message.TenantId.Should().Be(42, "a tenant-owned aggregate supplies the authoritative tenant");
+        message.Status.Should().Be(OutboxMessageStatus.Pending);
+        message.Attempts.Should().Be(0);
+        message.Payload.Should().Contain("\"formId\":123").And.Contain("\"name\":\"Survey\"");
+    }
+
+    [Fact]
+    public void Capture_WhenSourceIsNotTenantOwned_UsesAmbientTenantId()
+    {
+        // Arrange
+        var aggregate = new NonTenantAggregate();
+        aggregate.RaiseIntegrationEvent(formId: 1, name: "x");
+
+        // Act
+        var messages = _sut.Capture([aggregate], AmbientTenantId);
+
+        // Assert
+        messages.Should().ContainSingle();
+        messages[0].TenantId.Should().Be(AmbientTenantId);
+    }
+
+    [Fact]
+    public void Capture_IgnoresPlainDomainEventsThatAreNotIntegrationEvents()
+    {
+        // Arrange
+        var aggregate = new TestAggregate(tenantId: 42);
+        aggregate.RaisePlainDomainEvent();
+
+        // Act
+        var messages = _sut.Capture([aggregate], AmbientTenantId);
+
+        // Assert
+        messages.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Capture_ClearsTheEntityDomainEventsAfterCapturing()
+    {
+        // Arrange
+        var aggregate = new TestAggregate(tenantId: 42);
+        aggregate.RaiseIntegrationEvent(formId: 1, name: "x");
+
+        // Act
+        _sut.Capture([aggregate], AmbientTenantId);
+
+        // Assert
+        aggregate.DomainEvents.Should().BeEmpty("captured events must not be re-processed");
+    }
+
+    [Fact]
+    public void Capture_WithMultipleEventsAcrossEntities_BuildsOneMessagePerIntegrationEvent()
+    {
+        // Arrange
+        var first = new TestAggregate(tenantId: 1);
+        first.RaiseIntegrationEvent(formId: 1, name: "a");
+        first.RaiseIntegrationEvent(formId: 2, name: "b");
+        var second = new TestAggregate(tenantId: 2);
+        second.RaiseIntegrationEvent(formId: 3, name: "c");
+
+        // Act
+        var messages = _sut.Capture([first, second], AmbientTenantId);
+
+        // Assert
+        messages.Should().HaveCount(3);
+        messages.Select(m => m.TenantId).Should().Equal(1, 1, 2);
+    }
+
+    private sealed record TestPayload(long FormId, string Name);
+
+    private sealed class TestIntegrationEvent(long formId, string name) : DomainEventBase, IIntegrationEvent
+    {
+        private readonly TestPayload _payload = new(formId, name);
+        public string EventType => "test.created";
+        public int SchemaVersion => 2;
+        public object GetPayload() => _payload;
+    }
+
+    private sealed class PlainDomainEvent : DomainEventBase;
+
+    private sealed class TestAggregate(long tenantId) : TenantEntity(tenantId)
+    {
+        public void RaiseIntegrationEvent(long formId, string name)
+            => RegisterDomainEvent(new TestIntegrationEvent(formId, name));
+
+        public void RaisePlainDomainEvent() => RegisterDomainEvent(new PlainDomainEvent());
+    }
+
+    private sealed class NonTenantAggregate : BaseEntity
+    {
+        public void RaiseIntegrationEvent(long formId, string name)
+            => RegisterDomainEvent(new TestIntegrationEvent(formId, name));
+    }
+}

--- a/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxIntegrationEventDispatcherTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxIntegrationEventDispatcherTests.cs
@@ -1,13 +1,13 @@
 using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Infrastructure.Features.Outbox;
+using Endatix.Infrastructure.Identity.Authentication;
 using FluentAssertions;
 
 namespace Endatix.Infrastructure.Tests.Features.Outbox;
 
 public class OutboxIntegrationEventDispatcherTests
 {
-    private const long AmbientTenantId = 999;
     private readonly OutboxIntegrationEventDispatcher _sut = new();
 
     [Fact]
@@ -18,7 +18,7 @@ public class OutboxIntegrationEventDispatcherTests
         aggregate.RaiseIntegrationEvent(formId: 123, name: "Survey");
 
         // Act
-        var messages = _sut.Capture([aggregate], AmbientTenantId);
+        var messages = _sut.Capture([aggregate]);
 
         // Assert
         messages.Should().ContainSingle();
@@ -32,18 +32,18 @@ public class OutboxIntegrationEventDispatcherTests
     }
 
     [Fact]
-    public void Capture_WhenSourceIsNotTenantOwned_UsesAmbientTenantId()
+    public void Capture_WhenSourceIsNotTenantOwned_UsesDefaultTenantId()
     {
-        // Arrange
+        // Arrange — a non-tenant-owned (global) aggregate's event is app-level
         var aggregate = new NonTenantAggregate();
         aggregate.RaiseIntegrationEvent(formId: 1, name: "x");
 
         // Act
-        var messages = _sut.Capture([aggregate], AmbientTenantId);
+        var messages = _sut.Capture([aggregate]);
 
         // Assert
         messages.Should().ContainSingle();
-        messages[0].TenantId.Should().Be(AmbientTenantId);
+        messages[0].TenantId.Should().Be(AuthConstants.DEFAULT_TENANT_ID);
     }
 
     [Fact]
@@ -54,7 +54,7 @@ public class OutboxIntegrationEventDispatcherTests
         aggregate.RaisePlainDomainEvent();
 
         // Act
-        var messages = _sut.Capture([aggregate], AmbientTenantId);
+        var messages = _sut.Capture([aggregate]);
 
         // Assert
         messages.Should().BeEmpty();
@@ -68,7 +68,7 @@ public class OutboxIntegrationEventDispatcherTests
         aggregate.RaiseIntegrationEvent(formId: 1, name: "x");
 
         // Act
-        _sut.Capture([aggregate], AmbientTenantId);
+        _sut.Capture([aggregate]);
 
         // Assert
         aggregate.DomainEvents.Should().BeEmpty("captured events must not be re-processed");
@@ -83,7 +83,7 @@ public class OutboxIntegrationEventDispatcherTests
         aggregate.RaisePlainDomainEvent();
 
         // Act
-        var messages = _sut.Capture([aggregate], AmbientTenantId);
+        var messages = _sut.Capture([aggregate]);
 
         // Assert — only the integration event is captured and removed; the plain one stays in-process
         messages.Should().ContainSingle();
@@ -102,7 +102,7 @@ public class OutboxIntegrationEventDispatcherTests
         second.RaiseIntegrationEvent(formId: 3, name: "c");
 
         // Act
-        var messages = _sut.Capture([first, second], AmbientTenantId);
+        var messages = _sut.Capture([first, second]);
 
         // Assert
         messages.Should().HaveCount(3);

--- a/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxIntegrationEventDispatcherTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxIntegrationEventDispatcherTests.cs
@@ -75,6 +75,23 @@ public class OutboxIntegrationEventDispatcherTests
     }
 
     [Fact]
+    public void Capture_RemovesOnlyTheCapturedIntegrationEvents_AndKeepsPlainDomainEvents()
+    {
+        // Arrange
+        var aggregate = new TestAggregate(tenantId: 42);
+        aggregate.RaiseIntegrationEvent(formId: 1, name: "x");
+        aggregate.RaisePlainDomainEvent();
+
+        // Act
+        var messages = _sut.Capture([aggregate], AmbientTenantId);
+
+        // Assert — only the integration event is captured and removed; the plain one stays in-process
+        messages.Should().ContainSingle();
+        aggregate.DomainEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<PlainDomainEvent>();
+    }
+
+    [Fact]
     public void Capture_WithMultipleEventsAcrossEntities_BuildsOneMessagePerIntegrationEvent()
     {
         // Arrange


### PR DESCRIPTION
## Phase 2 — Activate capture in `ProcessEntities`

Captures `IIntegrationEvent`s raised on aggregates into `OutboxMessage` rows **in the same transaction** as the aggregate write (no dual write). Builds on the Phase 0/1 foundation merged in #779.

> No runtime effect yet — nothing raises an `IIntegrationEvent` until Phase 3 wires the slice events. This PR puts the (tested) machinery in place.

### Changes
- **`BaseEntity : HasDomainEventsBase`** — the real aggregates (`Form`/`Submission`/…) can now raise domain/integration events. `ClearDomainEvents()` made `public` so the capturer can clear after capture.
- **`Ignore<DomainEventBase>()`** in `AppDbContext.OnModelCreating` — EF was auto-discovering `DomainEventBase` as an entity once a mapped type inherited the base; this excludes the `[NotMapped]` `DomainEvents` collection from the model.
- **`OutboxIntegrationEventDispatcher`** — generic capture (`IIntegrationEvent` → `OutboxMessage`): serializes `GetPayload()`, resolves `TenantId` from `ITenantOwned` (else ambient), stamps `OccurredAt`/`SchemaVersion`/`TraceId`, then clears the entity's events. Never switches on concrete event types.
- **`AppDbContext.ProcessEntities`** — runs capture **after** Id/timestamp stamping (so payloads see valid aggregate Ids) and **before** `base.SaveChanges` (atomic); new outbox rows get `Id`/`CreatedAt` stamped explicitly.
- Registered the dispatcher in `InfrastructureDataBuilder`.

### Verification
- ✅ Build green; **no migration** — `has-pending-model-changes` reports no model change for `AppDbContext` and `AppIdentityDbContext` (the domain-events base adds zero columns).
- ✅ **5 unit tests** for the dispatcher (field mapping, tenant resolution, ignoring plain domain events, clearing, multi-event).
- ✅ **2 integration tests** proving the full atomic capture through a real `SaveChanges` on SQLite: one outbox row committed on success; **zero** rows after a failed aggregate write (rolls back together). Adds `Microsoft.EntityFrameworkCore.Sqlite` (test-only).

### Next
Phase 3 — in-process relay → existing webhook path: make the 5 slice events implement `IIntegrationEvent`, raise them via `RegisterDomainEvent`, and deliver from the outbox.

## Related Issues
 Issue: #790

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added outbox-based capture of domain events, ensuring transactional consistency between aggregate writes and event persistence for reliable async processing.

* **Chores**
  * Updated dependencies to include SQLite support for integration testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->