### PR TITLE
feat(e801): capability-scoped export request filters

### DIFF
--- a/src/Endatix.Api/Endpoints/Submissions/Export.ExportRequest.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/Export.ExportRequest.cs
@@ -18,4 +18,16 @@ public class ExportRequest
     /// Optional codebook label locale for this export run. Overrides format settings.
     /// </summary>
     public string? Locale { get; set; }
+
+    public DateTime? CreatedAfter { get; set; }
+
+    public DateTime? CreatedBefore { get; set; }
+
+    public DateTime? CompletedAfter { get; set; }
+
+    public DateTime? CompletedBefore { get; set; }
+
+    public long? MinSubmissionId { get; set; }
+
+    public long? MaxSubmissionId { get; set; }
 }

--- a/src/Endatix.Api/Endpoints/Submissions/Export.ExportValidator.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/Export.ExportValidator.cs
@@ -30,6 +30,36 @@ public class ExportValidator : Validator<ExportRequest>
           RuleFor(x => x.Locale)
                .MaximumLength(32)
                .When(x => x.Locale is not null);
+
+          // CreatedBefore / CompletedBefore are exclusive upper bounds in the reporting repository.
+          RuleFor(x => x)
+               .Must(request => !request.CreatedAfter.HasValue ||
+                                !request.CreatedBefore.HasValue ||
+                                request.CreatedAfter < request.CreatedBefore)
+               .WithMessage("CreatedAfter must be earlier than CreatedBefore (exclusive upper bound).")
+               .WithName("CreatedAfter");
+
+          RuleFor(x => x)
+               .Must(request => !request.CompletedAfter.HasValue ||
+                                !request.CompletedBefore.HasValue ||
+                                request.CompletedAfter < request.CompletedBefore)
+               .WithMessage("CompletedAfter must be earlier than CompletedBefore (exclusive upper bound).")
+               .WithName("CompletedAfter");
+
+          RuleFor(x => x)
+               .Must(request => !request.MinSubmissionId.HasValue ||
+                                !request.MaxSubmissionId.HasValue ||
+                                request.MinSubmissionId <= request.MaxSubmissionId)
+               .WithMessage("MinSubmissionId must be less than or equal to MaxSubmissionId.")
+               .WithName("MinSubmissionId");
+
+          RuleFor(x => x.MinSubmissionId)
+               .GreaterThan(0)
+               .When(x => x.MinSubmissionId.HasValue);
+
+          RuleFor(x => x.MaxSubmissionId)
+               .GreaterThan(0)
+               .When(x => x.MaxSubmissionId.HasValue);
      }
 
      private static IReadOnlyList<string> GetSupportedExportFormats(IExporterFactory exporterFactory)

--- a/src/Endatix.Api/Endpoints/Submissions/Export.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/Export.cs
@@ -269,15 +269,7 @@ public partial class Export : Endpoint<ExportRequest>
 
         var disallowedFilters = ExportRequestFilterGuard.GetDisallowedWireNames(
             capability.AllowedFilters,
-            request.IncludeTestSubmissions,
-            request.CreatedAfter,
-            request.CreatedBefore,
-            request.CompletedAfter,
-            request.CompletedBefore,
-            request.MinSubmissionId,
-            request.MaxSubmissionId,
-            request.Locale,
-            NormalizeColumnScope(request.ColumnScope));
+            CreateExportFilterContext(request));
         if (disallowedFilters.Count > 0)
         {
             return Result.Invalid(new ValidationError(
@@ -310,16 +302,8 @@ public partial class Export : Endpoint<ExportRequest>
         CancellationToken cancellationToken)
     {
         var disallowedOnLegacy = ExportRequestFilterGuard.GetDisallowedWireNames(
-            ExportRequestFilterKind.None,
-            request.IncludeTestSubmissions,
-            request.CreatedAfter,
-            request.CreatedBefore,
-            request.CompletedAfter,
-            request.CompletedBefore,
-            request.MinSubmissionId,
-            request.MaxSubmissionId,
-            request.Locale,
-            NormalizeColumnScope(request.ColumnScope));
+            ExportRequestFilters.None,
+            CreateExportFilterContext(request));
         if (disallowedOnLegacy.Count > 0)
         {
             return Result.Invalid(new ValidationError(
@@ -369,6 +353,18 @@ public partial class Export : Endpoint<ExportRequest>
             exportConfig.SqlFunctionName,
             exportConfig.ExportPageSize));
     }
+
+    private static ExportFilterContext CreateExportFilterContext(ExportRequest request) =>
+        new(
+            IncludeTestSubmissions: request.IncludeTestSubmissions,
+            CreatedAfter: request.CreatedAfter,
+            CreatedBefore: request.CreatedBefore,
+            CompletedAfter: request.CompletedAfter,
+            CompletedBefore: request.CompletedBefore,
+            MinSubmissionId: request.MinSubmissionId,
+            MaxSubmissionId: request.MaxSubmissionId,
+            Locale: request.Locale,
+            ColumnScope: NormalizeColumnScope(request.ColumnScope));
 
     private static string[]? NormalizeColumnScope(string[]? columnScope) =>
         columnScope is { Length: > 0 } ? columnScope : null;

--- a/src/Endatix.Api/Endpoints/Submissions/Export.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/Export.cs
@@ -267,12 +267,35 @@ public partial class Export : Endpoint<ExportRequest>
                 $"Export format with ID {exportFormat.Id} has an invalid item type."));
         }
 
+        var disallowedFilters = ExportRequestFilterGuard.GetDisallowedWireNames(
+            capability.AllowedFilters,
+            request.IncludeTestSubmissions,
+            request.CreatedAfter,
+            request.CreatedBefore,
+            request.CompletedAfter,
+            request.CompletedBefore,
+            request.MinSubmissionId,
+            request.MaxSubmissionId,
+            request.Locale,
+            NormalizeColumnScope(request.ColumnScope));
+        if (disallowedFilters.Count > 0)
+        {
+            return Result.Invalid(new ValidationError(
+                $"Filter(s) not supported for export capability '{capability.WireKey}': {string.Join(", ", disallowedFilters)}."));
+        }
+
         SubmissionExportExecutionSettings executionSettings = new(
             ExportFormatId: exportFormat.Id,
             SettingsJson: exportFormat.SettingsJson,
             IncludeTestSubmissions: request.IncludeTestSubmissions,
             ColumnScope: NormalizeColumnScope(request.ColumnScope),
-            Locale: NormalizeLocale(request.Locale));
+            Locale: NormalizeLocale(request.Locale),
+            CreatedAfter: request.CreatedAfter,
+            CreatedBefore: request.CreatedBefore,
+            CompletedAfter: request.CompletedAfter,
+            CompletedBefore: request.CompletedBefore,
+            MinSubmissionId: request.MinSubmissionId,
+            MaxSubmissionId: request.MaxSubmissionId);
 
         return Result.Success(new ValidatedExportOperation(
             exportFormat.WireKey,
@@ -286,6 +309,23 @@ public partial class Export : Endpoint<ExportRequest>
         ExportRequest request,
         CancellationToken cancellationToken)
     {
+        var disallowedOnLegacy = ExportRequestFilterGuard.GetDisallowedWireNames(
+            ExportRequestFilterKind.None,
+            request.IncludeTestSubmissions,
+            request.CreatedAfter,
+            request.CreatedBefore,
+            request.CompletedAfter,
+            request.CompletedBefore,
+            request.MinSubmissionId,
+            request.MaxSubmissionId,
+            request.Locale,
+            NormalizeColumnScope(request.ColumnScope));
+        if (disallowedOnLegacy.Count > 0)
+        {
+            return Result.Invalid(new ValidationError(
+                $"Filter(s) are not supported on legacy ExportId exports: {string.Join(", ", disallowedOnLegacy)}. Use ExportFormatId."));
+        }
+
         var exportId = request.ExportId!.Value;
         var spec = new TenantSettingsByTenantIdSpec(_tenantContext.TenantId);
         var tenantSettings = await _tenantSettingsRepository.FirstOrDefaultAsync(spec, cancellationToken);

--- a/src/Endatix.Core/Abstractions/Exporting/SubmissionExportReadModel.cs
+++ b/src/Endatix.Core/Abstractions/Exporting/SubmissionExportReadModel.cs
@@ -26,7 +26,13 @@ public sealed record SubmissionExportExecutionSettings(
     /// When true, CSV writers emit boolean values as category ids <c>0</c>/<c>1</c>
     /// (Crunch/Shoji). When false, booleans stay lowercase <c>true</c>/<c>false</c>.
     /// </summary>
-    bool EncodeBooleansAsCategoryIds = false);
+    bool EncodeBooleansAsCategoryIds = false,
+    DateTime? CreatedAfter = null,
+    DateTime? CreatedBefore = null,
+    DateTime? CompletedAfter = null,
+    DateTime? CompletedBefore = null,
+    long? MinSubmissionId = null,
+    long? MaxSubmissionId = null);
 
 /// <summary>
 /// Serialized <see cref="SubmissionExportColumnPlanEntry.Source"/> values.

--- a/src/Endatix.Modules.Reporting.Contracts/Export/ExportCapability.cs
+++ b/src/Endatix.Modules.Reporting.Contracts/Export/ExportCapability.cs
@@ -11,7 +11,7 @@ public sealed record ExportCapability(
     string Label,
     string ItemTypeName,
     string Description,
-    ExportRequestFilterKind AllowedFilters);
+    ExportRequestFilters AllowedFilters);
 
 /// <summary>
 /// Export capability exposed to admin APIs and Hub.

--- a/src/Endatix.Modules.Reporting.Contracts/Export/ExportCapability.cs
+++ b/src/Endatix.Modules.Reporting.Contracts/Export/ExportCapability.cs
@@ -10,7 +10,8 @@ public sealed record ExportCapability(
     string WireKey,
     string Label,
     string ItemTypeName,
-    string Description);
+    string Description,
+    ExportRequestFilterKind AllowedFilters);
 
 /// <summary>
 /// Export capability exposed to admin APIs and Hub.
@@ -22,4 +23,5 @@ public sealed record ExportCapabilityDto(
     string WireKey,
     string Label,
     string ItemTypeName,
-    string Description);
+    string Description,
+    IReadOnlyList<string> AllowedFilters);

--- a/src/Endatix.Modules.Reporting.Contracts/Export/ExportFilterContext.cs
+++ b/src/Endatix.Modules.Reporting.Contracts/Export/ExportFilterContext.cs
@@ -1,0 +1,15 @@
+namespace Endatix.Modules.Reporting.Contracts.Export;
+
+/// <summary>
+/// Request-time export filter values used for capability validation.
+/// </summary>
+public sealed record ExportFilterContext(
+    bool? IncludeTestSubmissions,
+    DateTime? CreatedAfter,
+    DateTime? CreatedBefore,
+    DateTime? CompletedAfter,
+    DateTime? CompletedBefore,
+    long? MinSubmissionId,
+    long? MaxSubmissionId,
+    string? Locale,
+    IReadOnlyList<string>? ColumnScope);

--- a/src/Endatix.Modules.Reporting.Contracts/Export/ExportQueryOptions.cs
+++ b/src/Endatix.Modules.Reporting.Contracts/Export/ExportQueryOptions.cs
@@ -6,5 +6,10 @@ namespace Endatix.Modules.Reporting.Contracts.Export;
 public sealed record ExportQueryOptions(
     int PageSize = 500,
     long? AfterSubmissionId = null,
-    bool IncludeTestSubmissions = false);
-
+    bool IncludeTestSubmissions = false,
+    DateTime? CreatedAfter = null,
+    DateTime? CreatedBefore = null,
+    DateTime? CompletedAfter = null,
+    DateTime? CompletedBefore = null,
+    long? MinSubmissionId = null,
+    long? MaxSubmissionId = null);

--- a/src/Endatix.Modules.Reporting.Contracts/Export/ExportRequestFilterGuard.cs
+++ b/src/Endatix.Modules.Reporting.Contracts/Export/ExportRequestFilterGuard.cs
@@ -6,51 +6,43 @@ namespace Endatix.Modules.Reporting.Contracts.Export;
 public static class ExportRequestFilterGuard
 {
     public static IReadOnlyList<string> GetDisallowedWireNames(
-        ExportRequestFilterKind allowed,
-        bool? includeTestSubmissions,
-        DateTime? createdAfter,
-        DateTime? createdBefore,
-        DateTime? completedAfter,
-        DateTime? completedBefore,
-        long? minSubmissionId,
-        long? maxSubmissionId,
-        string? locale,
-        IReadOnlyList<string>? columnScope)
+        ExportRequestFilters allowed,
+        ExportFilterContext filters)
     {
         List<string> disallowed = [];
 
-        if (includeTestSubmissions.HasValue &&
-            !allowed.HasFlag(ExportRequestFilterKind.IncludeTestSubmissions))
+        if (filters.IncludeTestSubmissions.HasValue &&
+            !allowed.HasFlag(ExportRequestFilters.IncludeTestSubmissions))
         {
             disallowed.Add(ExportRequestFilterWireNames.IncludeTestSubmissions);
         }
 
-        if ((createdAfter.HasValue || createdBefore.HasValue) &&
-            !allowed.HasFlag(ExportRequestFilterKind.CreatedAtRange))
+        if ((filters.CreatedAfter.HasValue || filters.CreatedBefore.HasValue) &&
+            !allowed.HasFlag(ExportRequestFilters.CreatedAtRange))
         {
             disallowed.Add(ExportRequestFilterWireNames.CreatedAtRange);
         }
 
-        if ((completedAfter.HasValue || completedBefore.HasValue) &&
-            !allowed.HasFlag(ExportRequestFilterKind.CompletedAtRange))
+        if ((filters.CompletedAfter.HasValue || filters.CompletedBefore.HasValue) &&
+            !allowed.HasFlag(ExportRequestFilters.CompletedAtRange))
         {
             disallowed.Add(ExportRequestFilterWireNames.CompletedAtRange);
         }
 
-        if ((minSubmissionId.HasValue || maxSubmissionId.HasValue) &&
-            !allowed.HasFlag(ExportRequestFilterKind.SubmissionIdRange))
+        if ((filters.MinSubmissionId.HasValue || filters.MaxSubmissionId.HasValue) &&
+            !allowed.HasFlag(ExportRequestFilters.SubmissionIdRange))
         {
             disallowed.Add(ExportRequestFilterWireNames.SubmissionIdRange);
         }
 
-        if (!string.IsNullOrWhiteSpace(locale) &&
-            !allowed.HasFlag(ExportRequestFilterKind.Locale))
+        if (!string.IsNullOrWhiteSpace(filters.Locale) &&
+            !allowed.HasFlag(ExportRequestFilters.Locale))
         {
             disallowed.Add(ExportRequestFilterWireNames.Locale);
         }
 
-        if (columnScope is { Count: > 0 } &&
-            !allowed.HasFlag(ExportRequestFilterKind.ColumnScope))
+        if (filters.ColumnScope is { Count: > 0 } &&
+            !allowed.HasFlag(ExportRequestFilters.ColumnScope))
         {
             disallowed.Add(ExportRequestFilterWireNames.ColumnScope);
         }

--- a/src/Endatix.Modules.Reporting.Contracts/Export/ExportRequestFilterGuard.cs
+++ b/src/Endatix.Modules.Reporting.Contracts/Export/ExportRequestFilterGuard.cs
@@ -1,0 +1,60 @@
+namespace Endatix.Modules.Reporting.Contracts.Export;
+
+/// <summary>
+/// Detects request-time filters that are not allowed for a given capability.
+/// </summary>
+public static class ExportRequestFilterGuard
+{
+    public static IReadOnlyList<string> GetDisallowedWireNames(
+        ExportRequestFilterKind allowed,
+        bool? includeTestSubmissions,
+        DateTime? createdAfter,
+        DateTime? createdBefore,
+        DateTime? completedAfter,
+        DateTime? completedBefore,
+        long? minSubmissionId,
+        long? maxSubmissionId,
+        string? locale,
+        IReadOnlyList<string>? columnScope)
+    {
+        List<string> disallowed = [];
+
+        if (includeTestSubmissions.HasValue &&
+            !allowed.HasFlag(ExportRequestFilterKind.IncludeTestSubmissions))
+        {
+            disallowed.Add(ExportRequestFilterWireNames.IncludeTestSubmissions);
+        }
+
+        if ((createdAfter.HasValue || createdBefore.HasValue) &&
+            !allowed.HasFlag(ExportRequestFilterKind.CreatedAtRange))
+        {
+            disallowed.Add(ExportRequestFilterWireNames.CreatedAtRange);
+        }
+
+        if ((completedAfter.HasValue || completedBefore.HasValue) &&
+            !allowed.HasFlag(ExportRequestFilterKind.CompletedAtRange))
+        {
+            disallowed.Add(ExportRequestFilterWireNames.CompletedAtRange);
+        }
+
+        if ((minSubmissionId.HasValue || maxSubmissionId.HasValue) &&
+            !allowed.HasFlag(ExportRequestFilterKind.SubmissionIdRange))
+        {
+            disallowed.Add(ExportRequestFilterWireNames.SubmissionIdRange);
+        }
+
+        if (!string.IsNullOrWhiteSpace(locale) &&
+            !allowed.HasFlag(ExportRequestFilterKind.Locale))
+        {
+            disallowed.Add(ExportRequestFilterWireNames.Locale);
+        }
+
+        if (columnScope is { Count: > 0 } &&
+            !allowed.HasFlag(ExportRequestFilterKind.ColumnScope))
+        {
+            disallowed.Add(ExportRequestFilterWireNames.ColumnScope);
+        }
+
+        return disallowed;
+    }
+}

--- a/src/Endatix.Modules.Reporting.Contracts/Export/ExportRequestFilterKind.cs
+++ b/src/Endatix.Modules.Reporting.Contracts/Export/ExportRequestFilterKind.cs
@@ -1,0 +1,73 @@
+using System.Text.Json.Serialization;
+
+namespace Endatix.Modules.Reporting.Contracts.Export;
+
+/// <summary>
+/// Request-time export filters that a capability may accept.
+/// Extensible per export type — add flags as new filters are introduced.
+/// </summary>
+[Flags]
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum ExportRequestFilterKind
+{
+    None = 0,
+    IncludeTestSubmissions = 1 << 0,
+    CreatedAtRange = 1 << 1,
+    CompletedAtRange = 1 << 2,
+    SubmissionIdRange = 1 << 3,
+    Locale = 1 << 4,
+    ColumnScope = 1 << 5,
+}
+
+/// <summary>
+/// Common <see cref="ExportRequestFilterKind"/> sets for built-in capabilities.
+/// </summary>
+public static class ExportRequestFilterSets
+{
+    public const ExportRequestFilterKind Submissions =
+        ExportRequestFilterKind.IncludeTestSubmissions |
+        ExportRequestFilterKind.CreatedAtRange |
+        ExportRequestFilterKind.CompletedAtRange |
+        ExportRequestFilterKind.SubmissionIdRange |
+        ExportRequestFilterKind.Locale |
+        ExportRequestFilterKind.ColumnScope;
+
+    /// <summary>
+    /// Native codebook streams persisted FormSchema codebook JSON as-is (no request filters applied).
+    /// </summary>
+    public const ExportRequestFilterKind NativeCodebook = ExportRequestFilterKind.None;
+
+    /// <summary>
+    /// Shoji codebook applies request locale to display strings; columnScope is not applied.
+    /// </summary>
+    public const ExportRequestFilterKind ShojiCodebook = ExportRequestFilterKind.Locale;
+}
+
+/// <summary>
+/// Wire names and helpers for <see cref="ExportRequestFilterKind"/>.
+/// </summary>
+public static class ExportRequestFilterWireNames
+{
+    public const string IncludeTestSubmissions = "includeTestSubmissions";
+    public const string CreatedAtRange = "createdAtRange";
+    public const string CompletedAtRange = "completedAtRange";
+    public const string SubmissionIdRange = "submissionIdRange";
+    public const string Locale = "locale";
+    public const string ColumnScope = "columnScope";
+
+    private static readonly (ExportRequestFilterKind Kind, string Name)[] _all =
+    [
+        (ExportRequestFilterKind.IncludeTestSubmissions, IncludeTestSubmissions),
+        (ExportRequestFilterKind.CreatedAtRange, CreatedAtRange),
+        (ExportRequestFilterKind.CompletedAtRange, CompletedAtRange),
+        (ExportRequestFilterKind.SubmissionIdRange, SubmissionIdRange),
+        (ExportRequestFilterKind.Locale, Locale),
+        (ExportRequestFilterKind.ColumnScope, ColumnScope),
+    ];
+
+    public static IReadOnlyList<string> ToWireNames(ExportRequestFilterKind allowed) =>
+        _all
+            .Where(entry => allowed.HasFlag(entry.Kind))
+            .Select(entry => entry.Name)
+            .ToList();
+}

--- a/src/Endatix.Modules.Reporting.Contracts/Export/ExportRequestFilters.cs
+++ b/src/Endatix.Modules.Reporting.Contracts/Export/ExportRequestFilters.cs
@@ -8,7 +8,7 @@ namespace Endatix.Modules.Reporting.Contracts.Export;
 /// </summary>
 [Flags]
 [JsonConverter(typeof(JsonStringEnumConverter))]
-public enum ExportRequestFilterKind
+public enum ExportRequestFilters
 {
     None = 0,
     IncludeTestSubmissions = 1 << 0,
@@ -20,31 +20,31 @@ public enum ExportRequestFilterKind
 }
 
 /// <summary>
-/// Common <see cref="ExportRequestFilterKind"/> sets for built-in capabilities.
+/// Common <see cref="ExportRequestFilters"/> sets for built-in capabilities.
 /// </summary>
 public static class ExportRequestFilterSets
 {
-    public const ExportRequestFilterKind Submissions =
-        ExportRequestFilterKind.IncludeTestSubmissions |
-        ExportRequestFilterKind.CreatedAtRange |
-        ExportRequestFilterKind.CompletedAtRange |
-        ExportRequestFilterKind.SubmissionIdRange |
-        ExportRequestFilterKind.Locale |
-        ExportRequestFilterKind.ColumnScope;
+    public const ExportRequestFilters Submissions =
+        ExportRequestFilters.IncludeTestSubmissions |
+        ExportRequestFilters.CreatedAtRange |
+        ExportRequestFilters.CompletedAtRange |
+        ExportRequestFilters.SubmissionIdRange |
+        ExportRequestFilters.Locale |
+        ExportRequestFilters.ColumnScope;
 
     /// <summary>
     /// Native codebook streams persisted FormSchema codebook JSON as-is (no request filters applied).
     /// </summary>
-    public const ExportRequestFilterKind NativeCodebook = ExportRequestFilterKind.None;
+    public const ExportRequestFilters NativeCodebook = ExportRequestFilters.None;
 
     /// <summary>
     /// Shoji codebook applies request locale to display strings; columnScope is not applied.
     /// </summary>
-    public const ExportRequestFilterKind ShojiCodebook = ExportRequestFilterKind.Locale;
+    public const ExportRequestFilters ShojiCodebook = ExportRequestFilters.Locale;
 }
 
 /// <summary>
-/// Wire names and helpers for <see cref="ExportRequestFilterKind"/>.
+/// Wire names and helpers for <see cref="ExportRequestFilters"/>.
 /// </summary>
 public static class ExportRequestFilterWireNames
 {
@@ -55,19 +55,19 @@ public static class ExportRequestFilterWireNames
     public const string Locale = "locale";
     public const string ColumnScope = "columnScope";
 
-    private static readonly (ExportRequestFilterKind Kind, string Name)[] _all =
+    private static readonly (ExportRequestFilters Filter, string Name)[] _all =
     [
-        (ExportRequestFilterKind.IncludeTestSubmissions, IncludeTestSubmissions),
-        (ExportRequestFilterKind.CreatedAtRange, CreatedAtRange),
-        (ExportRequestFilterKind.CompletedAtRange, CompletedAtRange),
-        (ExportRequestFilterKind.SubmissionIdRange, SubmissionIdRange),
-        (ExportRequestFilterKind.Locale, Locale),
-        (ExportRequestFilterKind.ColumnScope, ColumnScope),
+        (ExportRequestFilters.IncludeTestSubmissions, IncludeTestSubmissions),
+        (ExportRequestFilters.CreatedAtRange, CreatedAtRange),
+        (ExportRequestFilters.CompletedAtRange, CompletedAtRange),
+        (ExportRequestFilters.SubmissionIdRange, SubmissionIdRange),
+        (ExportRequestFilters.Locale, Locale),
+        (ExportRequestFilters.ColumnScope, ColumnScope),
     ];
 
-    public static IReadOnlyList<string> ToWireNames(ExportRequestFilterKind allowed) =>
+    public static IReadOnlyList<string> ToWireNames(ExportRequestFilters allowed) =>
         _all
-            .Where(entry => allowed.HasFlag(entry.Kind))
+            .Where(entry => allowed.HasFlag(entry.Filter))
             .Select(entry => entry.Name)
             .ToList();
 }

--- a/src/Endatix.Modules.Reporting/Data/ReportingExportRepository.cs
+++ b/src/Endatix.Modules.Reporting/Data/ReportingExportRepository.cs
@@ -26,50 +26,17 @@ internal sealed class ReportingExportRepository(
         ExportQueryOptions options,
         CancellationToken cancellationToken)
     {
-        var flattenedRows = BuildExportableRowsQuery(tenantId, formId);
-
-        if (options.IncludeTestSubmissions)
+        var probeOptions = options with { PageSize = 1, AfterSubmissionId = null };
+        await foreach (var _ in StreamFlattenedSubmissionsAsync(
+                           tenantId,
+                           formId,
+                           probeOptions,
+                           cancellationToken))
         {
-            return await flattenedRows.AnyAsync(cancellationToken);
+            return true;
         }
 
-        // Probe flattened rows in bounded batches and require a non-test core submission
-        // for at least one ID. Avoids materializing all IDs or cross-DbContext joins.
-        long? afterSubmissionId = null;
-        while (true)
-        {
-            var batchIds = await flattenedRows
-                .Where(row => afterSubmissionId == null || row.SubmissionId > afterSubmissionId)
-                .OrderBy(row => row.SubmissionId)
-                .Take(DEFAULT_PAGE_SIZE)
-                .Select(row => row.SubmissionId)
-                .ToListAsync(cancellationToken);
-
-            if (batchIds.Count == 0)
-            {
-                return false;
-            }
-
-            var hasExportableRow = await appDbContext.Submissions
-                .AsNoTracking()
-                .AnyAsync(
-                    submission => submission.TenantId == tenantId &&
-                                  submission.FormId == formId &&
-                                  !submission.IsTestSubmission &&
-                                  batchIds.Contains(submission.Id),
-                    cancellationToken);
-            if (hasExportableRow)
-            {
-                return true;
-            }
-
-            if (batchIds.Count < DEFAULT_PAGE_SIZE)
-            {
-                return false;
-            }
-
-            afterSubmissionId = batchIds[^1];
-        }
+        return false;
     }
 
     public async IAsyncEnumerable<FlattenedExportRow> StreamFlattenedSubmissionsAsync(
@@ -83,8 +50,13 @@ internal sealed class ReportingExportRepository(
 
         while (true)
         {
-            var batch = await BuildExportableRowsQuery(tenantId, formId)
-                .Where(row => afterSubmissionId == null || row.SubmissionId > afterSubmissionId)
+            var batchQuery = BuildExportableRowsQuery(tenantId, formId, options);
+            if (afterSubmissionId is not null)
+            {
+                batchQuery = batchQuery.Where(row => row.SubmissionId > afterSubmissionId);
+            }
+
+            var batch = await batchQuery
                 .OrderBy(row => row.SubmissionId)
                 .Take(pageSize)
                 .ToListAsync(cancellationToken);
@@ -95,12 +67,15 @@ internal sealed class ReportingExportRepository(
             }
 
             var submissionIds = batch.Select(row => row.SubmissionId).ToList();
-            var submissions = await appDbContext.Submissions
+            var submissionsQuery = appDbContext.Submissions
                 .AsNoTracking()
                 .Where(submission => submission.TenantId == tenantId &&
                                      submission.FormId == formId &&
-                                     (options.IncludeTestSubmissions || !submission.IsTestSubmission) &&
-                                     submissionIds.Contains(submission.Id))
+                                     submissionIds.Contains(submission.Id));
+
+            submissionsQuery = ApplyCoreSubmissionFilters(submissionsQuery, options);
+
+            var submissions = await submissionsQuery
                 .ToDictionaryAsync(submission => submission.Id, cancellationToken);
 
             foreach (var flattened in batch)
@@ -108,7 +83,7 @@ internal sealed class ReportingExportRepository(
                 if (!submissions.TryGetValue(flattened.SubmissionId, out var submission))
                 {
                     logger.LogWarning(
-                        "Skipping flattened submission {SubmissionId} for tenant {TenantId} form {FormId}: core submission row not found.",
+                        "Skipping flattened submission {SubmissionId} for tenant {TenantId} form {FormId}: core submission row not found or filtered out.",
                         flattened.SubmissionId,
                         tenantId,
                         formId);
@@ -136,15 +111,64 @@ internal sealed class ReportingExportRepository(
         }
     }
 
-    private IQueryable<FlattenedSubmission> BuildExportableRowsQuery(long tenantId, long formId)
+    private IQueryable<FlattenedSubmission> BuildExportableRowsQuery(
+        long tenantId,
+        long formId,
+        ExportQueryOptions options)
     {
-        return reportingDbContext.FlattenedSubmissions
+        var query = reportingDbContext.FlattenedSubmissions
             .AsNoTracking()
             .Where(row => row.TenantId == tenantId &&
                           row.FormId == formId &&
                           !row.IsDeleted &&
                           row.Integration.Code == SubmissionIntegrationStatusCodes.Processed &&
                           row.DataJson != null);
+
+        if (options.MinSubmissionId is long minSubmissionId)
+        {
+            query = query.Where(row => row.SubmissionId >= minSubmissionId);
+        }
+
+        if (options.MaxSubmissionId is long maxSubmissionId)
+        {
+            query = query.Where(row => row.SubmissionId <= maxSubmissionId);
+        }
+
+        return query;
+    }
+
+    private static IQueryable<Endatix.Core.Entities.Submission> ApplyCoreSubmissionFilters(
+        IQueryable<Endatix.Core.Entities.Submission> query,
+        ExportQueryOptions options)
+    {
+        if (!options.IncludeTestSubmissions)
+        {
+            query = query.Where(submission => !submission.IsTestSubmission);
+        }
+
+        if (options.CreatedAfter is DateTime createdAfter)
+        {
+            query = query.Where(submission => submission.CreatedAt >= createdAfter);
+        }
+
+        if (options.CreatedBefore is DateTime createdBefore)
+        {
+            query = query.Where(submission => submission.CreatedAt < createdBefore);
+        }
+
+        if (options.CompletedAfter is DateTime completedAfter)
+        {
+            query = query.Where(submission =>
+                submission.CompletedAt != null && submission.CompletedAt >= completedAfter);
+        }
+
+        if (options.CompletedBefore is DateTime completedBefore)
+        {
+            query = query.Where(submission =>
+                submission.CompletedAt != null && submission.CompletedAt < completedBefore);
+        }
+
+        return query;
     }
 
     private static int NormalizePageSize(int pageSize) =>

--- a/src/Endatix.Modules.Reporting/Data/ReportingExportRepository.cs
+++ b/src/Endatix.Modules.Reporting/Data/ReportingExportRepository.cs
@@ -27,16 +27,14 @@ internal sealed class ReportingExportRepository(
         CancellationToken cancellationToken)
     {
         var probeOptions = options with { PageSize = 1, AfterSubmissionId = null };
-        await foreach (var _ in StreamFlattenedSubmissionsAsync(
-                           tenantId,
-                           formId,
-                           probeOptions,
-                           cancellationToken))
-        {
-            return true;
-        }
+        await using var enumerator =
+            StreamFlattenedSubmissionsAsync(
+                tenantId,
+                formId,
+                probeOptions,
+                cancellationToken).GetAsyncEnumerator(cancellationToken);
 
-        return false;
+        return await enumerator.MoveNextAsync();
     }
 
     public async IAsyncEnumerable<FlattenedExportRow> StreamFlattenedSubmissionsAsync(

--- a/src/Endatix.Modules.Reporting/Endpoints/Settings/ExportCapabilities/List.cs
+++ b/src/Endatix.Modules.Reporting/Endpoints/Settings/ExportCapabilities/List.cs
@@ -29,7 +29,8 @@ public sealed class List(IExportCapabilityRegistry capabilityRegistry)
                 capability.WireKey,
                 capability.Label,
                 capability.ItemTypeName,
-                capability.Description))
+                capability.Description,
+                ExportRequestFilterWireNames.ToWireNames(capability.AllowedFilters)))
             .ToList();
 
         return Send.OkAsync(capabilities, ct);

--- a/src/Endatix.Modules.Reporting/Features/Export/Capabilities/NativeCodebookExportCapability.cs
+++ b/src/Endatix.Modules.Reporting/Features/Export/Capabilities/NativeCodebookExportCapability.cs
@@ -15,5 +15,6 @@ internal static class NativeCodebookExportCapability
         WireKey: "codebook",
         Label: "Codebook",
         ItemTypeName: typeof(DynamicExportRow).FullName!,
-        Description: "Standard Endatix codebook JSON for question metadata.");
+        Description: "Standard Endatix codebook JSON for question metadata.",
+        AllowedFilters: ExportRequestFilterSets.NativeCodebook);
 }

--- a/src/Endatix.Modules.Reporting/Features/Export/Capabilities/SubmissionsExportCapabilities.cs
+++ b/src/Endatix.Modules.Reporting/Features/Export/Capabilities/SubmissionsExportCapabilities.cs
@@ -15,7 +15,8 @@ internal static class SubmissionsExportCapabilities
         WireKey: "csv",
         Label: "CSV",
         ItemTypeName: typeof(SubmissionExportRow).FullName!,
-        Description: "Tabular CSV export with one row per submission.");
+        Description: "Tabular CSV export with one row per submission.",
+        AllowedFilters: ExportRequestFilterSets.Submissions);
 
     internal static readonly ExportCapability _csvShoji = new(
         ExportTarget.Submissions,
@@ -24,7 +25,8 @@ internal static class SubmissionsExportCapabilities
         WireKey: "csv-shoji",
         Label: "CSV (Shoji / Crunch)",
         ItemTypeName: typeof(SubmissionExportRow).FullName!,
-        Description: "Crunch-compatible CSV: -- key separators and boolean category ids 0/1.");
+        Description: "Crunch-compatible CSV: -- key separators and boolean category ids 0/1.",
+        AllowedFilters: ExportRequestFilterSets.Submissions);
 
     internal static readonly ExportCapability _json = new(
         ExportTarget.Submissions,
@@ -33,7 +35,8 @@ internal static class SubmissionsExportCapabilities
         WireKey: "json",
         Label: "JSON",
         ItemTypeName: typeof(SubmissionExportRow).FullName!,
-        Description: "Tabular JSON export with one object per submission.");
+        Description: "Tabular JSON export with one object per submission.",
+        AllowedFilters: ExportRequestFilterSets.Submissions);
 
     internal static IEnumerable<ExportCapability> All => [_csv, _csvShoji, _json];
 }

--- a/src/Endatix.Modules.Reporting/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookExportCapability.cs
+++ b/src/Endatix.Modules.Reporting/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookExportCapability.cs
@@ -15,5 +15,6 @@ internal static class ShojiCodebookExportCapability
         WireKey: "codebook-shoji",
         Label: "Codebook (Shoji)",
         ItemTypeName: typeof(DynamicExportRow).FullName!,
-        Description: "Shoji produces Crunch-compatible codebook JSON.");
+        Description: "Shoji produces Crunch-compatible codebook JSON.",
+        AllowedFilters: ExportRequestFilterSets.ShojiCodebook);
 }

--- a/src/Endatix.Modules.Reporting/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookExportDataSource.cs
+++ b/src/Endatix.Modules.Reporting/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookExportDataSource.cs
@@ -60,7 +60,8 @@ internal sealed class ShojiCodebookExportDataSource(
         var codebookJson = ShojiCodebookGenerator.Generate(
             schema.FlatteningMap,
             schema.Codebook,
-            settings.KeySeparator);
+            settings.KeySeparator,
+            settings.Locale);
         yield return new DynamicExportRow { Data = codebookJson };
     }
 

--- a/src/Endatix.Modules.Reporting/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookGenerator.cs
+++ b/src/Endatix.Modules.Reporting/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookGenerator.cs
@@ -13,6 +13,12 @@ namespace Endatix.Modules.Reporting.Features.Export.Integrations.Crunch.Shoji;
 /// </summary>
 internal static class ShojiCodebookGenerator
 {
+    /// <summary>
+    /// Locale for the current synchronous <see cref="Generate"/> call only.
+    /// Prefer passing locale through call chains if Generate becomes async.
+    /// </summary>
+    private static readonly AsyncLocal<string?> _activeLocale = new();
+
     private static readonly (string Name, int Id, int NumericValue)[] _booleanCategories =
     [
         ("No", 0, 0),
@@ -25,32 +31,50 @@ internal static class ShojiCodebookGenerator
         ("True", 1, 1),
     ];
 
+    private static string ActiveLocale =>
+        string.IsNullOrWhiteSpace(_activeLocale.Value)
+            ? FormSchemaCodebookPropertyNames.Default
+            : _activeLocale.Value;
+
     internal static string Generate(
         string flatteningMapJson,
         string codebookJson,
-        string keySeparator = ExportFormatSettings.DefaultKeySeparator)
+        string keySeparator = ExportFormatSettings.DefaultKeySeparator,
+        string locale = FormSchemaCodebookPropertyNames.Default)
     {
-        var flatteningMap = FormSchemaFlatteningMap.FromJson(flatteningMapJson);
-        using var codebookDocument = JsonDocument.Parse(codebookJson);
-        var codebook = codebookDocument.RootElement;
+        var previousLocale = _activeLocale.Value;
+        _activeLocale.Value = string.IsNullOrWhiteSpace(locale)
+            ? FormSchemaCodebookPropertyNames.Default
+            : locale.Trim();
 
-        var questions = ReadObjectMap(codebook, FormSchemaCodebookPropertyNames.Questions);
-        var codebookColumns = ReadObjectMap(codebook, FormSchemaCodebookPropertyNames.Columns);
-        var groupedColumnKeys = BuildGroupedColumnKeys(flatteningMap);
-
-        System.Buffers.ArrayBufferWriter<byte> buffer = new();
-        using (Utf8JsonWriter writer = new(buffer))
+        try
         {
-            WriteShojiCodebook(
-                writer,
-                flatteningMap,
-                questions,
-                groupedColumnKeys,
-                codebookColumns,
-                keySeparator);
-        }
+            var flatteningMap = FormSchemaFlatteningMap.FromJson(flatteningMapJson);
+            using var codebookDocument = JsonDocument.Parse(codebookJson);
+            var codebook = codebookDocument.RootElement;
 
-        return System.Text.Encoding.UTF8.GetString(buffer.WrittenSpan);
+            var questions = ReadObjectMap(codebook, FormSchemaCodebookPropertyNames.Questions);
+            var codebookColumns = ReadObjectMap(codebook, FormSchemaCodebookPropertyNames.Columns);
+            var groupedColumnKeys = BuildGroupedColumnKeys(flatteningMap);
+
+            System.Buffers.ArrayBufferWriter<byte> buffer = new();
+            using (Utf8JsonWriter writer = new(buffer))
+            {
+                WriteShojiCodebook(
+                    writer,
+                    flatteningMap,
+                    questions,
+                    groupedColumnKeys,
+                    codebookColumns,
+                    keySeparator);
+            }
+
+            return System.Text.Encoding.UTF8.GetString(buffer.WrittenSpan);
+        }
+        finally
+        {
+            _activeLocale.Value = previousLocale;
+        }
     }
 
     private static void WriteShojiCodebook(
@@ -1885,11 +1909,25 @@ internal static class ShojiCodebookGenerator
             return resolved.GetString() ?? string.Empty;
         }
 
-        if (resolved.ValueKind == JsonValueKind.Object &&
-            resolved.TryGetProperty(FormSchemaCodebookPropertyNames.Default, out var defaultValue) &&
-            defaultValue.ValueKind == JsonValueKind.String)
+        if (resolved.ValueKind == JsonValueKind.Object)
         {
-            return defaultValue.GetString() ?? string.Empty;
+            var locale = ActiveLocale;
+            if (!string.Equals(locale, FormSchemaCodebookPropertyNames.Default, StringComparison.Ordinal) &&
+                resolved.TryGetProperty(locale, out var localizedValue) &&
+                localizedValue.ValueKind == JsonValueKind.String)
+            {
+                var localizedText = localizedValue.GetString();
+                if (!string.IsNullOrWhiteSpace(localizedText))
+                {
+                    return localizedText;
+                }
+            }
+
+            if (resolved.TryGetProperty(FormSchemaCodebookPropertyNames.Default, out var defaultValue) &&
+                defaultValue.ValueKind == JsonValueKind.String)
+            {
+                return defaultValue.GetString() ?? string.Empty;
+            }
         }
 
         return string.Empty;

--- a/src/Endatix.Modules.Reporting/Features/Export/Tabular/TabularExportDataSource.cs
+++ b/src/Endatix.Modules.Reporting/Features/Export/Tabular/TabularExportDataSource.cs
@@ -22,6 +22,11 @@ internal sealed class TabularExportDataSource(
     private const string MissingRowsMessage =
         "No processed flattened submissions found for this form. Run admin backfill to populate the reporting read model before exporting.";
 
+    private const string NoMatchingFiltersMessage =
+        "No submissions matched the export filters. Broaden date/id/test filters or clear them and try again.";
+
+    private const string CrunchProjectionArtifactsKey = "ReportingCrunchProjectionArtifacts";
+
     public bool Matches(ExportDataSourceRequest request) =>
         string.IsNullOrWhiteSpace(request.SqlFunctionName) &&
         capabilityRegistry.Matches(request.Format, request.ItemType) &&
@@ -50,7 +55,7 @@ internal sealed class TabularExportDataSource(
         context.Options.Metadata ??= new Dictionary<string, object>();
         context.Options.Metadata[SubmissionExportMetadataKeys.ResolvedFormatSettings] = settings;
 
-        ExportQueryOptions queryOptions = new(IncludeTestSubmissions: settings.IncludeTestSubmissions);
+        var queryOptions = CreateQueryOptions(context.Options, settings, pageSize: 1);
 
         var hasRows = await reportingExportRepository.HasExportableRowsAsync(
             context.TenantId,
@@ -59,7 +64,13 @@ internal sealed class TabularExportDataSource(
             cancellationToken);
         if (!hasRows)
         {
-            return Result<ExportOptions>.Conflict(MissingRowsMessage);
+            var hasAnyProcessedRows = await reportingExportRepository.HasExportableRowsAsync(
+                context.TenantId,
+                context.FormId,
+                new ExportQueryOptions(PageSize: 1, IncludeTestSubmissions: true),
+                cancellationToken);
+            return Result<ExportOptions>.Conflict(
+                hasAnyProcessedRows ? NoMatchingFiltersMessage : MissingRowsMessage);
         }
 
         IReadOnlySet<string>? columnScope = settings.ColumnScope is null
@@ -96,9 +107,10 @@ internal sealed class TabularExportDataSource(
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
         var settings = ResolveSettings(context.Request.Format, context.Options);
-        ExportQueryOptions options = new(
-            PageSize: context.ExportPageSize ?? 500,
-            IncludeTestSubmissions: settings.IncludeTestSubmissions);
+        var options = CreateQueryOptions(
+            context.Options,
+            settings,
+            pageSize: context.ExportPageSize ?? 500);
         var projection = TryGetCrunchProjectionArtifacts(context.Options);
 
         await foreach (var row in reportingExportRepository.StreamFlattenedSubmissionsAsync(
@@ -110,8 +122,6 @@ internal sealed class TabularExportDataSource(
             yield return MapSubmissionRow(row, projection);
         }
     }
-
-    private const string CrunchProjectionArtifactsKey = "ReportingCrunchProjectionArtifacts";
 
     private sealed record CrunchProjectionArtifacts(string FlatteningMapJson, string CodebookJson);
 
@@ -140,6 +150,31 @@ internal sealed class TabularExportDataSource(
         }
 
         return null;
+    }
+
+    private static ExportQueryOptions CreateQueryOptions(
+        ExportOptions options,
+        ExportFormatSettings settings,
+        int pageSize)
+    {
+        if (options.Metadata is not null &&
+            options.Metadata.TryGetValue(SubmissionExportMetadataKeys.ExecutionSettings, out var settingsObject) &&
+            settingsObject is SubmissionExportExecutionSettings executionSettings)
+        {
+            return new ExportQueryOptions(
+                PageSize: pageSize,
+                IncludeTestSubmissions: settings.IncludeTestSubmissions,
+                CreatedAfter: executionSettings.CreatedAfter,
+                CreatedBefore: executionSettings.CreatedBefore,
+                CompletedAfter: executionSettings.CompletedAfter,
+                CompletedBefore: executionSettings.CompletedBefore,
+                MinSubmissionId: executionSettings.MinSubmissionId,
+                MaxSubmissionId: executionSettings.MaxSubmissionId);
+        }
+
+        return new ExportQueryOptions(
+            PageSize: pageSize,
+            IncludeTestSubmissions: settings.IncludeTestSubmissions);
     }
 
     private ExportFormatSettings ResolveSettings(string format, ExportOptions options)

--- a/src/Endatix.Persistence.PostgreSql/Scripts/Tools/GenerateSubmissions.sql
+++ b/src/Endatix.Persistence.PostgreSql/Scripts/Tools/GenerateSubmissions.sql
@@ -4,6 +4,8 @@
 -- This script performs a bulk insert for public."Submissions" by duplicating
 -- an existing submission multiple times with incremental IDs and timestamps.
 -- Run this to generate test data for submissions.
+--
+-- RestrictionKey is intentionally omitted (unique constraint).
 -- ============================================================================
 
 -- Set these variables as needed:
@@ -15,17 +17,54 @@
 -- CTE to select the base submission data that will be duplicated
 WITH base AS (
     SELECT
-        "IsComplete", "JsonData", "FormId", "FormDefinitionId", "CurrentPage", "Metadata",
-        "CompletedAt", "Token_ExpiresAt", "CreatedAt", "ModifiedAt", "DeletedAt",
-        "IsDeleted", "Status", "TenantId", "SubmittedBy"
+        "IsComplete",
+        "JsonData",
+        "FormId",
+        "FormDefinitionId",
+        "CurrentPage",
+        "Metadata",
+        "CompletedAt",
+        "Token_Value",
+        "Token_ExpiresAt",
+        "CreatedAt",
+        "ModifiedAt",
+        "DeletedAt",
+        "IsDeleted",
+        "Status",
+        "TenantId",
+        "SubmittedBy",
+        "IsTestSubmission",
+        "SubmitterDisplayId",
+        "SubmitterId",
+        "SubmitterProfileSnapshot",
+        "Revision"
     FROM public."Submissions"
     WHERE "Id" = :submission_id
 )
 -- Perform the bulk insert with generated IDs and staggered timestamps
 INSERT INTO public."Submissions" (
-    "Id", "IsComplete", "JsonData", "FormId", "FormDefinitionId", "CurrentPage", "Metadata",
-    "CompletedAt", "Token_ExpiresAt", "CreatedAt", "ModifiedAt", "DeletedAt",
-    "IsDeleted", "Status", "TenantId", "SubmittedBy"
+    "Id",
+    "IsComplete",
+    "JsonData",
+    "FormId",
+    "FormDefinitionId",
+    "CurrentPage",
+    "Metadata",
+    "CompletedAt",
+    "Token_Value",
+    "Token_ExpiresAt",
+    "CreatedAt",
+    "ModifiedAt",
+    "DeletedAt",
+    "IsDeleted",
+    "Status",
+    "TenantId",
+    "SubmittedBy",
+    "IsTestSubmission",
+    "SubmitterDisplayId",
+    "SubmitterId",
+    "SubmitterProfileSnapshot",
+    "Revision"
 )
 SELECT
     :submission_id + gs.i AS "Id",
@@ -36,6 +75,7 @@ SELECT
     b."CurrentPage",
     b."Metadata",
     b."CompletedAt" + (gs.i * INTERVAL '1 minute'),
+    b."Token_Value",
     b."Token_ExpiresAt" + (gs.i * INTERVAL '1 minute'),
     b."CreatedAt" + (gs.i * INTERVAL '1 minute'),
     b."ModifiedAt" + (gs.i * INTERVAL '1 minute'),
@@ -43,6 +83,11 @@ SELECT
     b."IsDeleted",
     b."Status",
     b."TenantId",
-    b."SubmittedBy"
+    b."SubmittedBy",
+    b."IsTestSubmission",
+    b."SubmitterDisplayId",
+    b."SubmitterId",
+    b."SubmitterProfileSnapshot",
+    b."Revision"
 FROM base b
 CROSS JOIN generate_series(1, :num_items) AS gs(i);

--- a/tests/Endatix.Api.Tests/Endpoints/Submissions/ExportTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Submissions/ExportTests.cs
@@ -70,7 +70,8 @@ public class ExportTests
             "csv",
             "CSV",
             typeof(SubmissionExportRow).FullName!,
-            "Tabular CSV export with one row per submission.");
+            "Tabular CSV export with one row per submission.",
+            ExportRequestFilterSets.Submissions);
         ExportCapability json = new(
             ExportTarget.Submissions,
             ExportDeliveryFormat.Json,
@@ -78,26 +79,60 @@ public class ExportTests
             "json",
             "JSON",
             typeof(SubmissionExportRow).FullName!,
-            "Tabular JSON export with one object per submission.");
+            "Tabular JSON export with one object per submission.",
+            ExportRequestFilterSets.Submissions);
+        ExportCapability codebook = new(
+            ExportTarget.Codebook,
+            ExportDeliveryFormat.Json,
+            ExportProfile.Native,
+            "codebook",
+            "Codebook",
+            typeof(DynamicExportRow).FullName!,
+            "Native codebook export.",
+            ExportRequestFilterSets.NativeCodebook);
+        ExportCapability codebookShoji = new(
+            ExportTarget.Codebook,
+            ExportDeliveryFormat.Json,
+            ExportProfile.Shoji,
+            "codebook-shoji",
+            "Codebook (Shoji)",
+            typeof(DynamicExportRow).FullName!,
+            "Shoji codebook export.",
+            ExportRequestFilterSets.ShojiCodebook);
 
-        registry.TryGetByWireKey("csv", out Arg.Any<ExportCapability>())
-            .Returns(callInfo =>
-            {
-                callInfo[1] = csv;
-                return true;
-            });
-        registry.TryGetByWireKey("json", out Arg.Any<ExportCapability>())
-            .Returns(callInfo =>
-            {
-                callInfo[1] = json;
-                return true;
-            });
+        RegisterCapability(registry, "csv", csv);
+        RegisterCapability(registry, "json", json);
+        RegisterCapability(registry, "codebook", codebook);
+        RegisterCapability(registry, "codebook-shoji", codebookShoji);
 
         return registry;
     }
 
+    private static void RegisterCapability(
+        IExportCapabilityRegistry registry,
+        string wireKey,
+        ExportCapability capability)
+    {
+        registry.TryGetByWireKey(wireKey, out Arg.Any<ExportCapability>())
+            .Returns(callInfo =>
+            {
+                callInfo[1] = capability;
+                return true;
+            });
+    }
+
     private static ExportFormatRecord CreateCsvExportFormatRecord(long id, string? settingsJson = null) =>
         new(id, "CSV", ExportTarget.Submissions, ExportDeliveryFormat.Csv, ExportProfile.Native, "csv", settingsJson);
+
+    private static ExportFormatRecord CreateCodebookExportFormatRecord(long id, string wireKey = "codebook") =>
+        new(
+            id,
+            wireKey == "codebook-shoji" ? "Codebook (Shoji)" : "Codebook",
+            ExportTarget.Codebook,
+            ExportDeliveryFormat.Json,
+            wireKey == "codebook-shoji" ? ExportProfile.Shoji : ExportProfile.Native,
+            wireKey,
+            null);
 
     [Fact]
     public async Task HandleAsync_FormNotFound_ReturnsBadRequest()
@@ -720,6 +755,202 @@ public class ExportTests
                 o.Metadata.ContainsKey("FormId") &&
                 o.Metadata["FormId"].Equals(formId)),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithExportFormatId_ForwardsRequestTimeFilters()
+    {
+        var formId = 1L;
+        var exportFormatId = 200L;
+        var tenantId = SampleData.TENANT_ID;
+        DateTime createdAfter = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        DateTime createdBefore = new(2026, 1, 3, 0, 0, 0, DateTimeKind.Utc);
+        DateTime completedAfter = new(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc);
+        DateTime completedBefore = new(2026, 1, 4, 0, 0, 0, DateTimeKind.Utc);
+        var request = new ExportRequest
+        {
+            FormId = formId,
+            ExportFormatId = exportFormatId,
+            IncludeTestSubmissions = false,
+            Locale = "es",
+            CreatedAfter = createdAfter,
+            CreatedBefore = createdBefore,
+            CompletedAfter = completedAfter,
+            CompletedBefore = completedBefore,
+            MinSubmissionId = 10,
+            MaxSubmissionId = 99,
+            ColumnScope = ["q1"],
+        };
+
+        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var exporter = CreateMockExporter("csv", typeof(SubmissionExportRow));
+        var fileExport = new FileExport("text/csv", "submissions-1.csv");
+
+        _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>()).Returns(form);
+        _tenantContext.TenantId.Returns(tenantId);
+        _exportFormatRepository.GetByIdAsync(tenantId, exportFormatId, Arg.Any<CancellationToken>())
+            .Returns(CreateCsvExportFormatRecord(exportFormatId));
+        _exporterFactory.GetExporter("csv", typeof(SubmissionExportRow)).Returns(exporter);
+        exporter.GetHeadersAsync(Arg.Any<ExportOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(fileExport));
+        _mediator.Send(Arg.Any<SubmissionsExportQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(fileExport));
+
+        await _reportingEndpoint.HandleAsync(request, CancellationToken.None);
+
+        _reportingEndpoint.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        await _mediator.Received(1).Send(
+            Arg.Is<SubmissionsExportQuery>(q =>
+                ((SubmissionExportExecutionSettings)q.Options.Metadata![SubmissionExportMetadataKeys.ExecutionSettings]).Locale == "es" &&
+                ((SubmissionExportExecutionSettings)q.Options.Metadata[SubmissionExportMetadataKeys.ExecutionSettings]).CreatedAfter == createdAfter &&
+                ((SubmissionExportExecutionSettings)q.Options.Metadata[SubmissionExportMetadataKeys.ExecutionSettings]).CreatedBefore == createdBefore &&
+                ((SubmissionExportExecutionSettings)q.Options.Metadata[SubmissionExportMetadataKeys.ExecutionSettings]).CompletedAfter == completedAfter &&
+                ((SubmissionExportExecutionSettings)q.Options.Metadata[SubmissionExportMetadataKeys.ExecutionSettings]).CompletedBefore == completedBefore &&
+                ((SubmissionExportExecutionSettings)q.Options.Metadata[SubmissionExportMetadataKeys.ExecutionSettings]).MinSubmissionId == 10 &&
+                ((SubmissionExportExecutionSettings)q.Options.Metadata[SubmissionExportMetadataKeys.ExecutionSettings]).MaxSubmissionId == 99 &&
+                ((SubmissionExportExecutionSettings)q.Options.Metadata[SubmissionExportMetadataKeys.ExecutionSettings]).IncludeTestSubmissions == false),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithNativeCodebook_RejectsRequestFilters()
+    {
+        var formId = 1L;
+        var exportFormatId = 300L;
+        var tenantId = SampleData.TENANT_ID;
+        var request = new ExportRequest
+        {
+            FormId = formId,
+            ExportFormatId = exportFormatId,
+            IncludeTestSubmissions = true,
+            Locale = "es",
+        };
+
+        var form = new Form(tenantId, "Test Form") { Id = formId };
+
+        _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>()).Returns(form);
+        _tenantContext.TenantId.Returns(tenantId);
+        _exportFormatRepository.GetByIdAsync(tenantId, exportFormatId, Arg.Any<CancellationToken>())
+            .Returns(CreateCodebookExportFormatRecord(exportFormatId));
+
+        await _reportingEndpoint.HandleAsync(request, CancellationToken.None);
+
+        _reportingEndpoint.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        await _mediator.DidNotReceive().Send(Arg.Any<SubmissionsExportQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithShojiCodebook_AcceptsLocaleAndRejectsRowFilters()
+    {
+        var formId = 1L;
+        var exportFormatId = 301L;
+        var tenantId = SampleData.TENANT_ID;
+        var request = new ExportRequest
+        {
+            FormId = formId,
+            ExportFormatId = exportFormatId,
+            Locale = "es",
+            CreatedAfter = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+        };
+
+        var form = new Form(tenantId, "Test Form") { Id = formId };
+
+        _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>()).Returns(form);
+        _tenantContext.TenantId.Returns(tenantId);
+        _exportFormatRepository.GetByIdAsync(tenantId, exportFormatId, Arg.Any<CancellationToken>())
+            .Returns(CreateCodebookExportFormatRecord(exportFormatId, "codebook-shoji"));
+
+        await _reportingEndpoint.HandleAsync(request, CancellationToken.None);
+
+        _reportingEndpoint.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        await _mediator.DidNotReceive().Send(Arg.Any<SubmissionsExportQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithShojiCodebook_ForwardsLocale()
+    {
+        var formId = 1L;
+        var exportFormatId = 302L;
+        var tenantId = SampleData.TENANT_ID;
+        var request = new ExportRequest
+        {
+            FormId = formId,
+            ExportFormatId = exportFormatId,
+            Locale = "es",
+        };
+
+        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var exporter = CreateMockExporter("codebook-shoji", typeof(DynamicExportRow));
+        var fileExport = new FileExport("application/json", "codebook-1.json");
+
+        _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>()).Returns(form);
+        _tenantContext.TenantId.Returns(tenantId);
+        _exportFormatRepository.GetByIdAsync(tenantId, exportFormatId, Arg.Any<CancellationToken>())
+            .Returns(CreateCodebookExportFormatRecord(exportFormatId, "codebook-shoji"));
+        _exporterFactory.GetExporter("codebook-shoji", typeof(DynamicExportRow)).Returns(exporter);
+        exporter.GetHeadersAsync(Arg.Any<ExportOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(fileExport));
+        _mediator.Send(Arg.Any<SubmissionsExportQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(fileExport));
+
+        await _reportingEndpoint.HandleAsync(request, CancellationToken.None);
+
+        _reportingEndpoint.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        await _mediator.Received(1).Send(
+            Arg.Is<SubmissionsExportQuery>(q =>
+                ((SubmissionExportExecutionSettings)q.Options.Metadata![SubmissionExportMetadataKeys.ExecutionSettings]).Locale == "es"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithExportId_RejectsRequestFilters()
+    {
+        var formId = 1L;
+        var exportId = 100L;
+        var tenantId = SampleData.TENANT_ID;
+        var request = new ExportRequest
+        {
+            FormId = formId,
+            ExportId = exportId,
+            IncludeTestSubmissions = true,
+        };
+
+        var form = new Form(tenantId, "Test Form") { Id = formId };
+
+        _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>()).Returns(form);
+        _tenantContext.TenantId.Returns(tenantId);
+
+        await _endpoint.HandleAsync(request, CancellationToken.None);
+
+        _endpoint.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        await _tenantSettingsRepository.DidNotReceive()
+            .FirstOrDefaultAsync(Arg.Any<TenantSettingsByTenantIdSpec>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_ExportHandlerConflict_ReturnsConflict()
+    {
+        var formId = 1L;
+        var tenantId = SampleData.TENANT_ID;
+        var request = new ExportRequest { FormId = formId, ExportFormatId = 100L };
+
+        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var exporter = CreateMockExporter("csv", typeof(SubmissionExportRow));
+        var fileExport = new FileExport("text/csv", "submissions-1.csv");
+
+        _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>()).Returns(form);
+        _tenantContext.TenantId.Returns(tenantId);
+        _exportFormatRepository.GetByIdAsync(tenantId, 100L, Arg.Any<CancellationToken>())
+            .Returns(CreateCsvExportFormatRecord(100L));
+        _exporterFactory.GetExporter("csv", typeof(SubmissionExportRow)).Returns(exporter);
+        exporter.GetHeadersAsync(Arg.Any<ExportOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(fileExport));
+        _mediator.Send(Arg.Any<SubmissionsExportQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result<FileExport>.Conflict("No submissions matched the export filters."));
+
+        await _reportingEndpoint.HandleAsync(request, CancellationToken.None);
+
+        _reportingEndpoint.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status409Conflict);
     }
 
     private static IExporter CreateMockExporter(string format, Type itemType)

--- a/tests/Endatix.Api.Tests/Endpoints/Submissions/ExportValidatorTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Submissions/ExportValidatorTests.cs
@@ -1,0 +1,159 @@
+using Endatix.Api.Endpoints.Submissions;
+using Endatix.Core.Abstractions.Exporting;
+using Endatix.Core.Entities;
+using FluentValidation.TestHelper;
+
+namespace Endatix.Api.Tests.Endpoints.Submissions;
+
+public sealed class ExportValidatorTests
+{
+    private readonly ExportValidator _validator;
+
+    public ExportValidatorTests()
+    {
+        IExporterFactory exporterFactory = Substitute.For<IExporterFactory>();
+        exporterFactory.GetSupportedFormats<SubmissionExportRow>().Returns(["csv", "json"]);
+        exporterFactory.GetSupportedFormats<DynamicExportRow>().Returns(["codebook", "codebook-shoji"]);
+        _validator = new ExportValidator(exporterFactory);
+    }
+
+    [Fact]
+    public async Task Validate_WithValidRequest_Passes()
+    {
+        ExportRequest request = new()
+        {
+            FormId = 1,
+            ExportFormatId = 10,
+            Locale = "es",
+            CreatedAfter = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            CreatedBefore = new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc),
+            MinSubmissionId = 1,
+            MaxSubmissionId = 10,
+        };
+
+        TestValidationResult<ExportRequest> result = await _validator.TestValidateAsync(request);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public async Task Validate_WhenFormIdMissing_Fails()
+    {
+        ExportRequest request = new() { FormId = 0, ExportFormatId = 10 };
+
+        TestValidationResult<ExportRequest> result = await _validator.TestValidateAsync(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.FormId);
+    }
+
+    [Fact]
+    public async Task Validate_WhenLocaleTooLong_Fails()
+    {
+        ExportRequest request = new()
+        {
+            FormId = 1,
+            ExportFormatId = 10,
+            Locale = new string('x', 33),
+        };
+
+        TestValidationResult<ExportRequest> result = await _validator.TestValidateAsync(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.Locale);
+    }
+
+    [Fact]
+    public async Task Validate_WhenCreatedAfterNotBeforeCreatedBefore_Fails()
+    {
+        ExportRequest request = new()
+        {
+            FormId = 1,
+            ExportFormatId = 10,
+            CreatedAfter = new DateTime(2026, 1, 3, 0, 0, 0, DateTimeKind.Utc),
+            CreatedBefore = new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc),
+        };
+
+        TestValidationResult<ExportRequest> result = await _validator.TestValidateAsync(request);
+
+        result.ShouldHaveValidationErrorFor("CreatedAfter");
+    }
+
+    [Fact]
+    public async Task Validate_WhenCreatedAfterEqualsCreatedBefore_Fails()
+    {
+        DateTime stamp = new(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc);
+        ExportRequest request = new()
+        {
+            FormId = 1,
+            ExportFormatId = 10,
+            CreatedAfter = stamp,
+            CreatedBefore = stamp,
+        };
+
+        TestValidationResult<ExportRequest> result = await _validator.TestValidateAsync(request);
+
+        result.ShouldHaveValidationErrorFor("CreatedAfter");
+    }
+
+    [Fact]
+    public async Task Validate_WhenCompletedAfterNotBeforeCompletedBefore_Fails()
+    {
+        ExportRequest request = new()
+        {
+            FormId = 1,
+            ExportFormatId = 10,
+            CompletedAfter = new DateTime(2026, 1, 5, 0, 0, 0, DateTimeKind.Utc),
+            CompletedBefore = new DateTime(2026, 1, 4, 0, 0, 0, DateTimeKind.Utc),
+        };
+
+        TestValidationResult<ExportRequest> result = await _validator.TestValidateAsync(request);
+
+        result.ShouldHaveValidationErrorFor("CompletedAfter");
+    }
+
+    [Fact]
+    public async Task Validate_WhenMinSubmissionIdGreaterThanMax_Fails()
+    {
+        ExportRequest request = new()
+        {
+            FormId = 1,
+            ExportFormatId = 10,
+            MinSubmissionId = 20,
+            MaxSubmissionId = 10,
+        };
+
+        TestValidationResult<ExportRequest> result = await _validator.TestValidateAsync(request);
+
+        result.ShouldHaveValidationErrorFor("MinSubmissionId");
+    }
+
+    [Fact]
+    public async Task Validate_WhenSubmissionIdNotPositive_Fails()
+    {
+        ExportRequest request = new()
+        {
+            FormId = 1,
+            ExportFormatId = 10,
+            MinSubmissionId = 0,
+            MaxSubmissionId = -1,
+        };
+
+        TestValidationResult<ExportRequest> result = await _validator.TestValidateAsync(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.MinSubmissionId);
+        result.ShouldHaveValidationErrorFor(x => x.MaxSubmissionId);
+    }
+
+    [Fact]
+    public async Task Validate_WhenExportFormatUnsupported_Fails()
+    {
+        ExportRequest request = new()
+        {
+            FormId = 1,
+            ExportFormat = "xlsx",
+        };
+
+        TestValidationResult<ExportRequest> result = await _validator.TestValidateAsync(request);
+
+        result.ShouldHaveValidationErrorFor(x => x.ExportFormat);
+    }
+}

--- a/tests/Endatix.IntegrationTests/Infrastructure/ReportingExportRepositoryIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/ReportingExportRepositoryIntegrationTests.cs
@@ -1,0 +1,363 @@
+using Endatix.Core.Abstractions;
+using Endatix.Core.Entities;
+using Endatix.Infrastructure.Data;
+using Endatix.Infrastructure.Features.Outbox;
+using Endatix.IntegrationTests.Shared;
+using Endatix.Modules.Reporting.Contracts.Export;
+using Endatix.Modules.Reporting.Data;
+using Endatix.Modules.Reporting.Domain;
+using Endatix.Modules.Reporting.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Endatix.IntegrationTests;
+
+/// <summary>
+/// PostgreSQL integration coverage for export request-time filters in
+/// <see cref="ReportingExportRepository"/> (date ranges, test inclusion, submission id range).
+/// </summary>
+[Collection(nameof(DbIntegrationTestCollection))]
+[Trait("Category", "Infrastructure")]
+[Trait("Priority", "P1")]
+[Trait("DbSpecific", "PostgreSql")]
+public sealed class ReportingExportRepositoryIntegrationTests
+{
+    private const long TenantId = 41;
+
+    private static readonly DateTime Day1 = new(2026, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Day2 = new(2026, 1, 2, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Day3 = new(2026, 1, 3, 12, 0, 0, DateTimeKind.Utc);
+    private static readonly DateTime Day4 = new(2026, 1, 4, 12, 0, 0, DateTimeKind.Utc);
+
+    private readonly DbIntegrationFixture _fixture;
+
+    public ReportingExportRepositoryIntegrationTests(DbIntegrationFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task StreamFlattenedSubmissionsAsync_ExcludesTestSubmissionsByDefault()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SeededExportFixture seed = await SeedExportFixtureAsync(cancellationToken);
+
+        await using AppDbContext appDb = CreateAppDbContext();
+        await using ReportingDbContext reportingDb = CreateReportingDbContext();
+        ReportingExportRepository repository = CreateRepository(reportingDb, appDb);
+
+        List<long> ids = await CollectIdsAsync(
+            repository,
+            seed.FormId,
+            new ExportQueryOptions(IncludeTestSubmissions: false),
+            cancellationToken);
+
+        ids.Should().Equal(seed.ProductionDay1Id, seed.ProductionDay2Id, seed.ProductionDay3Id);
+    }
+
+    [Fact]
+    public async Task StreamFlattenedSubmissionsAsync_WhenIncludeTest_ReturnsAllRows()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SeededExportFixture seed = await SeedExportFixtureAsync(cancellationToken);
+
+        await using AppDbContext appDb = CreateAppDbContext();
+        await using ReportingDbContext reportingDb = CreateReportingDbContext();
+        ReportingExportRepository repository = CreateRepository(reportingDb, appDb);
+
+        List<long> ids = await CollectIdsAsync(
+            repository,
+            seed.FormId,
+            new ExportQueryOptions(IncludeTestSubmissions: true),
+            cancellationToken);
+
+        ids.Should().Equal(
+            seed.ProductionDay1Id,
+            seed.ProductionDay2Id,
+            seed.ProductionDay3Id,
+            seed.TestDay3Id);
+    }
+
+    [Fact]
+    public async Task StreamFlattenedSubmissionsAsync_FiltersByCreatedAtRange_ExclusiveBefore()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SeededExportFixture seed = await SeedExportFixtureAsync(cancellationToken);
+
+        await using AppDbContext appDb = CreateAppDbContext();
+        await using ReportingDbContext reportingDb = CreateReportingDbContext();
+        ReportingExportRepository repository = CreateRepository(reportingDb, appDb);
+
+        // Day2 inclusive lower bound, Day3 exclusive upper bound → only production Day2 row.
+        List<long> ids = await CollectIdsAsync(
+            repository,
+            seed.FormId,
+            new ExportQueryOptions(
+                IncludeTestSubmissions: true,
+                CreatedAfter: Day2,
+                CreatedBefore: Day3),
+            cancellationToken);
+
+        ids.Should().Equal(seed.ProductionDay2Id);
+    }
+
+    [Fact]
+    public async Task StreamFlattenedSubmissionsAsync_FiltersByCompletedAtRange_ExclusiveBefore()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SeededExportFixture seed = await SeedExportFixtureAsync(cancellationToken);
+
+        await using AppDbContext appDb = CreateAppDbContext();
+        await using ReportingDbContext reportingDb = CreateReportingDbContext();
+        ReportingExportRepository repository = CreateRepository(reportingDb, appDb);
+
+        // Production Day1 completed Day2, Day2 completed Day3; Day3 incomplete; test completed Day4.
+        List<long> ids = await CollectIdsAsync(
+            repository,
+            seed.FormId,
+            new ExportQueryOptions(
+                IncludeTestSubmissions: true,
+                CompletedAfter: Day2,
+                CompletedBefore: Day4),
+            cancellationToken);
+
+        ids.Should().Equal(seed.ProductionDay1Id, seed.ProductionDay2Id);
+    }
+
+    [Fact]
+    public async Task StreamFlattenedSubmissionsAsync_FiltersBySubmissionIdRange()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SeededExportFixture seed = await SeedExportFixtureAsync(cancellationToken);
+
+        await using AppDbContext appDb = CreateAppDbContext();
+        await using ReportingDbContext reportingDb = CreateReportingDbContext();
+        ReportingExportRepository repository = CreateRepository(reportingDb, appDb);
+
+        List<long> ids = await CollectIdsAsync(
+            repository,
+            seed.FormId,
+            new ExportQueryOptions(
+                IncludeTestSubmissions: true,
+                MinSubmissionId: seed.ProductionDay2Id,
+                MaxSubmissionId: seed.ProductionDay3Id),
+            cancellationToken);
+
+        ids.Should().Equal(seed.ProductionDay2Id, seed.ProductionDay3Id);
+    }
+
+    [Fact]
+    public async Task StreamFlattenedSubmissionsAsync_CombinesFiltersWithAnd()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SeededExportFixture seed = await SeedExportFixtureAsync(cancellationToken);
+
+        await using AppDbContext appDb = CreateAppDbContext();
+        await using ReportingDbContext reportingDb = CreateReportingDbContext();
+        ReportingExportRepository repository = CreateRepository(reportingDb, appDb);
+
+        // Created on/after Day2, production only, id ≤ production Day3 → Day2 and Day3 production rows.
+        List<long> ids = await CollectIdsAsync(
+            repository,
+            seed.FormId,
+            new ExportQueryOptions(
+                IncludeTestSubmissions: false,
+                CreatedAfter: Day2,
+                MaxSubmissionId: seed.ProductionDay3Id),
+            cancellationToken);
+
+        ids.Should().Equal(seed.ProductionDay2Id, seed.ProductionDay3Id);
+    }
+
+    [Fact]
+    public async Task HasExportableRowsAsync_WhenFiltersMatchNothing_ReturnsFalse()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SeededExportFixture seed = await SeedExportFixtureAsync(cancellationToken);
+
+        await using AppDbContext appDb = CreateAppDbContext();
+        await using ReportingDbContext reportingDb = CreateReportingDbContext();
+        ReportingExportRepository repository = CreateRepository(reportingDb, appDb);
+
+        bool hasRows = await repository.HasExportableRowsAsync(
+            TenantId,
+            seed.FormId,
+            new ExportQueryOptions(
+                IncludeTestSubmissions: false,
+                CreatedAfter: Day4),
+            cancellationToken);
+
+        hasRows.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task HasExportableRowsAsync_WhenRowsExist_ReturnsTrue()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SeededExportFixture seed = await SeedExportFixtureAsync(cancellationToken);
+
+        await using AppDbContext appDb = CreateAppDbContext();
+        await using ReportingDbContext reportingDb = CreateReportingDbContext();
+        ReportingExportRepository repository = CreateRepository(reportingDb, appDb);
+
+        bool hasRows = await repository.HasExportableRowsAsync(
+            TenantId,
+            seed.FormId,
+            new ExportQueryOptions(IncludeTestSubmissions: false),
+            cancellationToken);
+
+        hasRows.Should().BeTrue();
+    }
+
+    private async Task<SeededExportFixture> SeedExportFixtureAsync(CancellationToken cancellationToken)
+    {
+        await _fixture.Checkpoint.ResetAsync(_fixture.ConnectionString, _fixture.Provider, cancellationToken);
+        await ReportingTestSchema.EnsureMigratedAsync(_fixture.ConnectionString, _fixture.Provider, cancellationToken);
+
+        await using AppDbContext appDb = CreateAppDbContext();
+        Tenant tenant = new("export-filter-tenant") { Id = TenantId };
+        appDb.Set<Tenant>().Add(tenant);
+        await appDb.SaveChangesAsync(cancellationToken);
+
+        // Two-step form+definition save avoids Form ↔ ActiveDefinition circular insert.
+        Form form = new(TenantId, "Export filter form");
+        appDb.Forms.Add(form);
+        await appDb.SaveChangesAsync(cancellationToken);
+
+        FormDefinition definition = new(TenantId, isDraft: false, jsonData: """{"pages":[]}""");
+        form.AddFormDefinition(definition);
+        appDb.Set<FormDefinition>().Add(definition);
+        await appDb.SaveChangesAsync(cancellationToken);
+
+        long formId = form.Id;
+        long formDefinitionId = definition.Id;
+
+        // Seed matrix (ids assigned by AppDbContext):
+        // production Day1 / completed Day2
+        // production Day2 / completed Day3
+        // production Day3 / incomplete
+        // test Day3 / completed Day4
+        long productionDay1Id = await SeedSubmissionAsync(
+            appDb, formId, formDefinitionId, isTest: false, isComplete: true, createdAt: Day1, completedAt: Day2, cancellationToken);
+        long productionDay2Id = await SeedSubmissionAsync(
+            appDb, formId, formDefinitionId, isTest: false, isComplete: true, createdAt: Day2, completedAt: Day3, cancellationToken);
+        long productionDay3Id = await SeedSubmissionAsync(
+            appDb, formId, formDefinitionId, isTest: false, isComplete: false, createdAt: Day3, completedAt: null, cancellationToken);
+        long testDay3Id = await SeedSubmissionAsync(
+            appDb, formId, formDefinitionId, isTest: true, isComplete: true, createdAt: Day3, completedAt: Day4, cancellationToken);
+
+        await using ReportingDbContext reportingDb = CreateReportingDbContext();
+        foreach (long submissionId in new[] { productionDay1Id, productionDay2Id, productionDay3Id, testDay3Id })
+        {
+            FlattenedSubmission row = new(submissionId, TenantId, formId);
+            row.MarkProcessed($$"""{"submissionId":{{submissionId}}}""");
+            reportingDb.FlattenedSubmissions.Add(row);
+        }
+
+        await reportingDb.SaveChangesAsync(cancellationToken);
+        return new SeededExportFixture(
+            formId,
+            formDefinitionId,
+            productionDay1Id,
+            productionDay2Id,
+            productionDay3Id,
+            testDay3Id);
+    }
+
+    private static async Task<long> SeedSubmissionAsync(
+        AppDbContext appDb,
+        long formId,
+        long formDefinitionId,
+        bool isTest,
+        bool isComplete,
+        DateTime createdAt,
+        DateTime? completedAt,
+        CancellationToken cancellationToken)
+    {
+        Submission submission = Submission.Create(new SubmissionCreateArgs(
+            TenantId: TenantId,
+            FormId: formId,
+            FormDefinitionId: formDefinitionId,
+            JsonData: """{"answer":"x"}""",
+            IsComplete: isComplete,
+            IsTestSubmission: isTest));
+
+        appDb.Submissions.Add(submission);
+        await appDb.SaveChangesAsync(cancellationToken);
+        long submissionId = submission.Id;
+
+        // OwnsOne Status uses shared static instances; clear tracking before the next Add.
+        appDb.ChangeTracker.Clear();
+
+        // Stamp filter-relevant timestamps after insert.
+        await appDb.Submissions
+            .Where(row => row.Id == submissionId)
+            .ExecuteUpdateAsync(
+                updates => updates
+                    .SetProperty(row => row.CreatedAt, createdAt)
+                    .SetProperty(row => row.CompletedAt, completedAt),
+                cancellationToken);
+
+        return submissionId;
+    }
+
+    private static async Task<List<long>> CollectIdsAsync(
+        ReportingExportRepository repository,
+        long formId,
+        ExportQueryOptions options,
+        CancellationToken cancellationToken)
+    {
+        List<long> ids = [];
+        await foreach (FlattenedExportRow row in repository.StreamFlattenedSubmissionsAsync(
+                           TenantId,
+                           formId,
+                           options,
+                           cancellationToken))
+        {
+            ids.Add(row.SubmissionId);
+        }
+
+        return ids;
+    }
+
+    private AppDbContext CreateAppDbContext()
+    {
+        ITenantContext tenantContext = Substitute.For<ITenantContext>();
+        tenantContext.TenantId.Returns(TenantId);
+
+        IncrementingIdGenerator idGenerator = new();
+        DbContextOptionsBuilder<AppDbContext> optionsBuilder = new();
+        IntegrationAppDbContextFactory.ConfigurePostgreSqlOptions(optionsBuilder, _fixture.ConnectionString);
+
+        return new AppDbContext(
+            optionsBuilder.Options,
+            idGenerator,
+            tenantContext,
+            new EfCoreValueGeneratorFactory(idGenerator),
+            new OutboxIntegrationEventDispatcher());
+    }
+
+    private ReportingDbContext CreateReportingDbContext()
+    {
+        ITenantContext tenantContext = Substitute.For<ITenantContext>();
+        tenantContext.TenantId.Returns(TenantId);
+
+        DbContextOptionsBuilder<ReportingDbContext> optionsBuilder =
+            ReportingTestSchema.ConfigureOptionsBuilder(_fixture.ConnectionString);
+
+        return new ReportingDbContext(optionsBuilder.Options, new IncrementingIdGenerator(), tenantContext);
+    }
+
+    private static ReportingExportRepository CreateRepository(
+        ReportingDbContext reportingDb,
+        AppDbContext appDb) =>
+        new(reportingDb, appDb, NullLogger<ReportingExportRepository>.Instance);
+
+    private sealed record SeededExportFixture(
+        long FormId,
+        long FormDefinitionId,
+        long ProductionDay1Id,
+        long ProductionDay2Id,
+        long ProductionDay3Id,
+        long TestDay3Id);
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Endpoints/Settings/ExportCapabilities/ListExportCapabilitiesEndpointTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Endpoints/Settings/ExportCapabilities/ListExportCapabilitiesEndpointTests.cs
@@ -21,8 +21,8 @@ public sealed class ListExportCapabilitiesEndpointTests
     {
         List<ExportCapability> capabilities =
         [
-            new(ExportTarget.Submissions, ExportDeliveryFormat.Csv, ExportProfile.Native, "csv", "CSV", "type1", "CSV export"),
-            new(ExportTarget.Codebook, ExportDeliveryFormat.Json, ExportProfile.Shoji, "codebook-shoji", "Codebook (Shoji)", "type2", "Shoji codebook"),
+            new(ExportTarget.Submissions, ExportDeliveryFormat.Csv, ExportProfile.Native, "csv", "CSV", "type1", "CSV export", ExportRequestFilterSets.Submissions),
+            new(ExportTarget.Codebook, ExportDeliveryFormat.Json, ExportProfile.Shoji, "codebook-shoji", "Codebook (Shoji)", "type2", "Shoji codebook", ExportRequestFilterSets.ShojiCodebook),
         ];
         _registry.GetAll().Returns(capabilities);
 

--- a/tests/Endatix.Modules.Reporting.Tests/Features/Export/ExportRequestFilterGuardTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/Export/ExportRequestFilterGuardTests.cs
@@ -1,0 +1,66 @@
+using Endatix.Modules.Reporting.Contracts.Export;
+using FluentAssertions;
+
+namespace Endatix.Modules.Reporting.Tests.Features.Export;
+
+public sealed class ExportRequestFilterGuardTests
+{
+    [Fact]
+    public void GetDisallowedWireNames_WhenCodebookReceivesRowFilters_ReturnsThoseFilters()
+    {
+        var disallowed = ExportRequestFilterGuard.GetDisallowedWireNames(
+            ExportRequestFilterSets.ShojiCodebook,
+            includeTestSubmissions: true,
+            createdAfter: DateTime.UtcNow.AddDays(-1),
+            createdBefore: null,
+            completedAfter: null,
+            completedBefore: null,
+            minSubmissionId: 10,
+            maxSubmissionId: null,
+            locale: "es",
+            columnScope: null);
+
+        disallowed.Should().BeEquivalentTo(
+        [
+            ExportRequestFilterWireNames.IncludeTestSubmissions,
+            ExportRequestFilterWireNames.CreatedAtRange,
+            ExportRequestFilterWireNames.SubmissionIdRange,
+        ]);
+    }
+
+    [Fact]
+    public void GetDisallowedWireNames_WhenNativeCodebookReceivesLocale_ReturnsLocale()
+    {
+        var disallowed = ExportRequestFilterGuard.GetDisallowedWireNames(
+            ExportRequestFilterSets.NativeCodebook,
+            includeTestSubmissions: null,
+            createdAfter: null,
+            createdBefore: null,
+            completedAfter: null,
+            completedBefore: null,
+            minSubmissionId: null,
+            maxSubmissionId: null,
+            locale: "es",
+            columnScope: null);
+
+        disallowed.Should().Equal(ExportRequestFilterWireNames.Locale);
+    }
+
+    [Fact]
+    public void GetDisallowedWireNames_WhenSubmissionsReceivesAllFilters_ReturnsEmpty()
+    {
+        var disallowed = ExportRequestFilterGuard.GetDisallowedWireNames(
+            ExportRequestFilterSets.Submissions,
+            includeTestSubmissions: false,
+            createdAfter: DateTime.UtcNow.AddDays(-7),
+            createdBefore: DateTime.UtcNow,
+            completedAfter: DateTime.UtcNow.AddDays(-7),
+            completedBefore: DateTime.UtcNow,
+            minSubmissionId: 1,
+            maxSubmissionId: 100,
+            locale: "es",
+            columnScope: ["q1"]);
+
+        disallowed.Should().BeEmpty();
+    }
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Features/Export/ExportRequestFilterGuardTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/Export/ExportRequestFilterGuardTests.cs
@@ -10,15 +10,16 @@ public sealed class ExportRequestFilterGuardTests
     {
         var disallowed = ExportRequestFilterGuard.GetDisallowedWireNames(
             ExportRequestFilterSets.ShojiCodebook,
-            includeTestSubmissions: true,
-            createdAfter: DateTime.UtcNow.AddDays(-1),
-            createdBefore: null,
-            completedAfter: null,
-            completedBefore: null,
-            minSubmissionId: 10,
-            maxSubmissionId: null,
-            locale: "es",
-            columnScope: null);
+            new ExportFilterContext(
+                IncludeTestSubmissions: true,
+                CreatedAfter: DateTime.UtcNow.AddDays(-1),
+                CreatedBefore: null,
+                CompletedAfter: null,
+                CompletedBefore: null,
+                MinSubmissionId: 10,
+                MaxSubmissionId: null,
+                Locale: "es",
+                ColumnScope: null));
 
         disallowed.Should().BeEquivalentTo(
         [
@@ -33,15 +34,16 @@ public sealed class ExportRequestFilterGuardTests
     {
         var disallowed = ExportRequestFilterGuard.GetDisallowedWireNames(
             ExportRequestFilterSets.NativeCodebook,
-            includeTestSubmissions: null,
-            createdAfter: null,
-            createdBefore: null,
-            completedAfter: null,
-            completedBefore: null,
-            minSubmissionId: null,
-            maxSubmissionId: null,
-            locale: "es",
-            columnScope: null);
+            new ExportFilterContext(
+                IncludeTestSubmissions: null,
+                CreatedAfter: null,
+                CreatedBefore: null,
+                CompletedAfter: null,
+                CompletedBefore: null,
+                MinSubmissionId: null,
+                MaxSubmissionId: null,
+                Locale: "es",
+                ColumnScope: null));
 
         disallowed.Should().Equal(ExportRequestFilterWireNames.Locale);
     }
@@ -51,15 +53,16 @@ public sealed class ExportRequestFilterGuardTests
     {
         var disallowed = ExportRequestFilterGuard.GetDisallowedWireNames(
             ExportRequestFilterSets.Submissions,
-            includeTestSubmissions: false,
-            createdAfter: DateTime.UtcNow.AddDays(-7),
-            createdBefore: DateTime.UtcNow,
-            completedAfter: DateTime.UtcNow.AddDays(-7),
-            completedBefore: DateTime.UtcNow,
-            minSubmissionId: 1,
-            maxSubmissionId: 100,
-            locale: "es",
-            columnScope: ["q1"]);
+            new ExportFilterContext(
+                IncludeTestSubmissions: false,
+                CreatedAfter: DateTime.UtcNow.AddDays(-7),
+                CreatedBefore: DateTime.UtcNow,
+                CompletedAfter: DateTime.UtcNow.AddDays(-7),
+                CompletedBefore: DateTime.UtcNow,
+                MinSubmissionId: 1,
+                MaxSubmissionId: 100,
+                Locale: "es",
+                ColumnScope: ["q1"]));
 
         disallowed.Should().BeEmpty();
     }


### PR DESCRIPTION
# feat(e801): capability-scoped export request filters

## Description
- Add per-capability `AllowedFilters` (`ExportRequestFilterKind`) exposed on export capabilities, with `ExportRequestFilterGuard` rejecting unsupported request filters.
- Wire request-time filters on submissions export: `includeTestSubmissions`, created/completed date ranges (`*Before` exclusive), submission id range, and `locale` / `columnScope` where allowed.
- Filter sets: **Submissions** = full set; **native codebook** = none; **Shoji codebook** = `locale` only.
- Distinguish 409 when reporting rows exist but filters match nothing vs when the read model is empty (needs backfill).
- Legacy `ExportId` path rejects request filters (use `ExportFormatId`).

## Test plan
- [ ] Capabilities list returns `allowedFilters` matching the matrix above
- [ ] CSV/JSON export with date + test filters returns expected subset
- [ ] Codebook export with row filters → 400; Shoji codebook with `locale` succeeds; native codebook with `locale` → 400
- [ ] Filtered export with no matches → 409 with filter message (not backfill message)
- [ ] `dotnet test` Reporting tests for `ExportRequestFilterGuard` + capabilities list

## Related Issues
Closes #801

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added created/completed date-range and submission ID filters to submission exports.
  * Export capabilities now indicate which filters they support.
  * Added locale-aware Shoji codebook exports.
  * Improved export results and messaging when filters match no submissions.

* **Bug Fixes**
  * Added validation for invalid date ranges and submission ID bounds.
  * Unsupported filters are now rejected with clearer errors, including for legacy exports.

* **Tests**
  * Expanded coverage for filter validation, export capabilities, filtering behavior, localization, and conflict responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->