### PR TITLE
feat(e906): Increase Create Access Token allowed ExpiryInMinutes

### DIFF
--- a/docs/endatix-docs/docs/guides/form-prefilling.mdx
+++ b/docs/endatix-docs/docs/guides/form-prefilling.mdx
@@ -139,7 +139,7 @@ Use the endpoint `POST /api/forms/{formId}/submissions/{submissionId}/access-tok
 ```
 
 **Parameters:**
-- `expiryMinutes` - Token lifetime in minutes (minimum: 1, maximum: 10080 / 1 week)
+- `expiryMinutes` - Token lifetime in minutes (minimum: 1, maximum: 86400 / 60 days)
 - `permissions` - Array of permissions to grant:
   - `"view"` - Read-only access to submission data
   - `"edit"` - Permission to modify submission data

--- a/docs/endatix-docs/swagger.json
+++ b/docs/endatix-docs/swagger.json
@@ -874,8 +874,8 @@
         "tags": [
           "Forms"
         ],
-        "summary": "Generate short-lived access token for submission",
-        "description": "Creates a temporary signed token for sharing submission access with granular permissions",
+        "summary": "Generate access token for submission",
+        "description": "Creates a signed token for sharing submission access with granular permissions. Expiry is 1–86400 minutes (up to 60 days).",
         "operationId": "EndatixApiEndpointsSubmissionsCreateAccessToken",
         "parameters": [
           {
@@ -4194,7 +4194,7 @@
             "type": "integer",
             "description": "Token expiry time in minutes.",
             "format": "int32",
-            "maximum": 10080.0,
+            "maximum": 86400.0,
             "minimum": 0.0,
             "minLength": 1,
             "nullable": false,

--- a/src/Endatix.Api/Endpoints/Submissions/CreateAccessToken.CreateAccessTokenValidator.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/CreateAccessToken.CreateAccessTokenValidator.cs
@@ -9,6 +9,9 @@ namespace Endatix.Api.Endpoints.Submissions;
 /// </summary>
 public class CreateAccessTokenValidator : Validator<CreateAccessTokenRequest>
 {
+    /// <summary>Maximum allowed token lifetime: 60 days.</summary>
+    public const int MaxExpiryMinutes = 60 * 24 * 60; // 86_400 or 60 days
+
     /// <summary>
     /// Default constructor
     /// </summary>
@@ -23,7 +26,7 @@ public class CreateAccessTokenValidator : Validator<CreateAccessTokenRequest>
         RuleFor(x => x.ExpiryMinutes)
             .NotEmpty()
             .GreaterThan(0)
-            .LessThanOrEqualTo(10080); // 1 week
+            .LessThanOrEqualTo(MaxExpiryMinutes);
 
         RuleFor(x => x.Permissions)
             .NotEmpty();

--- a/src/Endatix.Api/Endpoints/Submissions/CreateAccessToken.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/CreateAccessToken.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.Abstractions.Authorization;
@@ -8,7 +9,7 @@ using Endatix.Core.UseCases.Submissions.CreateAccessToken;
 namespace Endatix.Api.Endpoints.Submissions;
 
 /// <summary>
-/// Endpoint for generating short-lived submission access tokens.
+/// Endpoint for generating submission access tokens.
 /// </summary>
 public class CreateAccessToken(IMediator mediator)
     : Endpoint<CreateAccessTokenRequest, Results<Ok<CreateAccessTokenResponse>, ProblemHttpResult>>
@@ -22,12 +23,29 @@ public class CreateAccessToken(IMediator mediator)
         Permissions(Actions.Submissions.View, Actions.Submissions.Edit, Actions.Submissions.Export);
         Summary(s =>
         {
-            s.Summary = "Generate short-lived access token for submission";
-            s.Description = "Creates a temporary signed token for sharing submission access with granular permissions";
-            s.Responses[200] = "Access token generated successfully";
-            s.Responses[400] = "Invalid input data";
-            s.Responses[404] = "Submission not found";
+            s.Summary = "Generate access token for submission";
+            s.Description =
+                "Creates a signed token for sharing submission access with granular permissions. " +
+                $"Expiry is 1–{CreateAccessTokenValidator.MaxExpiryMinutes} minutes (up to 60 days).";
+            s.ExampleRequest = new CreateAccessTokenRequest
+            {
+                FormId = 1,
+                SubmissionId = 42,
+                ExpiryMinutes = 1440,
+                Permissions = ["view", "edit"]
+            };
+            s.ResponseExamples[200] = new CreateAccessTokenResponse(
+                "42.1769113804.rw.qRHaddrBDolnRRMq",
+                DateTime.UtcNow.AddDays(1),
+                ["view", "edit"]);
+            s.Responses[200] = "Access token generated successfully.";
+            s.Responses[400] = "Invalid input data.";
+            s.Responses[404] = "Submission not found.";
         });
+        Description(builder => builder
+            .Produces<CreateAccessTokenResponse>(200, "application/json")
+            .ProducesProblem(400)
+            .ProducesProblem(404));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Core/Abstractions/Submissions/ISubmissionAccessTokenService.cs
+++ b/src/Endatix.Core/Abstractions/Submissions/ISubmissionAccessTokenService.cs
@@ -3,16 +3,16 @@ using Endatix.Core.Infrastructure.Result;
 namespace Endatix.Core.Abstractions.Submissions;
 
 /// <summary>
-/// Service for generating and validating short-lived submission access tokens.
+/// Service for generating and validating submission access tokens.
 /// Tokens are stateless and signed using HMAC-SHA256.
 /// </summary>
 public interface ISubmissionAccessTokenService
 {
     /// <summary>
-    /// Generates a short-lived access token for a submission.
+    /// Generates an access token for a submission.
     /// </summary>
     /// <param name="submissionId">The ID of the submission</param>
-    /// <param name="expiryMinutes">Expiry time in minutes (recommended: 5-10080)</param>
+    /// <param name="expiryMinutes">Expiry time in minutes (API max: 86400 / 60 days)</param>
     /// <param name="permissions">Collection of permissions: "view", "edit", "export"</param>
     /// <returns>Token data with expiry information</returns>
     Result<SubmissionAccessTokenDto> GenerateAccessToken(long submissionId, int expiryMinutes, IEnumerable<string> permissions);

--- a/tests/Endatix.Api.Tests/Endpoints/Submissions/CreateAccessTokenValidatorTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Submissions/CreateAccessTokenValidatorTests.cs
@@ -1,0 +1,66 @@
+using Endatix.Api.Endpoints.Submissions;
+using FluentValidation.TestHelper;
+
+namespace Endatix.Api.Tests.Endpoints.Submissions;
+
+public class CreateAccessTokenValidatorTests
+{
+    private readonly CreateAccessTokenValidator _validator = new();
+
+    private static CreateAccessTokenRequest ValidRequest(int? expiryMinutes = 60) =>
+        new()
+        {
+            FormId = 1,
+            SubmissionId = 42,
+            ExpiryMinutes = expiryMinutes,
+            Permissions = ["view"]
+        };
+
+    [Fact]
+    public void Validate_MaxExpiryMinutes_IsSixtyDays()
+    {
+        CreateAccessTokenValidator.MaxExpiryMinutes.Should().Be(86_400);
+    }
+
+    [Fact]
+    public void Validate_ValidRequest_Passes()
+    {
+        var result = _validator.TestValidate(ValidRequest());
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ExpiryAtMax_Passes()
+    {
+        var result = _validator.TestValidate(ValidRequest(CreateAccessTokenValidator.MaxExpiryMinutes));
+
+        result.ShouldNotHaveValidationErrorFor(x => x.ExpiryMinutes);
+    }
+
+    [Fact]
+    public void Validate_ExpiryAboveMax_Fails()
+    {
+        var result = _validator.TestValidate(ValidRequest(CreateAccessTokenValidator.MaxExpiryMinutes + 1));
+
+        result.ShouldHaveValidationErrorFor(x => x.ExpiryMinutes);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_NonPositiveExpiry_Fails(int expiryMinutes)
+    {
+        var result = _validator.TestValidate(ValidRequest(expiryMinutes));
+
+        result.ShouldHaveValidationErrorFor(x => x.ExpiryMinutes);
+    }
+
+    [Fact]
+    public void Validate_MissingExpiry_Fails()
+    {
+        var result = _validator.TestValidate(ValidRequest(null));
+
+        result.ShouldHaveValidationErrorFor(x => x.ExpiryMinutes);
+    }
+}


### PR DESCRIPTION
# feat(e906): Increase Create Access Token allowed ExpiryInMinutes

## Description
- Raise submission access-token ExpiryMinutes max to 60 days and improve endpoint OpenAPI docs
- Update docs
- Update tests

## Related Issues
- closes #906

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
<img width="1041" height="467" alt="image" src="https://github.com/user-attachments/assets/50bf982a-2257-4825-b421-8a72d4f213ce" />
