### PR TITLE
feat(e887): Distinguish empty completed-export from missing backfill on tabular export

### DIFF
--- a/src/Endatix.Modules.Reporting.Contracts/Export/IReportingExportRepository.cs
+++ b/src/Endatix.Modules.Reporting.Contracts/Export/IReportingExportRepository.cs
@@ -6,13 +6,8 @@ namespace Endatix.Modules.Reporting.Contracts.Export;
 public interface IReportingExportRepository
 {
     /// <summary>
-    /// Checks if the repository has exportable rows for the given tenant and form.
+    /// Returns true when at least one processed flattened row matches the export query.
     /// </summary>
-    /// <param name="tenantId">The ID of the tenant.</param>
-    /// <param name="formId">The ID of the form.</param>
-    /// <param name="options">The export query options.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>True if the repository has exportable rows, false otherwise.</returns>
     Task<bool> HasExportableRowsAsync(
         long tenantId,
         long formId,
@@ -20,13 +15,17 @@ public interface IReportingExportRepository
         CancellationToken cancellationToken);
 
     /// <summary>
+    /// Returns true when the form has at least one completed core submission (including tests).
+    /// Used to distinguish "nothing to export" from "completed rows need backfill".
+    /// </summary>
+    Task<bool> HasCompletedSubmissionsAsync(
+        long tenantId,
+        long formId,
+        CancellationToken cancellationToken);
+
+    /// <summary>
     /// Streams flattened submissions for the given tenant and form.
     /// </summary>
-    /// <param name="tenantId">The ID of the tenant.</param>
-    /// <param name="formId">The ID of the form.</param>
-    /// <param name="options">The export query options.</param>
-    /// <param name="cancellationToken">A token to cancel the operation.</param>
-    /// <returns>An async enumerable of flattened export rows.</returns>
     IAsyncEnumerable<FlattenedExportRow> StreamFlattenedSubmissionsAsync(
         long tenantId,
         long formId,

--- a/src/Endatix.Modules.Reporting/Data/ReportingExportRepository.cs
+++ b/src/Endatix.Modules.Reporting/Data/ReportingExportRepository.cs
@@ -37,6 +37,18 @@ internal sealed class ReportingExportRepository(
         return await enumerator.MoveNextAsync();
     }
 
+    public Task<bool> HasCompletedSubmissionsAsync(
+        long tenantId,
+        long formId,
+        CancellationToken cancellationToken) =>
+        appDbContext.Submissions
+            .AsNoTracking()
+            .AnyAsync(
+                submission => submission.TenantId == tenantId &&
+                              submission.FormId == formId &&
+                              submission.IsComplete,
+                cancellationToken);
+
     public async IAsyncEnumerable<FlattenedExportRow> StreamFlattenedSubmissionsAsync(
         long tenantId,
         long formId,

--- a/src/Endatix.Modules.Reporting/Features/Export/Tabular/TabularExportDataSource.cs
+++ b/src/Endatix.Modules.Reporting/Features/Export/Tabular/TabularExportDataSource.cs
@@ -52,6 +52,9 @@ internal sealed class TabularExportDataSource(
     private const string MissingRowsMessage =
         "No processed flattened submissions found for this form. Run admin backfill to populate the reporting read model before exporting.";
 
+    private const string NoCompletedSubmissionsMessage =
+        "No completed submissions are available to export for this form. Incomplete drafts are not included in the reporting export.";
+
     private const string NoMatchingFiltersMessage =
         "No submissions matched the export filters. Broaden date/id/test filters or clear them and try again.";
 
@@ -102,13 +105,8 @@ internal sealed class TabularExportDataSource(
             cancellationToken);
         if (!hasRows)
         {
-            var hasAnyProcessedRows = await reportingExportRepository.HasExportableRowsAsync(
-                context.TenantId,
-                context.FormId,
-                new ExportQueryOptions(PageSize: 1, IncludeTestSubmissions: true),
-                cancellationToken);
             return Result<ExportOptions>.Conflict(
-                hasAnyProcessedRows ? NoMatchingFiltersMessage : MissingRowsMessage);
+                await ResolveEmptyExportMessageAsync(context, cancellationToken));
         }
 
         IReadOnlySet<string>? columnScope = settings.ColumnScope is null
@@ -138,6 +136,28 @@ internal sealed class TabularExportDataSource(
         }
 
         return Result.Success(context.Options);
+    }
+
+    private async Task<string> ResolveEmptyExportMessageAsync(
+        ExportDataSourceContext context,
+        CancellationToken cancellationToken)
+    {
+        var hasAnyProcessedRows = await reportingExportRepository.HasExportableRowsAsync(
+            context.TenantId,
+            context.FormId,
+            new ExportQueryOptions(PageSize: 1, IncludeTestSubmissions: true),
+            cancellationToken);
+        if (hasAnyProcessedRows)
+        {
+            return NoMatchingFiltersMessage;
+        }
+
+        var hasCompletedSubmissions = await reportingExportRepository.HasCompletedSubmissionsAsync(
+            context.TenantId,
+            context.FormId,
+            cancellationToken);
+
+        return hasCompletedSubmissions ? MissingRowsMessage : NoCompletedSubmissionsMessage;
     }
 
     public async IAsyncEnumerable<IExportItem> StreamAsync(

--- a/tests/Endatix.IntegrationTests/Infrastructure/ReportingExportRepositoryIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/ReportingExportRepositoryIntegrationTests.cs
@@ -342,6 +342,24 @@ public sealed class ReportingExportRepositoryIntegrationTests
     }
 
     [Fact]
+    public async Task HasCompletedSubmissionsAsync_WhenCompletedExist_ReturnsTrue()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SeededExportFixture seed = await SeedExportFixtureAsync(cancellationToken);
+
+        await using AppDbContext appDb = CreateAppDbContext();
+        await using ReportingDbContext reportingDb = CreateReportingDbContext();
+        ReportingExportRepository repository = CreateRepository(reportingDb, appDb);
+
+        bool hasCompleted = await repository.HasCompletedSubmissionsAsync(
+            TenantId,
+            seed.FormId,
+            cancellationToken);
+
+        hasCompleted.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task StreamFlattenedSubmissionsAsync_ProjectsStartedAtFromCoreSubmission()
     {
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;

--- a/tests/Endatix.Modules.Reporting.Tests/Features/Export/Tabular/TabularExportDataSourceTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/Export/Tabular/TabularExportDataSourceTests.cs
@@ -64,7 +64,7 @@ public sealed class TabularExportDataSourceTests
     }
 
     [Fact]
-    public async Task PrepareOptionsAsync_WithNoExportableRows_ReturnsMissingRowsMessage()
+    public async Task PrepareOptionsAsync_WithCompletedButNoFlattenedRows_ReturnsMissingRowsMessage()
     {
         string definitionJson = FormSchemaFixtureLoader.LoadText("simple-definition.json");
         FormSchemaCompiler compiler = new();
@@ -80,6 +80,9 @@ public sealed class TabularExportDataSourceTests
         reportingExportRepository
             .HasExportableRowsAsync(TenantId, FormId, Arg.Any<ExportQueryOptions>(), Arg.Any<CancellationToken>())
             .Returns(false);
+        reportingExportRepository
+            .HasCompletedSubmissionsAsync(TenantId, FormId, Arg.Any<CancellationToken>())
+            .Returns(true);
 
         TabularExportDataSource dataSource = CreateDataSource(formSchemaRepository, reportingExportRepository);
 
@@ -89,6 +92,69 @@ public sealed class TabularExportDataSourceTests
         result.Status.Should().Be(ResultStatus.Conflict);
         result.Errors.Should().ContainSingle(error =>
             error.Contains("Run admin backfill", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task PrepareOptionsAsync_WithNoCompletedSubmissions_ReturnsNoCompletedMessage()
+    {
+        string definitionJson = FormSchemaFixtureLoader.LoadText("simple-definition.json");
+        FormSchemaCompiler compiler = new();
+        FormSchemaCompileResult compiled = compiler.CompilePersisted(definitionJson);
+        FormSchemaEntity schema = new(TenantId, FormId, 1, compiled.FlatteningMapJson, compiled.CodebookJson);
+
+        IFormSchemaRepository formSchemaRepository = Substitute.For<IFormSchemaRepository>();
+        formSchemaRepository
+            .GetByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>())
+            .Returns(schema);
+
+        IReportingExportRepository reportingExportRepository = Substitute.For<IReportingExportRepository>();
+        reportingExportRepository
+            .HasExportableRowsAsync(TenantId, FormId, Arg.Any<ExportQueryOptions>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        reportingExportRepository
+            .HasCompletedSubmissionsAsync(TenantId, FormId, Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        TabularExportDataSource dataSource = CreateDataSource(formSchemaRepository, reportingExportRepository);
+
+        Result<ExportOptions> result = await dataSource.PrepareOptionsAsync(CreateContext(), TestContext.Current.CancellationToken);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.Conflict);
+        result.Errors.Should().ContainSingle(error =>
+            error.Contains("No completed submissions are available to export", StringComparison.Ordinal));
+        result.Errors.Should().NotContain(error =>
+            error.Contains("backfill", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task PrepareOptionsAsync_WithProcessedRowsExcludedByFilters_ReturnsFilterMismatchMessage()
+    {
+        string definitionJson = FormSchemaFixtureLoader.LoadText("simple-definition.json");
+        FormSchemaCompiler compiler = new();
+        FormSchemaCompileResult compiled = compiler.CompilePersisted(definitionJson);
+        FormSchemaEntity schema = new(TenantId, FormId, 1, compiled.FlatteningMapJson, compiled.CodebookJson);
+
+        IFormSchemaRepository formSchemaRepository = Substitute.For<IFormSchemaRepository>();
+        formSchemaRepository
+            .GetByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>())
+            .Returns(schema);
+
+        IReportingExportRepository reportingExportRepository = Substitute.For<IReportingExportRepository>();
+        reportingExportRepository
+            .HasExportableRowsAsync(TenantId, FormId, Arg.Any<ExportQueryOptions>(), Arg.Any<CancellationToken>())
+            .Returns(false, true);
+
+        TabularExportDataSource dataSource = CreateDataSource(formSchemaRepository, reportingExportRepository);
+
+        Result<ExportOptions> result = await dataSource.PrepareOptionsAsync(CreateContext(), TestContext.Current.CancellationToken);
+
+        result.IsSuccess.Should().BeFalse();
+        result.Status.Should().Be(ResultStatus.Conflict);
+        result.Errors.Should().ContainSingle(error =>
+            error.Contains("No submissions matched the export filters", StringComparison.Ordinal));
+        await reportingExportRepository.DidNotReceive()
+            .HasCompletedSubmissionsAsync(Arg.Any<long>(), Arg.Any<long>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]


### PR DESCRIPTION
# feat(e887): Distinguish empty completed-export from missing backfill on tabular export

## Description
Add detection for any completed submission per formId and sending this via api response


## Related Issues
- closes #887 

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
<img width="584" height="91" alt="image" src="https://github.com/user-attachments/assets/f827bc78-27f7-4fac-b7a1-50a2f15d48a6" />
