### PR TITLE
fix: drop hardcoded InformationalVersion from Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
     <PropertyGroup>
+        <!-- Local-dev fallback only: CI/release builds override with -p:Version=<computed>.
+             InformationalVersion is deliberately NOT set — it defaults to the effective
+             Version (+ source commit SHA via SourceLink). -->
         <Version>0.1.1-beta</Version>
-        <InformationalVersion>This is an alpha prerelease package</InformationalVersion>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
The literal "This is an alpha prerelease package" was baked into every shipped assembly (stable releases included) because an explicit InformationalVersion wins over the default and is not touched by the -p:Version override the release pipeline uses. With the property removed it defaults to the effective Version plus the source commit SHA (SourceLink), e.g. 0.8.0+<sha>.

# Title of the Pull Request

## Description
Please include a summary of the changes and the related issue. Also, explain the context and the reason for the proposed changes.

## Related Issues
List any related issues (e.g., fixes #123, closes #456).

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [ ] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
