### PR TITLE
feat(e-export): SurveyJS flattening library for BI codebook (E2–E4b)

### DIFF
--- a/src/Endatix.Modules.Reporting/Domain/SurveyJs/CodebookColumnDefinition.cs
+++ b/src/Endatix.Modules.Reporting/Domain/SurveyJs/CodebookColumnDefinition.cs
@@ -1,0 +1,16 @@
+namespace Endatix.Modules.Reporting.Domain.SurveyJs;
+
+/// <summary>
+/// One export column derived from a SurveyJS form definition.
+/// </summary>
+internal sealed record CodebookColumnDefinition(
+    string Key,
+    CodebookColumnKind Kind,
+    string Label,
+    string DataType,
+    string? SourceQuestion = null,
+    string? ChoiceValue = null,
+    IReadOnlyList<LoopSegment>? LoopPath = null,
+    string? PanelName = null,
+    int? PanelIndex = null,
+    string? MatrixRowValue = null);

--- a/src/Endatix.Modules.Reporting/Domain/SurveyJs/CodebookColumnKind.cs
+++ b/src/Endatix.Modules.Reporting/Domain/SurveyJs/CodebookColumnKind.cs
@@ -1,0 +1,13 @@
+namespace Endatix.Modules.Reporting.Domain.SurveyJs;
+
+internal enum CodebookColumnKind
+{
+    Simple,
+    Calculated,
+    CheckboxChoice,
+    CheckboxOtherText,
+    PanelDynamicIndex,
+    NestedLoop,
+    MatrixRow,
+    RankingChoice,
+}

--- a/src/Endatix.Modules.Reporting/Domain/SurveyJs/ExportPathBuilder.cs
+++ b/src/Endatix.Modules.Reporting/Domain/SurveyJs/ExportPathBuilder.cs
@@ -1,0 +1,43 @@
+namespace Endatix.Modules.Reporting.Domain.SurveyJs;
+
+internal static class ExportPathBuilder
+{
+    internal const char SegmentSeparator = '_';
+    internal const string SegmentDelimiter = "__";
+
+    internal static string Join(params ReadOnlySpan<string> segments)
+    {
+        if (segments.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        if (segments.Length == 1)
+        {
+            return segments[0];
+        }
+
+        return string.Join(SegmentDelimiter, segments.ToArray());
+    }
+
+    internal static string ChoiceKey(string questionName, string choiceValue) =>
+        Join(questionName, choiceValue);
+
+    internal static string CheckboxChoiceKey(string questionName, string choiceValue) =>
+        ChoiceKey(questionName, choiceValue);
+
+    internal static string RankingChoiceKey(string questionName, string choiceValue) =>
+        ChoiceKey(questionName, choiceValue);
+
+    internal static string CheckboxOtherTextKey(string questionName) =>
+        Join(questionName, "other_text");
+
+    internal static string PanelIndexKey(string panelName, int index, string questionName) =>
+        Join(panelName, index.ToString(System.Globalization.CultureInfo.InvariantCulture), questionName);
+
+    internal static string NestedLoopKey(IReadOnlyList<string> choiceValues, string questionName) =>
+        Join([.. choiceValues, questionName]);
+
+    internal static string MatrixRowKey(string matrixName, string rowValue) =>
+        Join(matrixName, rowValue);
+}

--- a/src/Endatix.Modules.Reporting/Domain/SurveyJs/FlatteningLimitExceededException.cs
+++ b/src/Endatix.Modules.Reporting/Domain/SurveyJs/FlatteningLimitExceededException.cs
@@ -1,0 +1,3 @@
+namespace Endatix.Modules.Reporting.Domain.SurveyJs;
+
+internal sealed class FlatteningLimitExceededException(string message) : InvalidOperationException(message);

--- a/src/Endatix.Modules.Reporting/Domain/SurveyJs/FlatteningLimits.cs
+++ b/src/Endatix.Modules.Reporting/Domain/SurveyJs/FlatteningLimits.cs
@@ -1,0 +1,16 @@
+namespace Endatix.Modules.Reporting.Domain.SurveyJs;
+
+internal sealed class FlatteningLimits
+{
+    public int MaxNestingDepth { get; init; } = 5;
+
+    public int MaxPanelCount { get; init; } = 10;
+
+    public int MaxQuestions { get; init; } = 1_500;
+
+    public int MaxChoicesPerQuestion { get; init; } = 2_500;
+
+    public int MaxColumns { get; init; } = 16_000;
+
+    public static FlatteningLimits Default { get; } = new();
+}

--- a/src/Endatix.Modules.Reporting/Domain/SurveyJs/FormExportSchemaCompiler.cs
+++ b/src/Endatix.Modules.Reporting/Domain/SurveyJs/FormExportSchemaCompiler.cs
@@ -1,0 +1,35 @@
+using System.Text.Json;
+
+namespace Endatix.Modules.Reporting.Domain.SurveyJs;
+
+/// <summary>
+/// Compiles SurveyJS form definitions into append-only merged codebooks.
+/// </summary>
+internal sealed class FormExportSchemaCompiler(FlatteningLimits? limits = null)
+{
+    private readonly FlatteningLimits _limits = limits ?? FlatteningLimits.Default;
+
+    public MergedCodebook Compile(JsonElement definition, MergedCodebook? existing = null)
+    {
+        IReadOnlyList<CodebookColumnDefinition> newColumns = SurveyJsDefinitionFlattener.Flatten(definition, _limits);
+        return existing is null
+            ? new MergedCodebook(newColumns)
+            : existing.MergeAppendOnly(newColumns, _limits);
+    }
+
+    public MergedCodebook Compile(string definitionJson, MergedCodebook? existing = null)
+    {
+        using JsonDocument definition = JsonDocument.Parse(definitionJson);
+        return Compile(definition.RootElement, existing);
+    }
+
+    public MergedCodebook CompileFromPersistedSchema(string definitionJson, string? existingSchemaJson = null)
+    {
+        using JsonDocument definition = JsonDocument.Parse(definitionJson);
+        MergedCodebook? existing = string.IsNullOrWhiteSpace(existingSchemaJson)
+            ? null
+            : MergedCodebook.FromJson(existingSchemaJson);
+
+        return Compile(definition.RootElement, existing);
+    }
+}

--- a/src/Endatix.Modules.Reporting/Domain/SurveyJs/LoopSegment.cs
+++ b/src/Endatix.Modules.Reporting/Domain/SurveyJs/LoopSegment.cs
@@ -1,0 +1,9 @@
+namespace Endatix.Modules.Reporting.Domain.SurveyJs;
+
+/// <summary>
+/// One level in a choice-driven <c>paneldynamic</c> loop path.
+/// </summary>
+internal sealed record LoopSegment(
+    string PanelValueName,
+    string PropertyName,
+    string ChoiceValue);

--- a/src/Endatix.Modules.Reporting/Domain/SurveyJs/MergedCodebook.cs
+++ b/src/Endatix.Modules.Reporting/Domain/SurveyJs/MergedCodebook.cs
@@ -1,0 +1,137 @@
+using System.Text.Json;
+
+namespace Endatix.Modules.Reporting.Domain.SurveyJs;
+
+/// <summary>
+/// Append-only merged codebook produced from one or more form definition versions.
+/// </summary>
+internal sealed class MergedCodebook
+{
+    private readonly Dictionary<string, CodebookColumnDefinition> _columnsByKey;
+
+    public MergedCodebook(IEnumerable<CodebookColumnDefinition> columns)
+    {
+        List<CodebookColumnDefinition> columnList = columns.ToList();
+        _columnsByKey = new Dictionary<string, CodebookColumnDefinition>(columnList.Count, StringComparer.Ordinal);
+        foreach (CodebookColumnDefinition column in columnList)
+        {
+            _columnsByKey.TryAdd(column.Key, column);
+        }
+
+        Columns = columnList;
+    }
+
+    public IReadOnlyList<CodebookColumnDefinition> Columns { get; }
+
+    public MergedCodebook MergeAppendOnly(IEnumerable<CodebookColumnDefinition> newColumns, FlatteningLimits? limits = null)
+    {
+        FlatteningLimits effectiveLimits = limits ?? FlatteningLimits.Default;
+        List<CodebookColumnDefinition> merged = [.. Columns];
+
+        foreach (CodebookColumnDefinition column in newColumns)
+        {
+            if (_columnsByKey.ContainsKey(column.Key))
+            {
+                continue;
+            }
+
+            if (merged.Count >= effectiveLimits.MaxColumns)
+            {
+                throw new FlatteningLimitExceededException(
+                    $"Codebook column limit of {effectiveLimits.MaxColumns} exceeded.");
+            }
+
+            merged.Add(column);
+            _columnsByKey[column.Key] = column;
+        }
+
+        return new MergedCodebook(merged);
+    }
+
+    public string ToJson()
+    {
+        var payload = Columns.Select(column => new
+        {
+            key = column.Key,
+            kind = column.Kind.ToString(),
+            label = column.Label,
+            dataType = column.DataType,
+            sourceQuestion = column.SourceQuestion,
+            choiceValue = column.ChoiceValue,
+            panelName = column.PanelName,
+            panelIndex = column.PanelIndex,
+            matrixRowValue = column.MatrixRowValue,
+            loopPath = column.LoopPath?.Select(segment => new
+            {
+                panelValueName = segment.PanelValueName,
+                propertyName = segment.PropertyName,
+                choiceValue = segment.ChoiceValue,
+            }),
+        });
+
+        return JsonSerializer.Serialize(payload);
+    }
+
+    public static MergedCodebook FromJson(string json)
+    {
+        using JsonDocument document = JsonDocument.Parse(json);
+        List<CodebookColumnDefinition> columns = [];
+
+        foreach (JsonElement item in document.RootElement.EnumerateArray())
+        {
+            string key = item.GetProperty("key").GetString()!;
+            CodebookColumnKind kind = Enum.Parse<CodebookColumnKind>(item.GetProperty("kind").GetString()!);
+            string label = item.GetProperty("label").GetString() ?? key;
+            string dataType = item.TryGetProperty("dataType", out JsonElement dataTypeProp)
+                ? dataTypeProp.GetString() ?? "string"
+                : "string";
+
+            string? sourceQuestion = item.TryGetProperty("sourceQuestion", out JsonElement sourceQuestionProp)
+                ? sourceQuestionProp.GetString()
+                : null;
+
+            string? choiceValue = item.TryGetProperty("choiceValue", out JsonElement choiceValueProp)
+                ? choiceValueProp.GetString()
+                : null;
+
+            string? panelName = item.TryGetProperty("panelName", out JsonElement panelNameProp)
+                ? panelNameProp.GetString()
+                : null;
+
+            int? panelIndex = item.TryGetProperty("panelIndex", out JsonElement panelIndexProp) &&
+                             panelIndexProp.ValueKind == JsonValueKind.Number
+                ? panelIndexProp.GetInt32()
+                : null;
+
+            string? matrixRowValue = item.TryGetProperty("matrixRowValue", out JsonElement matrixRowValueProp)
+                ? matrixRowValueProp.GetString()
+                : null;
+
+            List<LoopSegment>? loopPath = null;
+            if (item.TryGetProperty("loopPath", out JsonElement loopPathProp) &&
+                loopPathProp.ValueKind == JsonValueKind.Array)
+            {
+                loopPath = loopPathProp.EnumerateArray()
+                    .Select(segment => new LoopSegment(
+                        segment.GetProperty("panelValueName").GetString()!,
+                        segment.GetProperty("propertyName").GetString()!,
+                        segment.GetProperty("choiceValue").GetString()!))
+                    .ToList();
+            }
+
+            columns.Add(new CodebookColumnDefinition(
+                key,
+                kind,
+                label,
+                dataType,
+                sourceQuestion,
+                choiceValue,
+                loopPath,
+                panelName,
+                panelIndex,
+                matrixRowValue));
+        }
+
+        return new MergedCodebook(columns);
+    }
+}

--- a/src/Endatix.Modules.Reporting/Domain/SurveyJs/SurveyJsChoiceHelper.cs
+++ b/src/Endatix.Modules.Reporting/Domain/SurveyJs/SurveyJsChoiceHelper.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+
+namespace Endatix.Modules.Reporting.Domain.SurveyJs;
+
+internal static class SurveyJsChoiceHelper
+{
+    internal static IEnumerable<(string Value, string Text)> EnumerateChoices(JsonElement element)
+    {
+        if (!element.TryGetProperty("choices", out JsonElement choices) ||
+            choices.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+
+        foreach (JsonElement choice in choices.EnumerateArray())
+        {
+            if (choice.ValueKind == JsonValueKind.String)
+            {
+                string text = choice.GetString()!;
+                yield return (text, text);
+                continue;
+            }
+
+            if (choice.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            string? value = choice.TryGetProperty("value", out JsonElement valueProp)
+                ? valueProp.GetString()
+                : choice.TryGetProperty("text", out JsonElement textProp)
+                    ? textProp.GetString()
+                    : null;
+
+            if (value is null)
+            {
+                continue;
+            }
+
+            string textLabel = choice.TryGetProperty("text", out JsonElement labelProp)
+                ? labelProp.GetString() ?? value
+                : value;
+
+            yield return (value, textLabel);
+        }
+    }
+
+    internal static IEnumerable<(string Value, string Text)> EnumerateMatrixRows(JsonElement element)
+    {
+        if (!element.TryGetProperty("rows", out JsonElement rows) ||
+            rows.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+
+        foreach (JsonElement row in rows.EnumerateArray())
+        {
+            if (row.ValueKind == JsonValueKind.String)
+            {
+                string text = row.GetString()!;
+                yield return (text, text);
+                continue;
+            }
+
+            if (row.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            string? value = row.TryGetProperty("value", out JsonElement valueProp)
+                ? valueProp.GetString()
+                : row.TryGetProperty("text", out JsonElement textProp)
+                    ? textProp.GetString()
+                    : null;
+
+            if (value is null)
+            {
+                continue;
+            }
+
+            string textLabel = row.TryGetProperty("text", out JsonElement labelProp)
+                ? labelProp.GetString() ?? value
+                : value;
+
+            yield return (value, textLabel);
+        }
+    }
+}

--- a/src/Endatix.Modules.Reporting/Domain/SurveyJs/SurveyJsDefinitionFlattener.cs
+++ b/src/Endatix.Modules.Reporting/Domain/SurveyJs/SurveyJsDefinitionFlattener.cs
@@ -1,0 +1,678 @@
+using System.Text.Json;
+
+namespace Endatix.Modules.Reporting.Domain.SurveyJs;
+
+/// <summary>
+/// Walks a SurveyJS form definition and produces BI-ready codebook column definitions.
+/// Mirrors semantics of <c>getPlainData</c> / nested-loop SQL export without a SurveyJS runtime.
+/// </summary>
+internal static class SurveyJsDefinitionFlattener
+{
+    private sealed record CollectedElement(JsonElement Element, int Depth, string? ParentValueName);
+
+    private sealed record DynamicPanelNode(
+        string PanelName,
+        string ValueName,
+        string ValuePropertyName,
+        string? ParentValueName,
+        JsonElement Choices,
+        JsonElement[] TemplateElements);
+
+    private sealed record PanelPath(
+        IReadOnlyList<string> LoopPath,
+        IReadOnlyList<string> PropertyPath,
+        IReadOnlyList<JsonElement> ChoicesPath,
+        JsonElement[] TemplateElements);
+
+    public static IReadOnlyList<CodebookColumnDefinition> Flatten(
+        JsonElement definition,
+        FlatteningLimits? limits = null)
+    {
+        FlatteningLimits effectiveLimits = limits ?? FlatteningLimits.Default;
+        List<CollectedElement> allElements = CollectElements(definition, effectiveLimits);
+        HashSet<string> drivingCheckboxNames = allElements
+            .Where(item => IsDrivingCheckbox(item.Element))
+            .Select(item => GetElementName(item.Element)!)
+            .ToHashSet(StringComparer.Ordinal);
+
+        List<DynamicPanelNode> dynamicPanels = BuildDynamicPanelNodes(allElements, drivingCheckboxNames);
+        List<PanelPath> panelPaths = BuildPanelPaths(dynamicPanels, effectiveLimits);
+
+        List<CodebookColumnDefinition> columns = [];
+        HashSet<string> seenKeys = new(StringComparer.Ordinal);
+
+        AddSimpleColumns(allElements, drivingCheckboxNames, columns, seenKeys, effectiveLimits);
+        AddCheckboxColumns(allElements, drivingCheckboxNames, columns, seenKeys, effectiveLimits);
+        AddRankingColumns(allElements, columns, seenKeys, effectiveLimits);
+        AddMatrixColumns(allElements, columns, seenKeys, effectiveLimits);
+        AddStandalonePanelDynamicColumns(allElements, drivingCheckboxNames, columns, seenKeys, effectiveLimits);
+        AddNestedLoopColumns(panelPaths, allElements, drivingCheckboxNames, columns, seenKeys, effectiveLimits);
+        AddCalculatedValueColumns(definition, columns, seenKeys, effectiveLimits);
+
+        if (columns.Count > effectiveLimits.MaxColumns)
+        {
+            throw new FlatteningLimitExceededException(
+                $"Codebook column limit of {effectiveLimits.MaxColumns} exceeded.");
+        }
+
+        return columns;
+    }
+
+    private static List<CollectedElement> CollectElements(JsonElement definition, FlatteningLimits limits)
+    {
+        List<CollectedElement> elements = [];
+        CollectFromContainer(definition, depth: 0, parentValueName: null, elements, limits);
+        return elements;
+    }
+
+    private static void CollectFromContainer(
+        JsonElement container,
+        int depth,
+        string? parentValueName,
+        List<CollectedElement> elements,
+        FlatteningLimits limits)
+    {
+        if (depth > limits.MaxNestingDepth)
+        {
+            return;
+        }
+
+        if (container.TryGetProperty("pages", out JsonElement pages) && pages.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement page in pages.EnumerateArray())
+            {
+                if (page.TryGetProperty("elements", out JsonElement pageElements))
+                {
+                    CollectElementList(pageElements, depth, parentValueName: null, elements, limits);
+                }
+            }
+        }
+
+        if (container.TryGetProperty("elements", out JsonElement rootElements))
+        {
+            CollectElementList(rootElements, depth, parentValueName: null, elements, limits);
+        }
+    }
+
+    private static void CollectElementList(
+        JsonElement elementList,
+        int depth,
+        string? parentValueName,
+        List<CollectedElement> elements,
+        FlatteningLimits limits)
+    {
+        if (elementList.ValueKind != JsonValueKind.Array)
+        {
+            return;
+        }
+
+        foreach (JsonElement element in elementList.EnumerateArray())
+        {
+            string? type = GetElementType(element);
+            if (SurveyJsElementTypes.IsNonData(type))
+            {
+                continue;
+            }
+
+            elements.Add(new CollectedElement(element, depth, parentValueName));
+
+            if (string.Equals(type, "panel", StringComparison.OrdinalIgnoreCase) &&
+                element.TryGetProperty("elements", out JsonElement panelChildren))
+            {
+                CollectElementList(panelChildren, depth, parentValueName, elements, limits);
+            }
+
+            if (string.Equals(type, "paneldynamic", StringComparison.OrdinalIgnoreCase) &&
+                element.TryGetProperty("templateElements", out JsonElement templateElements))
+            {
+                string? panelValueName = element.TryGetProperty("valueName", out JsonElement valueNameProp)
+                    ? valueNameProp.GetString()
+                    : null;
+
+                CollectElementList(templateElements, depth + 1, panelValueName, elements, limits);
+            }
+        }
+    }
+
+    private static List<DynamicPanelNode> BuildDynamicPanelNodes(
+        IReadOnlyList<CollectedElement> allElements,
+        HashSet<string> drivingCheckboxNames)
+    {
+        List<DynamicPanelNode> nodes = [];
+
+        foreach (CollectedElement collected in allElements)
+        {
+            if (!string.Equals(GetElementType(collected.Element), "paneldynamic", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            string? valueName = collected.Element.TryGetProperty("valueName", out JsonElement valueNameProp)
+                ? valueNameProp.GetString()
+                : null;
+
+            if (string.IsNullOrWhiteSpace(valueName) || !drivingCheckboxNames.Contains(valueName))
+            {
+                continue;
+            }
+
+            CollectedElement? driver = allElements.FirstOrDefault(item =>
+                string.Equals(GetElementName(item.Element), valueName, StringComparison.Ordinal));
+
+            if (driver is null || !driver.Element.TryGetProperty("valuePropertyName", out JsonElement valuePropertyNameProp))
+            {
+                continue;
+            }
+
+            string? valuePropertyName = valuePropertyNameProp.GetString();
+            if (string.IsNullOrWhiteSpace(valuePropertyName))
+            {
+                continue;
+            }
+
+            JsonElement choices = driver.Element.TryGetProperty("choices", out JsonElement choicesProp)
+                ? choicesProp
+                : default;
+
+            JsonElement[] templateElements = collected.Element.TryGetProperty("templateElements", out JsonElement templateProp) &&
+                                             templateProp.ValueKind == JsonValueKind.Array
+                ? templateProp.EnumerateArray().ToArray()
+                : [];
+
+            nodes.Add(new DynamicPanelNode(
+                GetElementName(collected.Element) ?? valueName,
+                valueName,
+                valuePropertyName,
+                collected.ParentValueName,
+                choices,
+                templateElements));
+        }
+
+        return nodes;
+    }
+
+    private static List<PanelPath> BuildPanelPaths(
+        IReadOnlyList<DynamicPanelNode> dynamicPanels,
+        FlatteningLimits limits)
+    {
+        Dictionary<string, DynamicPanelNode> panelsByValueName = dynamicPanels.ToDictionary(
+            panel => panel.ValueName,
+            StringComparer.Ordinal);
+
+        List<PanelPath> paths = [];
+        IEnumerable<DynamicPanelNode> roots = dynamicPanels.Where(panel => panel.ParentValueName is null);
+
+        foreach (DynamicPanelNode root in roots)
+        {
+            BuildPanelPathsRecursive(
+                root,
+                loopPath: [],
+                propertyPath: [],
+                choicesPath: [],
+                panelsByValueName,
+                paths,
+                limits);
+        }
+
+        return paths;
+    }
+
+    private static void BuildPanelPathsRecursive(
+        DynamicPanelNode panel,
+        IReadOnlyList<string> loopPath,
+        IReadOnlyList<string> propertyPath,
+        IReadOnlyList<JsonElement> choicesPath,
+        IReadOnlyDictionary<string, DynamicPanelNode> panelsByValueName,
+        List<PanelPath> paths,
+        FlatteningLimits limits)
+    {
+        if (loopPath.Count >= limits.MaxNestingDepth)
+        {
+            return;
+        }
+
+        List<string> nextLoopPath = [.. loopPath, panel.ValueName];
+        List<string> nextPropertyPath = [.. propertyPath, panel.ValuePropertyName];
+        List<JsonElement> nextChoicesPath = [.. choicesPath, panel.Choices];
+
+        DynamicPanelNode? childPanel = panel.TemplateElements
+            .Where(template => string.Equals(GetElementType(template), "paneldynamic", StringComparison.OrdinalIgnoreCase))
+            .Select(template =>
+            {
+                string? childValueName = template.TryGetProperty("valueName", out JsonElement valueNameProp)
+                    ? valueNameProp.GetString()
+                    : null;
+
+                if (childValueName is not null && panelsByValueName.TryGetValue(childValueName, out DynamicPanelNode child))
+                {
+                    return child;
+                }
+
+                return null;
+            })
+            .FirstOrDefault(match => match is not null);
+
+        if (childPanel is not null &&
+            string.Equals(childPanel.ParentValueName, panel.ValueName, StringComparison.Ordinal))
+        {
+            BuildPanelPathsRecursive(
+                childPanel,
+                nextLoopPath,
+                nextPropertyPath,
+                nextChoicesPath,
+                panelsByValueName,
+                paths,
+                limits);
+            return;
+        }
+
+        paths.Add(new PanelPath(nextLoopPath, nextPropertyPath, nextChoicesPath, panel.TemplateElements));
+    }
+
+    private static void AddCalculatedValueColumns(
+        JsonElement definition,
+        List<CodebookColumnDefinition> columns,
+        HashSet<string> seenKeys,
+        FlatteningLimits limits)
+    {
+        if (!definition.TryGetProperty("calculatedValues", out JsonElement calculatedValues) ||
+            calculatedValues.ValueKind != JsonValueKind.Array)
+        {
+            return;
+        }
+
+        foreach (JsonElement calculatedValue in calculatedValues.EnumerateArray())
+        {
+            if (calculatedValue.TryGetProperty("includeIntoResult", out JsonElement includeProp) &&
+                includeProp.ValueKind == JsonValueKind.False)
+            {
+                continue;
+            }
+
+            string? name = calculatedValue.TryGetProperty("name", out JsonElement nameProp)
+                ? nameProp.GetString()
+                : null;
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                continue;
+            }
+
+            AddColumn(columns, seenKeys, limits, new CodebookColumnDefinition(
+                name,
+                CodebookColumnKind.Calculated,
+                name,
+                "string"));
+        }
+    }
+
+    private static void AddSimpleColumns(
+        IReadOnlyList<CollectedElement> allElements,
+        HashSet<string> drivingCheckboxNames,
+        List<CodebookColumnDefinition> columns,
+        HashSet<string> seenKeys,
+        FlatteningLimits limits)
+    {
+        foreach (CollectedElement collected in allElements.Where(item => item.Depth == 0))
+        {
+            string? type = GetElementType(collected.Element);
+            string? name = GetElementName(collected.Element);
+
+            if (string.IsNullOrWhiteSpace(name) ||
+                SurveyJsElementTypes.IsNonData(type) ||
+                SurveyJsElementTypes.ContainerTypes.Contains(type!) ||
+                string.Equals(type, "checkbox", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(type, "tagbox", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(type, "ranking", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(type, "matrix", StringComparison.OrdinalIgnoreCase) ||
+                drivingCheckboxNames.Contains(name))
+            {
+                continue;
+            }
+
+            AddColumn(columns, seenKeys, limits, new CodebookColumnDefinition(
+                name,
+                CodebookColumnKind.Simple,
+                GetElementTitle(collected.Element, name),
+                MapDataType(type)));
+        }
+    }
+
+    private static void AddCheckboxColumns(
+        IReadOnlyList<CollectedElement> allElements,
+        HashSet<string> drivingCheckboxNames,
+        List<CodebookColumnDefinition> columns,
+        HashSet<string> seenKeys,
+        FlatteningLimits limits)
+    {
+        foreach (CollectedElement collected in allElements.Where(item => item.Depth == 0))
+        {
+            string? type = GetElementType(collected.Element);
+            string? name = GetElementName(collected.Element);
+
+            if (string.IsNullOrWhiteSpace(name) ||
+                drivingCheckboxNames.Contains(name) ||
+                (!string.Equals(type, "checkbox", StringComparison.OrdinalIgnoreCase) &&
+                 !string.Equals(type, "tagbox", StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            int choiceCount = 0;
+            foreach ((string value, string text) in SurveyJsChoiceHelper.EnumerateChoices(collected.Element))
+            {
+                if (++choiceCount > limits.MaxChoicesPerQuestion)
+                {
+                    throw new FlatteningLimitExceededException(
+                        $"Choice limit of {limits.MaxChoicesPerQuestion} exceeded for question '{name}'.");
+                }
+
+                string key = ExportPathBuilder.CheckboxChoiceKey(name, value);
+                AddColumn(columns, seenKeys, limits, new CodebookColumnDefinition(
+                    key,
+                    CodebookColumnKind.CheckboxChoice,
+                    $"{GetElementTitle(collected.Element, name)} — {text}",
+                    "boolean",
+                    SourceQuestion: name,
+                    ChoiceValue: value));
+            }
+
+            if (collected.Element.TryGetProperty("showOtherItem", out JsonElement showOtherProp) &&
+                showOtherProp.ValueKind == JsonValueKind.True)
+            {
+                AddColumn(columns, seenKeys, limits, new CodebookColumnDefinition(
+                    ExportPathBuilder.CheckboxOtherTextKey(name),
+                    CodebookColumnKind.CheckboxOtherText,
+                    $"{GetElementTitle(collected.Element, name)} — Other",
+                    "string",
+                    SourceQuestion: name));
+            }
+        }
+    }
+
+    private static void AddRankingColumns(
+        IReadOnlyList<CollectedElement> allElements,
+        List<CodebookColumnDefinition> columns,
+        HashSet<string> seenKeys,
+        FlatteningLimits limits)
+    {
+        foreach (CollectedElement collected in allElements.Where(item => item.Depth == 0))
+        {
+            string? type = GetElementType(collected.Element);
+            string? name = GetElementName(collected.Element);
+
+            if (string.IsNullOrWhiteSpace(name) ||
+                !string.Equals(type, "ranking", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            int choiceCount = 0;
+            foreach ((string value, string text) in SurveyJsChoiceHelper.EnumerateChoices(collected.Element))
+            {
+                if (++choiceCount > limits.MaxChoicesPerQuestion)
+                {
+                    throw new FlatteningLimitExceededException(
+                        $"Choice limit of {limits.MaxChoicesPerQuestion} exceeded for question '{name}'.");
+                }
+
+                string key = ExportPathBuilder.RankingChoiceKey(name, value);
+                AddColumn(columns, seenKeys, limits, new CodebookColumnDefinition(
+                    key,
+                    CodebookColumnKind.RankingChoice,
+                    $"{GetElementTitle(collected.Element, name)} — {text}",
+                    "number",
+                    SourceQuestion: name,
+                    ChoiceValue: value));
+            }
+        }
+    }
+
+    private static void AddMatrixColumns(
+        IReadOnlyList<CollectedElement> allElements,
+        List<CodebookColumnDefinition> columns,
+        HashSet<string> seenKeys,
+        FlatteningLimits limits)
+    {
+        foreach (CollectedElement collected in allElements.Where(item => item.Depth == 0))
+        {
+            string? type = GetElementType(collected.Element);
+            string? name = GetElementName(collected.Element);
+
+            if (string.IsNullOrWhiteSpace(name) ||
+                !string.Equals(type, "matrix", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            foreach ((string value, string text) in SurveyJsChoiceHelper.EnumerateMatrixRows(collected.Element))
+            {
+                string key = ExportPathBuilder.MatrixRowKey(name, value);
+                AddColumn(columns, seenKeys, limits, new CodebookColumnDefinition(
+                    key,
+                    CodebookColumnKind.MatrixRow,
+                    $"{GetElementTitle(collected.Element, name)} — {text}",
+                    "string",
+                    SourceQuestion: name,
+                    MatrixRowValue: value));
+            }
+        }
+    }
+
+    private static void AddStandalonePanelDynamicColumns(
+        IReadOnlyList<CollectedElement> allElements,
+        HashSet<string> drivingCheckboxNames,
+        List<CodebookColumnDefinition> columns,
+        HashSet<string> seenKeys,
+        FlatteningLimits limits)
+    {
+        foreach (CollectedElement collected in allElements.Where(item => item.Depth == 0))
+        {
+            string? type = GetElementType(collected.Element);
+            string? name = GetElementName(collected.Element);
+
+            if (string.IsNullOrWhiteSpace(name) ||
+                !string.Equals(type, "paneldynamic", StringComparison.OrdinalIgnoreCase) ||
+                (collected.Element.TryGetProperty("valueName", out JsonElement valueNameProp) &&
+                 !string.IsNullOrWhiteSpace(valueNameProp.GetString()) &&
+                 drivingCheckboxNames.Contains(valueNameProp.GetString()!)))
+            {
+                continue;
+            }
+
+            if (!collected.Element.TryGetProperty("templateElements", out JsonElement templateElements) ||
+                templateElements.ValueKind != JsonValueKind.Array)
+            {
+                continue;
+            }
+
+            int maxPanelCount = collected.Element.TryGetProperty("maxPanelCount", out JsonElement maxPanelCountProp) &&
+                                maxPanelCountProp.ValueKind == JsonValueKind.Number
+                ? maxPanelCountProp.GetInt32()
+                : limits.MaxPanelCount;
+
+            for (int index = 0; index < maxPanelCount; index++)
+            {
+                foreach (JsonElement template in templateElements.EnumerateArray())
+                {
+                    string? childType = GetElementType(template);
+                    string? childName = GetElementName(template);
+
+                    if (string.IsNullOrWhiteSpace(childName) ||
+                        SurveyJsElementTypes.IsNonData(childType) ||
+                        string.Equals(childType, "paneldynamic", StringComparison.OrdinalIgnoreCase))
+                    {
+                        continue;
+                    }
+
+                    string key = ExportPathBuilder.PanelIndexKey(name, index, childName);
+                    AddColumn(columns, seenKeys, limits, new CodebookColumnDefinition(
+                        key,
+                        CodebookColumnKind.PanelDynamicIndex,
+                        $"{GetElementTitle(template, childName)} ({name} #{index + 1})",
+                        MapDataType(childType),
+                        SourceQuestion: childName,
+                        PanelName: name,
+                        PanelIndex: index));
+                }
+            }
+        }
+    }
+
+    private static void AddNestedLoopColumns(
+        IReadOnlyList<PanelPath> panelPaths,
+        IReadOnlyList<CollectedElement> allElements,
+        HashSet<string> drivingCheckboxNames,
+        List<CodebookColumnDefinition> columns,
+        HashSet<string> seenKeys,
+        FlatteningLimits limits)
+    {
+        foreach (PanelPath panelPath in panelPaths)
+        {
+            List<IReadOnlyList<string>> choiceCombinations = BuildChoiceCombinations(panelPath, limits);
+
+            foreach (JsonElement template in panelPath.TemplateElements)
+            {
+                string? childType = GetElementType(template);
+                string? childName = GetElementName(template);
+
+                if (string.IsNullOrWhiteSpace(childName) ||
+                    SurveyJsElementTypes.IsNonData(childType) ||
+                    string.Equals(childType, "paneldynamic", StringComparison.OrdinalIgnoreCase) ||
+                    drivingCheckboxNames.Contains(childName))
+                {
+                    continue;
+                }
+
+                foreach (IReadOnlyList<string> choiceValues in choiceCombinations)
+                {
+                    List<LoopSegment> loopSegments = [];
+                    for (int i = 0; i < panelPath.LoopPath.Count; i++)
+                    {
+                        loopSegments.Add(new LoopSegment(
+                            panelPath.LoopPath[i],
+                            panelPath.PropertyPath[i],
+                            choiceValues[i]));
+                    }
+
+                    string key = ExportPathBuilder.NestedLoopKey([.. choiceValues], childName);
+                    AddColumn(columns, seenKeys, limits, new CodebookColumnDefinition(
+                        key,
+                        CodebookColumnKind.NestedLoop,
+                        $"{GetElementTitle(template, childName)} ({string.Join(" / ", choiceValues)})",
+                        MapDataType(childType),
+                        SourceQuestion: childName,
+                        LoopPath: loopSegments));
+                }
+            }
+        }
+    }
+
+    private static List<IReadOnlyList<string>> BuildChoiceCombinations(
+        PanelPath panelPath,
+        FlatteningLimits limits)
+    {
+        List<IReadOnlyList<string>> levels = [];
+
+        for (int i = 0; i < panelPath.ChoicesPath.Count; i++)
+        {
+            JsonElement choicesElement = panelPath.ChoicesPath[i];
+            List<string> values = [];
+
+            if (choicesElement.ValueKind == JsonValueKind.Array)
+            {
+                foreach (JsonElement choice in choicesElement.EnumerateArray())
+                {
+                    if (choice.ValueKind == JsonValueKind.String)
+                    {
+                        values.Add(choice.GetString()!);
+                    }
+                    else if (choice.ValueKind == JsonValueKind.Object)
+                    {
+                        string? value = choice.TryGetProperty("value", out JsonElement valueProp)
+                            ? valueProp.GetString()
+                            : choice.TryGetProperty("text", out JsonElement textProp)
+                                ? textProp.GetString()
+                                : null;
+
+                        if (value is not null)
+                        {
+                            values.Add(value);
+                        }
+                    }
+                }
+            }
+
+            if (values.Count > limits.MaxChoicesPerQuestion)
+            {
+                throw new FlatteningLimitExceededException(
+                    $"Choice limit of {limits.MaxChoicesPerQuestion} exceeded for loop level {i + 1}.");
+            }
+
+            levels.Add(values);
+        }
+
+        return CartesianProduct(levels).ToList();
+    }
+
+    private static IEnumerable<IReadOnlyList<string>> CartesianProduct(IReadOnlyList<IReadOnlyList<string>> levels)
+    {
+        IEnumerable<IReadOnlyList<string>> results = [Array.Empty<string>()];
+
+        foreach (IReadOnlyList<string> level in levels)
+        {
+            results = results.SelectMany(prefix =>
+                level.Select(value => (IReadOnlyList<string>)[.. prefix, value]));
+        }
+
+        foreach (IReadOnlyList<string> result in results)
+        {
+            yield return result;
+        }
+    }
+
+    private static bool IsDrivingCheckbox(JsonElement element) =>
+        SurveyJsElementTypes.IsDrivingChoiceType(GetElementType(element)) &&
+        element.TryGetProperty("valuePropertyName", out JsonElement valuePropertyNameProp) &&
+        !string.IsNullOrWhiteSpace(valuePropertyNameProp.GetString()) &&
+        !string.IsNullOrWhiteSpace(GetElementName(element));
+
+    private static void AddColumn(
+        List<CodebookColumnDefinition> columns,
+        HashSet<string> seenKeys,
+        FlatteningLimits limits,
+        CodebookColumnDefinition column)
+    {
+        if (!seenKeys.Add(column.Key))
+        {
+            return;
+        }
+
+        if (columns.Count >= limits.MaxColumns)
+        {
+            throw new FlatteningLimitExceededException(
+                $"Codebook column limit of {limits.MaxColumns} exceeded.");
+        }
+
+        columns.Add(column);
+    }
+
+    private static string? GetElementType(JsonElement element) =>
+        element.TryGetProperty("type", out JsonElement typeProp) ? typeProp.GetString() : null;
+
+    private static string? GetElementName(JsonElement element) =>
+        element.TryGetProperty("name", out JsonElement nameProp) ? nameProp.GetString() : null;
+
+    private static string GetElementTitle(JsonElement element, string fallback) =>
+        element.TryGetProperty("title", out JsonElement titleProp) && !string.IsNullOrWhiteSpace(titleProp.GetString())
+            ? titleProp.GetString()!
+            : fallback;
+
+    private static string MapDataType(string? type) => type?.ToLowerInvariant() switch
+    {
+        "boolean" => "boolean",
+        "number" or "rating" => "number",
+        "file" => "file",
+        _ => "string",
+    };
+}

--- a/src/Endatix.Modules.Reporting/Domain/SurveyJs/SurveyJsElementTypes.cs
+++ b/src/Endatix.Modules.Reporting/Domain/SurveyJs/SurveyJsElementTypes.cs
@@ -1,0 +1,39 @@
+namespace Endatix.Modules.Reporting.Domain.SurveyJs;
+
+internal static class SurveyJsElementTypes
+{
+    internal static readonly HashSet<string> NonDataTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "html",
+        "expression",
+        "image",
+    };
+
+    internal static readonly HashSet<string> ContainerTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "panel",
+        "paneldynamic",
+    };
+
+    internal static readonly HashSet<string> ChoiceTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "checkbox",
+        "radiogroup",
+        "dropdown",
+        "tagbox",
+    };
+
+    internal static readonly HashSet<string> MatrixTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "matrix",
+        "matrixdropdown",
+        "matrixdynamic",
+    };
+
+    internal static bool IsNonData(string? type) =>
+        type is not null && NonDataTypes.Contains(type);
+
+    internal static bool IsDrivingChoiceType(string? type) =>
+        type is not null && (string.Equals(type, "checkbox", StringComparison.OrdinalIgnoreCase) ||
+                             string.Equals(type, "radiogroup", StringComparison.OrdinalIgnoreCase));
+}

--- a/src/Endatix.Modules.Reporting/Domain/SurveyJs/SurveyJsSubmissionFlattener.cs
+++ b/src/Endatix.Modules.Reporting/Domain/SurveyJs/SurveyJsSubmissionFlattener.cs
@@ -1,0 +1,238 @@
+using System.Text.Json;
+
+namespace Endatix.Modules.Reporting.Domain.SurveyJs;
+
+/// <summary>
+/// Maps submission JSON to codebook keys using a compiled <see cref="MergedCodebook"/>.
+/// </summary>
+internal static class SurveyJsSubmissionFlattener
+{
+    public static Dictionary<string, JsonElement?> Flatten(
+        JsonElement submission,
+        MergedCodebook codebook)
+    {
+        Dictionary<string, JsonElement?> result = new(StringComparer.Ordinal);
+
+        foreach (CodebookColumnDefinition column in codebook.Columns)
+        {
+            result[column.Key] = ExtractValue(submission, column);
+        }
+
+        return result;
+    }
+
+    public static string ToJson(Dictionary<string, JsonElement?> flattened)
+    {
+        using MemoryStream stream = new();
+        using Utf8JsonWriter writer = new(stream);
+        writer.WriteStartObject();
+
+        foreach ((string key, JsonElement? value) in flattened)
+        {
+            writer.WritePropertyName(key);
+            if (value is null)
+            {
+                writer.WriteNullValue();
+            }
+            else
+            {
+                value.Value.WriteTo(writer);
+            }
+        }
+
+        writer.WriteEndObject();
+        return System.Text.Encoding.UTF8.GetString(stream.ToArray());
+    }
+
+    private static JsonElement? ExtractValue(JsonElement submission, CodebookColumnDefinition column) =>
+        column.Kind switch
+        {
+            CodebookColumnKind.Simple or CodebookColumnKind.Calculated =>
+                TryGetProperty(submission, column.Key),
+
+            CodebookColumnKind.CheckboxChoice =>
+                ToBooleanJson(ContainsChoice(submission, column.SourceQuestion!, column.ChoiceValue!)),
+
+            CodebookColumnKind.RankingChoice =>
+                ToRankJson(GetRankPosition(submission, column.SourceQuestion!, column.ChoiceValue!)),
+
+            CodebookColumnKind.CheckboxOtherText =>
+                TryGetOtherText(submission, column.SourceQuestion!),
+
+            CodebookColumnKind.MatrixRow =>
+                TryGetMatrixRowValue(submission, column.SourceQuestion!, column.MatrixRowValue!),
+
+            CodebookColumnKind.PanelDynamicIndex =>
+                TryGetPanelIndexValue(submission, column),
+
+            CodebookColumnKind.NestedLoop =>
+                TryGetNestedLoopValue(submission, column),
+
+            _ => null,
+        };
+
+    private static JsonElement? TryGetProperty(JsonElement root, string propertyName)
+    {
+        if (root.ValueKind != JsonValueKind.Object ||
+            !root.TryGetProperty(propertyName, out JsonElement value))
+        {
+            return null;
+        }
+
+        return value;
+    }
+
+    private static bool ContainsChoice(JsonElement submission, string questionName, string choiceValue)
+    {
+        if (!submission.TryGetProperty(questionName, out JsonElement answer))
+        {
+            return false;
+        }
+
+        if (answer.ValueKind == JsonValueKind.Array)
+        {
+            foreach (JsonElement item in answer.EnumerateArray())
+            {
+                if (item.ValueKind == JsonValueKind.String &&
+                    string.Equals(item.GetString(), choiceValue, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        return answer.ValueKind == JsonValueKind.String &&
+               string.Equals(answer.GetString(), choiceValue, StringComparison.Ordinal);
+    }
+
+    private static JsonElement ToBooleanJson(bool value) =>
+        JsonDocument.Parse(value ? "1" : "0").RootElement.Clone();
+
+    private static int GetRankPosition(JsonElement submission, string questionName, string choiceValue)
+    {
+        if (!submission.TryGetProperty(questionName, out JsonElement answer) ||
+            answer.ValueKind != JsonValueKind.Array)
+        {
+            return 0;
+        }
+
+        int rank = 1;
+        foreach (JsonElement item in answer.EnumerateArray())
+        {
+            if (item.ValueKind == JsonValueKind.String &&
+                string.Equals(item.GetString(), choiceValue, StringComparison.Ordinal))
+            {
+                return rank;
+            }
+
+            rank++;
+        }
+
+        return 0;
+    }
+
+    private static JsonElement ToRankJson(int rank) =>
+        JsonDocument.Parse(rank.ToString(System.Globalization.CultureInfo.InvariantCulture)).RootElement.Clone();
+
+    private static JsonElement? TryGetOtherText(JsonElement submission, string questionName)
+    {
+        if (!submission.TryGetProperty(questionName, out JsonElement answer))
+        {
+            return null;
+        }
+
+        if (answer.ValueKind == JsonValueKind.Object &&
+            answer.TryGetProperty("other", out JsonElement other))
+        {
+            return other;
+        }
+
+        string otherCommentKey = $"{questionName}-Comment";
+        return TryGetProperty(submission, otherCommentKey);
+    }
+
+    private static JsonElement? TryGetMatrixRowValue(
+        JsonElement submission,
+        string matrixName,
+        string rowValue)
+    {
+        if (!submission.TryGetProperty(matrixName, out JsonElement matrixAnswer) ||
+            matrixAnswer.ValueKind != JsonValueKind.Object ||
+            !matrixAnswer.TryGetProperty(rowValue, out JsonElement rowAnswer))
+        {
+            return null;
+        }
+
+        return rowAnswer;
+    }
+
+    private static JsonElement? TryGetPanelIndexValue(JsonElement submission, CodebookColumnDefinition column)
+    {
+        if (column.PanelIndex is null || column.SourceQuestion is null)
+        {
+            return null;
+        }
+
+        if (string.IsNullOrWhiteSpace(column.PanelName) ||
+            !submission.TryGetProperty(column.PanelName, out JsonElement panelArray) ||
+            panelArray.ValueKind != JsonValueKind.Array)
+        {
+            return null;
+        }
+
+        int index = 0;
+        foreach (JsonElement panelItem in panelArray.EnumerateArray())
+        {
+            if (index == column.PanelIndex.Value)
+            {
+                return TryGetProperty(panelItem, column.SourceQuestion);
+            }
+
+            index++;
+        }
+
+        return null;
+    }
+
+    private static JsonElement? TryGetNestedLoopValue(JsonElement submission, CodebookColumnDefinition column)
+    {
+        if (column.LoopPath is null || column.LoopPath.Count == 0 || column.SourceQuestion is null)
+        {
+            return null;
+        }
+
+        JsonElement current = submission;
+
+        foreach (LoopSegment segment in column.LoopPath)
+        {
+            if (!current.TryGetProperty(segment.PanelValueName, out JsonElement panelArray) ||
+                panelArray.ValueKind != JsonValueKind.Array)
+            {
+                return null;
+            }
+
+            JsonElement? matchedItem = null;
+            foreach (JsonElement item in panelArray.EnumerateArray())
+            {
+                if (item.TryGetProperty(segment.PropertyName, out JsonElement propertyValue) &&
+                    propertyValue.ValueKind == JsonValueKind.String &&
+                    string.Equals(propertyValue.GetString(), segment.ChoiceValue, StringComparison.Ordinal))
+                {
+                    matchedItem = item;
+                    break;
+                }
+            }
+
+            if (matchedItem is null)
+            {
+                return null;
+            }
+
+            current = matchedItem.Value;
+        }
+
+        return TryGetProperty(current, column.SourceQuestion);
+    }
+}

--- a/src/Endatix.Modules.Reporting/Endatix.Modules.Reporting.csproj
+++ b/src/Endatix.Modules.Reporting/Endatix.Modules.Reporting.csproj
@@ -27,4 +27,8 @@
     <ProjectReference Include="..\Endatix.Infrastructure\Endatix.Infrastructure.csproj" />
     <ProjectReference Include="..\Endatix.Modules.Reporting.Contracts\Endatix.Modules.Reporting.Contracts.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Endatix.Modules.Reporting.Tests" />
+  </ItemGroup>
 </Project>

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/checkbox-definition.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/checkbox-definition.json
@@ -1,0 +1,18 @@
+{
+  "pages": [
+    {
+      "elements": [
+        {
+          "type": "checkbox",
+          "name": "colors",
+          "title": "Favorite colors",
+          "choices": [
+            { "value": "red", "text": "Red" },
+            { "value": "blue", "text": "Blue" }
+          ],
+          "showOtherItem": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/checkbox-expected-flat.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/checkbox-expected-flat.json
@@ -1,0 +1,5 @@
+{
+  "colors__red": 1,
+  "colors__blue": 0,
+  "colors__other_text": "Crimson"
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/checkbox-expected-keys.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/checkbox-expected-keys.json
@@ -1,0 +1,5 @@
+[
+  "colors__red",
+  "colors__blue",
+  "colors__other_text"
+]

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/checkbox-submission.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/checkbox-submission.json
@@ -1,0 +1,4 @@
+{
+  "colors": ["red", "other"],
+  "colors-Comment": "Crimson"
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/nested-loop-definition.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/nested-loop-definition.json
@@ -1,0 +1,29 @@
+{
+  "pages": [
+    {
+      "elements": [
+        {
+          "type": "checkbox",
+          "name": "cars",
+          "valuePropertyName": "carType",
+          "choices": [
+            { "value": "ford", "text": "Ford" },
+            { "value": "bmw", "text": "BMW" }
+          ]
+        },
+        {
+          "type": "paneldynamic",
+          "name": "carDetails",
+          "valueName": "cars",
+          "templateElements": [
+            {
+              "type": "text",
+              "name": "model",
+              "title": "Model"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/nested-loop-expected-flat.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/nested-loop-expected-flat.json
@@ -1,0 +1,4 @@
+{
+  "ford__model": "Focus",
+  "bmw__model": "X5"
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/nested-loop-expected-keys.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/nested-loop-expected-keys.json
@@ -1,0 +1,4 @@
+[
+  "ford__model",
+  "bmw__model"
+]

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/nested-loop-submission.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/nested-loop-submission.json
@@ -1,0 +1,6 @@
+{
+  "cars": [
+    { "carType": "ford", "model": "Focus" },
+    { "carType": "bmw", "model": "X5" }
+  ]
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/paneldynamic-definition.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/paneldynamic-definition.json
@@ -1,0 +1,20 @@
+{
+  "pages": [
+    {
+      "elements": [
+        {
+          "type": "paneldynamic",
+          "name": "contacts",
+          "maxPanelCount": 2,
+          "templateElements": [
+            {
+              "type": "text",
+              "name": "email",
+              "title": "Email"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/paneldynamic-expected-flat.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/paneldynamic-expected-flat.json
@@ -1,0 +1,4 @@
+{
+  "contacts__0__email": "a@example.com",
+  "contacts__1__email": "b@example.com"
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/paneldynamic-expected-keys.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/paneldynamic-expected-keys.json
@@ -1,0 +1,4 @@
+[
+  "contacts__0__email",
+  "contacts__1__email"
+]

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/paneldynamic-submission.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/paneldynamic-submission.json
@@ -1,0 +1,6 @@
+{
+  "contacts": [
+    { "email": "a@example.com" },
+    { "email": "b@example.com" }
+  ]
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/ranking-definition.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/ranking-definition.json
@@ -1,0 +1,19 @@
+{
+  "pages": [
+    {
+      "elements": [
+        {
+          "type": "ranking",
+          "name": "priorities",
+          "title": "Rank your priorities",
+          "choices": [
+            { "value": "price", "text": "Price" },
+            { "value": "design", "text": "Design" },
+            { "value": "reliability", "text": "Reliability" },
+            { "value": "color", "text": "Color" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/ranking-expected-flat.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/ranking-expected-flat.json
@@ -1,0 +1,6 @@
+{
+  "priorities__design": 1,
+  "priorities__price": 2,
+  "priorities__reliability": 0,
+  "priorities__color": 0
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/ranking-expected-keys.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/ranking-expected-keys.json
@@ -1,0 +1,6 @@
+[
+  "priorities__price",
+  "priorities__design",
+  "priorities__reliability",
+  "priorities__color"
+]

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/ranking-submission.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/ranking-submission.json
@@ -1,0 +1,3 @@
+{
+  "priorities": ["design", "price"]
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/simple-definition.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/simple-definition.json
@@ -1,0 +1,32 @@
+{
+  "pages": [
+    {
+      "name": "page1",
+      "elements": [
+        {
+          "type": "text",
+          "name": "firstName",
+          "title": "First name"
+        },
+        {
+          "type": "dropdown",
+          "name": "country",
+          "title": "Country",
+          "choices": ["US", "UK"]
+        },
+        {
+          "type": "html",
+          "name": "info",
+          "html": "<p>ignored</p>"
+        }
+      ]
+    }
+  ],
+  "calculatedValues": [
+    {
+      "name": "totalScore",
+      "expression": "1",
+      "includeIntoResult": true
+    }
+  ]
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/simple-expected-flat.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/simple-expected-flat.json
@@ -1,0 +1,5 @@
+{
+  "firstName": "Ada",
+  "country": "UK",
+  "totalScore": 42
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/simple-expected-keys.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/simple-expected-keys.json
@@ -1,0 +1,5 @@
+[
+  "firstName",
+  "country",
+  "totalScore"
+]

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/simple-submission.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/Fixtures/simple-submission.json
@@ -1,0 +1,5 @@
+{
+  "firstName": "Ada",
+  "country": "UK",
+  "totalScore": 42
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/SurveyJsDefinitionFlattenerTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/SurveyJsDefinitionFlattenerTests.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using Endatix.Modules.Reporting.Domain.SurveyJs;
+
+namespace Endatix.Modules.Reporting.Tests.Domain.SurveyJs;
+
+public class SurveyJsDefinitionFlattenerTests
+{
+    [Theory]
+    [InlineData("simple-definition.json", "simple-expected-keys.json")]
+    [InlineData("checkbox-definition.json", "checkbox-expected-keys.json")]
+    [InlineData("paneldynamic-definition.json", "paneldynamic-expected-keys.json")]
+    [InlineData("nested-loop-definition.json", "nested-loop-expected-keys.json")]
+    [InlineData("ranking-definition.json", "ranking-expected-keys.json")]
+    public void Flatten_ProducesExpectedKeys(string definitionFixture, string expectedKeysFixture)
+    {
+        JsonElement definition = SurveyJsFixtureLoader.LoadDefinition(definitionFixture);
+        FlatteningLimits limits = definitionFixture.Contains("paneldynamic", StringComparison.Ordinal)
+            ? new FlatteningLimits { MaxPanelCount = 2 }
+            : FlatteningLimits.Default;
+
+        IReadOnlyList<CodebookColumnDefinition> columns =
+            SurveyJsDefinitionFlattener.Flatten(definition, limits);
+
+        columns.Select(column => column.Key).Should().BeEquivalentTo(
+            SurveyJsFixtureLoader.LoadExpectedKeys(expectedKeysFixture),
+            options => options.WithStrictOrdering());
+    }
+
+    [Fact]
+    public void Flatten_SkipsNonDataElements()
+    {
+        JsonElement definition = SurveyJsFixtureLoader.LoadDefinition("simple-definition.json");
+
+        IReadOnlyList<CodebookColumnDefinition> columns =
+            SurveyJsDefinitionFlattener.Flatten(definition);
+
+        columns.Should().NotContain(column => column.Key == "info");
+    }
+
+    [Fact]
+    public void Compile_AppendOnlyMerge_PreservesHistoricalKeys()
+    {
+        const string versionOne = """
+            {
+              "pages": [
+                {
+                  "elements": [
+                    { "type": "text", "name": "firstName", "title": "First name" }
+                  ]
+                }
+              ]
+            }
+            """;
+
+        const string versionTwo = """
+            {
+              "pages": [
+                {
+                  "elements": [
+                    { "type": "text", "name": "firstName", "title": "First name" },
+                    { "type": "text", "name": "lastName", "title": "Last name" }
+                  ]
+                }
+              ]
+            }
+            """;
+
+        FormExportSchemaCompiler compiler = new();
+        MergedCodebook firstPass = compiler.Compile(versionOne);
+        MergedCodebook merged = compiler.Compile(versionTwo, firstPass);
+
+        merged.Columns.Select(column => column.Key).Should().Equal("firstName", "lastName");
+    }
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/SurveyJsFixtureLoader.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/SurveyJsFixtureLoader.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+using Endatix.Modules.Reporting.Domain.SurveyJs;
+
+namespace Endatix.Modules.Reporting.Tests.Domain.SurveyJs;
+
+internal static class SurveyJsFixtureLoader
+{
+    internal static JsonElement LoadDefinition(string fixtureName)
+    {
+        string path = Path.Combine(AppContext.BaseDirectory, "Domain", "SurveyJs", "Fixtures", fixtureName);
+        using JsonDocument document = JsonDocument.Parse(File.ReadAllText(path));
+        return document.RootElement.Clone();
+    }
+
+    internal static JsonElement LoadJson(string fixtureName)
+    {
+        string path = Path.Combine(AppContext.BaseDirectory, "Domain", "SurveyJs", "Fixtures", fixtureName);
+        using JsonDocument document = JsonDocument.Parse(File.ReadAllText(path));
+        return document.RootElement.Clone();
+    }
+
+    internal static IReadOnlyList<string> LoadExpectedKeys(string fixtureName)
+    {
+        JsonElement array = LoadJson(fixtureName);
+        return array.EnumerateArray().Select(item => item.GetString()!).ToList();
+    }
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/SurveyJsSubmissionFlattenerTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Domain/SurveyJs/SurveyJsSubmissionFlattenerTests.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using Endatix.Modules.Reporting.Domain.SurveyJs;
+
+namespace Endatix.Modules.Reporting.Tests.Domain.SurveyJs;
+
+public class SurveyJsSubmissionFlattenerTests
+{
+    [Fact]
+    public void Flatten_SimpleSubmission_MapsDirectProperties()
+    {
+        JsonElement definition = SurveyJsFixtureLoader.LoadDefinition("simple-definition.json");
+        JsonElement submission = SurveyJsFixtureLoader.LoadJson("simple-submission.json");
+        JsonElement expected = SurveyJsFixtureLoader.LoadJson("simple-expected-flat.json");
+
+        MergedCodebook codebook = new(SurveyJsDefinitionFlattener.Flatten(definition));
+        Dictionary<string, JsonElement?> flattened = SurveyJsSubmissionFlattener.Flatten(submission, codebook);
+
+        foreach (JsonProperty property in expected.EnumerateObject())
+        {
+            flattened[property.Name]!.Value.GetRawText().Should().Be(property.Value.GetRawText());
+        }
+    }
+
+    [Theory]
+    [InlineData("checkbox-definition.json", "checkbox-submission.json", "checkbox-expected-flat.json")]
+    [InlineData("paneldynamic-definition.json", "paneldynamic-submission.json", "paneldynamic-expected-flat.json")]
+    [InlineData("nested-loop-definition.json", "nested-loop-submission.json", "nested-loop-expected-flat.json")]
+    [InlineData("ranking-definition.json", "ranking-submission.json", "ranking-expected-flat.json")]
+    public void Flatten_MapsSubmissionToCodebookKeys(
+        string definitionFixture,
+        string submissionFixture,
+        string expectedFlatFixture)
+    {
+        JsonElement definition = SurveyJsFixtureLoader.LoadDefinition(definitionFixture);
+        FlatteningLimits limits = definitionFixture.Contains("paneldynamic", StringComparison.Ordinal)
+            ? new FlatteningLimits { MaxPanelCount = 2 }
+            : FlatteningLimits.Default;
+
+        MergedCodebook codebook = new(SurveyJsDefinitionFlattener.Flatten(definition, limits));
+        JsonElement submission = SurveyJsFixtureLoader.LoadJson(submissionFixture);
+        JsonElement expected = SurveyJsFixtureLoader.LoadJson(expectedFlatFixture);
+
+        Dictionary<string, JsonElement?> flattened =
+            SurveyJsSubmissionFlattener.Flatten(submission, codebook);
+
+        foreach (JsonProperty property in expected.EnumerateObject())
+        {
+            flattened.Should().ContainKey(property.Name);
+            JsonElement? actual = flattened[property.Name];
+            actual.Should().NotBeNull();
+            JsonElementsEqual(property.Value, actual!.Value).Should().BeTrue(
+                $"expected {property.Name} to equal {property.Value}");
+        }
+    }
+
+    private static bool JsonElementsEqual(JsonElement left, JsonElement right) =>
+        left.GetRawText() == right.GetRawText();
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Endatix.Modules.Reporting.Tests.csproj
+++ b/tests/Endatix.Modules.Reporting.Tests/Endatix.Modules.Reporting.Tests.csproj
@@ -11,4 +11,10 @@
     <ProjectReference Include="..\..\src\Endatix.Modules.Reporting\Endatix.Modules.Reporting.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Domain\SurveyJs\Fixtures\**\*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- Adds pure C# SurveyJS **definition flattening** (`SurveyJsDefinitionFlattener`) and **submission flattening** (`SurveyJsSubmissionFlattener`) for the reporting read model
- Introduces `FormExportSchemaCompiler` with append-only `MergedCodebook` merge and `FlatteningLimits`
- Column kinds: simple, calculated, checkbox/tagbox one-hot, matrix rows, paneldynamic indices, nested choice-driven loops, and **ranking rank-position** (`{q}__{choice}` = 1..n or 0)
- Internal canonical keys use `__` segments (Crunch alias transform deferred to PR-E6b)

## Test plan
- [x] `dotnet test tests/Endatix.Modules.Reporting.Tests` — 36 passed
- [x] Golden JSON fixtures: simple, checkbox, paneldynamic, nested loop, ranking, append-only merge
- [ ] Manual: n/a (no runtime wiring yet — PR-E5 handlers next)

## Follow-up
- PR-E5: background handlers + repositories
- PR-E6b: Crunch column alias transform at export time
- `choicesFromQuestion` ranking: static `choices` only in this PR; dynamic choice sources in E12/data-list work