### PR TITLE
chore(e815): Bump System.Security.Cryptography.Xml to 10.0.6 (CVE-2026-26171)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,6 +48,7 @@
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.ApplicationInsights" Version="5.0.0" />
     <PackageVersion Include="serilog.sinks.async" Version="2.1.0" />
+    <PackageVersion Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageVersion Include="xunit.v3" Version="3.2.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />

--- a/src/Endatix.WebHost/Endatix.WebHost.csproj
+++ b/src/Endatix.WebHost/Endatix.WebHost.csproj
@@ -5,6 +5,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		  <PrivateAssets>all</PrivateAssets>
 		</PackageReference>
+    <PackageReference Include="System.Security.Cryptography.Xml" />
     <ProjectReference Include="../Endatix.Hosting/Endatix.Hosting.csproj" />
     <ProjectReference Include="../Endatix.Api.Host/Endatix.Api.Host.csproj" />
   </ItemGroup>


### PR DESCRIPTION
# chore(e815): Bump System.Security.Cryptography.Xml to 10.0.6 (CVE-2026-26171)

## Description
Bump System.Security.Cryptography.Xml to 10.0.6 (CVE-2026-26171)

## Related Issues
- fixes https://github.com/endatix/endatix/issues/815

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Security Fix

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
