### PR TITLE
fix(e885): Default Export failing

### DIFF
--- a/src/Endatix.Api/Endpoints/Submissions/Export.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/Export.cs
@@ -181,36 +181,23 @@ public partial class Export : Endpoint<ExportRequest>
             return Result.Invalid(new ValidationError($"Form with ID {request.FormId} not found"));
         }
 
+        // Dual-mode: Reporting module may be registered while Hub uses legacy UI.
+        // - ExportFormatId → reporting (Hub reporting always sends this)
+        // - ExportId → tenant CustomExports (legacy named exports)
+        // - neither → classic built-in CSV (Hub "Default CSV Export")
+        // Do not auto-use tenant reporting default when neither id is set — that 409s
+        // forms without a compiled reporting schema.
         if (request.ExportFormatId.HasValue)
         {
             return await ResolveExportFormatIdConfigurationAsync(request, cancellationToken);
         }
 
-        // Explicit legacy ExportId must win over tenant default reporting format.
-        // Otherwise Hub legacy custom exports (json/codebook/etc.) silently become CSV
-        // whenever Reporting is registered and a tenant default exists.
         if (request.ExportId.HasValue)
         {
             return await ResolveExportIdConfigurationAsync(request, cancellationToken);
         }
 
-        if (_exportFormatRepository is not null)
-        {
-            var defaultFormatResult =
-                await ResolveTenantDefaultExportFormatAsync(request, cancellationToken);
-            if (defaultFormatResult is not null)
-            {
-                return defaultFormatResult;
-            }
-        }
-
-        if (_exportCapabilityRegistry is not null)
-        {
-            return Result.Invalid(new ValidationError(
-                "ExportFormatId is required when reporting export formats are enabled."));
-        }
-
-        return Result.Invalid(new ValidationError(ERROR_MESSAGE_COULD_NOT_DETERMINE_EXPORT_FORMAT));
+        return ResolveLegacyBuiltInConfiguration(request);
     }
 
     private async Task<Result<ValidatedExportOperation>> ResolveExportFormatIdConfigurationAsync(
@@ -239,17 +226,22 @@ public partial class Export : Endpoint<ExportRequest>
         return BuildValidatedExportOperation(request, exportFormat);
     }
 
-    private async Task<Result<ValidatedExportOperation>?> ResolveTenantDefaultExportFormatAsync(
-        ExportRequest request,
-        CancellationToken cancellationToken)
+    /// <summary>
+    /// Classic exporters without reporting execution settings (default SQL function
+    /// <c>export_form_submissions</c> when <see cref="ValidatedExportOperation.SqlFunctionName"/> is null).
+    /// </summary>
+    private static Result<ValidatedExportOperation> ResolveLegacyBuiltInConfiguration(ExportRequest request)
     {
-        var exportFormat = await _exportFormatRepository!.GetTenantDefaultAsync(
-            _tenantContext.TenantId,
-            cancellationToken);
+        var format = string.IsNullOrWhiteSpace(request.ExportFormat)
+            ? "csv"
+            : request.ExportFormat.Trim();
 
-        return exportFormat is null
-            ? null
-            : BuildValidatedExportOperation(request, exportFormat);
+        return Result.Success(new ValidatedExportOperation(
+            format,
+            typeof(SubmissionExportRow),
+            SqlFunctionName: null,
+            ExportPageSize: null,
+            ExecutionSettings: null));
     }
 
     private Result<ValidatedExportOperation> BuildValidatedExportOperation(

--- a/src/Endatix.Core/Abstractions/Exporting/IExportDataSource.cs
+++ b/src/Endatix.Core/Abstractions/Exporting/IExportDataSource.cs
@@ -5,10 +5,24 @@ namespace Endatix.Core.Abstractions.Exporting;
 /// <summary>
 /// Identifies an export request for data-source resolution.
 /// </summary>
+/// <param name="Format">
+/// The export format to use.
+/// </param>
+/// <param name="ItemType">
+/// The type of item to export.
+/// </param>
+/// <param name="SqlFunctionName">
+/// When set, selects a custom SQL function for export.
+/// </param>
+/// <param name="ExportFormatId">
+/// When set, selects reporting read-model data sources. Legacy SQL default / CustomExports
+/// leave this null so <c>TabularExportDataSource</c> does not steal built-in CSV.
+/// </param>
 public sealed record ExportDataSourceRequest(
     string Format,
     Type ItemType,
-    string? SqlFunctionName);
+    string? SqlFunctionName,
+    long? ExportFormatId = null);
 
 /// <summary>
 /// Runtime context passed to an export data source.

--- a/src/Endatix.Core/UseCases/Submissions/Export/SubmissionsExportHandler.cs
+++ b/src/Endatix.Core/UseCases/Submissions/Export/SubmissionsExportHandler.cs
@@ -29,7 +29,8 @@ public sealed class SubmissionsExportHandler(
             ExportDataSourceRequest dataSourceRequest = new(
                 request.Exporter.Format,
                 itemType,
-                request.SqlFunctionName);
+                request.SqlFunctionName,
+                TryGetExportFormatId(request.Options));
 
             var dataSource = dataSourceResolver.Resolve(dataSourceRequest);
             ExportDataSourceContext dataSourceContext = new(
@@ -80,6 +81,18 @@ public sealed class SubmissionsExportHandler(
 
             return Result<FileExport>.Error($"Export failed: {ex.Message}");
         }
+    }
+
+    private static long? TryGetExportFormatId(ExportOptions options)
+    {
+        if (options.Metadata is null ||
+            !options.Metadata.TryGetValue(SubmissionExportMetadataKeys.ExecutionSettings, out var settingsObject) ||
+            settingsObject is not SubmissionExportExecutionSettings executionSettings)
+        {
+            return null;
+        }
+
+        return executionSettings.ExportFormatId;
     }
 
     private static async IAsyncEnumerable<IExportItem> StreamExportItemsAsync(

--- a/src/Endatix.Infrastructure/Exporting/Transformers/LargeValuePlaceholderTransformer.cs
+++ b/src/Endatix.Infrastructure/Exporting/Transformers/LargeValuePlaceholderTransformer.cs
@@ -69,11 +69,14 @@ public sealed class LargeValuePlaceholderTransformer : IValueTransformer
                     ProcessObject(obj);
                     break;
                 case JsonValue val:
+                    // Only replace when TransformValue creates a new node. Re-assigning the
+                    // same JsonValue throws InvalidOperationException ("node already has a parent").
                     var transformed = TransformValue(val);
-                    if (transformed is not null)
+                    if (!ReferenceEquals(transformed, val))
                     {
                         array[i] = transformed;
                     }
+
                     break;
             }
         }
@@ -99,10 +102,11 @@ public sealed class LargeValuePlaceholderTransformer : IValueTransformer
                     break;
                 case JsonValue jsonVal:
                     var transformed = TransformValue(jsonVal);
-                    if (transformed is not null)
+                    if (!ReferenceEquals(transformed, jsonVal))
                     {
                         obj[prop.Key] = transformed;
                     }
+
                     break;
             }
         }

--- a/src/Endatix.Modules.Reporting/Features/Export/FormSchema/FormSchemaCodebookExportDataSource.cs
+++ b/src/Endatix.Modules.Reporting/Features/Export/FormSchema/FormSchemaCodebookExportDataSource.cs
@@ -28,6 +28,7 @@ internal sealed class FormSchemaCodebookExportDataSource(
     ];
 
     public bool Matches(ExportDataSourceRequest request) =>
+        request.ExportFormatId.HasValue &&
         string.IsNullOrWhiteSpace(request.SqlFunctionName) &&
         Capabilities.Any(capability =>
             string.Equals(capability.WireKey, request.Format, StringComparison.OrdinalIgnoreCase) &&

--- a/src/Endatix.Modules.Reporting/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookExportDataSource.cs
+++ b/src/Endatix.Modules.Reporting/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookExportDataSource.cs
@@ -28,6 +28,7 @@ internal sealed class ShojiCodebookExportDataSource(
     ];
 
     public bool Matches(ExportDataSourceRequest request) =>
+        request.ExportFormatId.HasValue &&
         string.IsNullOrWhiteSpace(request.SqlFunctionName) &&
         Capabilities.Any(capability =>
             string.Equals(capability.WireKey, request.Format, StringComparison.OrdinalIgnoreCase) &&

--- a/src/Endatix.Modules.Reporting/Features/Export/Tabular/TabularExportDataSource.cs
+++ b/src/Endatix.Modules.Reporting/Features/Export/Tabular/TabularExportDataSource.cs
@@ -58,6 +58,7 @@ internal sealed class TabularExportDataSource(
     private const string CrunchProjectionArtifactsKey = "ReportingCrunchProjectionArtifacts";
 
     public bool Matches(ExportDataSourceRequest request) =>
+        request.ExportFormatId.HasValue &&
         string.IsNullOrWhiteSpace(request.SqlFunctionName) &&
         Capabilities.Any(capability =>
             string.Equals(capability.WireKey, request.Format, StringComparison.OrdinalIgnoreCase) &&

--- a/tests/Endatix.Api.Tests/Endpoints/Submissions/ExportTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Submissions/ExportTests.cs
@@ -404,21 +404,37 @@ public class ExportTests
     }
 
     [Fact]
-    public async Task HandleAsync_WithExportFormat_RequiresExportFormatIdWhenReportingEnabled()
+    public async Task HandleAsync_WithExportFormat_WhenReportingEnabled_UsesLegacyBuiltInExporter()
     {
         var formId = 1L;
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId, ExportFormat = "json" };
         var form = new Form(tenantId, "Test Form") { Id = formId };
+        var exporter = CreateMockExporter("json", typeof(SubmissionExportRow));
+        var fileExport = new FileExport("application/json", "submissions-1.json");
 
         _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>()).Returns(form);
         _tenantContext.TenantId.Returns(tenantId);
         _exportFormatRepository.GetTenantDefaultAsync(tenantId, Arg.Any<CancellationToken>())
-            .Returns((ExportFormatRecord?)null);
+            .Returns(CreateCsvExportFormatRecord(100L));
+        _exporterFactory.GetExporter("json", typeof(SubmissionExportRow))
+            .Returns(exporter);
+        exporter.GetHeadersAsync(Arg.Any<ExportOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(fileExport));
+        _mediator.Send(Arg.Any<SubmissionsExportQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(fileExport));
 
         await _reportingEndpoint.HandleAsync(request, CancellationToken.None);
 
-        _reportingEndpoint.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        _reportingEndpoint.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        await _mediator.Received(1).Send(
+            Arg.Is<SubmissionsExportQuery>(q =>
+                q.Exporter == exporter &&
+                q.SqlFunctionName == null &&
+                !q.Options.Metadata!.ContainsKey(SubmissionExportMetadataKeys.ExecutionSettings)),
+            Arg.Any<CancellationToken>());
+        await _exportFormatRepository.DidNotReceive()
+            .GetTenantDefaultAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -487,8 +503,9 @@ public class ExportTests
     }
 
     [Fact]
-    public async Task HandleAsync_WithDefaultFormat_Success()
+    public async Task HandleAsync_WithoutIds_WhenReportingDefaultExists_UsesLegacyBuiltInCsv()
     {
+        // Hub legacy "Default CSV Export" sends neither ExportFormatId nor ExportId.
         var formId = 1L;
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId };
@@ -517,18 +534,55 @@ public class ExportTests
             Arg.Is<SubmissionsExportQuery>(q =>
                 q.FormId == formId &&
                 q.Exporter == exporter &&
+                q.SqlFunctionName == null &&
+                !q.Options.Metadata!.ContainsKey(SubmissionExportMetadataKeys.ExecutionSettings)),
+            Arg.Any<CancellationToken>());
+        await _exportFormatRepository.DidNotReceive()
+            .GetTenantDefaultAsync(Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithDefaultFormat_Success()
+    {
+        var formId = 1L;
+        var tenantId = SampleData.TENANT_ID;
+        var request = new ExportRequest { FormId = formId };
+
+        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var exporter = CreateMockExporter("csv", typeof(SubmissionExportRow));
+        var fileExport = new FileExport("text/csv", "submissions-1.csv");
+
+        _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>())
+            .Returns(form);
+        _tenantContext.TenantId.Returns(tenantId);
+        _exporterFactory.GetExporter("csv", typeof(SubmissionExportRow))
+            .Returns(exporter);
+        exporter.GetHeadersAsync(Arg.Any<ExportOptions>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(fileExport));
+        _mediator.Send(Arg.Any<SubmissionsExportQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(fileExport));
+
+        await _reportingEndpoint.HandleAsync(request, CancellationToken.None);
+
+        _reportingEndpoint.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
+        _reportingEndpoint.HttpContext.Response.ContentType.Should().Be("text/csv");
+        await _mediator.Received(1).Send(
+            Arg.Is<SubmissionsExportQuery>(q =>
+                q.FormId == formId &&
+                q.Exporter == exporter &&
                 q.SqlFunctionName == null),
             Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task HandleAsync_WithDefaultFormat_ForwardsIncludeTestSubmissionsAndColumnScope()
+    public async Task HandleAsync_WithExportFormatId_ForwardsIncludeTestSubmissionsAndColumnScope()
     {
         var formId = 1L;
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest
         {
             FormId = formId,
+            ExportFormatId = 100L,
             IncludeTestSubmissions = false,
             ColumnScope = ["q1"],
         };
@@ -540,7 +594,7 @@ public class ExportTests
         _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>())
             .Returns(form);
         _tenantContext.TenantId.Returns(tenantId);
-        _exportFormatRepository.GetTenantDefaultAsync(tenantId, Arg.Any<CancellationToken>())
+        _exportFormatRepository.GetByIdAsync(tenantId, 100L, Arg.Any<CancellationToken>())
             .Returns(CreateCsvExportFormatRecord(100L));
         _exporterFactory.GetExporter("csv", typeof(SubmissionExportRow))
             .Returns(exporter);
@@ -574,8 +628,8 @@ public class ExportTests
         _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>())
             .Returns(form);
         _tenantContext.TenantId.Returns(tenantId);
-        _exportFormatRepository.GetTenantDefaultAsync(tenantId, Arg.Any<CancellationToken>())
-            .Returns((ExportFormatRecord?)null);
+        _exporterFactory.GetExporter("unsupported", typeof(SubmissionExportRow))
+            .Returns(_ => throw new InvalidOperationException("No exporter registered for format unsupported"));
 
         await _reportingEndpoint.HandleAsync(request, CancellationToken.None);
 

--- a/tests/Endatix.Infrastructure.Tests/Exporting/ExportDataSourceResolverTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Exporting/ExportDataSourceResolverTests.cs
@@ -8,10 +8,11 @@ namespace Endatix.Infrastructure.Tests.Exporting;
 public sealed class ExportDataSourceResolverTests
 {
     [Fact]
-    public void Resolve_PrefersReportingSourceOverSqlDefault()
+    public void Resolve_PrefersReportingSourceOverSqlDefault_WhenExportFormatIdPresent()
     {
         IExportDataSource tabular = Substitute.For<IExportDataSource>();
         tabular.Matches(Arg.Is<ExportDataSourceRequest>(r =>
+                r.ExportFormatId.HasValue &&
                 r.ItemType == typeof(SubmissionExportRow) &&
                 r.SqlFunctionName == null &&
                 (r.Format.Equals("csv", StringComparison.OrdinalIgnoreCase) ||
@@ -22,9 +23,30 @@ public sealed class ExportDataSourceResolverTests
 
         ExportDataSourceResolver resolver = new([tabular, sqlDefault]);
 
-        IExportDataSource resolved = resolver.Resolve(new ExportDataSourceRequest("csv", typeof(SubmissionExportRow), null));
+        IExportDataSource resolved = resolver.Resolve(
+            new ExportDataSourceRequest("csv", typeof(SubmissionExportRow), null, ExportFormatId: 100L));
 
         resolved.Should().BeSameAs(tabular);
+    }
+
+    [Fact]
+    public void Resolve_PrefersSqlDefault_WhenLegacyBuiltInHasNoExportFormatId()
+    {
+        // Regression: TabularExportDataSource used to match SqlFunctionName=null + csv and
+        // beat SqlFallback — Hub legacy Default CSV then required a compiled form schema.
+        IExportDataSource tabular = Substitute.For<IExportDataSource>();
+        tabular.Matches(Arg.Is<ExportDataSourceRequest>(r => r.ExportFormatId.HasValue))
+            .Returns(true);
+
+        IExportDataSource sqlDefault = new SqlDefaultSubmissionExportDataSource(
+            Substitute.For<Core.Abstractions.Repositories.ISubmissionExportRepository>());
+
+        ExportDataSourceResolver resolver = new([tabular, sqlDefault]);
+
+        IExportDataSource resolved = resolver.Resolve(
+            new ExportDataSourceRequest("csv", typeof(SubmissionExportRow), null, ExportFormatId: null));
+
+        resolved.Should().BeSameAs(sqlDefault);
     }
 
     [Fact]

--- a/tests/Endatix.Infrastructure.Tests/Features/Submissions/LargeValuePlaceholderTransformerTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Submissions/LargeValuePlaceholderTransformerTests.cs
@@ -108,6 +108,38 @@ public sealed class LargeValuePlaceholderTransformerTests
     }
 
     [Fact]
+    public void Transform_DoesNotThrow_WhenArrayContainsUnchangedValues()
+    {
+        // Regression: range-slider / numeric array answers re-assigned the same JsonValue
+        // into JsonArray and threw "The node already has a parent".
+        var sut = new LargeValuePlaceholderTransformer();
+        var node = JsonNode.Parse("""[10, 90, "ok"]""")!;
+
+        var exception = Record.Exception(() => sut.Transform(node, Ctx()));
+
+        Assert.Null(exception);
+        var arr = node.AsArray();
+        Assert.Equal(10, arr[0]!.GetValue<int>());
+        Assert.Equal(90, arr[1]!.GetValue<int>());
+        Assert.Equal("ok", arr[2]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void Transform_DoesNotThrow_WhenObjectContainsUnchangedValues()
+    {
+        var sut = new LargeValuePlaceholderTransformer();
+        var node = JsonNode.Parse("""{"min":0,"max":100,"label":"range"}""")!;
+
+        var exception = Record.Exception(() => sut.Transform(node, Ctx()));
+
+        Assert.Null(exception);
+        var obj = node.AsObject();
+        Assert.Equal(0, obj["min"]!.GetValue<int>());
+        Assert.Equal(100, obj["max"]!.GetValue<int>());
+        Assert.Equal("range", obj["label"]!.GetValue<string>());
+    }
+
+    [Fact]
     public void Transform_ReplacesDataUriInNestedObject()
     {
         var sut = new LargeValuePlaceholderTransformer();

--- a/tests/Endatix.Modules.Reporting.Tests/Features/Export/FormSchema/FormSchemaCodebookExportDataSourceTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/Export/FormSchema/FormSchemaCodebookExportDataSourceTests.cs
@@ -134,14 +134,15 @@ public sealed class FormSchemaCodebookExportDataSourceTests
     }
 
     [Fact]
-    public void Matches_ReturnsTrueOnlyForCodebookNativeDynamicExportRow()
+    public void Matches_ReturnsTrueOnlyForCodebookNativeDynamicExportRowWithExportFormatId()
     {
         FormSchemaCodebookExportDataSource dataSource = CreateDataSource(
             Substitute.For<IFormSchemaRepository>());
 
-        dataSource.Matches(new ExportDataSourceRequest("codebook", typeof(DynamicExportRow), null)).Should().BeTrue();
-        dataSource.Matches(new ExportDataSourceRequest("codebook-shoji", typeof(DynamicExportRow), null)).Should().BeFalse();
-        dataSource.Matches(new ExportDataSourceRequest("codebook", typeof(SubmissionExportRow), null)).Should().BeFalse();
+        dataSource.Matches(new ExportDataSourceRequest("codebook", typeof(DynamicExportRow), null, 100L)).Should().BeTrue();
+        dataSource.Matches(new ExportDataSourceRequest("codebook", typeof(DynamicExportRow), null)).Should().BeFalse();
+        dataSource.Matches(new ExportDataSourceRequest("codebook-shoji", typeof(DynamicExportRow), null, 100L)).Should().BeFalse();
+        dataSource.Matches(new ExportDataSourceRequest("codebook", typeof(SubmissionExportRow), null, 100L)).Should().BeFalse();
     }
 
     private static ExportDataSourceContext CreateContext(ExportOptions? options = null) =>

--- a/tests/Endatix.Modules.Reporting.Tests/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookExportDataSourceTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookExportDataSourceTests.cs
@@ -133,13 +133,14 @@ public sealed class ShojiCodebookExportDataSourceTests
     }
 
     [Fact]
-    public void Matches_ReturnsTrueOnlyForCodebookShojiDynamicExportRow()
+    public void Matches_ReturnsTrueOnlyForCodebookShojiDynamicExportRowWithExportFormatId()
     {
         ShojiCodebookExportDataSource dataSource = CreateDataSource(Substitute.For<IFormSchemaRepository>());
 
-        dataSource.Matches(new ExportDataSourceRequest("codebook-shoji", typeof(DynamicExportRow), null)).Should().BeTrue();
-        dataSource.Matches(new ExportDataSourceRequest("json", typeof(DynamicExportRow), null)).Should().BeFalse();
-        dataSource.Matches(new ExportDataSourceRequest("codebook-shoji", typeof(SubmissionExportRow), null)).Should().BeFalse();
+        dataSource.Matches(new ExportDataSourceRequest("codebook-shoji", typeof(DynamicExportRow), null, 100L)).Should().BeTrue();
+        dataSource.Matches(new ExportDataSourceRequest("codebook-shoji", typeof(DynamicExportRow), null)).Should().BeFalse();
+        dataSource.Matches(new ExportDataSourceRequest("json", typeof(DynamicExportRow), null, 100L)).Should().BeFalse();
+        dataSource.Matches(new ExportDataSourceRequest("codebook-shoji", typeof(SubmissionExportRow), null, 100L)).Should().BeFalse();
     }
 
     private static ExportDataSourceContext CreateContext(string? settingsJson = null)

--- a/tests/Endatix.Modules.Reporting.Tests/Features/Export/Tabular/TabularExportDataSourceTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/Export/Tabular/TabularExportDataSourceTests.cs
@@ -343,17 +343,18 @@ public sealed class TabularExportDataSourceTests
     }
 
     [Fact]
-    public void Matches_ReturnsTrueOnlyForTabularSubmissionExportWithoutSqlFunction()
+    public void Matches_ReturnsTrueOnlyForTabularSubmissionExportWithExportFormatId()
     {
         TabularExportDataSource dataSource = CreateDataSource(
             Substitute.For<IFormSchemaRepository>(),
             Substitute.For<IReportingExportRepository>());
 
-        dataSource.Matches(new ExportDataSourceRequest("csv", typeof(SubmissionExportRow), null)).Should().BeTrue();
-        dataSource.Matches(new ExportDataSourceRequest("json", typeof(SubmissionExportRow), null)).Should().BeTrue();
-        dataSource.Matches(new ExportDataSourceRequest("codebook", typeof(SubmissionExportRow), null)).Should().BeFalse();
-        dataSource.Matches(new ExportDataSourceRequest("xml", typeof(SubmissionExportRow), null)).Should().BeFalse();
-        dataSource.Matches(new ExportDataSourceRequest("csv", typeof(SubmissionExportRow), "custom_fn")).Should().BeFalse();
+        dataSource.Matches(new ExportDataSourceRequest("csv", typeof(SubmissionExportRow), null, 100L)).Should().BeTrue();
+        dataSource.Matches(new ExportDataSourceRequest("json", typeof(SubmissionExportRow), null, 100L)).Should().BeTrue();
+        dataSource.Matches(new ExportDataSourceRequest("csv", typeof(SubmissionExportRow), null)).Should().BeFalse();
+        dataSource.Matches(new ExportDataSourceRequest("codebook", typeof(SubmissionExportRow), null, 100L)).Should().BeFalse();
+        dataSource.Matches(new ExportDataSourceRequest("xml", typeof(SubmissionExportRow), null, 100L)).Should().BeFalse();
+        dataSource.Matches(new ExportDataSourceRequest("csv", typeof(SubmissionExportRow), "custom_fn", 100L)).Should().BeFalse();
     }
 
     private static TabularExportDataSource CreateDataSource(


### PR DESCRIPTION
# fix(e885): Default Export failing

## Description
- Unforce ExportFormatId for new exports and use reporting data sources only match when ExportFormatId is present (Hub reporting always sets this via execution settings). Legacy default leaves it null → SQL export_form_submissions.
- Fix issue foe legacy exports and array based answers like qRangeSlider `([10, 90])`, where TransformValue returned the same JsonValue, then array[i] = transformed tried to re-parent it and exporter was throwing with "The node already has a parent"

## Related Issues
- fixes #885 

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting a specific export format when generating submission exports.
  * Preserved classic CSV export behavior when no export format is specified.
  * Improved routing between custom, reporting, and built-in export options.

* **Bug Fixes**
  * Fixed errors that could occur when processing unchanged JSON values during export transformations.
  * Improved handling of unsupported export formats and export-format matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->