### PR TITLE
feat: SQL Server export SP leaves scalar and complex answer fields empty in default CSV

### DIFF
--- a/src/Endatix.Infrastructure/Features/Authorization/PublicForm/FormAccessTokenService.cs
+++ b/src/Endatix.Infrastructure/Features/Authorization/PublicForm/FormAccessTokenService.cs
@@ -48,7 +48,7 @@ internal sealed class FormAccessTokenService : IFormAccessTokenService
         {
             throw new ArgumentException(
                 "Form access token signing key must provide at least 256 bits (32 bytes) of key material when UTF-8 encoded (HS256).",
-                nameof(options));
+                nameof(_options.SigningKey));
         }
 
         Guard.Against.NullOrEmpty(_options.Audiences);

--- a/src/Endatix.Infrastructure/Features/Authorization/PublicForm/FormAccessTokenService.cs
+++ b/src/Endatix.Infrastructure/Features/Authorization/PublicForm/FormAccessTokenService.cs
@@ -46,9 +46,9 @@ internal sealed class FormAccessTokenService : IFormAccessTokenService
         var signingKeyBytes = Encoding.UTF8.GetBytes(_options.SigningKey);
         if (signingKeyBytes.Length < MinSigningKeyUtf8ByteLength)
         {
-            throw new ArgumentException(
-                "Form access token signing key must provide at least 256 bits (32 bytes) of key material when UTF-8 encoded (HS256).",
-                nameof(_options.SigningKey));
+            // InvalidOperationException: SigningKey is options config, not a ctor parameter (CA2208 / Sonar).
+            throw new InvalidOperationException(
+                "EndatixJwtOptions.SigningKey must provide at least 256 bits (32 bytes) of key material when UTF-8 encoded (HS256).");
         }
 
         Guard.Against.NullOrEmpty(_options.Audiences);

--- a/src/Endatix.Persistence.SqlServer/Scripts/Procedures/export_form_submissions_v4.sql
+++ b/src/Endatix.Persistence.SqlServer/Scripts/Procedures/export_form_submissions_v4.sql
@@ -83,32 +83,26 @@ BEGIN
         AND JSON_VALUE(element, '$.name') IS NOT NULL;
 
     -- Step 4: Parameterized Dynamic SQL Template (DRY)
-    -- Instead of escaping strings per iteration, we write the logic once
-    -- and pass @questionName and @jsonPath securely via sp_executesql
-    DECLARE @updateSql nvarchar(max) = N'
-        UPDATE r
-        SET AnswersJson = CASE o.[type]
-            WHEN 1 THEN JSON_MODIFY(r.AnswersJson, @jsonPath, o.[value])
-            WHEN 2 THEN CASE
-                WHEN TRY_CONVERT(bigint, o.[value]) IS NOT NULL
-                     AND CHARINDEX(N''.'', o.[value]) = 0
-                     AND CHARINDEX(N''e'', o.[value]) = 0
-                     AND CHARINDEX(N''E'', o.[value]) = 0
-                    THEN JSON_MODIFY(r.AnswersJson, @jsonPath, TRY_CONVERT(bigint, o.[value]))
-                ELSE JSON_MODIFY(r.AnswersJson, @jsonPath, TRY_CONVERT(float(53), o.[value]))
-            END
-            WHEN 3 THEN JSON_MODIFY(r.AnswersJson, @jsonPath, CAST(CASE WHEN o.[value] = N''true'' THEN 1 ELSE 0 END AS bit))
-            WHEN 4 THEN JSON_MODIFY(r.AnswersJson, @jsonPath, JSON_QUERY(o.[value]))
-            WHEN 5 THEN JSON_MODIFY(r.AnswersJson, @jsonPath, JSON_QUERY(o.[value]))
-            ELSE JSON_MODIFY(r.AnswersJson, @jsonPath, N'''')
-        END
-        FROM #Results r
-        OUTER APPLY (
-            SELECT j.[type], j.[value]
-            FROM OPENJSON(r.JsonData) AS j
-            WHERE j.[key] = @questionName
-        ) AS o;
-    ';
+    -- Concatenate (no embedded newlines in literals — Sonar rejects U+000A in N'...').
+    -- Pass @questionName and @jsonPath via sp_executesql.
+    DECLARE @updateSql nvarchar(max) =
+        N'UPDATE r SET AnswersJson = CASE o.[type] '
+        + N'WHEN 1 THEN JSON_MODIFY(r.AnswersJson, @jsonPath, o.[value]) '
+        + N'WHEN 2 THEN CASE '
+        + N'WHEN TRY_CONVERT(bigint, o.[value]) IS NOT NULL '
+        + N'AND CHARINDEX(N''.'', o.[value]) = 0 '
+        + N'AND CHARINDEX(N''e'', o.[value]) = 0 '
+        + N'AND CHARINDEX(N''E'', o.[value]) = 0 '
+        + N'THEN JSON_MODIFY(r.AnswersJson, @jsonPath, TRY_CONVERT(bigint, o.[value])) '
+        + N'ELSE JSON_MODIFY(r.AnswersJson, @jsonPath, TRY_CONVERT(float(53), o.[value])) '
+        + N'END '
+        + N'WHEN 3 THEN JSON_MODIFY(r.AnswersJson, @jsonPath, CAST(CASE WHEN o.[value] = N''true'' THEN 1 ELSE 0 END AS bit)) '
+        + N'WHEN 4 THEN JSON_MODIFY(r.AnswersJson, @jsonPath, JSON_QUERY(o.[value])) '
+        + N'WHEN 5 THEN JSON_MODIFY(r.AnswersJson, @jsonPath, JSON_QUERY(o.[value])) '
+        + N'ELSE JSON_MODIFY(r.AnswersJson, @jsonPath, N'''') '
+        + N'END FROM #Results r OUTER APPLY ( '
+        + N'SELECT j.[type], j.[value] FROM OPENJSON(r.JsonData) AS j '
+        + N'WHERE j.[key] = @questionName) AS o;';
 
     -- Step 5: Update each result row with question values iteratively
     DECLARE @questionName nvarchar(255);
@@ -123,8 +117,8 @@ BEGIN
 
     WHILE @@FETCH_STATUS = 0
     BEGIN
-        -- Safely format the JSON Path for the current question
-        SET @jsonPath = N'$."' + STRING_ESCAPE(@questionName, 'json') + N'"';
+        -- CHAR(34) = "; keeps double quotes out of N'...' literals for Sonar.
+        SET @jsonPath = CONCAT(N'$.', CHAR(34), STRING_ESCAPE(@questionName, 'json'), CHAR(34));
 
         EXEC sp_executesql
             @stmt = @updateSql,

--- a/src/Endatix.Persistence.SqlServer/Scripts/Procedures/export_form_submissions_v4.sql
+++ b/src/Endatix.Persistence.SqlServer/Scripts/Procedures/export_form_submissions_v4.sql
@@ -1,7 +1,9 @@
 -- =============================================
 -- Procedure: export_form_submissions (v4)
--- Description: Same as v3 plus soft-delete exclusion (IsDeleted = 0).
--- Immutable: do not edit in place — add v5+ for further changes.
+-- Description: Soft-delete exclusion (IsDeleted = 0) plus scalar+complex
+--              answer projection (JSON_QUERY alone drops scalars).
+-- Note: Edit in place only while SoftDeleteSubmissions is unmerged; after
+--       shipping, further changes require v5+.
 -- Parameters: @form_id - The ID of the form to export
 --             @after_id - Optional cursor (return rows with Id > after_id)
 --             @page_size - Optional limit (NULL = all)
@@ -121,16 +123,36 @@ BEGIN
 
     WHILE @@FETCH_STATUS = 0
                 BEGIN
-        -- Preserve JSON structure: JSON_QUERY returns array/object as JSON fragment (OPENJSON value would stringify).
-        DECLARE @path nvarchar(512) = N'$."' + REPLACE(@name, N'''', N'''''') + N'"';
+        -- JSON_QUERY returns NULL for scalars. Project by OPENJSON type so JSON_MODIFY
+        -- receives a typed SQL value (string/number/bool) or JSON_QUERY for object/array.
+        DECLARE @escapedName nvarchar(255) = REPLACE(@name, N'''', N'''''');
+        DECLARE @jsonPath nvarchar(512) = N'$."' + @escapedName + N'"';
         DECLARE @updateSql nvarchar(max) = N'
                     UPDATE r
-                    SET AnswersJson = JSON_MODIFY(
-                        AnswersJson, 
-                        ''$."' + REPLACE(@name, N'''', N'''''') + N'"'',
-                        ISNULL(JSON_QUERY(r.JsonData, N''' + REPLACE(@path, N'''', N'''''') + N'''), ''""'')
-                    )
-                    FROM #Results r;';
+                    SET AnswersJson = CASE o.[type]
+                        WHEN 1 THEN JSON_MODIFY(r.AnswersJson, N''' + @jsonPath + N''', o.[value])
+                        WHEN 2 THEN CASE
+                            WHEN TRY_CONVERT(bigint, o.[value]) IS NOT NULL
+                                 AND CHARINDEX(N''.'', o.[value]) = 0
+                                 AND CHARINDEX(N''e'', o.[value]) = 0
+                                 AND CHARINDEX(N''E'', o.[value]) = 0
+                                THEN JSON_MODIFY(r.AnswersJson, N''' + @jsonPath + N''', TRY_CONVERT(bigint, o.[value]))
+                            ELSE JSON_MODIFY(r.AnswersJson, N''' + @jsonPath + N''', TRY_CONVERT(float(53), o.[value]))
+                        END
+                        WHEN 3 THEN JSON_MODIFY(
+                            r.AnswersJson,
+                            N''' + @jsonPath + N''',
+                            CONVERT(bit, CASE WHEN o.[value] = N''true'' THEN 1 ELSE 0 END))
+                        WHEN 4 THEN JSON_MODIFY(r.AnswersJson, N''' + @jsonPath + N''', JSON_QUERY(o.[value]))
+                        WHEN 5 THEN JSON_MODIFY(r.AnswersJson, N''' + @jsonPath + N''', JSON_QUERY(o.[value]))
+                        ELSE JSON_MODIFY(r.AnswersJson, N''' + @jsonPath + N''', N'''')
+                    END
+                    FROM #Results r
+                    OUTER APPLY (
+                        SELECT j.[type], j.[value]
+                        FROM OPENJSON(r.JsonData) AS j
+                        WHERE j.[key] = N''' + @escapedName + N'''
+                    ) AS o;';
 
         EXEC sp_executesql @updateSql;
 

--- a/src/Endatix.Persistence.SqlServer/Scripts/Procedures/export_form_submissions_v4.sql
+++ b/src/Endatix.Persistence.SqlServer/Scripts/Procedures/export_form_submissions_v4.sql
@@ -125,27 +125,30 @@ BEGIN
                 BEGIN
         -- JSON_QUERY returns NULL for scalars. Project by OPENJSON type so JSON_MODIFY
         -- receives a typed SQL value (string/number/bool) or JSON_QUERY for object/array.
-        DECLARE @escapedName nvarchar(255) = REPLACE(@name, N'''', N'''''');
-        DECLARE @jsonPath nvarchar(512) = N'$."' + @escapedName + N'"';
+        -- Escape once per context: SQL literals for OPENJSON key / dynamic SQL embedding;
+        -- JSON path segment via STRING_ESCAPE so quotes and backslashes are valid.
+        DECLARE @escapedName nvarchar(510) = REPLACE(@name, N'''', N'''''');
+        DECLARE @jsonPath nvarchar(max) = N'$."' + STRING_ESCAPE(@name, 'json') + N'"';
+        DECLARE @escapedJsonPath nvarchar(max) = REPLACE(@jsonPath, N'''', N'''''');
         DECLARE @updateSql nvarchar(max) = N'
                     UPDATE r
                     SET AnswersJson = CASE o.[type]
-                        WHEN 1 THEN JSON_MODIFY(r.AnswersJson, N''' + @jsonPath + N''', o.[value])
+                        WHEN 1 THEN JSON_MODIFY(r.AnswersJson, N''' + @escapedJsonPath + N''', o.[value])
                         WHEN 2 THEN CASE
                             WHEN TRY_CONVERT(bigint, o.[value]) IS NOT NULL
                                  AND CHARINDEX(N''.'', o.[value]) = 0
                                  AND CHARINDEX(N''e'', o.[value]) = 0
                                  AND CHARINDEX(N''E'', o.[value]) = 0
-                                THEN JSON_MODIFY(r.AnswersJson, N''' + @jsonPath + N''', TRY_CONVERT(bigint, o.[value]))
-                            ELSE JSON_MODIFY(r.AnswersJson, N''' + @jsonPath + N''', TRY_CONVERT(float(53), o.[value]))
+                                THEN JSON_MODIFY(r.AnswersJson, N''' + @escapedJsonPath + N''', TRY_CONVERT(bigint, o.[value]))
+                            ELSE JSON_MODIFY(r.AnswersJson, N''' + @escapedJsonPath + N''', TRY_CONVERT(float(53), o.[value]))
                         END
                         WHEN 3 THEN JSON_MODIFY(
                             r.AnswersJson,
-                            N''' + @jsonPath + N''',
+                            N''' + @escapedJsonPath + N''',
                             CONVERT(bit, CASE WHEN o.[value] = N''true'' THEN 1 ELSE 0 END))
-                        WHEN 4 THEN JSON_MODIFY(r.AnswersJson, N''' + @jsonPath + N''', JSON_QUERY(o.[value]))
-                        WHEN 5 THEN JSON_MODIFY(r.AnswersJson, N''' + @jsonPath + N''', JSON_QUERY(o.[value]))
-                        ELSE JSON_MODIFY(r.AnswersJson, N''' + @jsonPath + N''', N'''')
+                        WHEN 4 THEN JSON_MODIFY(r.AnswersJson, N''' + @escapedJsonPath + N''', JSON_QUERY(o.[value]))
+                        WHEN 5 THEN JSON_MODIFY(r.AnswersJson, N''' + @escapedJsonPath + N''', JSON_QUERY(o.[value]))
+                        ELSE JSON_MODIFY(r.AnswersJson, N''' + @escapedJsonPath + N''', N'''')
                     END
                     FROM #Results r
                     OUTER APPLY (

--- a/src/Endatix.Persistence.SqlServer/Scripts/Procedures/export_form_submissions_v4.sql
+++ b/src/Endatix.Persistence.SqlServer/Scripts/Procedures/export_form_submissions_v4.sql
@@ -31,141 +31,114 @@ BEGIN
         StartedAt datetime2,
         SubmitterId bigint,
         SubmitterDisplayId nvarchar(256),
-        JsonData nvarchar(max), -- Store JsonData locally to avoid repeated lookups
+        JsonData nvarchar(max),
         AnswersJson nvarchar(max)
     );
 
-    -- Step 2: Get submissions (with paging)
-    ;WITH BaseSubmissions AS
-    (
-        SELECT
-            FormId,
-            Id,
-            IsComplete,
-            CompletedAt,
-            CreatedAt,
-            ModifiedAt,
-            StartedAt,
-            SubmitterId,
-            SubmitterDisplayId,
-            CONVERT(nvarchar(max), JsonData) AS JsonData,
-            '{}' AS AnswersJson
-        FROM dbo.Submissions
-        WHERE FormId = @form_id
-          AND IsDeleted = 0
-          AND (@after_id IS NULL OR Id > @after_id)
-    )
+    -- Step 2: Get submissions (with paging) directly into the temp table
     INSERT INTO #Results
-        (FormId, Id, IsComplete, CompletedAt, CreatedAt, ModifiedAt, StartedAt, SubmitterId, SubmitterDisplayId, JsonData, AnswersJson)
+        (
+        FormId, Id, IsComplete, CompletedAt, CreatedAt,
+        ModifiedAt, StartedAt, SubmitterId, SubmitterDisplayId,
+        JsonData, AnswersJson
+        )
     SELECT TOP (ISNULL(@page_size, 2147483647))
-        FormId,
-        Id,
-        IsComplete,
-        CompletedAt,
-        CreatedAt,
-        ModifiedAt,
-        StartedAt,
-        SubmitterId,
-        SubmitterDisplayId,
-        JsonData,
-        AnswersJson
-    FROM BaseSubmissions
+        FormId, Id, IsComplete, CompletedAt, CreatedAt,
+        ModifiedAt, StartedAt, SubmitterId, SubmitterDisplayId,
+        CONVERT(nvarchar(max), JsonData), '{}'
+    FROM dbo.Submissions
+    WHERE FormId = @form_id
+        AND IsDeleted = 0
+        AND (@after_id IS NULL OR Id > @after_id)
     ORDER BY Id ASC;
 
-    -- Step 3: Find all question names
-    DECLARE @QuestionNames TABLE (name nvarchar(255));
+    -- Step 3: Find all question names from the Form Definition
+    DECLARE @QuestionNames TABLE (Name nvarchar(255));
 
     ;WITH
         element_tree
         AS
         (
-            -- Base case
-                            SELECT
-                    JSON_QUERY(elem.value, '$') AS element
-                FROM
-                    dbo.FormDefinitions fd
-                        CROSS APPLY OPENJSON(JSON_QUERY(CONVERT(nvarchar(max), fd.JsonData), '$.pages')) AS page
-                        CROSS APPLY OPENJSON(JSON_QUERY(page.value, '$.elements')) AS elem
-                WHERE 
-                        fd.FormId = @form_id
+            -- Base case: Top level elements
+                            SELECT elem.[value] AS element
+                FROM dbo.FormDefinitions fd
+        CROSS APPLY OPENJSON(CONVERT(nvarchar(max), fd.JsonData), '$.pages') AS page
+        CROSS APPLY OPENJSON(page.[value], '$.elements') AS elem
+                WHERE fd.FormId = @form_id
                     AND ISJSON(CONVERT(nvarchar(max), fd.JsonData)) = 1
-                    AND JSON_QUERY(CONVERT(nvarchar(max), fd.JsonData), '$.pages') IS NOT NULL
 
             UNION ALL
 
-                -- Recursive case
-                SELECT
-                    JSON_QUERY(nested_elem.value, '$') AS element
-                FROM
-                    element_tree et
-                        CROSS APPLY OPENJSON(JSON_QUERY(et.element, '$.elements')) AS nested_elem
-                WHERE 
-                        JSON_VALUE(et.element, '$.type') = 'panel'
+                -- Recursive case: Nested elements inside panels
+                SELECT nested_elem.[value] AS element
+                FROM element_tree et
+        CROSS APPLY OPENJSON(et.element, '$.elements') AS nested_elem
+                WHERE JSON_VALUE(et.element, '$.type') = 'panel'
         )
     INSERT INTO @QuestionNames
-    SELECT DISTINCT
-        JSON_VALUE(element, '$.name') AS name
-    FROM
-        element_tree
-    WHERE 
-                    JSON_VALUE(element, '$.type') <> 'panel'
+        (Name)
+    SELECT DISTINCT JSON_VALUE(element, '$.name')
+    FROM element_tree
+    WHERE JSON_VALUE(element, '$.type') <> 'panel'
         AND JSON_VALUE(element, '$.name') IS NOT NULL;
 
-    -- Step 4: Update each result row with question values
-    DECLARE @name nvarchar(255);
+    -- Step 4: Parameterized Dynamic SQL Template (DRY)
+    -- Instead of escaping strings per iteration, we write the logic once
+    -- and pass @questionName and @jsonPath securely via sp_executesql
+    DECLARE @updateSql nvarchar(max) = N'
+        UPDATE r
+        SET AnswersJson = CASE o.[type]
+            WHEN 1 THEN JSON_MODIFY(r.AnswersJson, @jsonPath, o.[value])
+            WHEN 2 THEN CASE
+                WHEN TRY_CONVERT(bigint, o.[value]) IS NOT NULL
+                     AND CHARINDEX(N''.'', o.[value]) = 0
+                     AND CHARINDEX(N''e'', o.[value]) = 0
+                     AND CHARINDEX(N''E'', o.[value]) = 0
+                    THEN JSON_MODIFY(r.AnswersJson, @jsonPath, TRY_CONVERT(bigint, o.[value]))
+                ELSE JSON_MODIFY(r.AnswersJson, @jsonPath, TRY_CONVERT(float(53), o.[value]))
+            END
+            WHEN 3 THEN JSON_MODIFY(r.AnswersJson, @jsonPath, CAST(CASE WHEN o.[value] = N''true'' THEN 1 ELSE 0 END AS bit))
+            WHEN 4 THEN JSON_MODIFY(r.AnswersJson, @jsonPath, JSON_QUERY(o.[value]))
+            WHEN 5 THEN JSON_MODIFY(r.AnswersJson, @jsonPath, JSON_QUERY(o.[value]))
+            ELSE JSON_MODIFY(r.AnswersJson, @jsonPath, N'''')
+        END
+        FROM #Results r
+        OUTER APPLY (
+            SELECT j.[type], j.[value]
+            FROM OPENJSON(r.JsonData) AS j
+            WHERE j.[key] = @questionName
+        ) AS o;
+    ';
 
-    DECLARE question_cursor CURSOR FOR 
-                SELECT name
+    -- Step 5: Update each result row with question values iteratively
+    DECLARE @questionName nvarchar(255);
+    DECLARE @jsonPath nvarchar(max);
+
+    DECLARE question_cursor CURSOR LOCAL FAST_FORWARD FOR
+        SELECT Name
     FROM @QuestionNames;
 
     OPEN question_cursor;
-    FETCH NEXT FROM question_cursor INTO @name;
+    FETCH NEXT FROM question_cursor INTO @questionName;
 
     WHILE @@FETCH_STATUS = 0
-                BEGIN
-        -- JSON_QUERY returns NULL for scalars. Project by OPENJSON type so JSON_MODIFY
-        -- receives a typed SQL value (string/number/bool) or JSON_QUERY for object/array.
-        -- Escape once per context: SQL literals for OPENJSON key / dynamic SQL embedding;
-        -- JSON path segment via STRING_ESCAPE so quotes and backslashes are valid.
-        DECLARE @escapedName nvarchar(510) = REPLACE(@name, N'''', N'''''');
-        DECLARE @jsonPath nvarchar(max) = N'$."' + STRING_ESCAPE(@name, 'json') + N'"';
-        DECLARE @escapedJsonPath nvarchar(max) = REPLACE(@jsonPath, N'''', N'''''');
-        DECLARE @updateSql nvarchar(max) = N'
-                    UPDATE r
-                    SET AnswersJson = CASE o.[type]
-                        WHEN 1 THEN JSON_MODIFY(r.AnswersJson, N''' + @escapedJsonPath + N''', o.[value])
-                        WHEN 2 THEN CASE
-                            WHEN TRY_CONVERT(bigint, o.[value]) IS NOT NULL
-                                 AND CHARINDEX(N''.'', o.[value]) = 0
-                                 AND CHARINDEX(N''e'', o.[value]) = 0
-                                 AND CHARINDEX(N''E'', o.[value]) = 0
-                                THEN JSON_MODIFY(r.AnswersJson, N''' + @escapedJsonPath + N''', TRY_CONVERT(bigint, o.[value]))
-                            ELSE JSON_MODIFY(r.AnswersJson, N''' + @escapedJsonPath + N''', TRY_CONVERT(float(53), o.[value]))
-                        END
-                        WHEN 3 THEN JSON_MODIFY(
-                            r.AnswersJson,
-                            N''' + @escapedJsonPath + N''',
-                            CONVERT(bit, CASE WHEN o.[value] = N''true'' THEN 1 ELSE 0 END))
-                        WHEN 4 THEN JSON_MODIFY(r.AnswersJson, N''' + @escapedJsonPath + N''', JSON_QUERY(o.[value]))
-                        WHEN 5 THEN JSON_MODIFY(r.AnswersJson, N''' + @escapedJsonPath + N''', JSON_QUERY(o.[value]))
-                        ELSE JSON_MODIFY(r.AnswersJson, N''' + @escapedJsonPath + N''', N'''')
-                    END
-                    FROM #Results r
-                    OUTER APPLY (
-                        SELECT j.[type], j.[value]
-                        FROM OPENJSON(r.JsonData) AS j
-                        WHERE j.[key] = N''' + @escapedName + N'''
-                    ) AS o;';
+    BEGIN
+        -- Safely format the JSON Path for the current question
+        SET @jsonPath = N'$."' + STRING_ESCAPE(@questionName, 'json') + N'"';
 
-        EXEC sp_executesql @updateSql;
+        EXEC sp_executesql
+            @stmt = @updateSql,
+            @params = N'@questionName nvarchar(255), @jsonPath nvarchar(max)',
+            @questionName = @questionName,
+            @jsonPath = @jsonPath;
 
-        FETCH NEXT FROM question_cursor INTO @name;
+        FETCH NEXT FROM question_cursor INTO @questionName;
     END;
 
     CLOSE question_cursor;
     DEALLOCATE question_cursor;
 
-    -- Return the results
+    -- Return the final projected results
     SELECT
         FormId,
         Id,

--- a/src/Endatix.WebHost/appsettings.Development.json
+++ b/src/Endatix.WebHost/appsettings.Development.json
@@ -51,7 +51,7 @@
     "Auth": {
       "Providers": {
         "EndatixJwt": {
-          "SigningKey": "{JWT_SIGNING_KEY}",
+          "SigningKey": "TEST:Endatix.LocalDev.JwtSigningKey.NotForProduction.UseUserSecrets",
           "AccessExpiryInMinutes": 90,
           "RefreshExpiryInDays": 7,
           "Issuer": "endatix-api",

--- a/tests/Endatix.Infrastructure.Tests/Exporting/LegacyExportSqlScalarProjectionTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Exporting/LegacyExportSqlScalarProjectionTests.cs
@@ -17,6 +17,7 @@ public sealed class LegacyExportSqlScalarProjectionTests
         script.Should().Contain("OPENJSON(r.JsonData)");
         script.Should().Contain("TRY_CONVERT(bigint");
         script.Should().Contain("TRY_CONVERT(float(53)");
+        script.Should().Contain("STRING_ESCAPE(@name, 'json')");
         script.Should().NotContain("ISNULL(JSON_QUERY(r.JsonData");
     }
 }

--- a/tests/Endatix.Infrastructure.Tests/Exporting/LegacyExportSqlScalarProjectionTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Exporting/LegacyExportSqlScalarProjectionTests.cs
@@ -17,7 +17,8 @@ public sealed class LegacyExportSqlScalarProjectionTests
         script.Should().Contain("OPENJSON(r.JsonData)");
         script.Should().Contain("TRY_CONVERT(bigint");
         script.Should().Contain("TRY_CONVERT(float(53)");
-        script.Should().Contain("STRING_ESCAPE(@name, 'json')");
+        script.Should().Contain("STRING_ESCAPE(@questionName, 'json')");
+        script.Should().Contain("sp_executesql");
         script.Should().NotContain("ISNULL(JSON_QUERY(r.JsonData");
     }
 }

--- a/tests/Endatix.Infrastructure.Tests/Exporting/LegacyExportSqlScalarProjectionTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Exporting/LegacyExportSqlScalarProjectionTests.cs
@@ -1,0 +1,22 @@
+using System.Reflection;
+using Endatix.Framework.Scripts;
+using FluentAssertions;
+
+namespace Endatix.Infrastructure.Tests.Exporting;
+
+public sealed class LegacyExportSqlScalarProjectionTests
+{
+    [Fact]
+    public void ReadSqlScript_SqlServerExportV4_ProjectsScalarsViaOpenJson()
+    {
+        Assembly assembly = Assembly.Load("Endatix.Persistence.SqlServer");
+
+        string script = ScriptReader.ReadSqlScript("Procedures/export_form_submissions_v4.sql", assembly);
+
+        // JSON_QUERY alone drops scalars; v4 must project via OPENJSON types into JSON_MODIFY.
+        script.Should().Contain("OPENJSON(r.JsonData)");
+        script.Should().Contain("TRY_CONVERT(bigint");
+        script.Should().Contain("TRY_CONVERT(float(53)");
+        script.Should().NotContain("ISNULL(JSON_QUERY(r.JsonData");
+    }
+}

--- a/tests/Endatix.IntegrationTests/CriticalPaths/Submissions/LegacyExportFormSubmissionsAnswersFlowTests.cs
+++ b/tests/Endatix.IntegrationTests/CriticalPaths/Submissions/LegacyExportFormSubmissionsAnswersFlowTests.cs
@@ -1,0 +1,175 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Endatix.Core.Abstractions.Repositories;
+using Endatix.Core.Entities;
+using Endatix.Infrastructure.Data;
+using Endatix.IntegrationTests.Shared;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Endatix.IntegrationTests;
+
+/// <summary>
+/// Provider-agnostic coverage for legacy <c>export_form_submissions</c> answer projection
+/// (form → submission → SQL export). Uses the AllQuestions definition plus the export
+/// submission fixture (originally from endatix/endatix#891; valid on every provider).
+/// </summary>
+[Collection(nameof(EndatixIntegrationTestCollection))]
+[Trait("Category", "CriticalPath")]
+[Trait("Priority", "P0")]
+public sealed class LegacyExportFormSubmissionsAnswersFlowTests
+{
+    private const string SeedPassword = "Password123!";
+    private const long LegacyCsvExportId = 8802;
+
+    private readonly EndatixIntegrationWebHostFixture _fixture;
+
+    public LegacyExportFormSubmissionsAnswersFlowTests(EndatixIntegrationWebHostFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task ExportRows_AllQuestionsSubmission_IncludesScalarAndComplexAnswers()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        IntegrationTestWorld world = await _fixture.PrepareWorldAsync(
+            IntegrationWorldOptions.MultiTenant with { DefaultPassword = SeedPassword },
+            cancellationToken);
+
+        using HttpClient client = await world.AsAsync(TestPersona.TenantAdmin, cancellationToken: cancellationToken);
+        await EnsureTenantSettingsAsync(world.Services, world.Tenants[0].Id, cancellationToken);
+
+        string definitionJson = AllQuestionsReportingFixtureLoader.LoadDefinitionText();
+        string submissionJson = AllQuestionsReportingFixtureLoader.LoadExportSubmissionText();
+        string formId = await CreateFormAsync(client, definitionJson, cancellationToken);
+
+        HttpResponseMessage createResponse = await client.PostAsJsonAsync(
+            $"/api/forms/{formId}/submissions",
+            new
+            {
+                isComplete = true,
+                currentPage = 0,
+                jsonData = submissionJson
+            },
+            cancellationToken);
+        createResponse.EnsureSuccessStatusCode();
+
+        // Act
+        await using AsyncServiceScope scope = world.Services.CreateAsyncScope();
+        ISubmissionExportRepository exportRepository =
+            scope.ServiceProvider.GetRequiredService<ISubmissionExportRepository>();
+
+        List<SubmissionExportRow> rows = [];
+        await foreach (SubmissionExportRow row in exportRepository.GetExportRowsAsync<SubmissionExportRow>(
+                           long.Parse(formId),
+                           sqlFunctionName: "export_form_submissions",
+                           pageSize: 100,
+                           cancellationToken))
+        {
+            rows.Add(row);
+        }
+
+        // Assert — keys that were blank in submissions-all-questions-sql-server.csv
+        Assert.Single(rows);
+        using JsonDocument expectedDocument = JsonDocument.Parse(submissionJson);
+        using JsonDocument actualDocument = JsonDocument.Parse(rows[0].AnswersModel);
+        JsonElement expected = expectedDocument.RootElement;
+        JsonElement actual = actualDocument.RootElement;
+
+        AssertAnswer(actual, expected, "qBoolean");
+        AssertAnswer(actual, expected, "qComment");
+        AssertAnswer(actual, expected, "qDropdown");
+        AssertAnswer(actual, expected, "qExpression");
+        AssertAnswer(actual, expected, "qPanelText");
+        AssertAnswer(actual, expected, "qRadioGroup");
+        AssertAnswer(actual, expected, "qRating");
+        AssertAnswer(actual, expected, "qSignaturePad");
+        AssertAnswer(actual, expected, "qSlider");
+        AssertAnswer(actual, expected, "qText");
+        AssertAnswer(actual, expected, "qTextDate");
+        AssertAnswer(actual, expected, "qTextNumber");
+        AssertAnswer(actual, expected, "qTagBox");
+        AssertAnswer(actual, expected, "qRanking");
+        AssertAnswer(actual, expected, "qRangeSlider");
+        AssertAnswer(actual, expected, "qMatrix");
+        AssertAnswer(actual, expected, "qMatrixDropdown");
+        AssertAnswer(actual, expected, "qMatrixDynamic");
+        AssertAnswer(actual, expected, "qMultipleText");
+        AssertAnswer(actual, expected, "qLoop");
+        AssertAnswer(actual, expected, "questionSongs");
+    }
+
+    private static void AssertAnswer(JsonElement actualRoot, JsonElement expectedRoot, string name)
+    {
+        actualRoot.TryGetProperty(name, out JsonElement actual)
+            .Should().BeTrue($"AnswersModel should include '{name}'");
+        expectedRoot.TryGetProperty(name, out JsonElement expected)
+            .Should().BeTrue($"fixture should include '{name}'");
+
+        ReportingJsonAssertions.AssertJsonElementMatches(
+            actual,
+            expected,
+            $"answer '{name}' should match submitted JsonData");
+    }
+
+    private static async Task EnsureTenantSettingsAsync(
+        IServiceProvider services,
+        long tenantId,
+        CancellationToken cancellationToken)
+    {
+        await using AsyncServiceScope scope = services.CreateAsyncScope();
+        AppDbContext db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+
+        TenantSettings? settings = await db.TenantSettings
+            .FirstOrDefaultAsync(row => row.TenantId == tenantId, cancellationToken);
+
+        if (settings is null)
+        {
+            settings = new TenantSettings(tenantId);
+            db.TenantSettings.Add(settings);
+        }
+
+        CustomExportConfiguration export = new()
+        {
+            Id = LegacyCsvExportId,
+            Name = "Answers CSV",
+            Format = "csv",
+            SqlFunctionName = "export_form_submissions",
+            ItemTypeName = typeof(SubmissionExportRow).FullName,
+            ExportPageSize = 0
+        };
+
+        List<CustomExportConfiguration> exports = settings.CustomExports
+            .Where(item => item.Id != LegacyCsvExportId)
+            .ToList();
+        exports.Add(export);
+        settings.UpdateCustomExports(exports);
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+
+    private static async Task<string> CreateFormAsync(
+        HttpClient client,
+        string definitionJson,
+        CancellationToken cancellationToken)
+    {
+        HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/forms",
+            new
+            {
+                name = $"export-answers-form-{Guid.NewGuid():N}",
+                isEnabled = true,
+                formDefinitionJsonData = definitionJson
+            },
+            cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        await using Stream stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        using JsonDocument document = await JsonDocument.ParseAsync(stream, cancellationToken: cancellationToken);
+        return document.RootElement.GetProperty("id").GetString()
+            ?? throw new InvalidOperationException("Form create response missing id.");
+    }
+}

--- a/tests/Endatix.IntegrationTests/CriticalPaths/Submissions/LegacyExportFormSubmissionsAnswersFlowTests.cs
+++ b/tests/Endatix.IntegrationTests/CriticalPaths/Submissions/LegacyExportFormSubmissionsAnswersFlowTests.cs
@@ -57,15 +57,22 @@ public sealed class LegacyExportFormSubmissionsAnswersFlowTests
             cancellationToken);
         createResponse.EnsureSuccessStatusCode();
 
-        // Act
+        // Act — consume TenantSettings.CustomExports (ExportId resolution path), not a pinned name
         await using AsyncServiceScope scope = world.Services.CreateAsyncScope();
+        AppDbContext db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+        TenantSettings tenantSettings = await db.TenantSettings
+            .SingleAsync(row => row.TenantId == world.Tenants[0].Id, cancellationToken);
+        string? sqlFunctionName = tenantSettings.CustomExports
+            .Single(item => item.Id == LegacyCsvExportId)
+            .SqlFunctionName;
+
         ISubmissionExportRepository exportRepository =
             scope.ServiceProvider.GetRequiredService<ISubmissionExportRepository>();
 
         List<SubmissionExportRow> rows = [];
         await foreach (SubmissionExportRow row in exportRepository.GetExportRowsAsync<SubmissionExportRow>(
                            long.Parse(formId),
-                           sqlFunctionName: "export_form_submissions",
+                           sqlFunctionName,
                            pageSize: 100,
                            cancellationToken))
         {

--- a/tests/Endatix.IntegrationTests/Infrastructure/AllQuestionsReportingFixtureLoader.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/AllQuestionsReportingFixtureLoader.cs
@@ -13,6 +13,12 @@ internal static class AllQuestionsReportingFixtureLoader
     internal static string LoadSubmissionText() =>
         File.ReadAllText(Path.Combine(FixturesRoot, "all-questions-submission.json"));
 
+    /// <summary>
+    /// Rich AllQuestions submission used for legacy export answer-projection coverage.
+    /// </summary>
+    internal static string LoadExportSubmissionText() =>
+        File.ReadAllText(Path.Combine(FixturesRoot, "all-questions-submission-with-file.json"));
+
     internal static JsonElement LoadExpectedFlat()
     {
         using JsonDocument document = JsonDocument.Parse(

--- a/tests/Endatix.IntegrationTests/Infrastructure/EndatixIntegrationWebHostFixture.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/EndatixIntegrationWebHostFixture.cs
@@ -14,6 +14,11 @@ public sealed class EndatixIntegrationWebHostFixture : IAsyncLifetime, IIntegrat
 
     public DatabaseCheckpoint Checkpoint => Database.Checkpoint;
 
+    /// <summary>
+    /// Active test database provider (<c>ENDATIX_TEST_DB_PROVIDER</c>).
+    /// </summary>
+    public TestDatabaseProvider Provider => Database.Provider;
+
     IServiceProvider IIntegrationTestHostFixture.Services => Factory.Services;
 
     public IntegrationSeedBuilder Seed { get; private set; } = null!;

--- a/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FlattenedFormDefinition/Fixtures/AllQuestions/all-questions-submission-with-file.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FlattenedFormDefinition/Fixtures/AllQuestions/all-questions-submission-with-file.json
@@ -1,0 +1,56 @@
+{
+  "qExpression": 23,
+  "qRadioGroup": "email",
+  "qRating": 4,
+  "qSlider": 40,
+  "qRangeSlider": [80, 200],
+  "qDropdown": "sword",
+  "qLoop": [
+    {
+      "itemText": "Puma",
+      "itemValue": "puma",
+      "loopIndex": 0,
+      "qLoopBoolean": true,
+      "qLoopRating": 5,
+      "qLoopColor": "5"
+    },
+    {
+      "itemText": "Sword",
+      "itemValue": "sword",
+      "loopIndex": 0,
+      "qLoopBoolean": true,
+      "qLoopRating": 5,
+      "qLoopColor": "2"
+    },
+    {
+      "itemText": "Other (pick)",
+      "itemValue": "other",
+      "loopIndex": 1,
+      "qLoopBoolean": true,
+      "qLoopRating": 5,
+      "qLoopColor": "other",
+      "qLoopColor-Comment": "SOS Color"
+    }
+  ],
+  "questionSongs": ["other"],
+  "questionSongs-Comment": "Message in a bottle",
+  "qTagBox": ["puma"],
+  "qBoolean": true,
+  "qRanking": ["banana", "apple", "orange"],
+  "qText": "Jack Smith",
+  "qTextNumber": 23,
+  "qTextDate": "1994-08-04",
+  "qComment": "Message in a bottle, yeah",
+  "qMultipleText": { "phone": "123121", "emergency": "911" },
+  "qMatrix": { "quality": "excellent", "speed": "excellent" },
+  "qMatrixDropdown": {
+    "alice": { "punctuality": 2, "teamwork": 4 },
+    "bob": { "punctuality": 4, "teamwork": 3 }
+  },
+  "qMatrixDynamic": [
+    { "company": "SOS", "years": 3 },
+    { "company": "J&J", "years": 23 }
+  ],
+  "qPanelText": "Intel Inside",
+  "qSignaturePad": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAADICAYAAABS39xVAAAMPElEQVR4AezdT3rbxhkH4EFO0GWkVXqD9ASR9tEZ0qwrL3oCOzfo80hdNz0Du7d9gvQGzcrqrjcwipElGgIp/gExxMzg5UOGIAkMvnk/5/eAIE1/E1wIECBQiIDAKqRRyiRAIASB5U8BAQLFCAisYlp1eqFGIFC6gMAqvYPqJ7AgAYG1oGabKoHSBQRW6R1UP4FtApU+J7AqbaxpEahRQGDV2FVzIlCpgMCqtLGmRaBGAYG1raueI0AgSwGBlWVbFEWAwDYBgbVNxXMECGQpILCybIuizidgTyUJCKySuqVWAgsXEFgL/wNg+gRKEhBYJXVLrQQWLnBiYC1cz/QJEDirgMA6K7edESBwioDAOkXPtgQInFVAYJ2Vu+idKZ7A7AICa/YWKIAAgUMFBNahUtYjQGB2AYE1ewsUQCA/gVwrEli5dkZdBAhsCAisDRJPECCQq4DAyrUz6iJAYENAYG2Q7H7i29XdVbztWstrBAikERBYe1xjOMXbxer+fXdrm9C8j7e4HG+Xq/vfLlZ3H+I6e4byMgECJwoIrFcAYwBdru7/F8Mp3rrVrrrbxrUN4fsQmh/iOl2Avb9c3b0LLgQIJBEQWAPWGDgX3dFUDKAujP4weHnfw6s2NG+77dtLwbXPqo7XzeKsAgKrxx1DJgZO99TWo6nu+Q+9W7f4+jWOc7G6F1yvE3mFwNECAuuJLL4FjCHz9PDrXdP8Hprw14eb26a7Xfdu8XHThva6Ce0vXzd4uRTHvHS09RLFIwIjBQRWBxcDpelOpneLL64xjB5+/MsfH368/duLF3oP/nvz5sOnmzfvuiBrYnDFW+/lx8UvoXX/6+MD/yFAYLTAvIE1uuzpNoxhFQNlOGIMnhhGw+d3PY7BFW9x2+F6bQg/xX0Nn/eYAIHDBRYfWG13knyTq/0Yg2fz+cOeidvGo7MQ3072Non7Elo9EIsEjhRYdGC9Fh4PN29eO+l+MG88Omvbzz9vC62L7lPIgweyIgECa4FFB1YbwkYwbXs7F0ZeYmjFc2Dd5vHTxe5ufb3qQquNJ/rXz1S/YIIEThdYdGCF0PwQBpf4dm7w1MkPH25ut36SuO1E/8k7MwCBigUWHljDzrYfh89M9TgG4bajt+5I6/1U+zAOgdoFBFavww8TnLvqDbex+EpoXV36ntaGlSeKFkhW/GIDa3j+aNvRTwr1GFqPnyD2Bm+7TyovV76n1SOxSGCrwGIDq5v4+oR7DKsYJFuFEjz5eDL+5rbpD92G8NMwRPuvWyZAIITu/1sMcwk8Hmn1vqvVhMavPczVDPstQmCxgdV2b8OeO3TOo6vnfcb7eKT1+F2t+ODp1obmrXNaTxjuCAwEFhtYA4fZHj6GVmiv+wXEMPX2sC9imcAXAYEV2mRfZfhCvP+/20Irvj0UWvvtrLEsgcUG1kM86f34szGn/zWcKf7IxNCKJ//7Ywmtvkady2Z1nMBiAysy7frZmPj6uW/xXNrjifjejmNo9R5aJLBogUUHVo6dj0daw9C6XN3/lmOtaiJwbgGBdW7xA/Y3DK02hO8v/vX3/xywqVUIVC1QdGDV3JlhaIW2/c7XHWruuLkdIiCwDlGaaZ1haLWhif8ij78sPVM/7HZ+AYE1fw92VjAMrW7l+FtaQquDcF2egMAqoOcxtAZfeVheaBXQJyWmFxBY6Y0n2UP8yoPQmoTSIAULCKyCmrcttJyIL6iBSj1ZQGCdTHjeAYahFU/EC63z9sDeUgu8Pr7Aet0m21e2hdbF6m74D11kW7/CCIwVEFhj5WbebhhaITQ/ONIKLpULCKyCG/wltMI/n6fg7eGzhPtaBQRW4Z39dHP75/6nh21o/ABg4T1V/usCAut1m2Je+XTz5p3QKqZdCj1BQGCdgJfTpkIrp26oJZWAwEolO8O420LLr5bO0Ijz7XJxexJYlbU8hlY3pfVXHOIPAAqtTsS1CgGBVUUbX07i4eb2ugnh3+Hp0oTmvdB6wnBXtIDAKrp9rxf/6eb2T/1XhVZfw3KpAksOrFJ7dnDd3ZFW01+56Y60+o8tEyhNQGCV1rEj6x3+PvzF6t5vaR1paPV8BARWPr1IUonf0krCatCZBATWTPDn3O2nwRdLu31fXa7u3nX3i7maaB0CAquOPu6dxTC04t879MnhXjYrZCYgsDJrSMpyYmh14/uOVofgWqaAwCqzb6Or7j45vA5N8/vzAE1o3j4vuyeQu8BBgZX7JNR3nEDbfv65t4V/0KKHYTFvAYGVd3+SVBc/OWxDe90bvAutu/Vbxd7zFglkJSCwsmrH+YqJodX/SZrw+Iul978GFwIZCwisjJuTurSnk/Dr3bQh/PTt6u5q/YQFApkJCKzMGnLucl4eZYXgJHxwyVhAYGXcnHOUFo+yBqHlS6XngLePUQICaxRbXRvF0OpmtD7p3obmrS+VdiLVX8uboMAqr2dJKu4+NfylP3DTfPOP/mPLBHIQEFg5dCGDGuKnhl0Z66Os0LbfOcrqRFyzEhBYWbVj3mI2jrK6t4bzVmTvBF4KCKyXHkc8qm/VeJQ1PAHvKKu+Ppc8I4FVcvcS1P50An49sq85rCksZCAgsDJoQoYlfD2XFcKVo6wMO7TQkgTWQhu/a9rOZW3oeCITAYGVSSNyKiOey+rqWR9ldee1PnaPXQnMLiCwZm9BngX0jrI+fA5hHV7BhcCMAgJrRvycdx2Psh5ubpvudh2Xc65VbcsROEdgLUfTTAkQSCogsJLyGpwAgSkFBNaUmsYiQCCpgMBKyru8wc2YQEoBgZVS19gECEwqILAm5TQYAQIpBQRWSl1jE6hZYIa5CawZ0O2SAIFxAgJrnJutCBCYQUBgzYBulwQIjBMQWOPcTt/KCAQIHC0gsI4mswEBAnMJCKy55O2XAIGjBQTW0WQ2IHCsgPWnEhBYU0kahwCB5AICKzmxHRAgMJWAwJpK0jgECCQXKCCwkhvYAQEChQgIrEIapUwCBEIQWP4UECBQjIDAKqZViyjUJAnsFBBYO3m8SIBATgICK6duqIUAgZ0CAmsnjxcJEEglMGZcgTVGzTYECMwiILBmYbdTAgTGCAisMWq2IUBgFgGBNQv76Ts1AoElCgisJXbdnAkUKiCwCm2csgksUUBgLbHr5lyWgGrXAgJrTWGBAIHcBQRW7h1SHwECawGBtaawQIBA7gL1B1buHVAfAQIHCwisg6msSIDA3AICa+4O2D8BAgcLCKyDqayYv4AKaxcQWLV32PwIVCQgsCpqpqkQqF1AYNXeYfMjUJFAL7AqmpWpECBQpYDAqrKtJkWgTgGBVWdfzYpAlQICq8q27p2UFQgUKSCwimybogksU0BgLbPvZk2gSAGBVWTbFE3gcIGa1hRYNXXTXAhULiCwKm+w6RGoSUBg1dRNcyFQuYDA2tNgLxMgkI+AwMqnFyohQGCPgMDaA+RlAgTyERBY+fRCJXML2H/2AgIr+xYpkACBZwGB9SzhngCB7AUEVvYtUiABAs8C0wXW84juCRAgkEhAYCWCNSwBAtMLCKzpTY1IgEAiAYGVCLbuYc2OwDwCAmsed3slQGCEgMAagWYTAgTmERBY87jbK4FSBLKqU2Bl1Q7FECCwS0Bg7dLxGgECWQkIrKzaoRgCBHYJCKxdOqe/ZgQCBCYUEFgTYhqKAIG0AgIrra/RCRCYUEBgTYhpqGULmH16AYGV3tgeCBCYSEBgTQRpGAIE0gsIrPTG9kCAwEQC2QTWRPMxDAECFQsIrIqba2oEahMQWLV11HwIVCwgsCpubrZTUxiBkQICaySczQgQOL+AwDq/uT0SIDBSQGCNhLMZAQKHCEy7jsCa1tNoBAgkFBBYCXENTYDAtAICa1pPoxEgkFBAYCXEPX1oIxAg0BcQWH0NywQIZC0gsLJuj+IIEOgLCKy+hmUC8wnY8wECAusAJKsQIJCHgMDKow+qIEDgAAGBdQCSVQgQyEOglsDKQ1MVBAgkFRBYSXkNToDAlAICa0pNYxEgkFRAYCXlNXgKAWMuV0BgLbf3Zk6gOAGBVVzLFExguQICa7m9N3MC+QsMKhRYAxAPCRDIV0Bg5dsblREgMBAQWAMQDwkQyFdAYOXbm9MrMwKBygQEVmUNNR0CNQsIrJq7a24EKhMQWJU11HSWKrCMeQusZfTZLAlUISCwqmijSRBYhsD/AQAA//84hSrKAAAABklEQVQDADYY8aCqZk3PAAAAAElFTkSuQmCC"
+}


### PR DESCRIPTION
# feat(e891): SQL Server export SP leaves scalar and complex answer fields empty in default CSV

## Description

>[!NOTE]
>SInce the `SoftDeleteSubmissions` migration is still not merged to main, we are modifying the `export_form_submissions_v4.sql` directly. This is why we have chosen to dely merging the `submission-and-export-changes` into `main`

- Fixing error during setup due to short signing key (default value) and misleading error
- Applying DB fix + integration tests to document the expected behavior

## Related Issues
- closes #891 

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legacy submission exports to preserve scalar, numeric, Boolean, and complex answer values correctly.
  * Corrected validation error details for insufficient JWT signing keys.

* **Test Coverage**
  * Added coverage for scalar and complex answer exports across supported submission scenarios.
  * Added fixture data for comprehensive form submissions, including nested and file-related answers.

* **Development**
  * Updated the development JWT signing key configuration for local use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->