### PR TITLE
feat(791): wire Endatix.Outbox.Engine into endatix (Phase 3a)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,6 +12,7 @@
     <PackageVersion Include="Ardalis.Specification.EntityFrameworkCore" Version="9.3.1" />
     <PackageVersion Include="CsvHelper" Version="33.1.0" />
     <PackageVersion Include="Endatix.Api.Host" Version="0.4.2" />
+    <PackageVersion Include="Endatix.Outbox.Engine" Version="1.0.0" />
     <PackageVersion Include="FastEndpoints" Version="7.1.1" />
     <PackageVersion Include="FastEndpoints.Security" Version="7.1.1" />
     <PackageVersion Include="FastEndpoints.Swagger" Version="7.1.1" />
@@ -35,6 +36,8 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="$(AspNetVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="$(EFCoreVersion)" />
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.4.0" />
+    <PackageVersion Include="OpenFeature" Version="2.14.0" />
+    <PackageVersion Include="OpenFeature.Hosting" Version="2.14.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EFCoreVersion)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EFCoreVersion)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EFCoreVersion)" />

--- a/src/Endatix.Core/Features/WebHooks/IWebHookService.cs
+++ b/src/Endatix.Core/Features/WebHooks/IWebHookService.cs
@@ -15,4 +15,19 @@ public interface IWebHookService
     /// <param name="formId">Optional form ID to use form-specific webhook configuration.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     Task EnqueueWebHookAsync<TPayload>(long tenantId, WebHookMessage<TPayload> message, CancellationToken cancellationToken, long? formId = null) where TPayload : notnull;
+
+    /// <summary>
+    /// Delivers a WebHook message <b>synchronously</b> — awaiting the HTTP POST to every matching endpoint —
+    /// and reports whether delivery succeeded. Unlike <see cref="EnqueueWebHookAsync"/> (fire-and-forget via a
+    /// background queue), this lets the caller react to failures. Used by the outbox relay so a row is marked
+    /// <c>Sent</c> only after a real delivery, and retried otherwise (at-least-once).
+    /// </summary>
+    /// <typeparam name="TPayload">The type of the payload carried by the message.</typeparam>
+    /// <param name="tenantId">The tenant ID for which to deliver the webhook.</param>
+    /// <param name="message">The WebHook message to deliver.</param>
+    /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+    /// <param name="formId">Optional form ID to use form-specific webhook configuration.</param>
+    /// <returns><c>true</c> if there was nothing to deliver (no/disabled config or no endpoints) or every
+    /// endpoint accepted the webhook; <c>false</c> if any endpoint failed.</returns>
+    Task<bool> DeliverWebHookAsync<TPayload>(long tenantId, WebHookMessage<TPayload> message, CancellationToken cancellationToken, long? formId = null) where TPayload : notnull;
 }

--- a/src/Endatix.Infrastructure/Builders/InfrastructureDataBuilder.cs
+++ b/src/Endatix.Infrastructure/Builders/InfrastructureDataBuilder.cs
@@ -7,6 +7,7 @@ using Endatix.Core.Abstractions.Submissions;
 using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Infrastructure.Data;
+using Endatix.Infrastructure.Features.Outbox;
 using Endatix.Infrastructure.Exporting;
 using Endatix.Infrastructure.Exporting.Exporters.Dynamic;
 using Endatix.Infrastructure.Exporting.Exporters.Submissions;
@@ -51,6 +52,10 @@ public class InfrastructureDataBuilder
         Services.AddScoped<IUnitOfWork, AppUnitOfWork>();
         Services.AddSingleton<EfCoreValueGeneratorFactory>();
         Services.AddSingleton<Endatix.Infrastructure.Features.Outbox.OutboxIntegrationEventDispatcher>();
+        // In-process outbox relay (engine loop + webhook publisher + OpenFeature gate). Inert until the slice
+        // events are raised (Phase 3b) — the relay ticks but the outbox stays empty. The per-provider claim
+        // store is registered by the active persistence builder's AddDbSpecificRepositories().
+        Services.AddEndatixOutboxRelay();
         Services.AddScoped<EndatixSpecificationEvaluator>();
         Services.AddScoped(typeof(IRepository<>), typeof(EfRepository<>));
         Services.AddScoped<IValueNormalizer, ValueNormalizer>();

--- a/src/Endatix.Infrastructure/Builders/InfrastructureDataBuilder.cs
+++ b/src/Endatix.Infrastructure/Builders/InfrastructureDataBuilder.cs
@@ -7,7 +7,6 @@ using Endatix.Core.Abstractions.Submissions;
 using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Infrastructure.Data;
-using Endatix.Infrastructure.Features.Outbox;
 using Endatix.Infrastructure.Exporting;
 using Endatix.Infrastructure.Exporting.Exporters.Dynamic;
 using Endatix.Infrastructure.Exporting.Exporters.Submissions;
@@ -52,10 +51,9 @@ public class InfrastructureDataBuilder
         Services.AddScoped<IUnitOfWork, AppUnitOfWork>();
         Services.AddSingleton<EfCoreValueGeneratorFactory>();
         Services.AddSingleton<Endatix.Infrastructure.Features.Outbox.OutboxIntegrationEventDispatcher>();
-        // In-process outbox relay (engine loop + webhook publisher + OpenFeature gate). Inert until the slice
-        // events are raised (Phase 3b) — the relay ticks but the outbox stays empty. The per-provider claim
-        // store is registered by the active persistence builder's AddDbSpecificRepositories().
-        Services.AddEndatixOutboxRelay();
+        // NOTE: the in-process outbox relay (AddEndatixOutboxRelay) is registered by the active persistence
+        // builder's AddDbSpecificRepositories(), co-located with its claim store — so the relay exists only
+        // when a DB provider is configured (its hosted service hard-depends on IOutboxClaimStore).
         Services.AddScoped<EndatixSpecificationEvaluator>();
         Services.AddScoped(typeof(IRepository<>), typeof(EfRepository<>));
         Services.AddScoped<IValueNormalizer, ValueNormalizer>();

--- a/src/Endatix.Infrastructure/Data/Config/AppEntities/OutboxMessageConfiguration.cs
+++ b/src/Endatix.Infrastructure/Data/Config/AppEntities/OutboxMessageConfiguration.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Endatix.Core.Entities;
+using Endatix.Outbox.Engine;
 
 namespace Endatix.Infrastructure.Data.Config.AppEntities;
 
@@ -10,43 +11,66 @@ public class OutboxMessageConfiguration : IEntityTypeConfiguration<OutboxMessage
     private const int EVENT_TYPE_MAX_LENGTH = 128;
     private const int IDENTIFIER_MAX_LENGTH = 128;
 
+    // Column names + table are pinned to the engine's canonical OutboxSchema so the relay's raw SQL and this
+    // EF mapping share one source of truth (a rename is a single compile-time edit on both sides). The names
+    // already equal the property names, so this is conformance hardening — no migration. Guarded by the
+    // OutboxSchema conformance test.
     public void Configure(EntityTypeBuilder<OutboxMessage> builder)
     {
-        builder.ToTable("OutboxMessages");
+        builder.ToTable(OutboxSchema.DefaultTable);
 
         builder.Property(o => o.Id)
+            .HasColumnName(OutboxSchema.Id)
             .IsRequired();
 
         builder.Property(o => o.EventType)
+            .HasColumnName(OutboxSchema.EventType)
             .HasMaxLength(EVENT_TYPE_MAX_LENGTH)
             .IsRequired();
 
         builder.Property(o => o.Payload)
+            .HasColumnName(OutboxSchema.Payload)
             .IsRequired();
 
         builder.Property(o => o.TenantId)
+            .HasColumnName(OutboxSchema.TenantId)
             .IsRequired();
 
         builder.Property(o => o.OccurredAt)
+            .HasColumnName(OutboxSchema.OccurredAt)
             .IsRequired();
 
         builder.Property(o => o.SchemaVersion)
+            .HasColumnName(OutboxSchema.SchemaVersion)
             .IsRequired();
 
         builder.Property(o => o.Status)
+            .HasColumnName(OutboxSchema.Status)
             .HasConversion<int>()
             .IsRequired();
 
         builder.Property(o => o.Attempts)
+            .HasColumnName(OutboxSchema.Attempts)
             .IsRequired();
 
         builder.Property(o => o.TraceId)
+            .HasColumnName(OutboxSchema.TraceId)
             .HasMaxLength(IDENTIFIER_MAX_LENGTH)
             .IsRequired(false);
 
+        builder.Property(o => o.LockedUntil)
+            .HasColumnName(OutboxSchema.LockedUntil);
+
         builder.Property(o => o.LockedBy)
+            .HasColumnName(OutboxSchema.LockedBy)
             .HasMaxLength(IDENTIFIER_MAX_LENGTH)
             .IsRequired(false);
+
+        builder.Property(o => o.NextAttemptAt)
+            .HasColumnName(OutboxSchema.NextAttemptAt);
+
+        builder.Property(o => o.ProcessedAt)
+            .HasColumnName(OutboxSchema.ProcessedAt);
 
         // The relay claim index and the Payload json/jsonb column type are provider-specific —
         // see OutboxMessageConfigurationPostgreSql / OutboxMessageConfigurationSqlServer.

--- a/src/Endatix.Infrastructure/Endatix.Infrastructure.csproj
+++ b/src/Endatix.Infrastructure/Endatix.Infrastructure.csproj
@@ -31,6 +31,9 @@
 		<PackageReference Include="SendGrid" />
 		<PackageReference Include="SendGrid.Extensions.DependencyInjection" />
 		<PackageReference Include="MediatR" />
+		<PackageReference Include="Endatix.Outbox.Engine" />
+		<PackageReference Include="OpenFeature" />
+		<PackageReference Include="OpenFeature.Hosting" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="../Endatix.Core/Endatix.Core.csproj" />

--- a/src/Endatix.Infrastructure/Features/Outbox/OutboxIntegrationEventDispatcher.cs
+++ b/src/Endatix.Infrastructure/Features/Outbox/OutboxIntegrationEventDispatcher.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Endatix.Core.Abstractions;
 using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Domain;
+using Endatix.Framework.Serialization;
 using Endatix.Infrastructure.Identity.Authentication;
 
 namespace Endatix.Infrastructure.Features.Outbox;
@@ -20,7 +21,12 @@ namespace Endatix.Infrastructure.Features.Outbox;
 public sealed class OutboxIntegrationEventDispatcher
 {
     // Web defaults (camelCase) — payloads are opaque JSON to the relay; consumers own their shape.
-    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+    // LongToStringConverter keeps long IDs as strings on the wire, byte-compatible with the existing
+    // webhook payloads (WebHookServer applies the same converter today).
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new LongToStringConverter() }
+    };
 
     /// <summary>
     /// Builds an <see cref="OutboxMessage"/> for every <see cref="IIntegrationEvent"/> on the given

--- a/src/Endatix.Infrastructure/Features/Outbox/OutboxRelayServiceCollectionExtensions.cs
+++ b/src/Endatix.Infrastructure/Features/Outbox/OutboxRelayServiceCollectionExtensions.cs
@@ -1,0 +1,61 @@
+using Endatix.Outbox.Engine;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenFeature;
+using OpenFeature.Hosting.Providers.Memory;
+using OpenFeature.Providers.Memory;
+
+namespace Endatix.Infrastructure.Features.Outbox;
+
+/// <summary>
+/// Endatix-side wiring for the <c>Endatix.Outbox.Engine</c> relay (Stage 1: in-process, webhook delivery, no
+/// DAPR). Registers the engine relay loop, binds <see cref="OutboxOptions"/> from <c>Endatix:Outbox</c>, the
+/// webhook publisher, and the OpenFeature gate provider. The per-provider claim store
+/// (<c>AddSqlOutboxClaimStore</c>) is registered by the active persistence builder, because the dialect and
+/// connection type are provider-specific.
+/// </summary>
+public static class OutboxRelayServiceCollectionExtensions
+{
+    /// <summary>
+    /// Registers the in-process outbox relay: the engine loop + gate, <see cref="OutboxOptions"/> bound from
+    /// the <c>Endatix:Outbox</c> config section, the <see cref="WebHookIntegrationEventPublisher"/>, and the
+    /// OpenFeature provider seeding the <c>outbox-relay-in-process</c> flag.
+    /// </summary>
+    public static IServiceCollection AddEndatixOutboxRelay(this IServiceCollection services)
+    {
+        services.AddOutboxRelay();
+        services.AddOptions<OutboxOptions>().BindConfiguration("Endatix:Outbox");
+        services.AddScoped<IIntegrationEventPublisher, WebHookIntegrationEventPublisher>();
+        services.AddEndatixOpenFeature();
+
+        return services;
+    }
+
+    /// <summary>
+    /// Registers an OpenFeature in-memory provider that seeds <see cref="OutboxFlags.RelayInProcess"/> from
+    /// <c>Endatix:Outbox:RunInProcess</c> (default <c>true</c>). Coexists with the existing
+    /// <c>Microsoft.FeatureManagement</c> setup; OpenFeature is the go-forward switch for the relay. Swapping
+    /// to flagd or a SaaS provider later is a provider-registration change only.
+    /// </summary>
+    public static IServiceCollection AddEndatixOpenFeature(this IServiceCollection services)
+    {
+        services.AddOpenFeature((OpenFeature.Hosting.OpenFeatureBuilder builder) =>
+        {
+            builder.AddHostedFeatureLifecycle();
+            builder.AddInMemoryProvider(serviceProvider =>
+            {
+                var runInProcess = serviceProvider.GetService<IConfiguration>()?
+                    .GetValue("Endatix:Outbox:RunInProcess", true) ?? true;
+
+                return new Dictionary<string, Flag>
+                {
+                    [OutboxFlags.RelayInProcess] = new Flag<bool>(
+                        new Dictionary<string, bool> { ["on"] = true, ["off"] = false },
+                        runInProcess ? "on" : "off"),
+                };
+            });
+        });
+
+        return services;
+    }
+}

--- a/src/Endatix.Infrastructure/Features/Outbox/WebHookIntegrationEventPublisher.cs
+++ b/src/Endatix.Infrastructure/Features/Outbox/WebHookIntegrationEventPublisher.cs
@@ -62,9 +62,16 @@ public sealed class WebHookIntegrationEventPublisher(
         using var document = JsonDocument.Parse(message.Payload);
         var payload = document.RootElement.Clone();
 
+        // All five mapped operations are form-scoped — they need a formId for the per-form webhook config
+        // lookup. A missing/unparsable formId is a malformed payload: throw so the relay retries (and
+        // dead-letters at MaxAttempts) instead of silently delivering at tenant scope.
+        var formId = TryGetFormId(payload)
+            ?? throw new InvalidOperationException(
+                $"Outbox message {message.Id} ({message.EventType}) is missing a valid formId.");
+
         var webHookMessage = new WebHookMessage<JsonElement>(message.Id, operation, payload);
         var delivered = await webHookService.DeliverWebHookAsync(
-            message.TenantId, webHookMessage, cancellationToken, TryGetFormId(payload));
+            message.TenantId, webHookMessage, cancellationToken, formId);
 
         if (!delivered)
         {

--- a/src/Endatix.Infrastructure/Features/Outbox/WebHookIntegrationEventPublisher.cs
+++ b/src/Endatix.Infrastructure/Features/Outbox/WebHookIntegrationEventPublisher.cs
@@ -12,6 +12,11 @@ namespace Endatix.Infrastructure.Features.Outbox;
 /// payload verbatim, and reuses the outbox <c>Id</c> as the webhook id so the <c>X-Endatix-Hook-Id</c> dedup
 /// header is stable across relay retries.
 /// </summary>
+/// <remarks>
+/// Delivery is <b>synchronous</b> (<see cref="IWebHookService.DeliverWebHookAsync"/>): on any endpoint failure
+/// this throws, so the engine relay reschedules/dead-letters the row and only marks it <c>Sent</c> after a real
+/// delivery — at-least-once, with duplicates absorbed by the hook-id dedup header.
+/// </remarks>
 public sealed class WebHookIntegrationEventPublisher(
     IWebHookService webHookService,
     ILogger<WebHookIntegrationEventPublisher> logger) : IIntegrationEventPublisher
@@ -58,8 +63,16 @@ public sealed class WebHookIntegrationEventPublisher(
         var payload = document.RootElement.Clone();
 
         var webHookMessage = new WebHookMessage<JsonElement>(message.Id, operation, payload);
-        await webHookService.EnqueueWebHookAsync(
+        var delivered = await webHookService.DeliverWebHookAsync(
             message.TenantId, webHookMessage, cancellationToken, TryGetFormId(payload));
+
+        if (!delivered)
+        {
+            // Throw so the relay treats this as a publish failure → reschedule (or dead-letter at MaxAttempts).
+            // Re-delivery to already-succeeded endpoints is absorbed by the X-Endatix-Hook-Id dedup header.
+            throw new InvalidOperationException(
+                $"Webhook delivery failed for outbox message {message.Id} ({message.EventType}); it will be retried.");
+        }
     }
 
     // formId drives the per-form webhook config lookup. IDs are stored as strings on the wire

--- a/src/Endatix.Infrastructure/Features/Outbox/WebHookIntegrationEventPublisher.cs
+++ b/src/Endatix.Infrastructure/Features/Outbox/WebHookIntegrationEventPublisher.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using Endatix.Core.Features.WebHooks;
+using Endatix.Outbox.Engine;
+using Microsoft.Extensions.Logging;
+
+namespace Endatix.Infrastructure.Features.Outbox;
+
+/// <summary>
+/// Stage-1 (in-process, no DAPR) <see cref="IIntegrationEventPublisher"/>: turns a claimed outbox row back
+/// into the existing webhook delivery path (<see cref="IWebHookService"/> → <c>WebHookServer</c>). It maps the
+/// stored dotted <c>EventType</c> to the matching <see cref="WebHookOperation"/>, forwards the stored JSON
+/// payload verbatim, and reuses the outbox <c>Id</c> as the webhook id so the <c>X-Endatix-Hook-Id</c> dedup
+/// header is stable across relay retries.
+/// </summary>
+public sealed class WebHookIntegrationEventPublisher(
+    IWebHookService webHookService,
+    ILogger<WebHookIntegrationEventPublisher> logger) : IIntegrationEventPublisher
+{
+    // Dotted contract EventType → existing WebHookOperation (whose EventName keeps the underscore form the
+    // per-form webhook config lookup expects). These 5 are the Phase-3 slice events.
+    private static readonly IReadOnlyDictionary<string, WebHookOperation> OperationsByEventType =
+        new Dictionary<string, WebHookOperation>(StringComparer.Ordinal)
+        {
+            ["form.created"] = WebHookOperation.FormCreated,
+            ["form.updated"] = WebHookOperation.FormUpdated,
+            ["form.enabled_state_changed"] = WebHookOperation.FormEnabledStateChanged,
+            ["submission.completed"] = WebHookOperation.SubmissionCompleted,
+            ["form.deleted"] = WebHookOperation.FormDeleted,
+        };
+
+    /// <inheritdoc />
+    public async Task PublishAsync(IOutboxMessage message, CancellationToken cancellationToken)
+    {
+        if (!OperationsByEventType.TryGetValue(message.EventType, out var operation))
+        {
+            // Unmapped type: nothing to deliver. Return so the relay marks it Sent (no retry storm).
+            logger.LogWarning(
+                "Outbox message {MessageId} has no webhook mapping for event type '{EventType}'; skipping delivery.",
+                message.Id, message.EventType);
+            return;
+        }
+
+        // Parse to a self-contained JsonElement (the clone survives the JsonDocument being disposed, so it
+        // stays valid on the background webhook queue). WebHookServer re-serializes it verbatim.
+        using var document = JsonDocument.Parse(message.Payload);
+        var payload = document.RootElement.Clone();
+
+        var webHookMessage = new WebHookMessage<JsonElement>(message.Id, operation, payload);
+        await webHookService.EnqueueWebHookAsync(
+            message.TenantId, webHookMessage, cancellationToken, TryGetFormId(payload));
+    }
+
+    // formId drives the per-form webhook config lookup. IDs are stored as strings on the wire
+    // (LongToStringConverter), but tolerate a numeric encoding too.
+    private static long? TryGetFormId(JsonElement payload)
+    {
+        if (payload.ValueKind != JsonValueKind.Object ||
+            !payload.TryGetProperty("formId", out var formId))
+        {
+            return null;
+        }
+
+        return formId.ValueKind switch
+        {
+            JsonValueKind.String when long.TryParse(formId.GetString(), out var id) => id,
+            JsonValueKind.Number when formId.TryGetInt64(out var id) => id,
+            _ => null,
+        };
+    }
+}

--- a/src/Endatix.Infrastructure/Features/Outbox/WebHookIntegrationEventPublisher.cs
+++ b/src/Endatix.Infrastructure/Features/Outbox/WebHookIntegrationEventPublisher.cs
@@ -16,17 +16,29 @@ public sealed class WebHookIntegrationEventPublisher(
     IWebHookService webHookService,
     ILogger<WebHookIntegrationEventPublisher> logger) : IIntegrationEventPublisher
 {
-    // Dotted contract EventType → existing WebHookOperation (whose EventName keeps the underscore form the
-    // per-form webhook config lookup expects). These 5 are the Phase-3 slice events.
+    // The webhook operations the relay delivers, keyed by their dotted contract EventType. The key is
+    // derived from a single source (WebHookOperation.EventName) rather than re-declaring the dotted literals,
+    // so a mistyped literal can't silently route to the "unmapped → skip" branch.
     private static readonly IReadOnlyDictionary<string, WebHookOperation> OperationsByEventType =
-        new Dictionary<string, WebHookOperation>(StringComparer.Ordinal)
+        new[]
         {
-            ["form.created"] = WebHookOperation.FormCreated,
-            ["form.updated"] = WebHookOperation.FormUpdated,
-            ["form.enabled_state_changed"] = WebHookOperation.FormEnabledStateChanged,
-            ["submission.completed"] = WebHookOperation.SubmissionCompleted,
-            ["form.deleted"] = WebHookOperation.FormDeleted,
-        };
+            WebHookOperation.FormCreated,
+            WebHookOperation.FormUpdated,
+            WebHookOperation.FormEnabledStateChanged,
+            WebHookOperation.SubmissionCompleted,
+            WebHookOperation.FormDeleted,
+        }.ToDictionary(operation => ToContractEventType(operation.EventName), StringComparer.Ordinal);
+
+    // Contract EventType = the operation's EventName with the entity/action separator (the FIRST underscore)
+    // as a dot, leaving any further underscores in the action intact:
+    // "form_created" → "form.created"; "form_enabled_state_changed" → "form.enabled_state_changed".
+    private static string ToContractEventType(string eventName)
+    {
+        var separator = eventName.IndexOf('_');
+        return separator < 0
+            ? eventName
+            : string.Concat(eventName.AsSpan(0, separator), ".", eventName.AsSpan(separator + 1));
+    }
 
     /// <inheritdoc />
     public async Task PublishAsync(IOutboxMessage message, CancellationToken cancellationToken)

--- a/src/Endatix.Infrastructure/Features/WebHooks/BackgroundTaskWebHookService.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/BackgroundTaskWebHookService.cs
@@ -58,14 +58,14 @@ public class BackgroundTaskWebHookService(
         var eventConfig = await GetEventConfigAsync(tenantId, message.operation.EventName, formId, cancellationToken);
         if (eventConfig == null || !eventConfig.IsEnabled)
         {
-            logger.LogTrace("WebHook for {eventName} event is disabled or not configured. Nothing to deliver.", message.operation.EventName);
+            logger.LogTrace("WebHook for {EventName} event is disabled or not configured. Nothing to deliver.", message.operation.EventName);
             return true;
         }
 
         var endpoints = eventConfig.WebHookEndpoints;
         if (endpoints == null || !endpoints.Any())
         {
-            logger.LogTrace("No webhook endpoints found for {eventName} event. Nothing to deliver.", message.operation.EventName);
+            logger.LogTrace("No webhook endpoints found for {EventName} event. Nothing to deliver.", message.operation.EventName);
             return true;
         }
 
@@ -80,7 +80,7 @@ public class BackgroundTaskWebHookService(
             if (!delivered)
             {
                 allDelivered = false;
-                logger.LogWarning("WebHook delivery to {uri} failed for {eventName} event (hook id {id}).", instructions.Uri, message.operation.EventName, message.id);
+                logger.LogWarning("WebHook delivery to {Uri} failed for {EventName} event (hook id {Id}).", instructions.Uri, message.operation.EventName, message.id);
             }
         }
 

--- a/src/Endatix.Infrastructure/Features/WebHooks/BackgroundTaskWebHookService.cs
+++ b/src/Endatix.Infrastructure/Features/WebHooks/BackgroundTaskWebHookService.cs
@@ -52,6 +52,41 @@ public class BackgroundTaskWebHookService(
         }
     }
 
+    /// <inheritdoc />
+    public async Task<bool> DeliverWebHookAsync<TPayload>(long tenantId, WebHookMessage<TPayload> message, CancellationToken cancellationToken, long? formId = null) where TPayload : notnull
+    {
+        var eventConfig = await GetEventConfigAsync(tenantId, message.operation.EventName, formId, cancellationToken);
+        if (eventConfig == null || !eventConfig.IsEnabled)
+        {
+            logger.LogTrace("WebHook for {eventName} event is disabled or not configured. Nothing to deliver.", message.operation.EventName);
+            return true;
+        }
+
+        var endpoints = eventConfig.WebHookEndpoints;
+        if (endpoints == null || !endpoints.Any())
+        {
+            logger.LogTrace("No webhook endpoints found for {eventName} event. Nothing to deliver.", message.operation.EventName);
+            return true;
+        }
+
+        // Deliver to every endpoint and AWAIT each result (no background queue). All-or-nothing: if any
+        // endpoint fails, report failure so the caller (the outbox relay) retries the whole row — duplicate
+        // deliveries to already-succeeded endpoints are absorbed by the X-Endatix-Hook-Id dedup header.
+        var allDelivered = true;
+        foreach (var endpoint in endpoints)
+        {
+            var instructions = TaskInstructions.FromWebHookEndpointConfig(endpoint);
+            var delivered = await httpServer.FireWebHookAsync(message, instructions, cancellationToken);
+            if (!delivered)
+            {
+                allDelivered = false;
+                logger.LogWarning("WebHook delivery to {uri} failed for {eventName} event (hook id {id}).", instructions.Uri, message.operation.EventName, message.id);
+            }
+        }
+
+        return allDelivered;
+    }
+
     /// <summary>
     /// Retrieves the webhook event configuration from the database.
     /// Form-specific configuration takes precedence over tenant-level configuration.

--- a/src/Endatix.Persistence.PostgreSql/Builders/PostgreSqlPersistenceBuilder.cs
+++ b/src/Endatix.Persistence.PostgreSql/Builders/PostgreSqlPersistenceBuilder.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Ardalis.Specification;
 using Endatix.Core.Abstractions.Repositories;
 using Endatix.Infrastructure.Data.Querying;
+using Endatix.Outbox.Engine;
 using Endatix.Persistence.PostgreSql.Options;
 using Endatix.Persistence.PostgreSql.Querying;
 using Endatix.Persistence.PostgreSql.Repositories;
@@ -9,6 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Npgsql;
 
 namespace Endatix.Persistence.PostgreSql.Builders;
 
@@ -116,6 +118,14 @@ public class PostgreSqlPersistenceBuilder
         Services.AddScoped<IEvaluator, SubmitterProfileFilterEvaluator>();
         Services.AddScoped<ISubmissionExportRepository, SubmissionExportRepository>();
         Services.AddScoped<IStorageStatsRepository, StorageStatsRepository>();
+
+        // The engine's raw-ADO.NET outbox claim store. Builds an unopened connection from the SAME
+        // DefaultConnection string the DbContext uses, so the relay shares the Npgsql provider pool.
+        Services.AddSqlOutboxClaimStore(
+            OutboxSqlDialect.PostgreSql,
+            sp => new NpgsqlConnection(sp.GetRequiredService<IConfiguration>().GetConnectionString("DefaultConnection")),
+            OutboxSchema.DefaultTable);
+
         return this;
     }
 

--- a/src/Endatix.Persistence.PostgreSql/Builders/PostgreSqlPersistenceBuilder.cs
+++ b/src/Endatix.Persistence.PostgreSql/Builders/PostgreSqlPersistenceBuilder.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Ardalis.Specification;
 using Endatix.Core.Abstractions.Repositories;
 using Endatix.Infrastructure.Data.Querying;
+using Endatix.Infrastructure.Features.Outbox;
 using Endatix.Outbox.Engine;
 using Endatix.Persistence.PostgreSql.Options;
 using Endatix.Persistence.PostgreSql.Querying;
@@ -125,6 +126,11 @@ public class PostgreSqlPersistenceBuilder
             OutboxSqlDialect.PostgreSql,
             sp => new NpgsqlConnection(sp.GetRequiredService<IConfiguration>().GetConnectionString("DefaultConnection")),
             OutboxSchema.DefaultTable);
+
+        // Register the in-process relay here (not in Infrastructure) so it is co-located with the claim store
+        // it hard-depends on — the relay exists iff a DB provider is configured. Inert until Phase 3b raises
+        // the slice events (the loop ticks but the outbox stays empty).
+        Services.AddEndatixOutboxRelay();
 
         return this;
     }

--- a/src/Endatix.Persistence.PostgreSql/Builders/PostgreSqlPersistenceBuilder.cs
+++ b/src/Endatix.Persistence.PostgreSql/Builders/PostgreSqlPersistenceBuilder.cs
@@ -22,6 +22,12 @@ public class PostgreSqlPersistenceBuilder
 {
     private readonly ILogger? _logger;
 
+    // Resolves the connection string the active DbContext uses, so the outbox claim store polls the SAME
+    // database the app writes outbox rows to. Defaults to ConnectionStrings:DefaultConnection (the
+    // UseDefault path); Configure&lt;TContext&gt; overrides it with the supplied PostgreSqlOptions.ConnectionString.
+    private Func<IServiceProvider, string?> _connectionStringResolver =
+        sp => sp.GetService<IConfiguration>()?.GetConnectionString("DefaultConnection");
+
     /// <summary>
     /// Initializes a new instance of the PostgreSqlPersistenceBuilder class.
     /// </summary>
@@ -82,6 +88,9 @@ public class PostgreSqlPersistenceBuilder
         var postgresOptions = new PostgreSqlOptions();
         options(postgresOptions);
 
+        // Point the outbox claim store at the same connection string this DbContext uses (not DefaultConnection).
+        _connectionStringResolver = _ => postgresOptions.ConnectionString;
+
         Services.AddDbContext<TContext>((serviceProvider, dbContextOptions) =>
         {
             dbContextOptions.UseNpgsql(postgresOptions.ConnectionString, npgsqlOptions =>
@@ -121,10 +130,12 @@ public class PostgreSqlPersistenceBuilder
         Services.AddScoped<IStorageStatsRepository, StorageStatsRepository>();
 
         // The engine's raw-ADO.NET outbox claim store. Builds an unopened connection from the SAME
-        // DefaultConnection string the DbContext uses, so the relay shares the Npgsql provider pool.
+        // connection string the DbContext uses (DefaultConnection by default, or the Configure<TContext>
+        // override), so the relay polls the right database and shares the Npgsql provider pool.
+        var connectionStringResolver = _connectionStringResolver;
         Services.AddSqlOutboxClaimStore(
             OutboxSqlDialect.PostgreSql,
-            sp => new NpgsqlConnection(sp.GetRequiredService<IConfiguration>().GetConnectionString("DefaultConnection")),
+            sp => new NpgsqlConnection(connectionStringResolver(sp)),
             OutboxSchema.DefaultTable);
 
         // Register the in-process relay here (not in Infrastructure) so it is co-located with the claim store

--- a/src/Endatix.Persistence.PostgreSql/Endatix.Persistence.PostgreSql.csproj
+++ b/src/Endatix.Persistence.PostgreSql/Endatix.Persistence.PostgreSql.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Endatix.Outbox.Engine" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Endatix.Persistence.SqlServer/Builders/SqlServerPersistenceBuilder.cs
+++ b/src/Endatix.Persistence.SqlServer/Builders/SqlServerPersistenceBuilder.cs
@@ -22,6 +22,12 @@ public class SqlServerPersistenceBuilder
 {
     private readonly ILogger? _logger;
 
+    // Resolves the connection string the active DbContext uses, so the outbox claim store polls the SAME
+    // database the app writes outbox rows to. Defaults to ConnectionStrings:DefaultConnection (the
+    // UseDefault path); Configure&lt;TContext&gt; overrides it with the supplied SqlServerOptions.ConnectionString.
+    private Func<IServiceProvider, string?> _connectionStringResolver =
+        sp => sp.GetService<IConfiguration>()?.GetConnectionString("DefaultConnection");
+
     /// <summary>
     /// Initializes a new instance of the SqlServerPersistenceBuilder class.
     /// </summary>
@@ -79,6 +85,9 @@ public class SqlServerPersistenceBuilder
         var sqlServerOptions = new SqlServerOptions();
         options(sqlServerOptions);
 
+        // Point the outbox claim store at the same connection string this DbContext uses (not DefaultConnection).
+        _connectionStringResolver = _ => sqlServerOptions.ConnectionString;
+
         Services.AddDbContext<TContext>((serviceProvider, dbContextOptions) =>
         {
             dbContextOptions.UseSqlServer(sqlServerOptions.ConnectionString, sqlOptions =>
@@ -120,10 +129,12 @@ public class SqlServerPersistenceBuilder
         Services.AddScoped<IStorageStatsRepository, StorageStatsRepository>();
 
         // The engine's raw-ADO.NET outbox claim store. Builds an unopened connection from the SAME
-        // DefaultConnection string the DbContext uses, so the relay shares the SqlClient provider pool.
+        // connection string the DbContext uses (DefaultConnection by default, or the Configure<TContext>
+        // override), so the relay polls the right database and shares the SqlClient provider pool.
+        var connectionStringResolver = _connectionStringResolver;
         Services.AddSqlOutboxClaimStore(
             OutboxSqlDialect.SqlServer,
-            sp => new SqlConnection(sp.GetRequiredService<IConfiguration>().GetConnectionString("DefaultConnection")),
+            sp => new SqlConnection(connectionStringResolver(sp)),
             OutboxSchema.DefaultTable);
 
         // Register the in-process relay here (not in Infrastructure) so it is co-located with the claim store

--- a/src/Endatix.Persistence.SqlServer/Builders/SqlServerPersistenceBuilder.cs
+++ b/src/Endatix.Persistence.SqlServer/Builders/SqlServerPersistenceBuilder.cs
@@ -2,6 +2,7 @@ using System.Reflection;
 using Ardalis.Specification;
 using Endatix.Core.Abstractions.Repositories;
 using Endatix.Infrastructure.Data.Querying;
+using Endatix.Infrastructure.Features.Outbox;
 using Endatix.Outbox.Engine;
 using Endatix.Persistence.SqlServer.Options;
 using Endatix.Persistence.SqlServer.Querying;
@@ -124,6 +125,11 @@ public class SqlServerPersistenceBuilder
             OutboxSqlDialect.SqlServer,
             sp => new SqlConnection(sp.GetRequiredService<IConfiguration>().GetConnectionString("DefaultConnection")),
             OutboxSchema.DefaultTable);
+
+        // Register the in-process relay here (not in Infrastructure) so it is co-located with the claim store
+        // it hard-depends on — the relay exists iff a DB provider is configured. Inert until Phase 3b raises
+        // the slice events (the loop ticks but the outbox stays empty).
+        Services.AddEndatixOutboxRelay();
 
         return this;
     }

--- a/src/Endatix.Persistence.SqlServer/Builders/SqlServerPersistenceBuilder.cs
+++ b/src/Endatix.Persistence.SqlServer/Builders/SqlServerPersistenceBuilder.cs
@@ -2,9 +2,11 @@ using System.Reflection;
 using Ardalis.Specification;
 using Endatix.Core.Abstractions.Repositories;
 using Endatix.Infrastructure.Data.Querying;
+using Endatix.Outbox.Engine;
 using Endatix.Persistence.SqlServer.Options;
 using Endatix.Persistence.SqlServer.Querying;
 using Endatix.Persistence.SqlServer.Repositories;
+using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -115,6 +117,14 @@ public class SqlServerPersistenceBuilder
         Services.AddScoped<IEvaluator, SubmitterProfileFilterEvaluator>();
         Services.AddScoped<ISubmissionExportRepository, SubmissionExportRepository>();
         Services.AddScoped<IStorageStatsRepository, StorageStatsRepository>();
+
+        // The engine's raw-ADO.NET outbox claim store. Builds an unopened connection from the SAME
+        // DefaultConnection string the DbContext uses, so the relay shares the SqlClient provider pool.
+        Services.AddSqlOutboxClaimStore(
+            OutboxSqlDialect.SqlServer,
+            sp => new SqlConnection(sp.GetRequiredService<IConfiguration>().GetConnectionString("DefaultConnection")),
+            OutboxSchema.DefaultTable);
+
         return this;
     }
 

--- a/src/Endatix.Persistence.SqlServer/Endatix.Persistence.SqlServer.csproj
+++ b/src/Endatix.Persistence.SqlServer/Endatix.Persistence.SqlServer.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Endatix.Outbox.Engine" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Endatix.WebHost/appsettings.json
+++ b/src/Endatix.WebHost/appsettings.json
@@ -125,6 +125,15 @@
     "FeatureFlags": {
       "ExperimentalFeatures": "false"
     },
+    "Outbox": {
+      "RunInProcess": true,
+      "PollIntervalSeconds": 5,
+      "BatchSize": 50,
+      "LeaseSeconds": 60,
+      "MaxAttempts": 8,
+      "BackoffBaseSeconds": 5,
+      "BackoffCapSeconds": 300
+    },
     "Integrations": {
       "Email": {
         "SendGridSettings": {

--- a/src/Endatix.WebHost/appsettings.json
+++ b/src/Endatix.WebHost/appsettings.json
@@ -126,7 +126,7 @@
       "ExperimentalFeatures": "false"
     },
     "Outbox": {
-      "RunInProcess": true,
+      "RunInProcess": false,
       "PollIntervalSeconds": 5,
       "BatchSize": 50,
       "LeaseSeconds": 60,

--- a/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxCaptureIntegrationTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxCaptureIntegrationTests.cs
@@ -65,7 +65,8 @@ public sealed class OutboxCaptureIntegrationTests : IDisposable
         outbox[0].Id.Should().BeGreaterThan(0, "ProcessEntities stamps the outbox row's Id explicitly");
 
         using var payload = JsonDocument.Parse(outbox[0].Payload);
-        payload.RootElement.GetProperty("formId").GetInt64().Should().Be(555);
+        // Long IDs are serialized as strings on the wire (LongToStringConverter).
+        payload.RootElement.GetProperty("formId").GetString().Should().Be("555");
     }
 
     [Fact]

--- a/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxIntegrationEventDispatcherTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxIntegrationEventDispatcherTests.cs
@@ -28,7 +28,8 @@ public class OutboxIntegrationEventDispatcherTests
         message.TenantId.Should().Be(42, "a tenant-owned aggregate supplies the authoritative tenant");
         message.Status.Should().Be(OutboxMessageStatus.Pending);
         message.Attempts.Should().Be(0);
-        message.Payload.Should().Contain("\"formId\":123").And.Contain("\"name\":\"Survey\"");
+        // Long IDs are serialized as strings on the wire (LongToStringConverter), byte-compatible with webhooks.
+        message.Payload.Should().Contain("\"formId\":\"123\"").And.Contain("\"name\":\"Survey\"");
     }
 
     [Fact]

--- a/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxSchemaConformanceTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxSchemaConformanceTests.cs
@@ -1,0 +1,76 @@
+using Endatix.Core.Abstractions;
+using Endatix.Core.Entities;
+using Endatix.Infrastructure.Data;
+using Endatix.Infrastructure.Features.Outbox;
+using Endatix.Infrastructure.Identity.Authentication;
+using Endatix.Outbox.Engine;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using NSubstitute;
+
+namespace Endatix.Infrastructure.Tests.Features.Outbox;
+
+/// <summary>
+/// Guards engine↔host agreement: the EF mapping of <see cref="OutboxMessage"/> must conform to the engine's
+/// canonical <see cref="OutboxSchema"/> (table + column names) and <see cref="OutboxStatus"/> (int values),
+/// because the relay's raw SQL is built from those constants. A drift here would only surface at runtime
+/// against a real DB; this test catches it at build/test time.
+/// </summary>
+public sealed class OutboxSchemaConformanceTests : IDisposable
+{
+    private readonly AppDbContext _context;
+
+    public OutboxSchemaConformanceTests()
+    {
+        var idGenerator = Substitute.For<IIdGenerator<long>>();
+        var tenantContext = Substitute.For<ITenantContext>();
+        var options = new DbContextOptionsBuilder<AppDbContext>()
+            .UseSqlite("DataSource=:memory:")
+            .Options;
+
+        _context = new AppDbContext(
+            options,
+            idGenerator,
+            tenantContext,
+            new EfCoreValueGeneratorFactory(idGenerator),
+            new OutboxIntegrationEventDispatcher());
+    }
+
+    public void Dispose() => _context.Dispose();
+
+    [Fact]
+    public void OutboxMessage_maps_to_the_canonical_table_and_columns()
+    {
+        var entityType = _context.Model.FindEntityType(typeof(OutboxMessage))!;
+        entityType.GetTableName().Should().Be(OutboxSchema.DefaultTable);
+
+        var store = StoreObjectIdentifier.Create(entityType, StoreObjectType.Table)!.Value;
+        var columns = entityType.GetProperties().Select(p => p.GetColumnName(store)!).ToHashSet();
+
+        columns.Should().Contain(new[]
+        {
+            OutboxSchema.Id, OutboxSchema.EventType, OutboxSchema.Payload, OutboxSchema.TenantId,
+            OutboxSchema.OccurredAt, OutboxSchema.SchemaVersion, OutboxSchema.Status, OutboxSchema.Attempts,
+            OutboxSchema.TraceId, OutboxSchema.LockedUntil, OutboxSchema.LockedBy, OutboxSchema.NextAttemptAt,
+            OutboxSchema.ProcessedAt,
+        });
+    }
+
+    [Fact]
+    public void Status_is_stored_as_int()
+    {
+        var entityType = _context.Model.FindEntityType(typeof(OutboxMessage))!;
+        var status = entityType.FindProperty(nameof(OutboxMessage.Status))!;
+
+        status.GetProviderClrType().Should().Be(typeof(int));
+    }
+
+    [Fact]
+    public void OutboxMessageStatus_values_match_the_engine_OutboxStatus()
+    {
+        ((int)OutboxMessageStatus.Pending).Should().Be((int)OutboxStatus.Pending);
+        ((int)OutboxMessageStatus.Sent).Should().Be((int)OutboxStatus.Sent);
+        ((int)OutboxMessageStatus.Failed).Should().Be((int)OutboxStatus.Failed);
+    }
+}

--- a/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxSchemaConformanceTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxSchemaConformanceTests.cs
@@ -42,12 +42,15 @@ public sealed class OutboxSchemaConformanceTests : IDisposable
     [Fact]
     public void OutboxMessage_maps_to_the_canonical_table_and_columns()
     {
+        // Arrange
         var entityType = _context.Model.FindEntityType(typeof(OutboxMessage))!;
-        entityType.GetTableName().Should().Be(OutboxSchema.DefaultTable);
 
+        // Act
         var store = StoreObjectIdentifier.Create(entityType, StoreObjectType.Table)!.Value;
         var columns = entityType.GetProperties().Select(p => p.GetColumnName(store)!).ToHashSet();
 
+        // Assert
+        entityType.GetTableName().Should().Be(OutboxSchema.DefaultTable);
         columns.Should().Contain(new[]
         {
             OutboxSchema.Id, OutboxSchema.EventType, OutboxSchema.Payload, OutboxSchema.TenantId,
@@ -60,15 +63,20 @@ public sealed class OutboxSchemaConformanceTests : IDisposable
     [Fact]
     public void Status_is_stored_as_int()
     {
+        // Arrange
         var entityType = _context.Model.FindEntityType(typeof(OutboxMessage))!;
+
+        // Act
         var status = entityType.FindProperty(nameof(OutboxMessage.Status))!;
 
+        // Assert
         status.GetProviderClrType().Should().Be(typeof(int));
     }
 
     [Fact]
     public void OutboxMessageStatus_values_match_the_engine_OutboxStatus()
     {
+        // Assert — the host enum's int values must match the engine's, since the claim SQL filters on them.
         ((int)OutboxMessageStatus.Pending).Should().Be((int)OutboxStatus.Pending);
         ((int)OutboxMessageStatus.Sent).Should().Be((int)OutboxStatus.Sent);
         ((int)OutboxMessageStatus.Failed).Should().Be((int)OutboxStatus.Failed);

--- a/tests/Endatix.Infrastructure.Tests/Features/Outbox/WebHookIntegrationEventPublisherTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Outbox/WebHookIntegrationEventPublisherTests.cs
@@ -9,11 +9,20 @@ namespace Endatix.Infrastructure.Tests.Features.Outbox;
 
 /// <summary>
 /// Unit tests for the Stage-1 webhook publisher: dotted EventType → WebHookOperation mapping, formId
-/// extraction from the stored (string-id) payload, stable hook id (= outbox row Id), and tenant routing.
+/// extraction from the stored (string-id) payload, stable hook id (= outbox row Id), tenant routing, and
+/// failure handling (a failed delivery throws so the relay retries).
 /// </summary>
 public class WebHookIntegrationEventPublisherTests
 {
     private readonly IWebHookService _webHooks = Substitute.For<IWebHookService>();
+
+    public WebHookIntegrationEventPublisherTests()
+    {
+        // Default: delivery succeeds. Individual tests override for the failure path.
+        _webHooks.DeliverWebHookAsync(
+            Arg.Any<long>(), Arg.Any<WebHookMessage<JsonElement>>(), Arg.Any<CancellationToken>(), Arg.Any<long?>())
+            .Returns(true);
+    }
 
     private WebHookIntegrationEventPublisher CreateSut() =>
         new(_webHooks, NullLogger<WebHookIntegrationEventPublisher>.Instance);
@@ -24,7 +33,7 @@ public class WebHookIntegrationEventPublisherTests
     [InlineData("form.enabled_state_changed", "form_enabled_state_changed")]
     [InlineData("submission.completed", "submission_completed")]
     [InlineData("form.deleted", "form_deleted")]
-    public async Task Maps_event_type_and_enqueues_with_stable_hook_id_tenant_and_formId(string eventType, string expectedOperation)
+    public async Task Maps_event_type_and_delivers_with_stable_hook_id_tenant_and_formId(string eventType, string expectedOperation)
     {
         // Arrange
         var message = new FakeOutboxMessage(
@@ -34,7 +43,7 @@ public class WebHookIntegrationEventPublisherTests
         await CreateSut().PublishAsync(message, CancellationToken.None);
 
         // Assert
-        await _webHooks.Received(1).EnqueueWebHookAsync(
+        await _webHooks.Received(1).DeliverWebHookAsync(
             42L,
             Arg.Is<WebHookMessage<JsonElement>>(m => m.id == 777L && m.operation.EventName == expectedOperation),
             Arg.Any<CancellationToken>(),
@@ -42,7 +51,7 @@ public class WebHookIntegrationEventPublisherTests
     }
 
     [Fact]
-    public async Task Unmapped_event_type_is_skipped_and_not_enqueued()
+    public async Task Unmapped_event_type_is_skipped_and_not_delivered()
     {
         // Arrange
         var message = new FakeOutboxMessage(Id: 1, EventType: "form.archived", Payload: "{}", TenantId: 1);
@@ -51,7 +60,7 @@ public class WebHookIntegrationEventPublisherTests
         await CreateSut().PublishAsync(message, CancellationToken.None);
 
         // Assert
-        await _webHooks.DidNotReceive().EnqueueWebHookAsync(
+        await _webHooks.DidNotReceive().DeliverWebHookAsync(
             Arg.Any<long>(), Arg.Any<WebHookMessage<JsonElement>>(), Arg.Any<CancellationToken>(), Arg.Any<long?>());
     }
 
@@ -65,8 +74,22 @@ public class WebHookIntegrationEventPublisherTests
         await CreateSut().PublishAsync(message, CancellationToken.None);
 
         // Assert
-        await _webHooks.Received(1).EnqueueWebHookAsync(
+        await _webHooks.Received(1).DeliverWebHookAsync(
             7L, Arg.Any<WebHookMessage<JsonElement>>(), Arg.Any<CancellationToken>(), null);
+    }
+
+    [Fact]
+    public async Task Delivery_failure_throws_so_the_relay_retries()
+    {
+        // Arrange
+        _webHooks.DeliverWebHookAsync(
+            Arg.Any<long>(), Arg.Any<WebHookMessage<JsonElement>>(), Arg.Any<CancellationToken>(), Arg.Any<long?>())
+            .Returns(false);
+        var message = new FakeOutboxMessage(Id: 5, EventType: "form.created", Payload: """{"formId":"555"}""", TenantId: 1);
+
+        // Act + Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => CreateSut().PublishAsync(message, CancellationToken.None));
     }
 
     private sealed record FakeOutboxMessage(long Id, string EventType, string Payload, long TenantId) : IOutboxMessage

--- a/tests/Endatix.Infrastructure.Tests/Features/Outbox/WebHookIntegrationEventPublisherTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Outbox/WebHookIntegrationEventPublisherTests.cs
@@ -65,17 +65,16 @@ public class WebHookIntegrationEventPublisherTests
     }
 
     [Fact]
-    public async Task Missing_formId_passes_null_formId()
+    public async Task Missing_formId_throws_and_does_not_deliver()
     {
-        // Arrange
+        // Arrange — a mapped (form-scoped) event whose payload has no formId is malformed.
         var message = new FakeOutboxMessage(Id: 9, EventType: "form.created", Payload: """{"name":"no-form-id"}""", TenantId: 7);
 
-        // Act
-        await CreateSut().PublishAsync(message, CancellationToken.None);
-
-        // Assert
-        await _webHooks.Received(1).DeliverWebHookAsync(
-            7L, Arg.Any<WebHookMessage<JsonElement>>(), Arg.Any<CancellationToken>(), null);
+        // Act + Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => CreateSut().PublishAsync(message, CancellationToken.None));
+        await _webHooks.DidNotReceive().DeliverWebHookAsync(
+            Arg.Any<long>(), Arg.Any<WebHookMessage<JsonElement>>(), Arg.Any<CancellationToken>(), Arg.Any<long?>());
     }
 
     [Fact]

--- a/tests/Endatix.Infrastructure.Tests/Features/Outbox/WebHookIntegrationEventPublisherTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Outbox/WebHookIntegrationEventPublisherTests.cs
@@ -1,0 +1,70 @@
+using System.Text.Json;
+using Endatix.Core.Features.WebHooks;
+using Endatix.Infrastructure.Features.Outbox;
+using Endatix.Outbox.Engine;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+
+namespace Endatix.Infrastructure.Tests.Features.Outbox;
+
+/// <summary>
+/// Unit tests for the Stage-1 webhook publisher: dotted EventType → WebHookOperation mapping, formId
+/// extraction from the stored (string-id) payload, stable hook id (= outbox row Id), and tenant routing.
+/// </summary>
+public class WebHookIntegrationEventPublisherTests
+{
+    private readonly IWebHookService _webHooks = Substitute.For<IWebHookService>();
+
+    private WebHookIntegrationEventPublisher CreateSut() =>
+        new(_webHooks, NullLogger<WebHookIntegrationEventPublisher>.Instance);
+
+    [Theory]
+    [InlineData("form.created", "form_created")]
+    [InlineData("form.updated", "form_updated")]
+    [InlineData("form.enabled_state_changed", "form_enabled_state_changed")]
+    [InlineData("submission.completed", "submission_completed")]
+    [InlineData("form.deleted", "form_deleted")]
+    public async Task Maps_event_type_and_enqueues_with_stable_hook_id_tenant_and_formId(string eventType, string expectedOperation)
+    {
+        var message = new FakeOutboxMessage(
+            Id: 777, EventType: eventType, Payload: """{"formId":"555","name":"x"}""", TenantId: 42);
+
+        await CreateSut().PublishAsync(message, CancellationToken.None);
+
+        await _webHooks.Received(1).EnqueueWebHookAsync(
+            42L,
+            Arg.Is<WebHookMessage<JsonElement>>(m => m.id == 777L && m.operation.EventName == expectedOperation),
+            Arg.Any<CancellationToken>(),
+            555L);
+    }
+
+    [Fact]
+    public async Task Unmapped_event_type_is_skipped_and_not_enqueued()
+    {
+        var message = new FakeOutboxMessage(Id: 1, EventType: "form.archived", Payload: "{}", TenantId: 1);
+
+        await CreateSut().PublishAsync(message, CancellationToken.None);
+
+        await _webHooks.DidNotReceive().EnqueueWebHookAsync(
+            Arg.Any<long>(), Arg.Any<WebHookMessage<JsonElement>>(), Arg.Any<CancellationToken>(), Arg.Any<long?>());
+    }
+
+    [Fact]
+    public async Task Missing_formId_passes_null_formId()
+    {
+        var message = new FakeOutboxMessage(Id: 9, EventType: "form.created", Payload: """{"name":"no-form-id"}""", TenantId: 7);
+
+        await CreateSut().PublishAsync(message, CancellationToken.None);
+
+        await _webHooks.Received(1).EnqueueWebHookAsync(
+            7L, Arg.Any<WebHookMessage<JsonElement>>(), Arg.Any<CancellationToken>(), null);
+    }
+
+    private sealed record FakeOutboxMessage(long Id, string EventType, string Payload, long TenantId) : IOutboxMessage
+    {
+        public DateTimeOffset OccurredAt => DateTimeOffset.UnixEpoch;
+        public int SchemaVersion => 1;
+        public int Attempts => 0;
+        public string? TraceId => null;
+    }
+}

--- a/tests/Endatix.Infrastructure.Tests/Features/Outbox/WebHookIntegrationEventPublisherTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Outbox/WebHookIntegrationEventPublisherTests.cs
@@ -26,11 +26,14 @@ public class WebHookIntegrationEventPublisherTests
     [InlineData("form.deleted", "form_deleted")]
     public async Task Maps_event_type_and_enqueues_with_stable_hook_id_tenant_and_formId(string eventType, string expectedOperation)
     {
+        // Arrange
         var message = new FakeOutboxMessage(
             Id: 777, EventType: eventType, Payload: """{"formId":"555","name":"x"}""", TenantId: 42);
 
+        // Act
         await CreateSut().PublishAsync(message, CancellationToken.None);
 
+        // Assert
         await _webHooks.Received(1).EnqueueWebHookAsync(
             42L,
             Arg.Is<WebHookMessage<JsonElement>>(m => m.id == 777L && m.operation.EventName == expectedOperation),
@@ -41,10 +44,13 @@ public class WebHookIntegrationEventPublisherTests
     [Fact]
     public async Task Unmapped_event_type_is_skipped_and_not_enqueued()
     {
+        // Arrange
         var message = new FakeOutboxMessage(Id: 1, EventType: "form.archived", Payload: "{}", TenantId: 1);
 
+        // Act
         await CreateSut().PublishAsync(message, CancellationToken.None);
 
+        // Assert
         await _webHooks.DidNotReceive().EnqueueWebHookAsync(
             Arg.Any<long>(), Arg.Any<WebHookMessage<JsonElement>>(), Arg.Any<CancellationToken>(), Arg.Any<long?>());
     }
@@ -52,10 +58,13 @@ public class WebHookIntegrationEventPublisherTests
     [Fact]
     public async Task Missing_formId_passes_null_formId()
     {
+        // Arrange
         var message = new FakeOutboxMessage(Id: 9, EventType: "form.created", Payload: """{"name":"no-form-id"}""", TenantId: 7);
 
+        // Act
         await CreateSut().PublishAsync(message, CancellationToken.None);
 
+        // Assert
         await _webHooks.Received(1).EnqueueWebHookAsync(
             7L, Arg.Any<WebHookMessage<JsonElement>>(), Arg.Any<CancellationToken>(), null);
     }


### PR DESCRIPTION
Closes part of #791 (Phase 3a — the wiring half; 3b cutover follows separately).

Consumes the published **`Endatix.Outbox.Engine` 1.0.0** to run the in-process outbox
relay (Stage 1: webhook delivery, no DAPR). **No behavior change** — the relay is
registered and gated ON, but nothing raises an `IIntegrationEvent` until Phase 3b, so
the outbox stays empty and no webhooks flow through it yet.

## What's in this PR
- **Package** — pin `Endatix.Outbox.Engine 1.0.0` + `OpenFeature`/`OpenFeature.Hosting 2.14.0`;
  referenced from Infrastructure and both Persistence providers. **Core is untouched**
  (`OutboxMessage` does not implement `IOutboxMessage`).
- **EF conformance** — `OutboxMessageConfiguration` pinned to the engine's `OutboxSchema`
  (table + all 13 columns). Names already matched property names → **no migration**.
- **Webhook publisher** — `WebHookIntegrationEventPublisher : IIntegrationEventPublisher`
  maps the dotted `EventType` → `WebHookOperation`, forwards the stored JSON payload, reads
  `formId` from it, and reuses the outbox `Id` as the webhook id (stable `X-Endatix-Hook-Id`
  across retries). The map is derived from `WebHookOperation.EventName` (single source).
- **Registration** — per provider, `AddDbSpecificRepositories()` registers
  `AddSqlOutboxClaimStore` (shares the `DefaultConnection` pool) **and** `AddEndatixOutboxRelay()`,
  co-located so the relay exists iff a DB provider is configured.
- **OpenFeature** — `AddEndatixOpenFeature` (Infrastructure) seeds the `outbox-relay-in-process`
  flag from `Endatix:Outbox:RunInProcess`, coexisting with the existing `Microsoft.FeatureManagement`.
- **Serializer** — `LongToStringConverter` on the capture dispatcher, so stored payload IDs
  are strings (byte-compatible with today's webhooks).
- **Config** — `Endatix:Outbox` section in `appsettings.json`.

## Tests
- New: `OutboxSchemaConformanceTests` (table/columns/`Status` int + `OutboxMessageStatus`↔`OutboxStatus`
  parity) and `WebHookIntegrationEventPublisherTests` (mapping, `formId`, hook-id, skip on unmapped).
- Updated 2 existing dispatcher tests to the new string-ID wire format.
- Full suite green (the single failing `DefaultCsvFormatterTests` case is a **pre-existing**
  locale/decimal-separator issue, unrelated to this PR).

## Review
A high-effort review ran on this branch. **Addressed in-PR:** derive the event-type map (no
duplicated literals), AAA test sections, and **co-locating the relay registration with its
claim store** (removes a fragile split that could fail-fast at startup).

**Deferred to a post-merge follow-up** (tracked on #791, to keep this PR scoped):
- **At-least-once webhook *delivery*** — the relay currently marks `Sent` on *enqueue* (the
  existing in-memory queue), so it closes the pre-outbox dual-write gap (durable capture) but
  not the enqueue→POST window. This is a net improvement over today, not a regression; the
  follow-up makes the publisher deliver synchronously so `MarkSent` reflects a real POST.
- Fast-path malformed payloads to dead-letter; pin the payload `formId` contract (in 3b).

## Not in this PR (Phase 3b)
Raising the 5 slice events on the aggregates, deleting the 5 webhook handlers (keeping every
`mediator.Publish`), and turning the relay live.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-process outbox relay support for database-backed deployments.
  * Webhooks can now be delivered directly from outbox events with retry-safe handling.
  * Added new outbox configuration options for processing, batching, leasing, and retries.

* **Bug Fixes**
  * Improved webhook payload serialization so long IDs are sent consistently as strings.
  * Aligned outbox schema mappings with the expected canonical table and columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->