### PR TITLE
feat(e892): Replace reporting FormSchema on compile when form has no real submissions

### DIFF
--- a/src/Endatix.Modules.Reporting/Data/FlattenedSubmissionRepository.cs
+++ b/src/Endatix.Modules.Reporting/Data/FlattenedSubmissionRepository.cs
@@ -46,4 +46,11 @@ internal sealed class FlattenedSubmissionRepository(
     {
         await unitOfWork.SaveChangesAsync(cancellationToken);
     }
+
+    /// <inheritdoc />
+    public Task<int> DeleteByFormIdAsync(long tenantId, long formId, CancellationToken cancellationToken) =>
+        dbContext.FlattenedSubmissions
+            .IgnoreQueryFilters()
+            .Where(row => row.TenantId == tenantId && row.FormId == formId)
+            .ExecuteDeleteAsync(cancellationToken);
 }

--- a/src/Endatix.Modules.Reporting/Data/IFlattenedSubmissionRepository.cs
+++ b/src/Endatix.Modules.Reporting/Data/IFlattenedSubmissionRepository.cs
@@ -37,4 +37,14 @@ public interface IFlattenedSubmissionRepository
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The task.</returns>
     Task SaveAsync(FlattenedSubmission flattenedSubmission, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Hard-deletes all flattened submission rows for a form (including soft-deleted rows).
+    /// Used after a replace-mode FormSchema compile to clear test flatten debris.
+    /// </summary>
+    /// <param name="tenantId">The tenant ID.</param>
+    /// <param name="formId">The form ID.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The number of rows deleted.</returns>
+    Task<int> DeleteByFormIdAsync(long tenantId, long formId, CancellationToken cancellationToken);
 }

--- a/src/Endatix.Modules.Reporting/Features/FormSchema/FormSchema/FormSchemaCompileMode.cs
+++ b/src/Endatix.Modules.Reporting/Features/FormSchema/FormSchema/FormSchemaCompileMode.cs
@@ -1,0 +1,17 @@
+namespace Endatix.Modules.Reporting.Features.FormSchema.FormSchema;
+
+/// <summary>
+/// Controls whether FormSchema compile merges historical columns/questions or rebuilds from the current definition only.
+/// </summary>
+public enum FormSchemaCompileMode
+{
+    /// <summary>
+    /// Append-only merge: retain historical FlatteningMap keys and codebook entries.
+    /// </summary>
+    Merge = 0,
+
+    /// <summary>
+    /// Replace: rebuild FlatteningMap and codebook from the current definition only.
+    /// </summary>
+    Replace = 1,
+}

--- a/src/Endatix.Modules.Reporting/Features/FormSchema/FormSchema/FormSchemaCompiler.cs
+++ b/src/Endatix.Modules.Reporting/Features/FormSchema/FormSchema/FormSchemaCompiler.cs
@@ -6,7 +6,9 @@ using Endatix.Modules.Reporting.Shared.SurveyJs;
 namespace Endatix.Modules.Reporting.Features.FormSchema.FormSchema;
 
 /// <summary>
-/// Compiles SurveyJS form definitions into append-only merged form schemas and codebooks.
+/// Compiles SurveyJS form definitions into form schemas and codebooks.
+/// Supports append-only <see cref="FormSchemaCompileMode.Merge"/> and full
+/// <see cref="FormSchemaCompileMode.Replace"/> from the current definition.
 /// </summary>
 internal sealed class FormSchemaCompiler(SchemaCompilationLimits? limits = null)
 {
@@ -29,19 +31,27 @@ internal sealed class FormSchemaCompiler(SchemaCompilationLimits? limits = null)
     public FormSchemaCompileResult CompilePersisted(
         string definitionJson,
         string? existingFlatteningMapJson = null,
-        string? existingCodebookJson = null)
+        string? existingCodebookJson = null,
+        FormSchemaCompileMode mode = FormSchemaCompileMode.Merge)
     {
-        using var definition = JsonDocument.Parse(definitionJson);
-        var existingFlatteningMap = string.IsNullOrWhiteSpace(existingFlatteningMapJson)
+        var flatteningMapJsonInput = mode == FormSchemaCompileMode.Replace
             ? null
-            : FormSchemaFlatteningMap.FromJson(existingFlatteningMapJson);
+            : existingFlatteningMapJson;
+        var codebookJsonInput = mode == FormSchemaCompileMode.Replace
+            ? null
+            : existingCodebookJson;
+
+        using var definition = JsonDocument.Parse(definitionJson);
+        var existingFlatteningMap = string.IsNullOrWhiteSpace(flatteningMapJsonInput)
+            ? null
+            : FormSchemaFlatteningMap.FromJson(flatteningMapJsonInput);
 
         var merged = Compile(definition.RootElement, existingFlatteningMap);
         var flatteningMapJson = FormSchemaFlatteningMap.ToJson(merged);
         var codebookJson = FormSchemaCodebookBuilder.Build(
             definition.RootElement,
             merged,
-            existingCodebookJson);
+            codebookJsonInput);
         var locales = SurveyJsLocalizationHelper.DiscoverLocales(definition.RootElement);
         var localesJson = JsonSerializer.Serialize(locales);
 

--- a/src/Endatix.Modules.Reporting/Features/FormSchema/FormSchemaProcessor.cs
+++ b/src/Endatix.Modules.Reporting/Features/FormSchema/FormSchemaProcessor.cs
@@ -16,6 +16,7 @@ internal sealed class FormSchemaProcessor(
     IFormsRepository formsRepository,
     IFormSchemaRepository schemaRepository,
     IFlattenedSubmissionRepository flattenedSubmissionRepository,
+    IReportingUnitOfWork unitOfWork,
     AppDbContext appDbContext,
     FormSchemaCompiler compiler,
     ILogger<FormSchemaProcessor> logger) : IFormSchemaProcessor
@@ -104,8 +105,26 @@ internal sealed class FormSchemaProcessor(
             definitionJson,
             mode: FormSchemaCompileMode.Replace);
 
-        await PersistAsync(tenantId, formId, formDefinitionId, existingSchema, compiled, cancellationToken);
-        await flattenedSubmissionRepository.DeleteByFormIdAsync(tenantId, formId, cancellationToken);
+        await unitOfWork.BeginTransactionAsync(cancellationToken);
+        try
+        {
+            await PersistAsync(tenantId, formId, formDefinitionId, existingSchema, compiled, cancellationToken);
+
+            // Count lives on App DB and cannot join this Reporting transaction; re-check
+            // immediately before delete so a concurrent first real submission is not wiped.
+            var realSubmissionCount = await CountRealSubmissionsAsync(tenantId, formId, cancellationToken);
+            if (realSubmissionCount == 0)
+            {
+                await flattenedSubmissionRepository.DeleteByFormIdAsync(tenantId, formId, cancellationToken);
+            }
+
+            await unitOfWork.CommitTransactionAsync(cancellationToken);
+        }
+        catch
+        {
+            await unitOfWork.RollbackTransactionAsync(cancellationToken);
+            throw;
+        }
     }
 
     private async Task MergeAsync(

--- a/src/Endatix.Modules.Reporting/Features/FormSchema/FormSchemaProcessor.cs
+++ b/src/Endatix.Modules.Reporting/Features/FormSchema/FormSchemaProcessor.cs
@@ -1,18 +1,22 @@
 using Endatix.Core.Abstractions.Repositories;
-using Endatix.Core.Entities;
+using Endatix.Infrastructure.Data;
 using Endatix.Modules.Reporting.Data;
-using Endatix.Modules.Reporting.Domain;
 using Endatix.Modules.Reporting.Features.FormSchema.FormSchema;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using FormSchemaEntity = Endatix.Modules.Reporting.Domain.FormSchema;
 
 namespace Endatix.Modules.Reporting.Features.FormSchema;
 
 /// <summary>
 /// Compiles and persists the export schema for a form definition.
+/// Uses replace mode when the form has no real (non-test) submissions; otherwise merge.
 /// </summary>
 internal sealed class FormSchemaProcessor(
     IFormsRepository formsRepository,
     IFormSchemaRepository schemaRepository,
+    IFlattenedSubmissionRepository flattenedSubmissionRepository,
+    AppDbContext appDbContext,
     FormSchemaCompiler compiler,
     ILogger<FormSchemaProcessor> logger) : IFormSchemaProcessor
 {
@@ -43,41 +47,42 @@ internal sealed class FormSchemaProcessor(
 
         try
         {
-            var existingSchema = await schemaRepository.GetByFormIdAsync(tenantId, formId, cancellationToken);
-            var compiled = compiler.CompilePersisted(
-                formDefinition.JsonData,
-                existingSchema?.FlatteningMap,
-                existingSchema?.Codebook);
+            var existingSchema = await schemaRepository.GetByFormIdAsync(
+                tenantId,
+                formId,
+                cancellationToken);
+            var realSubmissionCount = await CountRealSubmissionsAsync(tenantId, formId, cancellationToken);
+            var compileMode = realSubmissionCount == 0
+                ? FormSchemaCompileMode.Replace
+                : FormSchemaCompileMode.Merge;
 
-            var revision = existingSchema is null
-                ? formDefinitionId
-                : Math.Max(existingSchema.FormDefinitionRevision, formDefinitionId);
-
-            if (existingSchema is null)
+            if (compileMode == FormSchemaCompileMode.Replace)
             {
-                existingSchema = new Domain.FormSchema(
+                await ReplaceAsync(
                     tenantId,
                     formId,
-                    revision,
-                    compiled.FlatteningMapJson,
-                    compiled.CodebookJson,
-                    compiled.LocalesJson);
+                    formDefinitionId,
+                    formDefinition.JsonData,
+                    existingSchema,
+                    cancellationToken);
             }
             else
             {
-                existingSchema.UpdateSchema(
-                    revision,
-                    compiled.FlatteningMapJson,
-                    compiled.CodebookJson,
-                    compiled.LocalesJson);
+                await MergeAsync(
+                    tenantId,
+                    formId,
+                    formDefinitionId,
+                    formDefinition.JsonData,
+                    existingSchema,
+                    cancellationToken);
             }
 
-            await schemaRepository.SaveAsync(existingSchema, cancellationToken);
-
             logger.LogInformation(
-                "Compiled form schema for form {FormId} (definition {FormDefinitionId})",
+                "Compiled form schema for form {FormId} (definition {FormDefinitionId}, compileMode={CompileMode}, realSubmissionCount={RealSubmissionCount})",
                 formId,
-                formDefinitionId);
+                formDefinitionId,
+                compileMode,
+                realSubmissionCount);
         }
         catch (SchemaCompilationLimitExceededException ex)
         {
@@ -86,4 +91,83 @@ internal sealed class FormSchemaProcessor(
                 ex);
         }
     }
+
+    private async Task ReplaceAsync(
+        long tenantId,
+        long formId,
+        long formDefinitionId,
+        string definitionJson,
+        FormSchemaEntity? existingSchema,
+        CancellationToken cancellationToken)
+    {
+        var compiled = compiler.CompilePersisted(
+            definitionJson,
+            mode: FormSchemaCompileMode.Replace);
+
+        await PersistAsync(tenantId, formId, formDefinitionId, existingSchema, compiled, cancellationToken);
+        await flattenedSubmissionRepository.DeleteByFormIdAsync(tenantId, formId, cancellationToken);
+    }
+
+    private async Task MergeAsync(
+        long tenantId,
+        long formId,
+        long formDefinitionId,
+        string definitionJson,
+        FormSchemaEntity? existingSchema,
+        CancellationToken cancellationToken)
+    {
+        var compiled = compiler.CompilePersisted(
+            definitionJson,
+            existingSchema?.FlatteningMap,
+            existingSchema?.Codebook,
+            FormSchemaCompileMode.Merge);
+
+        await PersistAsync(tenantId, formId, formDefinitionId, existingSchema, compiled, cancellationToken);
+    }
+
+    private async Task PersistAsync(
+        long tenantId,
+        long formId,
+        long formDefinitionId,
+        FormSchemaEntity? existingSchema,
+        FormSchemaCompileResult compiled,
+        CancellationToken cancellationToken)
+    {
+        var revision = existingSchema is null
+            ? formDefinitionId
+            : Math.Max(existingSchema.FormDefinitionRevision, formDefinitionId);
+
+        if (existingSchema is null)
+        {
+            existingSchema = new FormSchemaEntity(
+                tenantId,
+                formId,
+                revision,
+                compiled.FlatteningMapJson,
+                compiled.CodebookJson,
+                compiled.LocalesJson);
+        }
+        else
+        {
+            existingSchema.UpdateSchema(
+                revision,
+                compiled.FlatteningMapJson,
+                compiled.CodebookJson,
+                compiled.LocalesJson);
+        }
+
+        await schemaRepository.SaveAsync(existingSchema, cancellationToken);
+    }
+
+    private Task<int> CountRealSubmissionsAsync(
+        long tenantId,
+        long formId,
+        CancellationToken cancellationToken) =>
+        appDbContext.Submissions
+            .AsNoTracking()
+            .CountAsync(
+                submission => submission.TenantId == tenantId &&
+                              submission.FormId == formId &&
+                              !submission.IsTestSubmission,
+                cancellationToken);
 }

--- a/src/Endatix.Modules.Reporting/README.md
+++ b/src/Endatix.Modules.Reporting/README.md
@@ -17,10 +17,21 @@ Database schema: `reporting`
 
 | Table | Purpose |
 |-------|---------|
-| `FormSchemas` | Append-only compiled form schema (`FlatteningMap` + `Codebook`) per tenant + form |
+| `FormSchemas` | Compiled form schema (`FlatteningMap` + `Codebook`) per tenant + form |
 | `FlattenedSubmissions` | Flat submission answers aligned to form schema |
 | `ExportFormats` | Export delivery configuration (CSV, JSON, codebook) |
 | `SurveyTypeExportMappings` | Allowed export formats per survey type (with optional default and tenant fallback) |
+
+### FormSchema compile modes
+
+On every compile path (outbox `form.definition.updated`, manual `POST .../reporting/compile-schema`, lazy provider compile):
+
+| Mode | When | Behavior |
+|------|------|----------|
+| **Replace** | Form has **0 real** submissions (`IsTestSubmission == false`) | Rebuild FlatteningMap + Codebook from the current definition only. After save, hard-delete that form’s `FlattenedSubmissions` rows (test flatten debris). |
+| **Merge** | Form has **≥1 real** submission | Append-only merge: retain historical columns, questions, and choice-catalog values. |
+
+Test submissions alone do **not** force merge. This is a defensive bridge until Form Publish makes publish the controlled compile moment.
 
 ## Registration
 

--- a/src/Endatix.Modules.Reporting/README.md
+++ b/src/Endatix.Modules.Reporting/README.md
@@ -24,7 +24,7 @@ Database schema: `reporting`
 
 ### FormSchema compile modes
 
-On every compile path (outbox `form.definition.updated`, manual `POST .../reporting/compile-schema`, lazy provider compile):
+On every compile path (outbox `form.definition.updated`, manual `POST .../reporting/compile-schema`):
 
 | Mode | When | Behavior |
 |------|------|----------|

--- a/tests/Endatix.IntegrationTests/Infrastructure/FlattenedSubmissionRepositoryTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/FlattenedSubmissionRepositoryTests.cs
@@ -149,6 +149,54 @@ public sealed class FlattenedSubmissionRepositoryTests
         filtered.Should().BeNull("deleted rows are excluded by the global IsDeleted query filter");
     }
 
+    [Fact]
+    public async Task DeleteByFormIdAsync_RemovesAllRowsForFormIncludingSoftDeleted()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        await ResetReportingSchemaAsync(cancellationToken);
+
+        await using ReportingDbContext dbContext = CreateContext(TenantId);
+        FlattenedSubmissionRepository repository = CreateRepository(dbContext);
+
+        FlattenedSubmission active = await repository.GetOrCreateAsync(
+            TenantId,
+            SubmissionId,
+            FormId,
+            cancellationToken);
+        active.MarkProcessed(ProcessedDataJson);
+        await repository.SaveAsync(active, cancellationToken);
+
+        FlattenedSubmission softDeleted = await repository.GetOrCreateAsync(
+            TenantId,
+            SubmissionId + 1,
+            FormId,
+            cancellationToken);
+        softDeleted.MarkDeleted();
+        await repository.SaveAsync(softDeleted, cancellationToken);
+
+        FlattenedSubmission otherForm = await repository.GetOrCreateAsync(
+            TenantId,
+            SubmissionId + 2,
+            formId: FormId + 1,
+            cancellationToken);
+        await repository.SaveAsync(otherForm, cancellationToken);
+
+        // Act
+        int deleted = await repository.DeleteByFormIdAsync(TenantId, FormId, cancellationToken);
+
+        // Assert
+        deleted.Should().Be(2);
+        (await dbContext.FlattenedSubmissions
+                .IgnoreQueryFilters()
+                .CountAsync(row => row.TenantId == TenantId && row.FormId == FormId, cancellationToken))
+            .Should().Be(0);
+        (await dbContext.FlattenedSubmissions
+                .IgnoreQueryFilters()
+                .CountAsync(row => row.SubmissionId == SubmissionId + 2, cancellationToken))
+            .Should().Be(1);
+    }
+
     private async Task ResetReportingSchemaAsync(CancellationToken cancellationToken)
     {
         await _fixture.Checkpoint.ResetAsync(_fixture.ConnectionString, _fixture.Provider, cancellationToken);

--- a/tests/Endatix.IntegrationTests/Infrastructure/FormSchemaProcessorReplaceMergeIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/FormSchemaProcessorReplaceMergeIntegrationTests.cs
@@ -1,0 +1,301 @@
+using Endatix.Core.Abstractions;
+using Endatix.Core.Abstractions.Repositories;
+using Endatix.Core.Entities;
+using Endatix.Infrastructure.Data;
+using Endatix.Infrastructure.Features.Outbox;
+using Endatix.IntegrationTests.Shared;
+using Endatix.Modules.Reporting.Data;
+using Endatix.Modules.Reporting.Domain;
+using Endatix.Modules.Reporting.Features.FormSchema;
+using Endatix.Modules.Reporting.Features.FormSchema.FormSchema;
+using Endatix.Modules.Reporting.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Endatix.IntegrationTests;
+
+/// <summary>
+/// PostgreSQL coverage for FormSchema replace vs merge gate (#892).
+/// </summary>
+[Collection(nameof(DbIntegrationTestCollection))]
+[Trait("Category", "Infrastructure")]
+[Trait("Priority", "P1")]
+[Trait("DbSpecific", "PostgreSql")]
+public sealed class FormSchemaProcessorReplaceMergeIntegrationTests
+{
+    private const long TenantId = 51;
+    private const long OtherFormFlattenedSubmissionId = 9001;
+
+    private static readonly string DefinitionWithOrphan = """
+        {
+          "pages": [
+            {
+              "name": "p1",
+              "elements": [
+                { "type": "text", "name": "orphan", "title": "Orphan" },
+                { "type": "text", "name": "keep", "title": "Keep" }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private static readonly string DefinitionWithoutOrphan = """
+        {
+          "pages": [
+            {
+              "name": "p1",
+              "elements": [
+                { "type": "text", "name": "keep", "title": "Keep" }
+              ]
+            }
+          ]
+        }
+        """;
+
+    private readonly DbIntegrationFixture _fixture;
+
+    public FormSchemaProcessorReplaceMergeIntegrationTests(DbIntegrationFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithZeroRealSubmissions_ReplacesSchemaAndDeletesFlattenedRows()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SeededForm seed = await SeedFormAsync(seedRealSubmission: false, seedTestSubmission: false, cancellationToken);
+        await SeedReportingStateWithOrphanAsync(seed, cancellationToken);
+
+        FormDefinition currentDefinition = new(TenantId, jsonData: DefinitionWithoutOrphan) { Id = seed.FormDefinitionId };
+        IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
+        formsRepository
+            .SingleOrDefaultAsync(Arg.Any<DefinitionByFormAndDefinitionIdSpec>(), cancellationToken)
+            .Returns(currentDefinition);
+
+        await using ReportingDbContext reportingDb = CreateReportingDbContext();
+        await using AppDbContext appDb = CreateAppDbContext();
+        FormSchemaProcessor processor = CreateProcessor(formsRepository, reportingDb, appDb);
+
+        // Act
+        await processor.ProcessAsync(TenantId, seed.FormId, seed.FormDefinitionId, cancellationToken);
+
+        // Assert
+        reportingDb.ChangeTracker.Clear();
+        FormSchema? schema = await reportingDb.FormSchemas
+            .SingleOrDefaultAsync(row => row.TenantId == TenantId && row.FormId == seed.FormId, cancellationToken);
+        schema.Should().NotBeNull();
+        schema!.FlatteningMap.Should().Contain("keep");
+        schema.FlatteningMap.Should().NotContain("orphan");
+        schema.Codebook.Should().Contain("keep");
+        schema.Codebook.Should().NotContain("\"orphan\"");
+
+        int flattenedForForm = await reportingDb.FlattenedSubmissions
+            .IgnoreQueryFilters()
+            .CountAsync(row => row.TenantId == TenantId && row.FormId == seed.FormId, cancellationToken);
+        flattenedForForm.Should().Be(0);
+
+        // Other form's flattened row must remain
+        int otherFormRows = await reportingDb.FlattenedSubmissions
+            .IgnoreQueryFilters()
+            .CountAsync(row => row.SubmissionId == OtherFormFlattenedSubmissionId, cancellationToken);
+        otherFormRows.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithOnlyTestSubmissions_ReplacesSchemaAndDeletesFlattenedRows()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SeededForm seed = await SeedFormAsync(seedRealSubmission: false, seedTestSubmission: true, cancellationToken);
+        await SeedReportingStateWithOrphanAsync(seed, cancellationToken);
+
+        FormDefinition currentDefinition = new(TenantId, jsonData: DefinitionWithoutOrphan) { Id = seed.FormDefinitionId };
+        IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
+        formsRepository
+            .SingleOrDefaultAsync(Arg.Any<DefinitionByFormAndDefinitionIdSpec>(), cancellationToken)
+            .Returns(currentDefinition);
+
+        await using ReportingDbContext reportingDb = CreateReportingDbContext();
+        await using AppDbContext appDb = CreateAppDbContext();
+        FormSchemaProcessor processor = CreateProcessor(formsRepository, reportingDb, appDb);
+
+        // Act
+        await processor.ProcessAsync(TenantId, seed.FormId, seed.FormDefinitionId, cancellationToken);
+
+        // Assert
+        reportingDb.ChangeTracker.Clear();
+        FormSchema schema = await reportingDb.FormSchemas
+            .SingleAsync(row => row.TenantId == TenantId && row.FormId == seed.FormId, cancellationToken);
+        schema.FlatteningMap.Should().Contain("keep");
+        schema.FlatteningMap.Should().NotContain("orphan");
+
+        int flattenedForForm = await reportingDb.FlattenedSubmissions
+            .IgnoreQueryFilters()
+            .CountAsync(row => row.TenantId == TenantId && row.FormId == seed.FormId, cancellationToken);
+        flattenedForForm.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithRealSubmission_MergesAndKeepsFlattenedRows()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SeededForm seed = await SeedFormAsync(seedRealSubmission: true, seedTestSubmission: false, cancellationToken);
+        await SeedReportingStateWithOrphanAsync(seed, cancellationToken);
+
+        FormDefinition currentDefinition = new(TenantId, jsonData: DefinitionWithoutOrphan) { Id = seed.FormDefinitionId };
+        IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
+        formsRepository
+            .SingleOrDefaultAsync(Arg.Any<DefinitionByFormAndDefinitionIdSpec>(), cancellationToken)
+            .Returns(currentDefinition);
+
+        await using ReportingDbContext reportingDb = CreateReportingDbContext();
+        await using AppDbContext appDb = CreateAppDbContext();
+        FormSchemaProcessor processor = CreateProcessor(formsRepository, reportingDb, appDb);
+
+        // Act
+        await processor.ProcessAsync(TenantId, seed.FormId, seed.FormDefinitionId, cancellationToken);
+
+        // Assert
+        reportingDb.ChangeTracker.Clear();
+        FormSchema schema = await reportingDb.FormSchemas
+            .SingleAsync(row => row.TenantId == TenantId && row.FormId == seed.FormId, cancellationToken);
+        schema.FlatteningMap.Should().Contain("orphan");
+        schema.FlatteningMap.Should().Contain("keep");
+
+        int flattenedForForm = await reportingDb.FlattenedSubmissions
+            .IgnoreQueryFilters()
+            .CountAsync(row => row.TenantId == TenantId && row.FormId == seed.FormId, cancellationToken);
+        flattenedForForm.Should().Be(1);
+    }
+
+    private async Task<SeededForm> SeedFormAsync(
+        bool seedRealSubmission,
+        bool seedTestSubmission,
+        CancellationToken cancellationToken)
+    {
+        await _fixture.Checkpoint.ResetAsync(_fixture.ConnectionString, _fixture.Provider, cancellationToken);
+        await ReportingTestSchema.EnsureMigratedAsync(_fixture.ConnectionString, _fixture.Provider, cancellationToken);
+
+        await using AppDbContext appDb = CreateAppDbContext();
+        Tenant tenant = new("form-schema-replace-tenant") { Id = TenantId };
+        appDb.Set<Tenant>().Add(tenant);
+        await appDb.SaveChangesAsync(cancellationToken);
+
+        Form form = new(TenantId, "Replace/merge form");
+        appDb.Forms.Add(form);
+        await appDb.SaveChangesAsync(cancellationToken);
+
+        FormDefinition definition = new(TenantId, isDraft: false, jsonData: DefinitionWithOrphan);
+        form.AddFormDefinition(definition);
+        appDb.Set<FormDefinition>().Add(definition);
+        await appDb.SaveChangesAsync(cancellationToken);
+
+        long formId = form.Id;
+        long formDefinitionId = definition.Id;
+
+        if (seedRealSubmission)
+        {
+            await SeedSubmissionAsync(appDb, formId, formDefinitionId, isTest: false, cancellationToken);
+        }
+
+        if (seedTestSubmission)
+        {
+            await SeedSubmissionAsync(appDb, formId, formDefinitionId, isTest: true, cancellationToken);
+        }
+
+        return new SeededForm(formId, formDefinitionId);
+    }
+
+    private async Task SeedReportingStateWithOrphanAsync(SeededForm seed, CancellationToken cancellationToken)
+    {
+        FormSchemaCompiler compiler = new();
+        FormSchemaCompileResult compiled = compiler.CompilePersisted(DefinitionWithOrphan);
+
+        await using ReportingDbContext reportingDb = CreateReportingDbContext();
+        FormSchema schema = new(
+            TenantId,
+            seed.FormId,
+            seed.FormDefinitionId,
+            compiled.FlatteningMapJson,
+            compiled.CodebookJson,
+            compiled.LocalesJson);
+        reportingDb.FormSchemas.Add(schema);
+
+        FlattenedSubmission formRow = new(submissionId: seed.FormId + 1000, TenantId, seed.FormId);
+        formRow.MarkProcessed("""{"keep":"x"}""");
+        reportingDb.FlattenedSubmissions.Add(formRow);
+
+        FlattenedSubmission otherFormRow = new(OtherFormFlattenedSubmissionId, TenantId, formId: seed.FormId + 99);
+        otherFormRow.MarkProcessed("""{"other":true}""");
+        reportingDb.FlattenedSubmissions.Add(otherFormRow);
+
+        await reportingDb.SaveChangesAsync(cancellationToken);
+    }
+
+    private static async Task SeedSubmissionAsync(
+        AppDbContext appDb,
+        long formId,
+        long formDefinitionId,
+        bool isTest,
+        CancellationToken cancellationToken)
+    {
+        Submission submission = Submission.Create(new SubmissionCreateArgs(
+            TenantId: TenantId,
+            FormId: formId,
+            FormDefinitionId: formDefinitionId,
+            JsonData: """{"keep":"x"}""",
+            IsComplete: true,
+            IsTestSubmission: isTest));
+        appDb.Submissions.Add(submission);
+        await appDb.SaveChangesAsync(cancellationToken);
+        appDb.ChangeTracker.Clear();
+    }
+
+    private static FormSchemaProcessor CreateProcessor(
+        IFormsRepository formsRepository,
+        ReportingDbContext reportingDb,
+        AppDbContext appDb)
+    {
+        ReportingUnitOfWork unitOfWork = new(reportingDb);
+        return new FormSchemaProcessor(
+            formsRepository,
+            new FormSchemaRepository(reportingDb, unitOfWork),
+            new FlattenedSubmissionRepository(reportingDb, unitOfWork),
+            appDb,
+            new FormSchemaCompiler(),
+            NullLogger<FormSchemaProcessor>.Instance);
+    }
+
+    private AppDbContext CreateAppDbContext()
+    {
+        ITenantContext tenantContext = Substitute.For<ITenantContext>();
+        tenantContext.TenantId.Returns(TenantId);
+
+        IncrementingIdGenerator idGenerator = new();
+        DbContextOptionsBuilder<AppDbContext> optionsBuilder = new();
+        IntegrationAppDbContextFactory.ConfigurePostgreSqlOptions(optionsBuilder, _fixture.ConnectionString);
+
+        return new AppDbContext(
+            optionsBuilder.Options,
+            idGenerator,
+            tenantContext,
+            new EfCoreValueGeneratorFactory(idGenerator),
+            new OutboxIntegrationEventDispatcher());
+    }
+
+    private ReportingDbContext CreateReportingDbContext()
+    {
+        ITenantContext tenantContext = Substitute.For<ITenantContext>();
+        tenantContext.TenantId.Returns(TenantId);
+
+        DbContextOptionsBuilder<ReportingDbContext> optionsBuilder =
+            ReportingTestSchema.ConfigureOptionsBuilder(_fixture.ConnectionString);
+
+        return new ReportingDbContext(optionsBuilder.Options, new IncrementingIdGenerator(), tenantContext);
+    }
+
+    private sealed record SeededForm(long FormId, long FormDefinitionId);
+}

--- a/tests/Endatix.IntegrationTests/Infrastructure/FormSchemaProcessorReplaceMergeIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/FormSchemaProcessorReplaceMergeIntegrationTests.cs
@@ -264,6 +264,7 @@ public sealed class FormSchemaProcessorReplaceMergeIntegrationTests
             formsRepository,
             new FormSchemaRepository(reportingDb, unitOfWork),
             new FlattenedSubmissionRepository(reportingDb, unitOfWork),
+            unitOfWork,
             appDb,
             new FormSchemaCompiler(),
             NullLogger<FormSchemaProcessor>.Instance);

--- a/tests/Endatix.IntegrationTests/Infrastructure/FormSchemaProviderIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/FormSchemaProviderIntegrationTests.cs
@@ -2,6 +2,8 @@ using System.Text.Json.Nodes;
 using Endatix.Core.Abstractions;
 using Endatix.Core.Abstractions.Repositories;
 using Endatix.Core.Entities;
+using Endatix.Infrastructure.Data;
+using Endatix.Infrastructure.Features.Outbox;
 using Endatix.IntegrationTests.Shared;
 using Endatix.Modules.Reporting.Data;
 using Endatix.Modules.Reporting.Domain;
@@ -42,13 +44,10 @@ public sealed class FormSchemaProviderIntegrationTests
             .SingleOrDefaultAsync(Arg.Any<DefinitionByFormAndDefinitionIdSpec>(), cancellationToken)
             .Returns(CreateFormDefinition());
 
-        await using ReportingDbContext dbContext = CreateContext(TenantId);
+        await using ReportingDbContext dbContext = CreateReportingContext(TenantId);
+        await using AppDbContext appDbContext = CreateAppDbContext();
         FormSchemaRepository schemaRepository = CreateSchemaRepository(dbContext);
-        FormSchemaProcessor schemaProcessor = new(
-            formsRepository,
-            schemaRepository,
-            new FormSchemaCompiler(),
-            NullLogger<FormSchemaProcessor>.Instance);
+        FormSchemaProcessor schemaProcessor = CreateProcessor(formsRepository, schemaRepository, appDbContext);
         FormSchemaProvider provider = new(schemaRepository, schemaProcessor);
 
         FormSchema? result = await provider.GetOrCompileAsync(
@@ -83,13 +82,10 @@ public sealed class FormSchemaProviderIntegrationTests
             .SingleOrDefaultAsync(Arg.Any<DefinitionByFormAndDefinitionIdSpec>(), cancellationToken)
             .Returns(CreateFormDefinition());
 
-        await using ReportingDbContext dbContext = CreateContext(TenantId);
+        await using ReportingDbContext dbContext = CreateReportingContext(TenantId);
+        await using AppDbContext appDbContext = CreateAppDbContext();
         FormSchemaRepository schemaRepository = CreateSchemaRepository(dbContext);
-        FormSchemaProcessor schemaProcessor = new(
-            formsRepository,
-            schemaRepository,
-            new FormSchemaCompiler(),
-            NullLogger<FormSchemaProcessor>.Instance);
+        FormSchemaProcessor schemaProcessor = CreateProcessor(formsRepository, schemaRepository, appDbContext);
         FormSchemaProvider provider = new(schemaRepository, schemaProcessor);
 
         FormSchema? first = await provider.GetOrCompileAsync(TenantId, FormId, FormDefinitionId, cancellationToken);
@@ -108,21 +104,54 @@ public sealed class FormSchemaProviderIntegrationTests
         await ReportingTestSchema.EnsureMigratedAsync(_fixture.ConnectionString, _fixture.Provider, cancellationToken);
     }
 
-    private ReportingDbContext CreateContext(long tenantId)
+    private ReportingDbContext CreateReportingContext(long tenantId)
     {
         ITenantContext tenantContext = Substitute.For<ITenantContext>();
         tenantContext.TenantId.Returns(tenantId);
 
-        Microsoft.EntityFrameworkCore.DbContextOptionsBuilder<ReportingDbContext> optionsBuilder =
+        DbContextOptionsBuilder<ReportingDbContext> optionsBuilder =
             ReportingTestSchema.ConfigureOptionsBuilder(_fixture.ConnectionString);
 
         return new ReportingDbContext(optionsBuilder.Options, new IncrementingIdGenerator(), tenantContext);
+    }
+
+    private AppDbContext CreateAppDbContext()
+    {
+        ITenantContext tenantContext = Substitute.For<ITenantContext>();
+        tenantContext.TenantId.Returns(TenantId);
+
+        IncrementingIdGenerator idGenerator = new();
+        DbContextOptionsBuilder<AppDbContext> optionsBuilder = new();
+        IntegrationAppDbContextFactory.ConfigurePostgreSqlOptions(optionsBuilder, _fixture.ConnectionString);
+
+        return new AppDbContext(
+            optionsBuilder.Options,
+            idGenerator,
+            tenantContext,
+            new EfCoreValueGeneratorFactory(idGenerator),
+            new OutboxIntegrationEventDispatcher());
     }
 
     private static FormSchemaRepository CreateSchemaRepository(ReportingDbContext dbContext)
     {
         ReportingUnitOfWork unitOfWork = new(dbContext);
         return new FormSchemaRepository(dbContext, unitOfWork);
+    }
+
+    private static FormSchemaProcessor CreateProcessor(
+        IFormsRepository formsRepository,
+        FormSchemaRepository schemaRepository,
+        AppDbContext appDbContext)
+    {
+        IFlattenedSubmissionRepository flattenedRepository = Substitute.For<IFlattenedSubmissionRepository>();
+
+        return new FormSchemaProcessor(
+            formsRepository,
+            schemaRepository,
+            flattenedRepository,
+            appDbContext,
+            new FormSchemaCompiler(),
+            NullLogger<FormSchemaProcessor>.Instance);
     }
 
     private static FormDefinition CreateFormDefinition()

--- a/tests/Endatix.IntegrationTests/Infrastructure/FormSchemaProviderIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/FormSchemaProviderIntegrationTests.cs
@@ -144,11 +144,13 @@ public sealed class FormSchemaProviderIntegrationTests
         AppDbContext appDbContext)
     {
         IFlattenedSubmissionRepository flattenedRepository = Substitute.For<IFlattenedSubmissionRepository>();
+        IReportingUnitOfWork unitOfWork = Substitute.For<IReportingUnitOfWork>();
 
         return new FormSchemaProcessor(
             formsRepository,
             schemaRepository,
             flattenedRepository,
+            unitOfWork,
             appDbContext,
             new FormSchemaCompiler(),
             NullLogger<FormSchemaProcessor>.Instance);

--- a/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FormSchema/FormSchemaCompilerTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FormSchema/FormSchemaCompilerTests.cs
@@ -6,6 +6,117 @@ namespace Endatix.Modules.Reporting.Tests.Features.FormSchema.FormSchema;
 public class FormSchemaCompilerTests
 {
   [Fact]
+  public void CompilePersisted_ReplaceMode_DropsHistoricalKeysAndChoices()
+  {
+    // Arrange
+    const string initialDefinition = """
+        {
+          "pages": [
+            {
+              "elements": [
+                {
+                  "type": "dropdown",
+                  "name": "qDropdown",
+                  "choices": [
+                    { "value": "axe", "text": "Axe" },
+                    { "value": "sword", "text": "Sword" },
+                    { "value": "hammer", "text": "Hammer" }
+                  ]
+                },
+                { "type": "text", "name": "orphan" }
+              ]
+            }
+          ]
+        }
+        """;
+
+    const string updatedDefinition = """
+        {
+          "pages": [
+            {
+              "elements": [
+                {
+                  "type": "dropdown",
+                  "name": "qDropdown",
+                  "choices": [
+                    { "value": "axe", "text": "Battle Axe" },
+                    { "value": "sword", "text": "Sword" }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    FormSchemaCompiler compiler = new();
+    FormSchemaCompileResult initial = compiler.CompilePersisted(initialDefinition);
+
+    // Act
+    FormSchemaCompileResult replaced = compiler.CompilePersisted(
+      updatedDefinition,
+      initial.FlatteningMapJson,
+      initial.CodebookJson,
+      FormSchemaCompileMode.Replace);
+
+    // Assert
+    replaced.FlatteningMap.Columns.Select(column => column.Key).Should().Equal("qDropdown");
+    replaced.FlatteningMapJson.Should().NotContain("orphan");
+
+    using JsonDocument codebook = JsonDocument.Parse(replaced.CodebookJson);
+    codebook.RootElement.GetProperty("questions").TryGetProperty("orphan", out _).Should().BeFalse();
+    List<JsonElement> choiceEntries = codebook.RootElement
+      .GetProperty("choiceCatalogs")
+      .GetProperty("qDropdown")
+      .GetProperty("choices")
+      .EnumerateArray()
+      .ToList();
+    choiceEntries.Should().HaveCount(2);
+    choiceEntries.Select(choice => choice.GetProperty("value").GetString()).Should().Equal("axe", "sword");
+    choiceEntries[0].GetProperty("text").GetProperty("default").GetString().Should().Be("Battle Axe");
+  }
+
+  [Fact]
+  public void CompilePersisted_MergeMode_RetainsHistoricalKeysWhenPassedExistingJson()
+  {
+    // Arrange
+    const string initialDefinition = """
+        {
+          "pages": [
+            {
+              "elements": [
+                { "type": "text", "name": "historical" }
+              ]
+            }
+          ]
+        }
+        """;
+    const string updatedDefinition = """
+        {
+          "pages": [
+            {
+              "elements": [
+                { "type": "text", "name": "current" }
+              ]
+            }
+          ]
+        }
+        """;
+    FormSchemaCompiler compiler = new();
+    FormSchemaCompileResult initial = compiler.CompilePersisted(initialDefinition);
+
+    // Act
+    FormSchemaCompileResult merged = compiler.CompilePersisted(
+      updatedDefinition,
+      initial.FlatteningMapJson,
+      initial.CodebookJson,
+      FormSchemaCompileMode.Merge);
+
+    // Assert
+    merged.FlatteningMap.Columns.Select(column => column.Key).Should().Equal("historical", "current");
+  }
+
+  [Fact]
   public void CompilePersisted_MergeChoiceCatalog_PreservesHistoricalIdsWithCurrentMetadata()
   {
     const string initialDefinition = """

--- a/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FormSchemaProcessorTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FormSchemaProcessorTests.cs
@@ -1,8 +1,7 @@
-using System.Text.Json;
 using Endatix.Core.Abstractions.Repositories;
 using Endatix.Core.Entities;
+using Endatix.Infrastructure.Data;
 using Endatix.Modules.Reporting.Data;
-using Endatix.Modules.Reporting.Domain;
 using Endatix.Modules.Reporting.Features.FormSchema;
 using Endatix.Modules.Reporting.Features.FormSchema.FormSchema;
 using FluentAssertions;
@@ -12,246 +11,36 @@ using NSubstitute;
 
 namespace Endatix.Modules.Reporting.Tests.Features.FormSchema;
 
+/// <summary>
+/// Early-exit processor cases. Replace vs merge gate + persist behavior are covered by
+/// FormSchemaCompilerTests and FormSchemaProcessorReplaceMergeIntegrationTests (real AppDbContext).
+/// </summary>
 public class FormSchemaProcessorTests
 {
   private const long TenantId = 1;
   private const long FormId = 100;
   private const long FormDefinitionId = 200;
-  private const long HistoricalFormDefinitionId = 100;
-
-  [Fact]
-  public async Task FormSchemaProcessor_ProcessAsync_WithNoExistingSchema_CreatesAndPersistsSchema()
-  {
-    IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
-    IFormSchemaRepository schemaRepository = Substitute.For<IFormSchemaRepository>();
-    FormDefinition definition = CreateFormDefinition(
-        FormDefinitionId,
-        """{"pages":[{"name":"p1","elements":[{"type":"text","name":"q1"}]}]}""");
-    formsRepository.SingleOrDefaultAsync(Arg.Any<DefinitionByFormAndDefinitionIdSpec>(), Arg.Any<CancellationToken>())
-        .Returns(definition);
-    schemaRepository.GetByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>())
-        .Returns((FormSchemaEntity?)null);
-
-    FormSchemaProcessor processor = new(
-        formsRepository,
-        schemaRepository,
-        new FormSchemaCompiler(),
-        NullLogger<FormSchemaProcessor>.Instance);
-
-    await processor.ProcessAsync(TenantId, FormId, FormDefinitionId, TestContext.Current.CancellationToken);
-
-    await schemaRepository.Received(1).SaveAsync(
-        Arg.Is<FormSchemaEntity>(schema =>
-            schema.TenantId == TenantId &&
-            schema.FormId == FormId &&
-            schema.FormDefinitionRevision == FormDefinitionId &&
-            schema.FlatteningMap.Contains("q1") &&
-            schema.Codebook.Contains("version") &&
-            schema.Locales.Contains("default")),
-        Arg.Any<CancellationToken>());
-  }
-
-  [Fact]
-  public async Task FormSchemaProcessor_ProcessAsync_WithLocalizedTitles_ReplacesLocalesOnUpdate()
-  {
-    IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
-    IFormSchemaRepository schemaRepository = Substitute.For<IFormSchemaRepository>();
-    FormDefinition definitionWithEs = CreateFormDefinition(
-        FormDefinitionId,
-        """
-            {
-              "pages": [
-                {
-                  "name": "p1",
-                  "elements": [
-                    {
-                      "type": "text",
-                      "name": "q1",
-                      "title": { "default": "Name", "es": "Nombre", "en": "Name" }
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-    FormSchemaEntity existing = new(
-        TenantId,
-        FormId,
-        FormDefinitionId,
-        FormSchemaEntity.EmptyFlatteningMapJson,
-        FormSchemaEntity.EmptyCodebookJson,
-        """["default","es","fr"]""");
-    formsRepository.SingleOrDefaultAsync(Arg.Any<DefinitionByFormAndDefinitionIdSpec>(), Arg.Any<CancellationToken>())
-        .Returns(definitionWithEs);
-    schemaRepository.GetByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>())
-        .Returns(existing);
-
-    FormSchemaProcessor processor = new(
-        formsRepository,
-        schemaRepository,
-        new FormSchemaCompiler(),
-        NullLogger<FormSchemaProcessor>.Instance);
-
-    await processor.ProcessAsync(TenantId, FormId, FormDefinitionId, TestContext.Current.CancellationToken);
-
-    existing.Locales.Should().Contain("default");
-    existing.Locales.Should().Contain("es");
-    existing.Locales.Should().Contain("en");
-    existing.Locales.Should().NotContain("fr");
-    await schemaRepository.Received(1).SaveAsync(existing, Arg.Any<CancellationToken>());
-  }
-
-  [Fact]
-  public async Task FormSchemaProcessor_ProcessAsync_WithExistingSchema_UpdatesPersistedSchema()
-  {
-    IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
-    IFormSchemaRepository schemaRepository = Substitute.For<IFormSchemaRepository>();
-    FormDefinition definition = CreateFormDefinition(
-        FormDefinitionId,
-        """{"pages":[{"name":"p1","elements":[{"type":"text","name":"q2"}]}]}""");
-    FormSchemaEntity existing = new(
-        TenantId,
-        FormId,
-        FormDefinitionId,
-        FormSchemaEntity.EmptyFlatteningMapJson,
-        FormSchemaEntity.EmptyCodebookJson);
-    formsRepository.SingleOrDefaultAsync(Arg.Any<DefinitionByFormAndDefinitionIdSpec>(), Arg.Any<CancellationToken>())
-        .Returns(definition);
-    schemaRepository.GetByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>())
-        .Returns(existing);
-
-    FormSchemaProcessor processor = new(
-        formsRepository,
-        schemaRepository,
-        new FormSchemaCompiler(),
-        NullLogger<FormSchemaProcessor>.Instance);
-
-    await processor.ProcessAsync(TenantId, FormId, FormDefinitionId, TestContext.Current.CancellationToken);
-
-    existing.FlatteningMap.Should().Contain("q2");
-    existing.Codebook.Should().Contain("version");
-    await schemaRepository.Received(1).SaveAsync(existing, Arg.Any<CancellationToken>());
-  }
-
-  [Fact]
-  public async Task FormSchemaProcessor_ProcessAsync_WithHistoricalDefinition_MergesIntoExistingSchemaWithoutRollingBackRevision()
-  {
-    // Arrange
-    IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
-    IFormSchemaRepository schemaRepository = Substitute.For<IFormSchemaRepository>();
-    FormDefinition historicalDefinition = CreateFormDefinition(
-        HistoricalFormDefinitionId,
-        """
-            {
-              "pages": [
-                {
-                  "name": "p1",
-                  "elements": [
-                    { "type": "text", "name": "q1", "title": "Question 1" }
-                  ]
-                }
-              ]
-            }
-            """);
-    FormSchemaCompiler compiler = new();
-    FormSchemaCompileResult existingCompiled = compiler.CompilePersisted(
-        """
-            {
-              "pages": [
-                {
-                  "name": "p1",
-                  "elements": [
-                    {
-                      "type": "checkbox",
-                      "name": "q2",
-                      "title": "Favorite colors",
-                      "choices": [
-                        { "value": "red", "text": "Red" },
-                        { "value": "blue", "text": "Blue" }
-                      ]
-                    },
-                    {
-                      "type": "matrixdropdown",
-                      "name": "q3",
-                      "title": "Team ratings",
-                      "columns": [
-                        { "name": "score", "title": "Score" }
-                      ],
-                      "choices": [1, 2, 3],
-                      "rows": [
-                        { "value": "alice", "text": "Alice" }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
-            """);
-    FormSchemaEntity existing = new(
-        TenantId,
-        FormId,
-        FormDefinitionId,
-        existingCompiled.FlatteningMapJson,
-        existingCompiled.CodebookJson);
-    formsRepository.SingleOrDefaultAsync(Arg.Any<DefinitionByFormAndDefinitionIdSpec>(), Arg.Any<CancellationToken>())
-        .Returns(historicalDefinition);
-    schemaRepository.GetByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>())
-        .Returns(existing);
-
-    FormSchemaProcessor processor = new(
-        formsRepository,
-        schemaRepository,
-        compiler,
-        NullLogger<FormSchemaProcessor>.Instance);
-
-    // Act
-    await processor.ProcessAsync(TenantId, FormId, HistoricalFormDefinitionId, TestContext.Current.CancellationToken);
-
-    // Assert
-    existing.FormDefinitionRevision.Should().Be(FormDefinitionId);
-    existing.FlatteningMap.Should().Contain("q1");
-    existing.FlatteningMap.Should().Contain("q2__red");
-    existing.FlatteningMap.Should().Contain("q3__alice__score");
-    await schemaRepository.Received(1).SaveAsync(existing, Arg.Any<CancellationToken>());
-
-    using JsonDocument codebook = JsonDocument.Parse(existing.Codebook);
-    JsonElement columns = codebook.RootElement.GetProperty("columns");
-
-    JsonElement redColumn = columns.GetProperty("q2__red");
-    redColumn.GetProperty("surveyJsType").GetString().Should().Be("checkbox");
-    redColumn.GetProperty("exportShape").GetString().Should().Be("multiple_response");
-    redColumn.GetProperty("choiceValue").GetString().Should().Be("red");
-    redColumn.GetProperty("choiceLabel").GetProperty("default").GetString().Should().Be("Red");
-    redColumn.GetProperty("title").GetProperty("default").GetString().Should().Be("Favorite colors");
-
-    JsonElement matrixCellColumn = columns.GetProperty("q3__alice__score");
-    matrixCellColumn.GetProperty("surveyJsType").GetString().Should().Be("matrixdropdown");
-    matrixCellColumn.GetProperty("exportShape").GetString().Should().Be("matrix_cell");
-    matrixCellColumn.GetProperty("matrixRowValue").GetString().Should().Be("alice");
-    matrixCellColumn.GetProperty("matrixColumnValue").GetString().Should().Be("score");
-    matrixCellColumn.GetProperty("rowLabel").GetProperty("default").GetString().Should().Be("Alice");
-    matrixCellColumn.GetProperty("columnLabel").GetProperty("default").GetString().Should().Be("Score");
-    matrixCellColumn.GetProperty("title").GetProperty("default").GetString().Should().Be("Team ratings");
-  }
 
   [Fact]
   public async Task FormSchemaProcessor_ProcessAsync_WithMissingDefinition_DoesNotPersistSchema()
   {
     IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
     IFormSchemaRepository schemaRepository = Substitute.For<IFormSchemaRepository>();
+    IFlattenedSubmissionRepository flattenedRepository = Substitute.For<IFlattenedSubmissionRepository>();
     formsRepository.SingleOrDefaultAsync(Arg.Any<DefinitionByFormAndDefinitionIdSpec>(), Arg.Any<CancellationToken>())
         .Returns((FormDefinition?)null);
 
-    FormSchemaProcessor processor = new(
+    FormSchemaProcessor processor = CreateProcessor(
         formsRepository,
         schemaRepository,
-        new FormSchemaCompiler(),
-        NullLogger<FormSchemaProcessor>.Instance);
+        flattenedRepository);
 
     await processor.ProcessAsync(TenantId, FormId, formDefinitionId: 999, TestContext.Current.CancellationToken);
 
     await schemaRepository.DidNotReceive().GetByFormIdAsync(Arg.Any<long>(), Arg.Any<long>(), Arg.Any<CancellationToken>());
     await schemaRepository.DidNotReceive().SaveAsync(Arg.Any<FormSchemaEntity>(), Arg.Any<CancellationToken>());
+    await flattenedRepository.DidNotReceive()
+        .DeleteByFormIdAsync(Arg.Any<long>(), Arg.Any<long>(), Arg.Any<CancellationToken>());
   }
 
   [Fact]
@@ -259,18 +48,15 @@ public class FormSchemaProcessorTests
   {
     IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
     IFormSchemaRepository schemaRepository = Substitute.For<IFormSchemaRepository>();
-    FormDefinition definition = CreateFormDefinition(
-        FormDefinitionId,
-        """{"pages":[]}""",
-        tenantId: 2);
+    IFlattenedSubmissionRepository flattenedRepository = Substitute.For<IFlattenedSubmissionRepository>();
+    FormDefinition definition = new(tenantId: 2, jsonData: """{"pages":[]}""") { Id = FormDefinitionId };
     formsRepository.SingleOrDefaultAsync(Arg.Any<DefinitionByFormAndDefinitionIdSpec>(), Arg.Any<CancellationToken>())
         .Returns(definition);
 
-    FormSchemaProcessor processor = new(
+    FormSchemaProcessor processor = CreateProcessor(
         formsRepository,
         schemaRepository,
-        new FormSchemaCompiler(),
-        NullLogger<FormSchemaProcessor>.Instance);
+        flattenedRepository);
 
     Func<Task> act = () => processor.ProcessAsync(TenantId, FormId, FormDefinitionId, TestContext.Current.CancellationToken);
 
@@ -279,6 +65,16 @@ public class FormSchemaProcessorTests
     await schemaRepository.DidNotReceive().SaveAsync(Arg.Any<FormSchemaEntity>(), Arg.Any<CancellationToken>());
   }
 
-  private static FormDefinition CreateFormDefinition(long id, string jsonData, long tenantId = TenantId) =>
-      new(tenantId, jsonData: jsonData) { Id = id };
+  private static FormSchemaProcessor CreateProcessor(
+      IFormsRepository formsRepository,
+      IFormSchemaRepository schemaRepository,
+      IFlattenedSubmissionRepository flattenedRepository) =>
+      new(
+          formsRepository,
+          schemaRepository,
+          flattenedRepository,
+          // Early-exit tests never query submissions.
+          Substitute.For<AppDbContext>(),
+          new FormSchemaCompiler(),
+          NullLogger<FormSchemaProcessor>.Instance);
 }

--- a/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FormSchemaProcessorTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FormSchemaProcessorTests.cs
@@ -73,6 +73,7 @@ public class FormSchemaProcessorTests
           formsRepository,
           schemaRepository,
           flattenedRepository,
+          Substitute.For<IReportingUnitOfWork>(),
           // Early-exit tests never query submissions.
           Substitute.For<AppDbContext>(),
           new FormSchemaCompiler(),


### PR DESCRIPTION
# feat(e892): Replace reporting FormSchema on compile when form has no real submissions

## Description
- FormSchemaProcessor counts real submissions once (TenantId + FormId + !IsTestSubmission)
- 0 real submission? -> Replace Schema (rebuild from current definition) + hard-delete flattened rows for that form
- 1 or more real submissions -> existing append-only Merge


## Related Issues
- closes https://github.com/endatix/endatix/issues/892

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added replace and merge modes for form schema compilation.
  * Schemas now rebuild when a form has no real submissions, removing outdated mappings and flattened data.
  * Schemas merge with existing mappings when real submissions exist, preserving historical data.
  * Test submissions do not trigger merge behavior.

* **Documentation**
  * Added guidance describing schema compile modes and their data-retention behavior.

* **Tests**
  * Added coverage for replace, merge, and flattened-data cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->