### PR TITLE
fix(e899): Fix the negative export format id for future migrations

### DIFF
--- a/src/Endatix.Modules.Reporting/Persistence/Migrations/PostgreSql/20260721062723_InitialReporting.cs
+++ b/src/Endatix.Modules.Reporting/Persistence/Migrations/PostgreSql/20260721062723_InitialReporting.cs
@@ -154,12 +154,14 @@ namespace Endatix.Modules.Reporting.Persistence.Migrations.PostgreSql
             // Deterministic bigint ids via hashtextextended — do NOT use tenantId * N.
             // Snowflake tenant ids already use most of the signed 64-bit range; multiplying overflows
             // (Postgres 22003: bigint out of range) when remigrating against real tenants.
+            // Clear the sign bit so seeded ids stay positive (Hub validateEndatixId + domain
+            // Guard.Against.NegativeOrZero reject negatives). Do not use abs() — abs(long.MinValue) overflows.
             migrationBuilder.Sql("""
                 INSERT INTO reporting."ExportFormats"
                     ("Id", "TenantId", "Name", "ExportTarget", "DeliveryFormat", "Profile",
                      "Description", "SettingsJson", "CreatedAt", "IsDeleted")
                 SELECT
-                    hashtextextended(t."Id"::text || ':csv', 0),
+                    GREATEST(1, hashtextextended(t."Id"::text || ':csv', 0) & 9223372036854775807::bigint),
                     t."Id",
                     'CSV',
                     'Submissions',
@@ -177,7 +179,7 @@ namespace Endatix.Modules.Reporting.Persistence.Migrations.PostgreSql
                     ("Id", "TenantId", "Name", "ExportTarget", "DeliveryFormat", "Profile",
                      "Description", "SettingsJson", "CreatedAt", "IsDeleted")
                 SELECT
-                    hashtextextended(t."Id"::text || ':json', 0),
+                    GREATEST(1, hashtextextended(t."Id"::text || ':json', 0) & 9223372036854775807::bigint),
                     t."Id",
                     'JSON',
                     'Submissions',
@@ -195,7 +197,7 @@ namespace Endatix.Modules.Reporting.Persistence.Migrations.PostgreSql
                     ("Id", "TenantId", "Name", "ExportTarget", "DeliveryFormat", "Profile",
                      "Description", "SettingsJson", "CreatedAt", "IsDeleted")
                 SELECT
-                    hashtextextended(t."Id"::text || ':codebook', 0),
+                    GREATEST(1, hashtextextended(t."Id"::text || ':codebook', 0) & 9223372036854775807::bigint),
                     t."Id",
                     'Codebook',
                     'Codebook',
@@ -213,10 +215,10 @@ namespace Endatix.Modules.Reporting.Persistence.Migrations.PostgreSql
                     ("Id", "TenantId", "SurveyTypeId", "ExportFormatId", "IsDefault",
                      "CreatedAt", "IsDeleted")
                 SELECT
-                    hashtextextended(t."Id"::text || ':default-map', 0),
+                    GREATEST(1, hashtextextended(t."Id"::text || ':default-map', 0) & 9223372036854775807::bigint),
                     t."Id",
                     NULL,
-                    hashtextextended(t."Id"::text || ':csv', 0),
+                    GREATEST(1, hashtextextended(t."Id"::text || ':csv', 0) & 9223372036854775807::bigint),
                     TRUE,
                     NOW(),
                     FALSE


### PR DESCRIPTION
# fix(e899): Fix the negative export format id for future migrations

## Description
- Uses  GREATEST(1, hashtextextended(t."Id"::text || ':json', 0) & 9223372036854775807::bigint) to turn all negatives into positive integers

## Related Issues
- fixes #899

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
