### PR TITLE
chore(e819): bump shell-quote to 1.8.4 to address CVE-2026-9277 via override

### DIFF
--- a/docs/endatix-docs/package.json
+++ b/docs/endatix-docs/package.json
@@ -57,10 +57,11 @@
       "fast-xml-builder": "^1.1.7",
       "fast-xml-parser": "^5.7.0",
       "fast-uri": "^3.1.2",
-      "uuid": "^11.1.1"
+      "uuid": "^11.1.1",
+      "shell-quote": "^1.8.4"
     },
     "comments": {
-      "overrides": "[serialize-javascript] to 7.0.5 to fix CVE-2020-7660 & CVE-2026-34043. Remove on @docusaurus 4x bump | [fast-xml-builder] to 1.1.7 to fix CVE-2026-44665. Remove on next redocusaurus bump | [fast-xml-parser] to 5.7.0 to fix CVE-2026-41650. Remove on next redocusaurus bump | [fast-uri] to 3.1.2 to fix CVE-2026-6322. Remove on next docusaurus bump | [uuid] to 11.1.1 to fix CVE-2026-41907. Remove on next docusaurus bump"
+      "overrides": "[serialize-javascript] to 7.0.5 to fix CVE-2020-7660 & CVE-2026-34043. Remove on @docusaurus 4x bump | [fast-xml-builder] to 1.1.7 to fix CVE-2026-44665. Remove on next redocusaurus bump | [fast-xml-parser] to 5.7.0 to fix CVE-2026-41650. Remove on next redocusaurus bump | [fast-uri] to 3.1.2 to fix CVE-2026-6322. Remove on next docusaurus bump | [uuid] to 11.1.1 to fix CVE-2026-41907. Remove on next docusaurus bump | [shell-quote] to 1.8.4 to fix CVE-2026-9277. Remove on next docusaurus bump"
     },
     "onlyBuiltDependencies": [
       "@swc/core",

--- a/docs/endatix-docs/pnpm-lock.yaml
+++ b/docs/endatix-docs/pnpm-lock.yaml
@@ -10,6 +10,7 @@ overrides:
   fast-xml-parser: ^5.7.0
   fast-uri: ^3.1.2
   uuid: ^11.1.1
+  shell-quote: ^1.8.4
 
 importers:
 
@@ -5537,8 +5538,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.9.0:
+    resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
   should-equal@2.0.0:
@@ -11409,7 +11410,7 @@ snapshots:
   launch-editor@2.13.2:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.9.0
 
   layout-base@1.0.2: {}
 
@@ -13562,7 +13563,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.9.0: {}
 
   should-equal@2.0.0:
     dependencies:


### PR DESCRIPTION
# chore: bump shell-quote to 1.8.4 to address CVE-2026-9277 via override 

## Description
Using override as `shell-quote` comes as transient dependency of docusaurus

## Related Issues
- closes https://github.com/endatix/endatix/issues/819

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Security fix

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
