### PR TITLE
feat(e902): Clean up FormSchema and FlattenedSubmissions on form.deleted

### DIFF
--- a/src/Endatix.Core/Events/FormDeletedEvent.cs
+++ b/src/Endatix.Core/Events/FormDeletedEvent.cs
@@ -9,13 +9,15 @@ namespace Endatix.Core.Events;
 /// </summary>
 public sealed class FormDeletedEvent(Form form) : DomainEventBase, IIntegrationEvent
 {
+    public const string EventTypeName = "form.deleted";
+
     public Form Form { get; init; } = form;
 
     // Revision captured at raise time, so the payload keeps this event's revision (not a later one).
     private readonly long _revision = form.Revision;
 
     /// <inheritdoc />
-    public string EventType => "form.deleted";
+    public string EventType => EventTypeName;
 
     /// <inheritdoc />
     public object GetPayload() => FormEventPayload.Create(Form, revision: _revision);

--- a/src/Endatix.Modules.Reporting/Data/FormSchemaRepository.cs
+++ b/src/Endatix.Modules.Reporting/Data/FormSchemaRepository.cs
@@ -32,4 +32,11 @@ internal sealed class FormSchemaRepository(
 
         await unitOfWork.SaveChangesAsync(cancellationToken);
     }
+
+    /// <inheritdoc />
+    public Task<int> DeleteByFormIdAsync(long tenantId, long formId, CancellationToken cancellationToken) =>
+        dbContext.FormSchemas
+            .IgnoreQueryFilters()
+            .Where(schema => schema.TenantId == tenantId && schema.FormId == formId)
+            .ExecuteDeleteAsync(cancellationToken);
 }

--- a/src/Endatix.Modules.Reporting/Data/IFormSchemaRepository.cs
+++ b/src/Endatix.Modules.Reporting/Data/IFormSchemaRepository.cs
@@ -16,4 +16,9 @@ public interface IFormSchemaRepository
     /// Inserts or updates a compiled form schema.
     /// </summary>
     Task SaveAsync(FormSchema schema, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Hard-deletes the compiled schema for a form (including soft-deleted rows).
+    /// </summary>
+    Task<int> DeleteByFormIdAsync(long tenantId, long formId, CancellationToken cancellationToken);
 }

--- a/src/Endatix.Modules.Reporting/Features/Outbox/SyncFormDeletionOutboxHandler.cs
+++ b/src/Endatix.Modules.Reporting/Features/Outbox/SyncFormDeletionOutboxHandler.cs
@@ -1,0 +1,58 @@
+using System.Text.Json;
+using Endatix.Core.Events;
+using Endatix.Infrastructure.Features.Outbox;
+using Endatix.Modules.Reporting.Data;
+using Endatix.Outbox.Engine;
+using Microsoft.Extensions.Logging;
+
+namespace Endatix.Modules.Reporting.Features.Outbox;
+
+/// <summary>
+/// Hard-deletes form-scoped Reporting rows when a form is deleted.
+/// </summary>
+internal sealed class SyncFormDeletionOutboxHandler(
+    IFormSchemaRepository formSchemaRepository,
+    IFlattenedSubmissionRepository flattenedSubmissionRepository,
+    IReportingUnitOfWork unitOfWork,
+    ILogger<SyncFormDeletionOutboxHandler> logger) : IOutboxIntegrationEventHandler
+{
+    /// <inheritdoc />
+    public IReadOnlyCollection<string> EventTypes { get; } = [FormDeletedEvent.EventTypeName];
+
+    /// <inheritdoc />
+    public async Task HandleAsync(IOutboxMessage message, CancellationToken cancellationToken)
+    {
+        using var document = JsonDocument.Parse(message.Payload);
+        var payload = document.RootElement;
+
+        var tenantId = message.GetRequiredTenantId(payload);
+        var formId = message.GetRequiredIdProp(payload, "formId");
+
+        await unitOfWork.BeginTransactionAsync(cancellationToken);
+        try
+        {
+            var schemasDeleted = await formSchemaRepository.DeleteByFormIdAsync(
+                tenantId,
+                formId,
+                cancellationToken);
+            var flattenedDeleted = await flattenedSubmissionRepository.DeleteByFormIdAsync(
+                tenantId,
+                formId,
+                cancellationToken);
+
+            await unitOfWork.CommitTransactionAsync(cancellationToken);
+
+            logger.LogInformation(
+                "Cleaned reporting rows for form {FormId} (schemasDeleted={SchemasDeleted}, flattenedDeleted={FlattenedDeleted}, outboxMessageId={OutboxMessageId})",
+                formId,
+                schemasDeleted,
+                flattenedDeleted,
+                message.Id);
+        }
+        catch
+        {
+            await unitOfWork.RollbackTransactionAsync(cancellationToken);
+            throw;
+        }
+    }
+}

--- a/src/Endatix.Modules.Reporting/Features/Outbox/SyncFormDeletionOutboxHandler.cs
+++ b/src/Endatix.Modules.Reporting/Features/Outbox/SyncFormDeletionOutboxHandler.cs
@@ -51,7 +51,7 @@ internal sealed class SyncFormDeletionOutboxHandler(
         }
         catch
         {
-            await unitOfWork.RollbackTransactionAsync(cancellationToken);
+            await unitOfWork.RollbackTransactionAsync(CancellationToken.None);
             throw;
         }
     }

--- a/src/Endatix.Modules.Reporting/ReportingModule.cs
+++ b/src/Endatix.Modules.Reporting/ReportingModule.cs
@@ -78,6 +78,7 @@ public sealed class ReportingModule : IEndatixModule, IHasFeatureFlag, IHasDbMig
         builder.Services.AddScoped<IOutboxIntegrationEventHandler, CompileFormSchemaOutboxHandler>();
         builder.Services.AddScoped<IOutboxIntegrationEventHandler, FlattenSubmissionOutboxHandler>();
         builder.Services.AddScoped<IOutboxIntegrationEventHandler, SyncSubmissionDeletionOutboxHandler>();
+        builder.Services.AddScoped<IOutboxIntegrationEventHandler, SyncFormDeletionOutboxHandler>();
         builder.AddOptions<ReportingOptions>(ReportingOptions.SECTION_NAME);
     }
 }

--- a/tests/Endatix.IntegrationTests/Infrastructure/SyncFormDeletionOutboxHandlerIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/SyncFormDeletionOutboxHandlerIntegrationTests.cs
@@ -1,0 +1,174 @@
+using Endatix.Core.Abstractions;
+using Endatix.Core.Entities;
+using Endatix.Core.Events;
+using Endatix.IntegrationTests.Shared;
+using Endatix.Modules.Reporting.Data;
+using Endatix.Modules.Reporting.Domain;
+using Endatix.Modules.Reporting.Features.FormSchema.FormSchema;
+using Endatix.Modules.Reporting.Features.Outbox;
+using Endatix.Modules.Reporting.Persistence;
+using Endatix.Outbox.Engine;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Text.Json;
+
+namespace Endatix.IntegrationTests;
+
+/// <summary>
+/// PostgreSQL coverage for form.deleted Reporting cleanup (#902).
+/// </summary>
+[Collection(nameof(DbIntegrationTestCollection))]
+[Trait("Category", "Infrastructure")]
+[Trait("Priority", "P1")]
+[Trait("DbSpecific", "PostgreSql")]
+public sealed class SyncFormDeletionOutboxHandlerIntegrationTests
+{
+    private const long TenantId = 61;
+    private const long FormId = 700;
+    private const long OtherFormId = 701;
+    private const long FormDefinitionId = 800;
+
+    private readonly DbIntegrationFixture _fixture;
+
+    public SyncFormDeletionOutboxHandlerIntegrationTests(DbIntegrationFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task HandleAsync_DeletesFormSchemaAndFlattenedRowsForFormOnly()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        await ResetReportingSchemaAsync(cancellationToken);
+
+        await using ReportingDbContext dbContext = CreateContext(TenantId);
+        ReportingUnitOfWork unitOfWork = new(dbContext);
+        FormSchemaRepository schemaRepository = new(dbContext, unitOfWork);
+        FlattenedSubmissionRepository flattenedRepository = new(dbContext, unitOfWork);
+
+        FormSchemaCompiler compiler = new();
+        FormSchemaCompileResult compiled = compiler.CompilePersisted(
+            """{"pages":[{"name":"p1","elements":[{"type":"text","name":"q1"}]}]}""");
+
+        FormSchema targetSchema = new(
+            TenantId,
+            FormId,
+            FormDefinitionId,
+            compiled.FlatteningMapJson,
+            compiled.CodebookJson,
+            compiled.LocalesJson);
+        FormSchema otherSchema = new(
+            TenantId,
+            OtherFormId,
+            FormDefinitionId,
+            compiled.FlatteningMapJson,
+            compiled.CodebookJson,
+            compiled.LocalesJson);
+        await schemaRepository.SaveAsync(targetSchema, cancellationToken);
+        await schemaRepository.SaveAsync(otherSchema, cancellationToken);
+
+        FlattenedSubmission targetRow = new(submissionId: 5001, TenantId, FormId);
+        targetRow.MarkProcessed("""{"q1":"a"}""");
+        FlattenedSubmission otherRow = new(submissionId: 5002, TenantId, OtherFormId);
+        otherRow.MarkProcessed("""{"q1":"b"}""");
+        dbContext.FlattenedSubmissions.Add(targetRow);
+        dbContext.FlattenedSubmissions.Add(otherRow);
+        await unitOfWork.SaveChangesAsync(cancellationToken);
+
+        SyncFormDeletionOutboxHandler handler = new(
+            schemaRepository,
+            flattenedRepository,
+            unitOfWork,
+            NullLogger<SyncFormDeletionOutboxHandler>.Instance);
+
+        // Act
+        await handler.HandleAsync(CreateMessage(), cancellationToken);
+
+        // Assert
+        dbContext.ChangeTracker.Clear();
+        (await dbContext.FormSchemas
+                .IgnoreQueryFilters()
+                .CountAsync(row => row.TenantId == TenantId && row.FormId == FormId, cancellationToken))
+            .Should().Be(0);
+        (await dbContext.FlattenedSubmissions
+                .IgnoreQueryFilters()
+                .CountAsync(row => row.TenantId == TenantId && row.FormId == FormId, cancellationToken))
+            .Should().Be(0);
+        (await dbContext.FormSchemas
+                .IgnoreQueryFilters()
+                .CountAsync(row => row.FormId == OtherFormId, cancellationToken))
+            .Should().Be(1);
+        (await dbContext.FlattenedSubmissions
+                .IgnoreQueryFilters()
+                .CountAsync(row => row.FormId == OtherFormId, cancellationToken))
+            .Should().Be(1);
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenNoReportingRows_SucceedsAsNoOp()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        await ResetReportingSchemaAsync(cancellationToken);
+
+        await using ReportingDbContext dbContext = CreateContext(TenantId);
+        ReportingUnitOfWork unitOfWork = new(dbContext);
+        SyncFormDeletionOutboxHandler handler = new(
+            new FormSchemaRepository(dbContext, unitOfWork),
+            new FlattenedSubmissionRepository(dbContext, unitOfWork),
+            unitOfWork,
+            NullLogger<SyncFormDeletionOutboxHandler>.Instance);
+
+        Func<Task> act = () => handler.HandleAsync(CreateMessage(), cancellationToken);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    private async Task ResetReportingSchemaAsync(CancellationToken cancellationToken)
+    {
+        await _fixture.Checkpoint.ResetAsync(_fixture.ConnectionString, _fixture.Provider, cancellationToken);
+        await ReportingTestSchema.EnsureMigratedAsync(_fixture.ConnectionString, _fixture.Provider, cancellationToken);
+    }
+
+    private ReportingDbContext CreateContext(long tenantId)
+    {
+        ITenantContext tenantContext = Substitute.For<ITenantContext>();
+        tenantContext.TenantId.Returns(tenantId);
+
+        DbContextOptionsBuilder<ReportingDbContext> optionsBuilder =
+            ReportingTestSchema.ConfigureOptionsBuilder(_fixture.ConnectionString);
+
+        return new ReportingDbContext(optionsBuilder.Options, new IncrementingIdGenerator(), tenantContext);
+    }
+
+    private static IOutboxMessage CreateMessage()
+    {
+        Form form = new(TenantId, "to-delete") { Id = FormId };
+        object payloadObject = new FormDeletedEvent(form).GetPayload();
+        string payload = JsonSerializer.Serialize(
+            payloadObject,
+            payloadObject.GetType(),
+            new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        return new FakeOutboxMessage(
+            Id: 1,
+            EventType: FormDeletedEvent.EventTypeName,
+            Payload: payload,
+            TenantId: TenantId);
+    }
+
+    private sealed record FakeOutboxMessage(
+        long Id,
+        string EventType,
+        string Payload,
+        long TenantId) : IOutboxMessage
+    {
+        public DateTimeOffset OccurredAt => DateTimeOffset.UnixEpoch;
+
+        public int SchemaVersion => 2;
+
+        public int Attempts => 0;
+
+        public string? TraceId => null;
+    }
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Features/Outbox/SyncFormDeletionOutboxHandlerTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/Outbox/SyncFormDeletionOutboxHandlerTests.cs
@@ -1,0 +1,129 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Events;
+using Endatix.Modules.Reporting.Data;
+using Endatix.Modules.Reporting.Features.Outbox;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Endatix.Modules.Reporting.Tests.Features.Outbox;
+
+public sealed class SyncFormDeletionOutboxHandlerTests
+{
+    private const long TenantId = 42;
+    private const long FormId = 100;
+
+    private readonly IFormSchemaRepository _formSchemaRepository =
+        Substitute.For<IFormSchemaRepository>();
+    private readonly IFlattenedSubmissionRepository _flattenedSubmissionRepository =
+        Substitute.For<IFlattenedSubmissionRepository>();
+    private readonly IReportingUnitOfWork _unitOfWork = Substitute.For<IReportingUnitOfWork>();
+
+    private SyncFormDeletionOutboxHandler CreateSut() =>
+        new(
+            _formSchemaRepository,
+            _flattenedSubmissionRepository,
+            _unitOfWork,
+            NullLogger<SyncFormDeletionOutboxHandler>.Instance);
+
+    [Fact]
+    public void EventTypes_IncludesFormDeleted()
+    {
+        CreateSut().EventTypes.Should().Contain(FormDeletedEvent.EventTypeName);
+    }
+
+    [Fact]
+    public async Task HandleAsync_DeletesSchemaAndFlattenedRowsInsideTransaction()
+    {
+        // Arrange
+        _formSchemaRepository
+            .DeleteByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>())
+            .Returns(1);
+        _flattenedSubmissionRepository
+            .DeleteByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>())
+            .Returns(3);
+        ReportingOutboxTestHelpers.FakeOutboxMessage message = CreateMessage();
+
+        // Act
+        await CreateSut().HandleAsync(message, TestContext.Current.CancellationToken);
+
+        // Assert
+        Received.InOrder(() =>
+        {
+            _unitOfWork.BeginTransactionAsync(Arg.Any<CancellationToken>());
+            _formSchemaRepository.DeleteByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>());
+            _flattenedSubmissionRepository.DeleteByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>());
+            _unitOfWork.CommitTransactionAsync(Arg.Any<CancellationToken>());
+        });
+        await _unitOfWork.DidNotReceive().RollbackTransactionAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenNoRowsExist_StillCommitsTransaction()
+    {
+        // Arrange
+        _formSchemaRepository
+            .DeleteByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>())
+            .Returns(0);
+        _flattenedSubmissionRepository
+            .DeleteByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>())
+            .Returns(0);
+        ReportingOutboxTestHelpers.FakeOutboxMessage message = CreateMessage();
+
+        // Act
+        await CreateSut().HandleAsync(message, TestContext.Current.CancellationToken);
+
+        // Assert
+        await _unitOfWork.Received(1).CommitTransactionAsync(Arg.Any<CancellationToken>());
+        await _unitOfWork.DidNotReceive().RollbackTransactionAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WhenDeleteFails_RollsBackTransaction()
+    {
+        // Arrange
+        _formSchemaRepository
+            .DeleteByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>())
+            .Returns(1);
+        _flattenedSubmissionRepository
+            .DeleteByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<int>(new InvalidOperationException("delete failed")));
+        ReportingOutboxTestHelpers.FakeOutboxMessage message = CreateMessage();
+
+        // Act
+        Func<Task> act = () => CreateSut().HandleAsync(message, TestContext.Current.CancellationToken);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>().WithMessage("delete failed");
+        await _unitOfWork.Received(1).RollbackTransactionAsync(Arg.Any<CancellationToken>());
+        await _unitOfWork.DidNotReceive().CommitTransactionAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task HandleAsync_WithMissingFormId_ThrowsAndDoesNotBeginTransaction()
+    {
+        ReportingOutboxTestHelpers.FakeOutboxMessage message = new(
+            Id: 7,
+            EventType: FormDeletedEvent.EventTypeName,
+            Payload: """{"tenantId":"42","name":"gone"}""",
+            TenantId: TenantId);
+
+        Func<Task> act = () => CreateSut().HandleAsync(message, TestContext.Current.CancellationToken);
+
+        await act.Should()
+            .ThrowAsync<InvalidOperationException>()
+            .WithMessage("*missing a valid formId*");
+        await _unitOfWork.DidNotReceive().BeginTransactionAsync(Arg.Any<CancellationToken>());
+    }
+
+    private static ReportingOutboxTestHelpers.FakeOutboxMessage CreateMessage()
+    {
+        Form form = new(TenantId, "to-delete") { Id = FormId };
+        string payload = ReportingOutboxTestHelpers.SerializePayload(
+            new FormDeletedEvent(form).GetPayload());
+
+        return new ReportingOutboxTestHelpers.FakeOutboxMessage(
+            Id: 1,
+            EventType: FormDeletedEvent.EventTypeName,
+            Payload: payload,
+            TenantId: TenantId);
+    }
+}


### PR DESCRIPTION
# feat(e902): Clean up `FormSchema` and `FlattenedSubmissions` on `form.deleted`

## Description
- Add a Reporting outbox handler for form.deleted (mirror SyncSubmissionDeletionOutboxHandler / CompileFormSchemaOutboxHandler).
- Payload: FormEventPayload — use tenantId + formId from the outbox message.
- Hard-delete by (TenantId, FormId):
- FlattenedSubmissions — reuse IFlattenedSubmissionRepository.DeleteByFormIdAsync (ExecuteDeleteAsync).
- FormSchemas — add DeleteByFormIdAsync on IFormSchemaRepository (same pattern; no delete API today).
- Run both deletes in one IReportingUnitOfWork transaction (both are Reporting DB).
- Out of scope: ExportFormats / SurveyTypeExportMappings (tenant-scoped, not form-scoped).
- Cover with unit + PostgreSQL integration tests (delete both tables; no-op when nothing exists).

## Related Issues
- closes #902 

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reporting data is now automatically removed when a form is deleted.
  * Cleanup includes compiled form schemas and flattened submissions, including previously soft-deleted records.
  * Deletion cleanup safely handles forms with no associated reporting data.

* **Tests**
  * Added integration and unit coverage for successful cleanup, no-op scenarios, invalid messages, and rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->