### PR TITLE
fix(e795): Fix error with forms search by removing LINQ side unsupported method

### DIFF
--- a/src/Endatix.Core/Specifications/FormsListFilterSpec.cs
+++ b/src/Endatix.Core/Specifications/FormsListFilterSpec.cs
@@ -24,6 +24,6 @@ public sealed class FormsListFilterSpec : Specification<Form>
         }
 
         var term = search.Trim().ToLowerInvariant();
-        query.Where(form => form.Name.ToLowerInvariant().Contains(term));
+        query.Where(form => form.Name.ToLower().Contains(term));
     }
 }


### PR DESCRIPTION
# fix: Fix error with forms search by removing LINQ side unsupported method

## Description
Removes the not supported `ToLowerInvariant()` method passed to LINQ

## Related Issues
- fixes https://github.com/endatix/endatix/issues/795

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
