### PR TITLE
chore(e817): fix the SQLitePCLRaw / SQLite CVE-2025-6965 

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,9 +36,10 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="$(EFCoreVersion)" />
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.4.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="$(EFCoreVersion)" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="$(EFCoreVersion)" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite.Core" Version="$(EFCoreVersion)" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="$(EFCoreVersion)" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="$(EFCoreVersion)" />
+    <PackageVersion Include="SQLite3MC.PCLRaw.bundle" Version="2.3.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="SendGrid" Version="9.29.3" />

--- a/tests/Endatix.Infrastructure.Tests/Endatix.Infrastructure.Tests.csproj
+++ b/tests/Endatix.Infrastructure.Tests/Endatix.Infrastructure.Tests.csproj
@@ -19,9 +19,11 @@
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-
+  <!-- CVE-2025-6965: use Sqlite.Core + SQLite3MC instead of EF.Sqlite (vulnerable bundle_e_sqlite3).
+       Remove when EF 10.0.11+ ships the same bundle switch — see endatix#817, dotnet/efcore#38257. -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite.Core" />
+    <PackageReference Include="SQLite3MC.PCLRaw.bundle" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# chore: fix the SQLitePCLRaw / SQLite CVE-2025-6965 

## Description
Since this is fixed with .NET 11, we have applied the workaround as per https://github.com/dotnet/efcore/issues/38257#issuecomment-4776740144 

Idea is to remove the dependency with the inclusion of the https://github.com/endatix/endatix/pulls

## Related Issues
- fixes https://github.com/endatix/endatix/issues/817 

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Security fix

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
