### PR TITLE
ci: hotfix line support (hotfix/X.Y.x maintenance branches)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ name: Build, Test & Release
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, "hotfix/**"] # PRs into maintenance-line branches validate too
   push:
-    branches: [main]
+    branches: [main, "hotfix/**"] # hotfix/X.Y.x pushes publish vX.Y.Z-hotfix.N builds
   workflow_dispatch:
 
 env:
@@ -145,6 +145,6 @@ jobs:
       contents: read # release writes use the App token inside the shared workflow
       packages: write # GitHub Packages push
       id-token: write # OIDC for Infisical inside the shared workflow
-    uses: endatix/release-workflows/.github/workflows/canary.yml@7c17ac843352ae0249d9ea7d799c6b6406ac2809 # v1
+    uses: endatix/release-workflows/.github/workflows/canary.yml@cca02534258a68b196f9295afe9fd855ad9eee83 # v1
     with:
       dotnet-version: "10.x" # global.json rolls forward within 10.0.x

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -21,7 +21,7 @@ jobs:
       contents: read
       packages: write # GitHub Packages push
       id-token: write # OIDC for Infisical (fetch-secrets)
-    uses: endatix/release-workflows/.github/workflows/release-artifacts.yml@7c17ac843352ae0249d9ea7d799c6b6406ac2809 # v1
+    uses: endatix/release-workflows/.github/workflows/release-artifacts.yml@cca02534258a68b196f9295afe9fd855ad9eee83 # v1
     with:
       promotion: rebuild
       fetch-secrets: true # ENDATIX_NUGET_ORG_USERNAME via Infisical (prod)

--- a/.github/workflows/release-hotfix.yml
+++ b/.github/workflows/release-hotfix.yml
@@ -1,0 +1,26 @@
+name: Start Hotfix Release
+
+# One-parameter, mistake-proof entry point for releasing from a hotfix line
+# (hotfix/X.Y.x): always a PATCH bump on that line — the version base is the
+# nearest stable ancestor of the branch, so v0.8.0 → v0.8.1 → v0.8.2 …
+# Creates a DRAFT release pinned to the branch head; review/edit the notes,
+# then click "Publish release". Releasing an older line automatically becomes
+# a maintenance release (no "Latest" badge; nuget.org ranks by semver so
+# nothing needs unlisting). For promoting canaries from main, use
+# "Start Stable Release" instead.
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Hotfix line branch to release from (e.g. hotfix/0.8.x)"
+        required: true
+
+jobs:
+  draft:
+    permissions:
+      contents: write # create the draft release (no tag exists until a human publishes it)
+    uses: endatix/release-workflows/.github/workflows/release-start.yml@cca02534258a68b196f9295afe9fd855ad9eee83 # v1
+    with:
+      ref: ${{ inputs.branch }}
+      bump: patch

--- a/.github/workflows/release-hotfix.yml
+++ b/.github/workflows/release-hotfix.yml
@@ -17,7 +17,25 @@ on:
         required: true
 
 jobs:
+  # Reject anything that is not a hotfix line branch (hotfix/X.Y.x) BEFORE the
+  # release job runs — e.g. typing `main` here would otherwise draft a patch
+  # release cut from main, bypassing the canary-promotion flow.
+  validate:
+    name: Validate branch name
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check hotfix line branch name
+        env:
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          if [[ ! "$BRANCH" =~ ^hotfix/[0-9]+\.[0-9]+\.x$ ]]; then
+            echo "::error::'${BRANCH}' is not a hotfix line branch — expected hotfix/X.Y.x (e.g. hotfix/0.8.x)"
+            exit 1
+          fi
+          echo "Branch name OK: ${BRANCH}"
+
   draft:
+    needs: validate
     permissions:
       contents: write # create the draft release (no tag exists until a human publishes it)
     uses: endatix/release-workflows/.github/workflows/release-start.yml@cca02534258a68b196f9295afe9fd855ad9eee83 # v1

--- a/.github/workflows/release-hotfix.yml
+++ b/.github/workflows/release-hotfix.yml
@@ -23,6 +23,7 @@ jobs:
   validate:
     name: Validate branch name
     runs-on: ubuntu-latest
+    permissions: {} # needs no token scopes at all
     steps:
       - name: Check hotfix line branch name
         env:

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -1,11 +1,10 @@
 name: Start Stable Release
 
 # Thin consumer of endatix/release-workflows: creates a DRAFT release with
-# aggregated notes pinned to a canary's commit — or, with `ref`, to a hotfix
-# branch head (hotfix/X.Y.x maintenance lines). Review/edit the notes in the
+# aggregated notes pinned to a canary's commit. Review/edit the notes in the
 # GitHub UI, then click "Publish release" — that creates the tag and triggers
 # release-artifacts.yml to publish the stable packages (GitHub Packages +
-# nuget.org).
+# nuget.org). For hotfix lines use "Start Hotfix Release" (release-hotfix.yml).
 
 on:
   workflow_dispatch:
@@ -15,14 +14,10 @@ on:
         required: false
         default: ""
       bump:
-        description: "Version bump relative to the base stable release"
+        description: "Version bump relative to the last stable release"
         type: choice
         options: [minor, patch, major]
         default: minor
-      ref:
-        description: "Hotfix mode: branch or SHA to release from (empty = newest canary flow)"
-        required: false
-        default: ""
 
 jobs:
   draft:
@@ -32,4 +27,3 @@ jobs:
     with:
       canary-tag: ${{ inputs.canary_tag }}
       bump: ${{ inputs.bump }}
-      ref: ${{ inputs.ref }}

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -1,7 +1,8 @@
 name: Start Stable Release
 
 # Thin consumer of endatix/release-workflows: creates a DRAFT release with
-# aggregated notes pinned to a canary's commit. Review/edit the notes in the
+# aggregated notes pinned to a canary's commit — or, with `ref`, to a hotfix
+# branch head (hotfix/X.Y.x maintenance lines). Review/edit the notes in the
 # GitHub UI, then click "Publish release" — that creates the tag and triggers
 # release-artifacts.yml to publish the stable packages (GitHub Packages +
 # nuget.org).
@@ -14,16 +15,21 @@ on:
         required: false
         default: ""
       bump:
-        description: "Version bump relative to the last stable release"
+        description: "Version bump relative to the base stable release"
         type: choice
         options: [minor, patch, major]
         default: minor
+      ref:
+        description: "Hotfix mode: branch or SHA to release from (empty = newest canary flow)"
+        required: false
+        default: ""
 
 jobs:
   draft:
     permissions:
       contents: write # create the draft release (no tag exists until a human publishes it)
-    uses: endatix/release-workflows/.github/workflows/release-start.yml@7c17ac843352ae0249d9ea7d799c6b6406ac2809 # v1
+    uses: endatix/release-workflows/.github/workflows/release-start.yml@cca02534258a68b196f9295afe9fd855ad9eee83 # v1
     with:
       canary-tag: ${{ inputs.canary_tag }}
       bump: ${{ inputs.bump }}
+      ref: ${{ inputs.ref }}


### PR DESCRIPTION
## What

Enables the hotfix / maintenance-line flow from [`endatix/release-workflows`](https://github.com/endatix/release-workflows) (see its README → *Hotfixes & maintenance lines* for the full write-up). Three small consumer-side changes:

- **`hotfix/**` added to CI triggers** — PRs targeting a `hotfix/X.Y.x` branch run the full test suite + build validation exactly like PRs to `main`, and every push/merge to such a branch publishes a `vX.Y.Z-hotfix.N` prerelease build (GitHub Packages only; distinct `-hotfix` identifier can't collide with main's `-canary` builds).
- **`ref` input on Start Stable Release** — cutting a stable from a hotfix branch: `ref: hotfix/0.8.x` + `bump: patch` → draft `v0.8.1` pinned to the *branch* head (never contains anything from main). Empty `ref` keeps the normal newest-canary flow.
- **Workflow pins bumped** to `release-workflows` v1 @ `cca0253` — brings the shared-side support: ancestor-based version math, automatic **maintenance** releases for older lines (no `Latest` badge, no floating tags move; nuget.org is naturally safe since it ranks by semver), and byte-identical promotion of `-hotfix.N` images where applicable.

## The flow (short version)

```bash
git checkout -b hotfix/0.8.x v0.8.0 && git push -u origin hotfix/0.8.x   # once per line
# fixes arrive by PR to hotfix/0.8.x (or cherry-pick from main)
# every push → 0.8.1-hotfix.N prerelease build
# Actions → Start Stable Release: ref=hotfix/0.8.x, bump=patch → draft v0.8.1 → review → Publish
# carry the fix to main by cherry-pick (squash-merge repos: no repeated whole-branch merges)
```

Version lines stay independent: main's canaries/stables always select the highest reachable release, so hotfix tags never disturb main's numbering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered hotfix release workflow supporting patch releases from specified hotfix branches.
  * Hotfix branch pushes can now be handled as release candidates alongside main branch pushes.

* **Chores**
  * Updated release automation workflow versions for improved release and artifact publishing reliability.
  * Clarified the release process for draft and stable package publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->