### PR TITLE
chore(e831): bump coverlet.collector NuGet from 6.0.4 to 10.0.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -51,7 +51,7 @@
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="SendGrid" Version="9.29.3" />
     <PackageVersion Include="SendGrid.Extensions.DependencyInjection" Version="1.0.1" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Serilog.Sinks.ApplicationInsights" Version="5.0.0" />

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -10,6 +10,8 @@
         <!-- Do not inherit oss RuntimeFrameworkVersion (10.0.6); use the SDK default so tests run on locally installed 10.0.x. -->
         <RuntimeFrameworkVersion />
         <RollForward>LatestMinor</RollForward>
+        <!-- Keep dotnet test on VSTest (coverlet.collector, trait filters). .NET 10 defaults to MTP otherwise. -->
+        <TestingPlatformDotnetTestSupport>false</TestingPlatformDotnetTestSupport>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
# chore: bump coverlet.collector NuGet from 6.0.4 to 10.0.1

## Description
Please include a summary of the changes and the related issue. Also, explain the context and the reason for the proposed changes.

## Related Issues
- fixes #831 

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
