### PR TITLE
fix(nuget): decouple Endatix.Hosting from the Reporting module

### DIFF
--- a/scripts/release-prepare.sh
+++ b/scripts/release-prepare.sh
@@ -23,6 +23,27 @@ dotnet build -c Release --no-restore -p:Version="${VERSION}"
 echo "──── Packing NuGet packages at version ${VERSION} ────"
 dotnet pack -c Release --no-build -p:Version="${VERSION}" -o build/packages/nuget
 
+# A published package must never depend on one of ours that was not packed with
+# it. NuGet turns a ProjectReference into a package dependency even when the
+# referenced project sets IsPackable=false, so the nuspec ends up pointing at an
+# id nobody ever pushed and every external `dotnet add package` dies with NU1101
+# — invisible in this repo (ProjectReferences always resolve) until the release
+# is already public. Only repo-owned ids are checked: a dependency such as
+# Endatix.Outbox.Engine ships from its own repo and is legitimately absent here.
+echo "──── Verifying packed dependencies are self-contained ────"
+UNPACKED_DEPS=0
+for nupkg in build/packages/nuget/*."${VERSION}".nupkg; do
+  pkg_id="$(basename "${nupkg}" ".${VERSION}.nupkg")"
+  while read -r dep; do
+    [[ -n "${dep}" ]] || continue
+    [[ -f "src/${dep}/${dep}.csproj" ]] || continue
+    [[ -f "build/packages/nuget/${dep}.${VERSION}.nupkg" ]] && continue
+    echo "::error::${pkg_id} declares a dependency on ${dep}, which was not packed. Make src/${dep}/${dep}.csproj packable or drop the ProjectReference." >&2
+    UNPACKED_DEPS=1
+  done < <(unzip -p "${nupkg}" '*.nuspec' | grep -o 'dependency id="[^"]*"' | sed 's/^dependency id="//; s/"$//' | sort -u)
+done
+[[ "${UNPACKED_DEPS}" -eq 0 ]] || exit 1
+
 # Container image via the .NET SDK (/t:PublishContainer) — no Dockerfile.
 # One single-arch image per architecture, each loaded into the local Docker
 # daemon: a daemon cannot hold a manifest list, so release-publish.sh stitches

--- a/src/Endatix.Api/Infrastructure/IHasFastEndpointsConfig.cs
+++ b/src/Endatix.Api/Infrastructure/IHasFastEndpointsConfig.cs
@@ -1,0 +1,22 @@
+using FastEndpoints;
+
+namespace Endatix.Api.Infrastructure;
+
+/// <summary>
+/// Optional capability for an <c>IEndatixModule</c> that needs to contribute FastEndpoints
+/// configuration — serializers, OpenAPI tags, and similar endpoint-level settings.
+/// </summary>
+/// <remarks>
+/// Applied by <c>EndatixBuilder.UseModule</c> only when the module is actually registered, so a
+/// module gated off by its feature flag contributes nothing. Implementing this keeps a module free
+/// of any dependency on <c>Endatix.Hosting</c>: the host composes the module, not the other way
+/// round. Mirrors the existing <c>IHasFeatureFlag</c> / <c>IHasDbMigrations</c> capabilities.
+/// </remarks>
+public interface IHasFastEndpointsConfig
+{
+    /// <summary>
+    /// Applies the module's FastEndpoints configuration.
+    /// </summary>
+    /// <param name="config">The FastEndpoints configuration to mutate.</param>
+    void ConfigureFastEndpoints(Config config);
+}

--- a/src/Endatix.Hosting/Builders/EndatixBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixBuilder.cs
@@ -1,10 +1,10 @@
 using System.Reflection;
 using Ardalis.GuardClauses;
+using Endatix.Api.Infrastructure;
 using Endatix.Framework.Hosting;
 using Endatix.Framework.Modules;
 using Endatix.Hosting.Builders.Logging;
 using Endatix.Infrastructure.Identity;
-using Endatix.Modules.Reporting;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -138,13 +138,6 @@ public class EndatixBuilder : IBuilderRoot
         // Configure health checks with default settings
         HealthChecks.UseDefaults();
         _logger.LogHealthChecksConfigurationCompleted();
-
-        UseModule(ReportingModule.Instance);
-        if (EndatixModuleRegistration.ShouldRegister(Configuration, ReportingModule.Instance))
-        {
-            // Only wire Reporting serializers and endpoint metadata when the module is active.
-            Api.ConfigureFastEndpoints(ReportingModule.ConfigureFastEndpoints);
-        }
 
         _logger.LogConfigurationCompleted();
         return this;
@@ -293,6 +286,11 @@ public class EndatixBuilder : IBuilderRoot
         _modules.Add(module);
         Infrastructure.Messaging.AddAssembly(module.Assembly);
         Api.ScanAssemblies(module.Assembly);
+
+        if (module is IHasFastEndpointsConfig endpointConfigModule)
+        {
+            Api.ConfigureFastEndpoints(endpointConfigModule.ConfigureFastEndpoints);
+        }
 
         _logger.LogModuleRegistered(module.Assembly.GetName().Name!);
         return this;

--- a/src/Endatix.Hosting/Endatix.Hosting.csproj
+++ b/src/Endatix.Hosting/Endatix.Hosting.csproj
@@ -28,7 +28,6 @@
     <ProjectReference Include="..\Endatix.Framework\Endatix.Framework.csproj" />
     <ProjectReference Include="..\Endatix.Infrastructure\Endatix.Infrastructure.csproj" />
     <ProjectReference Include="..\Endatix.Api\Endatix.Api.csproj" />
-    <ProjectReference Include="..\Endatix.Modules.Reporting\Endatix.Modules.Reporting.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Endatix.Modules.Reporting.Contracts/Endatix.Modules.Reporting.Contracts.csproj
+++ b/src/Endatix.Modules.Reporting.Contracts/Endatix.Modules.Reporting.Contracts.csproj
@@ -1,7 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
+    <!-- Published: Endatix.Api's submission export endpoint depends on these contracts, so any
+         Reporting implementation - including one shipped outside this repo - plugs in through them. -->
+    <PackageId>Endatix.Modules.Reporting.Contracts</PackageId>
+    <Description>Extension-point contracts for Endatix reporting and submission export. $(EndatixPlatformDescription)</Description>
     <EnablePackageValidation>false</EnablePackageValidation>
   </PropertyGroup>
 

--- a/src/Endatix.Modules.Reporting.Contracts/README.md
+++ b/src/Endatix.Modules.Reporting.Contracts/README.md
@@ -1,0 +1,25 @@
+# Endatix.Modules.Reporting.Contracts
+
+Extension-point contracts for Endatix reporting and submission export. This package contains only interfaces, DTOs and settings types — no implementation.
+
+`Endatix.Api`'s submission export endpoint depends on these contracts and degrades gracefully when no implementation is registered, so a reporting implementation can be supplied by any package that implements them.
+
+>[!TIP]
+>**[Endatix Platform](https://github.com/endatix/endatix)** is an open-source data collection and management library for .NET. It is designed for building secure, scalable, and integrated form-centric applications that work with SurveyJS. Endatix empowers business users with advanced workflows, automation, and meaningful insights.
+
+## Installation:
+
+```bash
+dotnet add package Endatix.Modules.Reporting.Contracts
+```
+
+You normally do not reference this package directly — it arrives as a transitive dependency of `Endatix.Api`. Reference it explicitly when implementing the contracts yourself.
+
+## What's inside
+
+- **Export contracts** — `IExportFormatRepository`, `IExportCapabilityRegistry`, `IColumnAliasTransformerRegistry`, `ExportTarget`, `ExportFormatSettings`, `ExportFilterContext`, `ExportRequestFilters`, `ColumnAliasProfile`
+- **Submission integration** — `SubmissionIntegrationSnapshotDto`, `SubmissionIntegrationStatusCodes`
+
+## License
+
+See the [Endatix Platform repository](https://github.com/endatix/endatix) for license information.

--- a/src/Endatix.Modules.Reporting/ReportingModule.cs
+++ b/src/Endatix.Modules.Reporting/ReportingModule.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
+using Endatix.Api.Infrastructure;
 using Endatix.Framework.FeatureFlags;
 using Endatix.Framework.Modules;
 using Endatix.Infrastructure.Data;
@@ -28,7 +29,7 @@ namespace Endatix.Modules.Reporting;
 /// <summary>
 /// Reporting module (export read model, flattening, export configuration).
 /// </summary>
-public sealed class ReportingModule : IEndatixModule, IHasFeatureFlag, IHasDbMigrations
+public sealed class ReportingModule : IEndatixModule, IHasFeatureFlag, IHasDbMigrations, IHasFastEndpointsConfig
 {
     public static readonly ReportingModule Instance = new();
 
@@ -40,8 +41,9 @@ public sealed class ReportingModule : IEndatixModule, IHasFeatureFlag, IHasDbMig
 
     /// <summary>
     /// Applies reporting-specific FastEndpoints configuration (serializers, OpenAPI tags).
+    /// Invoked by the host through <see cref="IHasFastEndpointsConfig"/> when the module registers.
     /// </summary>
-    public static void ConfigureFastEndpoints(Config config) =>
+    public void ConfigureFastEndpoints(Config config) =>
         ReportingModuleEndpointConfiguration.Configure(config);
 
     public void ConfigureServices(EndatixModuleBuilder builder)

--- a/src/Endatix.WebHost/Endatix.WebHost.csproj
+++ b/src/Endatix.WebHost/Endatix.WebHost.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="../Endatix.Hosting/Endatix.Hosting.csproj" />
     <ProjectReference Include="../Endatix.Api.Host/Endatix.Api.Host.csproj" />
+    <ProjectReference Include="../Endatix.Modules.Reporting/Endatix.Modules.Reporting.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Endatix.WebHost/Program.cs
+++ b/src/Endatix.WebHost/Program.cs
@@ -1,8 +1,11 @@
 using Endatix.Hosting;
+using Endatix.Modules.Reporting;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Host.ConfigureEndatix();
+// Modules are registered by the host, not by Endatix.Hosting, so the hosting library stays
+// independent of them. UseModule honours Endatix:FeatureFlags:ReportingModule.
+builder.Host.ConfigureEndatixWithDefaults(endatix => endatix.UseModule(ReportingModule.Instance));
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Goal

`Endatix.Hosting` cannot be restored from nuget.org by any external consumer. `dotnet add package Endatix.Hosting` fails outright:

```
error NU1101: Unable to find package Endatix.Modules.Reporting.
No packages exist with this id in source(s): nuget.org
```

## Cause

`Endatix.Hosting` took a `ProjectReference` on `Endatix.Modules.Reporting`, which is `IsPackable=false`. **NuGet turns a `ProjectReference` into a package dependency regardless of `IsPackable`**, so the published nuspec declared a dependency on an id that was never pushed — it 404s.

This is invisible inside the repo, because `ProjectReference`s always resolve locally. It only bites consumers, after the release is already public.

## Fix

Rather than publish the implementation, invert the direction so the hosting library no longer knows about the module.

Modules already declare optional capabilities through `IHasFeatureFlag` and `IHasDbMigrations`. This adds **`IHasFastEndpointsConfig`** in the same spirit and lets `UseModule` apply it:

```csharp
if (module is IHasFastEndpointsConfig endpointConfigModule)
{
    Api.ConfigureFastEndpoints(endpointConfigModule.ConfigureFastEndpoints);
}
```

`ReportingModule` implements it, so the host registers the module exactly the way any other module is registered, with no module-specific code left in `Endatix.Hosting`:

```csharp
builder.Host.ConfigureEndatixWithDefaults(endatix => endatix.UseModule(ReportingModule.Instance));
```

**The capability lives in `Endatix.Api`, not `Endatix.Framework`** — `Framework` has no FastEndpoints dependency and shouldn't gain one, while any module exposing endpoints already references `Api`. This also means a module never has to reference `Endatix.Hosting`, which matters beyond layering: `Endatix.Hosting` pulls in **both** persistence providers, so a module referencing it would drag SQL Server and PostgreSQL into every consumer's dependency closure.

Also drops a redundant guard — the previous code called `ShouldRegister` a second time around the FastEndpoints wiring, but `UseModule` already evaluates it and returns early when the flag is off.

## Why Contracts is published but the implementation is not

`Endatix.Modules.Reporting.Contracts` is the **extension point**, not the implementation: `Endatix.Api`'s submission export endpoint depends on it and degrades gracefully when nothing is registered. Publishing it is what lets *any* implementation plug in. It contains 30 files of interfaces, DTOs and settings types.

## Regression guard

`release-prepare.sh` now fails the build if a packed package declares a dependency on a repo-owned project that was not packed. Only repo-owned ids are checked, so packages like `Endatix.Outbox.Engine` that ship from their own repo are correctly ignored.

## Verification

- `dotnet build -c Release` — **0 errors**
- `dotnet pack` — 9 packages; `Contracts` **included**, implementation **excluded**
- `Endatix.Hosting` nuspec now lists only `Api`, `Framework`, `Infrastructure`, `Persistence.PostgreSql`, `Persistence.SqlServer` — no Reporting
- **A scratch project referencing `Endatix.Hosting` from a local feed restores successfully.** This is the regression proof: before this change the same project fails with `NU1101`
- The new guard passes against the packed feed
- Tests: Hosting 19/19 · Reporting 382/383 (1 pre-existing skip) · Api 637/637 · Core 1022/1022

One pre-existing failure in `Endatix.Infrastructure.Tests` (`DefaultCsvFormatterTests`, a decimal-separator/locale assertion) reproduces identically on clean `main` and is unrelated.

## No runtime change

Reporting stays gated behind `Endatix:FeatureFlags:ReportingModule`, off when the key is absent, and the OSS image still registers it exactly as before. `ReportingModuleStartupMigrationTests` boots `WebApplicationFactory<EndatixWebHost::Program>`, which is where registration now happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
