### PR TITLE
fix(893): Publish the endatix-api helm chart

### DIFF
--- a/scripts/release-prepare.sh
+++ b/scripts/release-prepare.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Consumer contract for endatix/release-workflows (prepare half):
-# build every NuGet package AND the Endatix.WebHost container image, all
-# stamped with the given version. Called by the shared pipeline for PR
-# validation (version 0.0.0-ci), canary releases, and stable rebuilds.
+# build every NuGet package, the Endatix.WebHost container image AND the Helm
+# chart, all stamped with the given version. Called by the shared pipeline for
+# PR validation (version 0.0.0-ci), canary releases, and stable rebuilds.
 # Builds only — nothing is pushed here (PR validation has no registry login).
 #
 # Usage: scripts/release-prepare.sh <version>
@@ -13,8 +13,8 @@ set -euo pipefail
 VERSION="${1:?usage: release-prepare.sh <version>}"
 : "${DOCKER_IMAGE:?DOCKER_IMAGE env var is required (is docker-image set on the caller workflow?)}"
 
-# Clean so the publish step only ever sees packages stamped with THIS version.
-rm -rf build/packages/nuget
+# Clean so the publish step only ever sees artifacts stamped with THIS version.
+rm -rf build/packages/nuget build/packages/helm
 
 echo "──── Building at version ${VERSION} ────"
 dotnet restore
@@ -37,3 +37,16 @@ for arch in "x64:amd64" "arm64:arm64"; do
     -p:ContainerRepository="${DOCKER_IMAGE}" \
     -p:ContainerImageTag="${VERSION}-${arch##*:}"
 done
+
+# Helm chart, released in lockstep with the image. Stamping BOTH version and
+# appVersion with the release version is what makes the chart self-consistent:
+# the deployment template falls back to .Chart.Version for the image tag, so a
+# chart at X.Y.Z always deploys the image built at X.Y.Z above. The 0.1.0 in
+# Chart.yaml is only a placeholder for local `helm template` runs.
+# lint first — on PRs this is the only thing that type-checks the templates.
+echo "──── Packaging Helm chart at version ${VERSION} ────"
+helm lint helm
+helm package helm \
+  --version "${VERSION}" \
+  --app-version "${VERSION}" \
+  --destination build/packages/helm

--- a/scripts/release-publish.sh
+++ b/scripts/release-publish.sh
@@ -19,10 +19,16 @@
 #   maintenance                   yes                      yes              no
 #   stable                        yes                      yes              yes
 #
+# The Helm chart ships to GHCR on every channel: OCI charts are addressed by
+# exact version with no floating pointer to protect, and the prerelease version
+# already keeps canaries out of `helm upgrade` unless --devel is passed.
+#
 # Usage: scripts/release-publish.sh <version>
 # Expects env vars (exported by the shared workflows):
 #   NUGET_SOURCE       GitHub NuGet feed (nuget.pkg.github.com/endatix)
+#   GH_PACKAGES_USER   actor for the GHCR/Helm registry login
 #   GH_PACKAGES_TOKEN  job token with packages:write
+#   HELM_OCI_REPO      OCI chart repo (oci://ghcr.io/endatix/charts)
 #   DOCKER_IMAGE       GHCR image name, from the caller's docker-image input
 #                      (the shared workflows do the ghcr.io login)
 #   NUGET_API_KEY      short-lived nuget.org key minted per run via OIDC
@@ -35,8 +41,10 @@ set -euo pipefail
 VERSION="${1:?usage: release-publish.sh <version>}"
 CHANNEL="${RELEASE_CHANNEL:-stable}"
 : "${NUGET_SOURCE:?NUGET_SOURCE env var is required}"
+: "${GH_PACKAGES_USER:?GH_PACKAGES_USER env var is required}"
 : "${GH_PACKAGES_TOKEN:?GH_PACKAGES_TOKEN env var is required}"
 : "${DOCKER_IMAGE:?DOCKER_IMAGE env var is required (is docker-image set on the caller workflow?)}"
+: "${HELM_OCI_REPO:?HELM_OCI_REPO env var is required}"
 
 # Public mirror for promoted releases. Not an input on the shared workflows
 # (they model a single image) — mirroring is this repo's own publish concern.
@@ -100,3 +108,10 @@ if [[ "$PUBLISH_PUBLIC" = true ]]; then
   echo "$ENDATIX_DOCKERHUB_TOKEN" | docker login docker.io -u "$ENDATIX_DOCKERHUB_USERNAME" --password-stdin
   docker buildx imagetools create "${DOCKERHUB_TAGS[@]}" "${DOCKER_IMAGE}:${VERSION}"
 fi
+
+# Helm chart. Helm keeps its own registry credentials (~/.config/helm), so the
+# workflow's docker login does not carry over — log in explicitly. The path is
+# pinned to the exact version for the same reason the NuGet globs are.
+echo "──── Pushing Helm chart to ${HELM_OCI_REPO} ────"
+echo "$GH_PACKAGES_TOKEN" | helm registry login ghcr.io -u "$GH_PACKAGES_USER" --password-stdin
+helm push "build/packages/helm/endatix-api-${VERSION}.tgz" "$HELM_OCI_REPO"


### PR DESCRIPTION
# Publish the endatix-api helm chart

## Description
Docker is published already and now we add the helm.

Helm chart and docker image are relased in locked steps. That is intentional.


## Related Issues
List any related issues #893

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [x] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [ ] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
