### PR TITLE
chore(e821): Add version scoped overrides for ws to address CVE-2026-48779

### DIFF
--- a/docs/endatix-docs/package.json
+++ b/docs/endatix-docs/package.json
@@ -58,10 +58,12 @@
       "fast-xml-parser": "^5.7.0",
       "fast-uri": "^3.1.2",
       "uuid": "^11.1.1",
-      "shell-quote": "^1.8.4"
+      "shell-quote": "^1.8.4",
+      "ws@>=7.0.0 <7.5.11": "^7.5.11",
+      "ws@>=8.0.0 <8.21.0": "^8.21.0"
     },
     "comments": {
-      "overrides": "[serialize-javascript] to 7.0.5 to fix CVE-2020-7660 & CVE-2026-34043. Remove on @docusaurus 4x bump | [fast-xml-builder] to 1.1.7 to fix CVE-2026-44665. Remove on next redocusaurus bump | [fast-xml-parser] to 5.7.0 to fix CVE-2026-41650. Remove on next redocusaurus bump | [fast-uri] to 3.1.2 to fix CVE-2026-6322. Remove on next docusaurus bump | [uuid] to 11.1.1 to fix CVE-2026-41907. Remove on next docusaurus bump | [shell-quote] to 1.8.4 to fix CVE-2026-9277. Remove on next docusaurus bump"
+      "overrides": "[serialize-javascript] to 7.0.5 to fix CVE-2020-7660 & CVE-2026-34043. Remove on @docusaurus 4x bump | [fast-xml-builder] to 1.1.7 to fix CVE-2026-44665. Remove on next redocusaurus bump | [fast-xml-parser] to 5.7.0 to fix CVE-2026-41650. Remove on next redocusaurus bump | [fast-uri] to 3.1.2 to fix CVE-2026-6322. Remove on next docusaurus bump | [uuid] to 11.1.1 to fix CVE-2026-41907. Remove on next docusaurus bump | [shell-quote] to 1.8.4 to fix CVE-2026-9277. Remove on next docusaurus bump | [ws] to 7.5.11 to fix CVE-2026-48779. Remove on next docusaurus bump | [ws] to 8.21.0 to fix CVE-2026-48779. Remove on next docusaurus bump"
     },
     "onlyBuiltDependencies": [
       "@swc/core",

--- a/docs/endatix-docs/pnpm-lock.yaml
+++ b/docs/endatix-docs/pnpm-lock.yaml
@@ -11,6 +11,8 @@ overrides:
   fast-uri: ^3.1.2
   uuid: ^11.1.1
   shell-quote: ^1.8.4
+  ws@>=7.0.0 <7.5.11: ^7.5.11
+  ws@>=8.0.0 <8.21.0: ^8.21.0
 
 importers:
 
@@ -6181,8 +6183,8 @@ packages:
   write-file-atomic@3.0.3:
     resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
 
-  ws@7.5.10:
-    resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
+  ws@7.5.11:
+    resolution: {integrity: sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==}
     engines: {node: '>=8.3.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -6193,8 +6195,8 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -14102,7 +14104,7 @@ snapshots:
       opener: 1.5.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      ws: 7.5.10
+      ws: 7.5.11
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -14149,7 +14151,7 @@ snapshots:
       sockjs: 0.3.24
       spdy: 4.0.2
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.106.2(@swc/core@1.15.26))
-      ws: 8.20.0
+      ws: 8.21.0
     optionalDependencies:
       webpack: 5.106.2(@swc/core@1.15.26)
     transitivePeerDependencies:
@@ -14256,9 +14258,9 @@ snapshots:
       signal-exit: 3.0.7
       typedarray-to-buffer: 3.1.5
 
-  ws@7.5.10: {}
+  ws@7.5.11: {}
 
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   wsl-utils@0.1.0:
     dependencies:


### PR DESCRIPTION
# chore: Add version scoped overrides for ws to address CVE-2026-48779

## Description
Adds override

## Related Issues
- fixes https://github.com/endatix/endatix/issues/821

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Security fix

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
