### PR TITLE
fix(e914): Shoji codebook: matrix subvariable issues when row has no text populated

### DIFF
--- a/src/Endatix.Modules.Reporting/Features/Export/ExportColumnPlanBuilder.cs
+++ b/src/Endatix.Modules.Reporting/Features/Export/ExportColumnPlanBuilder.cs
@@ -252,7 +252,7 @@ internal static class ExportColumnPlanBuilder
 
         return applyKeySeparator
             ? ExportKeyTransformer.Transform(sourceKey, keySeparator)
-            : sourceKey;
+            : ExportKeyTransformer.Sanitize(sourceKey);
     }
 
     private static Dictionary<string, JsonElement> ReadCodebookColumns(string codebookJson)

--- a/src/Endatix.Modules.Reporting/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookGenerator.cs
+++ b/src/Endatix.Modules.Reporting/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookGenerator.cs
@@ -1511,21 +1511,47 @@ internal static class ShojiCodebookGenerator
             var alias = ExportKeyTransformer.Transform(columnKey, keySeparator);
             writer.WriteStartObject();
             writer.WriteString(ShojiCodebookPropertyNames.Alias, alias);
-
-            if (codebookColumns.TryGetValue(columnKey, out var columnMetadata) &&
-                columnMetadata.TryGetProperty(labelProperty, out var label))
-            {
-                writer.WriteString(ShojiCodebookPropertyNames.Name, ReadDefaultLocalizedText(label));
-            }
-            else
-            {
-                writer.WriteString(ShojiCodebookPropertyNames.Name, alias);
-            }
-
+            writer.WriteString(
+                ShojiCodebookPropertyNames.Name,
+                ResolveSubvariableDisplayName(columnKey, codebookColumns, labelProperty, alias));
             writer.WriteEndObject();
         }
 
         writer.WriteEndArray();
+    }
+
+    private static string ResolveSubvariableDisplayName(
+        string columnKey,
+        IReadOnlyDictionary<string, JsonElement> codebookColumns,
+        string labelProperty,
+        string aliasFallback)
+    {
+        if (!codebookColumns.TryGetValue(columnKey, out var columnMetadata))
+        {
+            return aliasFallback;
+        }
+
+        if (columnMetadata.TryGetProperty(labelProperty, out var label))
+        {
+            var name = ReadDefaultLocalizedText(label).Trim();
+            if (!string.IsNullOrWhiteSpace(name))
+            {
+                return name;
+            }
+        }
+
+        // Value-only matrix rows leave rowLabel empty; fall back to the SurveyJS row value.
+        if (columnMetadata.TryGetProperty(FormSchemaPropertyNames.MatrixRowValue, out var rowValue) &&
+            rowValue.ValueKind == JsonValueKind.String)
+        {
+            var matrixRowValue = rowValue.GetString()?.Trim();
+            if (!string.IsNullOrWhiteSpace(matrixRowValue))
+            {
+                return matrixRowValue;
+            }
+        }
+
+        return aliasFallback.Trim();
     }
 
     private static void WriteMultipleResponseCategories(Utf8JsonWriter writer)
@@ -1570,7 +1596,9 @@ internal static class ShojiCodebookGenerator
                 }
 
                 writer.WriteStartObject();
-                writer.WriteString(ShojiCodebookPropertyNames.Name, ReadDefaultLocalizedText(choice, ShojiCodebookPropertyNames.Text));
+                writer.WriteString(
+                    ShojiCodebookPropertyNames.Name,
+                    ReadDefaultLocalizedText(choice, ShojiCodebookPropertyNames.Text).Trim());
                 writer.WriteNumber(FormSchemaCodebookPropertyNames.Id, idElement.GetInt32());
                 writer.WriteNumber(ShojiCodebookPropertyNames.NumericValue, idElement.GetInt32());
                 writer.WriteBoolean(ShojiCodebookPropertyNames.Missing, false);
@@ -1617,7 +1645,9 @@ internal static class ShojiCodebookGenerator
                 }
 
                 writer.WriteStartObject();
-                writer.WriteString(ShojiCodebookPropertyNames.Name, ReadDefaultLocalizedText(column, ShojiCodebookPropertyNames.Text));
+                writer.WriteString(
+                    ShojiCodebookPropertyNames.Name,
+                    ReadDefaultLocalizedText(column, ShojiCodebookPropertyNames.Text).Trim());
                 writer.WriteNumber(FormSchemaCodebookPropertyNames.Id, idElement.GetInt32());
                 writer.WriteNumber(ShojiCodebookPropertyNames.NumericValue, idElement.GetInt32());
                 writer.WriteBoolean(ShojiCodebookPropertyNames.Missing, false);

--- a/src/Endatix.Modules.Reporting/Features/FlattenedSubmission/FlattenedSubmissionFlattener.cs
+++ b/src/Endatix.Modules.Reporting/Features/FlattenedSubmission/FlattenedSubmissionFlattener.cs
@@ -188,6 +188,7 @@ internal static class FlattenedSubmissionFlattener
 
     private static bool ContainsChoice(JsonElement context, string questionName, string choiceValue)
     {
+        var normalizedChoice = choiceValue.Trim();
         if (context.TryGetPropertyValue(questionName) is not JsonElement answer)
         {
             return false;
@@ -196,14 +197,14 @@ internal static class FlattenedSubmissionFlattener
         if (answer.ValueKind is JsonValueKind.True or JsonValueKind.False)
         {
             var boolValue = answer.ValueKind == JsonValueKind.True ? "true" : "false";
-            return string.Equals(boolValue, choiceValue, StringComparison.OrdinalIgnoreCase);
+            return string.Equals(boolValue, normalizedChoice, StringComparison.OrdinalIgnoreCase);
         }
 
         if (answer.ValueKind == JsonValueKind.Array)
         {
             foreach (var item in answer.EnumerateArray())
             {
-                if (string.Equals(item.GetScalarStringValue(), choiceValue, StringComparison.Ordinal))
+                if (string.Equals(item.GetScalarStringValue(), normalizedChoice, StringComparison.Ordinal))
                 {
                     return true;
                 }
@@ -212,7 +213,7 @@ internal static class FlattenedSubmissionFlattener
             return false;
         }
 
-        return string.Equals(answer.GetScalarStringValue(), choiceValue, StringComparison.Ordinal);
+        return string.Equals(answer.GetScalarStringValue(), normalizedChoice, StringComparison.Ordinal);
     }
 
     private static JsonElement ToBooleanJson(bool value)
@@ -223,6 +224,7 @@ internal static class FlattenedSubmissionFlattener
 
     private static int GetRankPosition(JsonElement context, string questionName, string choiceValue)
     {
+        var normalizedChoice = choiceValue.Trim();
         if (context.TryGetPropertyValue(questionName) is not JsonElement answer ||
             answer.ValueKind != JsonValueKind.Array)
         {
@@ -232,7 +234,7 @@ internal static class FlattenedSubmissionFlattener
         var rank = 1;
         foreach (var item in answer.EnumerateArray())
         {
-            if (string.Equals(item.GetScalarStringValue(), choiceValue, StringComparison.Ordinal))
+            if (string.Equals(item.GetScalarStringValue(), normalizedChoice, StringComparison.Ordinal))
             {
                 return rank;
             }

--- a/src/Endatix.Modules.Reporting/Features/FormSchema/Codebook/FormSchemaCodebookBuilder.cs
+++ b/src/Endatix.Modules.Reporting/Features/FormSchema/Codebook/FormSchemaCodebookBuilder.cs
@@ -1129,20 +1129,13 @@ internal static class FormSchemaCodebookBuilder
             writer.WriteStartObject();
             writer.WriteString(SurveyJsPropertyNames.Value, value);
             writer.WritePropertyName(SurveyJsPropertyNames.Text);
-            var localized = SurveyJsLocalizationHelper.ReadLocalizedStrings(
-                FindMatrixRowElement(element, value),
-                SurveyJsPropertyNames.Text);
-            if (localized.Count == 0)
-            {
-                writer.WriteStartObject();
-                writer.WriteString(FormSchemaCodebookPropertyNames.Default, text);
-                writer.WriteEndObject();
-            }
-            else
-            {
-                SurveyJsLocalizationHelper.WriteLocalizedStrings(writer, localized);
-            }
-
+            // EnumerateMatrixRows already falls back to value; reuse for blank localized text.
+            WriteLocalizedStringsWithFallback(
+                writer,
+                SurveyJsLocalizationHelper.ReadLocalizedStrings(
+                    FindMatrixRowElement(element, value),
+                    SurveyJsPropertyNames.Text),
+                fallback: text);
             writer.WriteEndObject();
         }
 
@@ -1206,7 +1199,8 @@ internal static class FormSchemaCodebookBuilder
         IReadOnlyDictionary<string, string> localizedText,
         string fallback)
     {
-        if (localizedText.Count == 0)
+        if (localizedText.Count == 0 ||
+            localizedText.Values.All(string.IsNullOrWhiteSpace))
         {
             writer.WriteStartObject();
             writer.WriteString(FormSchemaCodebookPropertyNames.Default, fallback);
@@ -1222,12 +1216,13 @@ internal static class FormSchemaCodebookBuilder
         JsonElement questionElement,
         string rowValue)
     {
+        var rowElement = FindMatrixRowElement(questionElement, rowValue);
+        var localized = SurveyJsLocalizationHelper.ReadLocalizedStrings(
+            rowElement,
+            SurveyJsPropertyNames.Text);
         writer.WritePropertyName(FormSchemaCodebookPropertyNames.RowLabel);
-        SurveyJsLocalizationHelper.WriteLocalizedStrings(
-            writer,
-            SurveyJsLocalizationHelper.ReadLocalizedStrings(
-                FindMatrixRowElement(questionElement, rowValue),
-                SurveyJsPropertyNames.Text));
+        // SurveyJS allows value-only rows (no text). Mirror WriteChoiceLabel and fall back to value.
+        WriteLocalizedStringsWithFallback(writer, localized, fallback: rowValue);
     }
 
     private static void WriteMatrixColumnLabel(
@@ -1235,12 +1230,19 @@ internal static class FormSchemaCodebookBuilder
         JsonElement questionElement,
         string columnValue)
     {
+        var columnElement = FindMatrixColumnElement(questionElement, columnValue);
+        var localized = SurveyJsLocalizationHelper.ReadLocalizedStrings(
+            columnElement,
+            SurveyJsPropertyNames.Title);
+        if (localized.Count == 0)
+        {
+            localized = SurveyJsLocalizationHelper.ReadLocalizedStrings(
+                columnElement,
+                SurveyJsPropertyNames.Text);
+        }
+
         writer.WritePropertyName(FormSchemaCodebookPropertyNames.ColumnLabel);
-        SurveyJsLocalizationHelper.WriteLocalizedStrings(
-            writer,
-            SurveyJsLocalizationHelper.ReadLocalizedStrings(
-                FindMatrixColumnElement(questionElement, columnValue),
-                SurveyJsPropertyNames.Title));
+        WriteLocalizedStringsWithFallback(writer, localized, fallback: columnValue);
     }
 
     private static JsonElement FindChoiceElement(JsonElement element, string choiceValue)

--- a/src/Endatix.Modules.Reporting/Features/FormSchema/Codebook/FormSchemaCodebookBuilder.cs
+++ b/src/Endatix.Modules.Reporting/Features/FormSchema/Codebook/FormSchemaCodebookBuilder.cs
@@ -1234,7 +1234,8 @@ internal static class FormSchemaCodebookBuilder
         var localized = SurveyJsLocalizationHelper.ReadLocalizedStrings(
             columnElement,
             SurveyJsPropertyNames.Title);
-        if (localized.Count == 0)
+        if (localized.Count == 0 ||
+            localized.Values.All(string.IsNullOrWhiteSpace))
         {
             localized = SurveyJsLocalizationHelper.ReadLocalizedStrings(
                 columnElement,
@@ -1298,17 +1299,25 @@ internal static class FormSchemaCodebookBuilder
             return default;
         }
 
+        // FlatteningMap / MatrixRowValue are trimmed; normalize definition candidates the same way.
+        var target = SurveyJsChoiceHelper.NormalizeChoiceToken(rowValue) ?? rowValue;
         foreach (var row in rows.EnumerateArray())
         {
-            if (row.ValueKind == JsonValueKind.String && row.GetString() == rowValue)
+            if (row.ValueKind == JsonValueKind.String &&
+                string.Equals(
+                    SurveyJsChoiceHelper.NormalizeChoiceToken(row.GetString()),
+                    target,
+                    StringComparison.Ordinal))
             {
                 return row;
             }
 
             if (row.ValueKind == JsonValueKind.Object &&
                 string.Equals(
-                    row.GetStringProperty(SurveyJsPropertyNames.Value) ?? row.GetStringProperty(SurveyJsPropertyNames.Text),
-                    rowValue,
+                    SurveyJsChoiceHelper.NormalizeChoiceToken(
+                        row.GetStringProperty(SurveyJsPropertyNames.Value)
+                        ?? row.GetStringProperty(SurveyJsPropertyNames.Text)),
+                    target,
                     StringComparison.Ordinal))
             {
                 return row;

--- a/src/Endatix.Modules.Reporting/Shared/SurveyJs/ExportKeyTransformer.cs
+++ b/src/Endatix.Modules.Reporting/Shared/SurveyJs/ExportKeyTransformer.cs
@@ -5,15 +5,41 @@ namespace Endatix.Modules.Reporting.Shared.SurveyJs;
 /// </summary>
 internal static class ExportKeyTransformer
 {
-    internal static string Transform(string canonicalKey, string keySeparator)
+    /// <summary>
+    /// Trims whitespace on each path segment so Crunch/Shoji aliases and CSV headers
+    /// do not retain trailing spaces/tabs from SurveyJS choice values.
+    /// </summary>
+    internal static string Sanitize(string canonicalKey)
     {
-        if (string.IsNullOrEmpty(canonicalKey) ||
-            string.Equals(keySeparator, ExportPathBuilder.SEGMENT_DELIMITER, StringComparison.Ordinal))
+        if (string.IsNullOrEmpty(canonicalKey))
         {
             return canonicalKey;
         }
 
-        return canonicalKey.Replace(
+        if (!canonicalKey.Contains(ExportPathBuilder.SEGMENT_DELIMITER, StringComparison.Ordinal))
+        {
+            return canonicalKey.Trim();
+        }
+
+        var segments = canonicalKey.Split(ExportPathBuilder.SEGMENT_DELIMITER);
+        for (var i = 0; i < segments.Length; i++)
+        {
+            segments[i] = segments[i].Trim();
+        }
+
+        return string.Join(ExportPathBuilder.SEGMENT_DELIMITER, segments);
+    }
+
+    internal static string Transform(string canonicalKey, string keySeparator)
+    {
+        var sanitized = Sanitize(canonicalKey);
+        if (string.IsNullOrEmpty(sanitized) ||
+            string.Equals(keySeparator, ExportPathBuilder.SEGMENT_DELIMITER, StringComparison.Ordinal))
+        {
+            return sanitized;
+        }
+
+        return sanitized.Replace(
             ExportPathBuilder.SEGMENT_DELIMITER,
             keySeparator,
             StringComparison.Ordinal);
@@ -21,10 +47,11 @@ internal static class ExportKeyTransformer
 
     internal static string RemoveLastSegment(string canonicalKey)
     {
-        var separatorIndex = canonicalKey.LastIndexOf(
+        var sanitized = Sanitize(canonicalKey);
+        var separatorIndex = sanitized.LastIndexOf(
             ExportPathBuilder.SEGMENT_DELIMITER,
             StringComparison.Ordinal);
 
-        return separatorIndex < 0 ? canonicalKey : canonicalKey[..separatorIndex];
+        return separatorIndex < 0 ? sanitized : sanitized[..separatorIndex];
     }
 }

--- a/src/Endatix.Modules.Reporting/Shared/SurveyJs/ExportPathBuilder.cs
+++ b/src/Endatix.Modules.Reporting/Shared/SurveyJs/ExportPathBuilder.cs
@@ -14,10 +14,18 @@ internal static class ExportPathBuilder
 
         if (segments.Length == 1)
         {
-            return segments[0];
+            return segments[0].Trim();
         }
 
-        return string.Join(SEGMENT_DELIMITER, segments.ToArray());
+        // Trim each segment so trailing spaces in SurveyJS choice/row values do not
+        // leak into FlatteningMap keys (and later Shoji aliases / CSV headers).
+        var trimmed = new string[segments.Length];
+        for (var i = 0; i < segments.Length; i++)
+        {
+            trimmed[i] = segments[i].Trim();
+        }
+
+        return string.Join(SEGMENT_DELIMITER, trimmed);
     }
 
     internal static string ChoiceKey(string questionName, string choiceValue) =>

--- a/src/Endatix.Modules.Reporting/Shared/SurveyJs/SurveyJsChoiceHelper.cs
+++ b/src/Endatix.Modules.Reporting/Shared/SurveyJs/SurveyJsChoiceHelper.cs
@@ -8,7 +8,7 @@ internal static class SurveyJsChoiceHelper
     {
         if (choice.ValueKind == JsonValueKind.String)
         {
-            return choice.GetString();
+            return NormalizeChoiceToken(choice.GetString());
         }
 
         if (choice.ValueKind == JsonValueKind.Number)
@@ -25,13 +25,28 @@ internal static class SurveyJsChoiceHelper
         {
             return valueProp.ValueKind switch
             {
-                JsonValueKind.String => valueProp.GetString(),
+                JsonValueKind.String => NormalizeChoiceToken(valueProp.GetString()),
                 JsonValueKind.Number => valueProp.GetRawText(),
                 _ => null,
             };
         }
 
-        return choice.GetStringProperty(SurveyJsPropertyNames.Text);
+        return NormalizeChoiceToken(choice.GetStringProperty(SurveyJsPropertyNames.Text));
+    }
+
+    /// <summary>
+    /// Trims SurveyJS choice/row tokens so export keys and answer matching stay aligned.
+    /// Trailing spaces/tabs in definition values otherwise break Crunch column matching.
+    /// </summary>
+    private static string? NormalizeChoiceToken(string? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        return trimmed.Length == 0 ? null : trimmed;
     }
 
     private static string GetChoiceTextLabel(JsonElement choice, string value)
@@ -42,20 +57,20 @@ internal static class SurveyJsChoiceHelper
             return value;
         }
 
-        var title = choice.GetStringProperty(SurveyJsPropertyNames.Title);
+        var title = choice.GetNonEmptyStringProperty(SurveyJsPropertyNames.Title);
         if (title is not null)
         {
             return title;
         }
 
-        var text = choice.GetStringProperty(SurveyJsPropertyNames.Text);
-        return text ?? value;
+        return choice.GetNonEmptyStringProperty(SurveyJsPropertyNames.Text) ?? value;
     }
 
     private static string? GetNamedItemValueString(JsonElement element) =>
-        element.GetStringProperty(SurveyJsPropertyNames.Name)
-        ?? element.GetStringProperty(SurveyJsPropertyNames.Value)
-        ?? element.GetStringProperty(SurveyJsPropertyNames.Text);
+        NormalizeChoiceToken(
+            element.GetStringProperty(SurveyJsPropertyNames.Name)
+            ?? element.GetStringProperty(SurveyJsPropertyNames.Value)
+            ?? element.GetStringProperty(SurveyJsPropertyNames.Text));
 
     internal static List<string> GetChoiceValues(JsonElement choicesElement)
     {

--- a/src/Endatix.Modules.Reporting/Shared/SurveyJs/SurveyJsChoiceHelper.cs
+++ b/src/Endatix.Modules.Reporting/Shared/SurveyJs/SurveyJsChoiceHelper.cs
@@ -38,7 +38,7 @@ internal static class SurveyJsChoiceHelper
     /// Trims SurveyJS choice/row tokens so export keys and answer matching stay aligned.
     /// Trailing spaces/tabs in definition values otherwise break Crunch column matching.
     /// </summary>
-    private static string? NormalizeChoiceToken(string? value)
+    internal static string? NormalizeChoiceToken(string? value)
     {
         if (value is null)
         {
@@ -66,11 +66,22 @@ internal static class SurveyJsChoiceHelper
         return choice.GetNonEmptyStringProperty(SurveyJsPropertyNames.Text) ?? value;
     }
 
-    private static string? GetNamedItemValueString(JsonElement element) =>
-        NormalizeChoiceToken(
-            element.GetStringProperty(SurveyJsPropertyNames.Name)
-            ?? element.GetStringProperty(SurveyJsPropertyNames.Value)
-            ?? element.GetStringProperty(SurveyJsPropertyNames.Text));
+    private static string? GetNamedItemValueString(JsonElement element)
+    {
+        var fromName = NormalizeChoiceToken(element.GetStringProperty(SurveyJsPropertyNames.Name));
+        if (fromName is not null)
+        {
+            return fromName;
+        }
+
+        var fromValue = NormalizeChoiceToken(element.GetStringProperty(SurveyJsPropertyNames.Value));
+        if (fromValue is not null)
+        {
+            return fromValue;
+        }
+
+        return NormalizeChoiceToken(element.GetStringProperty(SurveyJsPropertyNames.Text));
+    }
 
     internal static List<string> GetChoiceValues(JsonElement choicesElement)
     {

--- a/src/Endatix.Modules.Reporting/Shared/SurveyJs/SurveyJsJsonElementExtensions.cs
+++ b/src/Endatix.Modules.Reporting/Shared/SurveyJs/SurveyJsJsonElementExtensions.cs
@@ -33,7 +33,7 @@ internal static class SurveyJsJsonElementExtensions
 
     public static bool IsSingleSelectBaseSelect(this JsonElement element) =>
         SurveyJsElementType.TryResolve(element.GetSurveyJsType()) is
-            { Category: SurveyJsElementCategory.BaseSelect } &&
+        { Category: SurveyJsElementCategory.BaseSelect } &&
         !element.IsMultiSelectBaseSelect();
 
     public static bool IsRangeSlider(this JsonElement element) =>
@@ -66,17 +66,8 @@ internal static class SurveyJsJsonElementExtensions
     }
 
     /// <summary>
-    /// Gets a non-empty string property, or <c>null</c> if the property is missing or empty.
-    /// </summary>
-    public static string? GetNonEmptyStringProperty(this JsonElement element, string propertyName)
-    {
-        var value = element.GetStringProperty(propertyName);
-
-        return string.IsNullOrWhiteSpace(value) ? null : value;
-    }
-
-    /// <summary>
     /// Gets a non-empty string value, or <c>null</c> if the value is not a string or is empty.
+    /// Trims surrounding whitespace so submission answers match compiled choice keys.
     /// </summary>
     public static string? GetNonEmptyStringValue(this JsonElement element)
     {
@@ -85,7 +76,17 @@ internal static class SurveyJsJsonElementExtensions
             return null;
         }
 
-        var value = element.GetString();
+        var value = element.GetString()?.Trim();
+        return string.IsNullOrWhiteSpace(value) ? null : value;
+    }
+
+    /// <summary>
+    /// Gets a non-empty string property, or <c>null</c> if the property is missing or empty.
+    /// </summary>
+    public static string? GetNonEmptyStringProperty(this JsonElement element, string propertyName)
+    {
+        var value = element.GetStringProperty(propertyName)?.Trim();
+
         return string.IsNullOrWhiteSpace(value) ? null : value;
     }
 

--- a/tests/Endatix.Modules.Reporting.Tests/Features/Export/ShojiCodebookGeneratorTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/Export/ShojiCodebookGeneratorTests.cs
@@ -247,6 +247,16 @@ public sealed class ShojiCodebookGeneratorTests
             .ToList();
         p4Aliases.Should().Equal("P4--Colchones", "P4--Almohadas");
 
+        // Whitespace-valued row must still resolve distinct display text via FindMatrixRowElement.
+        string colchonesLabel = metadata
+            .GetProperty("P4")
+            .GetProperty("subvariables")
+            .EnumerateArray()
+            .Single(item => item.GetProperty("alias").GetString() == "P4--Colchones")
+            .GetProperty("name")
+            .GetString()!;
+        colchonesLabel.Should().Be("Mattresses (display)");
+
         List<string> p4Categories = metadata
             .GetProperty("P4")
             .GetProperty("categories")
@@ -264,5 +274,16 @@ public sealed class ShojiCodebookGeneratorTests
         compiled.FlatteningMap.Columns.Select(column => column.Key)
             .Should()
             .NotContain(key => key != key.Trim());
+
+        // Assert — persisted codebook column rowLabel keeps the distinct SurveyJS text
+        using JsonDocument codebook = JsonDocument.Parse(compiled.CodebookJson);
+        codebook.RootElement
+            .GetProperty("columns")
+            .GetProperty("P4__Colchones")
+            .GetProperty("rowLabel")
+            .GetProperty("default")
+            .GetString()
+            .Should()
+            .Be("Mattresses (display)");
     }
 }

--- a/tests/Endatix.Modules.Reporting.Tests/Features/Export/ShojiCodebookGeneratorTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/Export/ShojiCodebookGeneratorTests.cs
@@ -113,4 +113,156 @@ public sealed class ShojiCodebookGeneratorTests
             names.Add(name).Should().BeTrue($"display name '{name}' must be unique");
         }
     }
+
+    [Fact]
+    public void Generate_MatrixValueOnlyRows_SubvariableNamesFallBackToRowValue()
+    {
+        // Arrange — reproduces endatix#914: value-only / blank-text matrix rows.
+        string definitionJson = FormSchemaFixtureLoader.LoadText("matrix-value-only-rows-definition.json");
+        FormSchemaCompiler compiler = new();
+        FormSchemaCompileResult compiled = compiler.CompilePersisted(definitionJson);
+
+        // Act
+        using JsonDocument document = JsonDocument.Parse(
+            ShojiCodebookGenerator.Generate(
+                compiled.FlatteningMapJson,
+                compiled.CodebookJson,
+                ExportFormatSettings.InterimCrunchKeySeparator));
+        JsonElement p7 = document.RootElement
+            .GetProperty("body")
+            .GetProperty("table")
+            .GetProperty("metadata")
+            .GetProperty("P7");
+
+        // Assert
+        p7.GetProperty("type").GetString().Should().Be("categorical_array");
+        List<(string Alias, string Name)> subvariables = p7
+            .GetProperty("subvariables")
+            .EnumerateArray()
+            .Select(item => (
+                item.GetProperty("alias").GetString()!,
+                item.GetProperty("name").GetString()!))
+            .ToList();
+
+        subvariables.Should().Equal(
+            ("P7--Deprati", "Deprati"),
+            ("P7--Etafashion", "Etafashion"),
+            ("P7--Sukasa", "Sukasa"),
+            ("P7--Pycca", "Pycca Stores"),
+            ("P7--Todo Hogar", "Todo Hogar"),
+            ("P7--Tiendas en línea / Páginas web", "Tiendas en línea / Páginas web"));
+
+        subvariables.Should().OnlyContain(item => !string.IsNullOrWhiteSpace(item.Name));
+    }
+
+    [Fact]
+    public void Generate_MatrixEmptyRowLabel_FallsBackToMatrixRowValue()
+    {
+        // Arrange — defense in depth for pre-fix persisted artifacts with blank rowLabel.
+        string definitionJson = FormSchemaFixtureLoader.LoadText("matrix-value-only-rows-definition.json");
+        FormSchemaCompileResult compiled = new FormSchemaCompiler().CompilePersisted(definitionJson);
+
+        System.Text.Json.Nodes.JsonObject root =
+            System.Text.Json.Nodes.JsonNode.Parse(compiled.CodebookJson)!.AsObject();
+        System.Text.Json.Nodes.JsonObject columns = root["columns"]!.AsObject();
+        foreach (KeyValuePair<string, System.Text.Json.Nodes.JsonNode?> column in columns)
+        {
+            System.Text.Json.Nodes.JsonObject columnObject = column.Value!.AsObject();
+            columnObject["rowLabel"] = new System.Text.Json.Nodes.JsonObject
+            {
+                ["default"] = string.Empty,
+            };
+        }
+
+        string mutatedCodebookJson = root.ToJsonString();
+
+        // Act
+        using JsonDocument document = JsonDocument.Parse(
+            ShojiCodebookGenerator.Generate(
+                compiled.FlatteningMapJson,
+                mutatedCodebookJson,
+                ExportFormatSettings.InterimCrunchKeySeparator));
+        List<string> names = document.RootElement
+            .GetProperty("body")
+            .GetProperty("table")
+            .GetProperty("metadata")
+            .GetProperty("P7")
+            .GetProperty("subvariables")
+            .EnumerateArray()
+            .Select(item => item.GetProperty("name").GetString()!)
+            .ToList();
+
+        // Assert — ignores blank rowLabel; uses matrixRowValue (not display text).
+        names.Should().Equal(
+            "Deprati",
+            "Etafashion",
+            "Sukasa",
+            "Pycca",
+            "Todo Hogar",
+            "Tiendas en línea / Páginas web");
+    }
+
+    [Fact]
+    public void Generate_TrailingWhitespaceInChoiceValues_StripsFromAliasesAndNames()
+    {
+        // Arrange — Crunch rejects subvariable aliases with trailing spaces
+        // ("Expected column P11--Visitando...  not found" when CSV headers are trimmed).
+        string definitionJson = FormSchemaFixtureLoader.LoadText("trailing-whitespace-choices-definition.json");
+        FormSchemaCompileResult compiled = new FormSchemaCompiler().CompilePersisted(definitionJson);
+
+        // Act
+        using JsonDocument document = JsonDocument.Parse(
+            ShojiCodebookGenerator.Generate(
+                compiled.FlatteningMapJson,
+                compiled.CodebookJson,
+                ExportFormatSettings.InterimCrunchKeySeparator));
+        JsonElement metadata = document.RootElement
+            .GetProperty("body")
+            .GetProperty("table")
+            .GetProperty("metadata");
+
+        // Assert — checkbox multiple_response subvariable aliases have no trailing whitespace
+        List<(string Alias, string Name)> p11 = metadata
+            .GetProperty("P11")
+            .GetProperty("subvariables")
+            .EnumerateArray()
+            .Select(item => (
+                item.GetProperty("alias").GetString()!,
+                item.GetProperty("name").GetString()!))
+            .ToList();
+
+        p11.Should().Equal(
+            ("P11--Redes sociales", "Redes sociales"),
+            ("P11--Visitando los centros comerciales", "Visitando los centros comerciales"),
+            ("P11--Otros", "Otros"));
+        p11.Should().OnlyContain(item =>
+            item.Alias == item.Alias.Trim() && item.Name == item.Name.Trim());
+
+        // Assert — matrix row aliases and category names are trimmed
+        List<string> p4Aliases = metadata
+            .GetProperty("P4")
+            .GetProperty("subvariables")
+            .EnumerateArray()
+            .Select(item => item.GetProperty("alias").GetString()!)
+            .ToList();
+        p4Aliases.Should().Equal("P4--Colchones", "P4--Almohadas");
+
+        List<string> p4Categories = metadata
+            .GetProperty("P4")
+            .GetProperty("categories")
+            .EnumerateArray()
+            .Select(item => item.GetProperty("name").GetString()!)
+            .ToList();
+        p4Categories.Should().Equal("Marca", "Precio");
+        p4Categories.Should().OnlyContain(name => name == name.Trim());
+
+        // Assert — FlatteningMap keys are also trimmed (source of truth)
+        compiled.FlatteningMap.Columns.Select(column => column.Key).Should().Contain(
+            "P11__Visitando los centros comerciales",
+            "P11__Otros",
+            "P4__Colchones");
+        compiled.FlatteningMap.Columns.Select(column => column.Key)
+            .Should()
+            .NotContain(key => key != key.Trim());
+    }
 }

--- a/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FlattenedFormDefinition/Fixtures/AllQuestions/all-questions-expected-codebook.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FlattenedFormDefinition/Fixtures/AllQuestions/all-questions-expected-codebook.json
@@ -1841,7 +1841,9 @@
         "es": "Informaci\u00F3n de contacto"
       },
       "matrixRowValue": "emergency",
-      "rowLabel": {}
+      "rowLabel": {
+        "default": "emergency"
+      }
     },
     "qMultipleText__phone": {
       "parentKey": "qMultipleText",
@@ -1852,7 +1854,9 @@
         "es": "Informaci\u00F3n de contacto"
       },
       "matrixRowValue": "phone",
-      "rowLabel": {}
+      "rowLabel": {
+        "default": "phone"
+      }
     },
     "qPanelText": {
       "parentKey": "qPanelText",

--- a/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FlattenedFormDefinition/Fixtures/matrix-value-only-rows-definition.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FlattenedFormDefinition/Fixtures/matrix-value-only-rows-definition.json
@@ -1,0 +1,29 @@
+{
+  "pages": [
+    {
+      "elements": [
+        {
+          "type": "matrix",
+          "name": "P7",
+          "title": {
+            "es": "7) Experience by purchase channel"
+          },
+          "isRequired": true,
+          "columns": [
+            "Muy insatisfecho\t",
+            "Neutral\t",
+            "Muy satisfcatoria"
+          ],
+          "rows": [
+            { "value": "Deprati" },
+            { "value": "Etafashion" },
+            { "value": "Sukasa", "text": "" },
+            { "value": "Pycca", "text": "Pycca Stores" },
+            { "value": "Todo Hogar" },
+            { "value": "Tiendas en línea / Páginas web" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FlattenedFormDefinition/Fixtures/trailing-whitespace-choices-definition.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FlattenedFormDefinition/Fixtures/trailing-whitespace-choices-definition.json
@@ -1,0 +1,34 @@
+{
+  "pages": [
+    {
+      "elements": [
+        {
+          "type": "checkbox",
+          "name": "P11",
+          "title": "Where did you look for information?",
+          "choices": [
+            { "value": "Redes sociales", "text": "Redes sociales" },
+            {
+              "value": "Visitando los centros comerciales ",
+              "text": "Visitando los centros comerciales "
+            },
+            { "value": "Otros\t", "text": "Otros\t" }
+          ]
+        },
+        {
+          "type": "matrix",
+          "name": "P4",
+          "title": "Importance by product",
+          "columns": [
+            { "value": "Marca", "text": "Marca" },
+            { "value": "Precio\t", "text": "Precio\t" }
+          ],
+          "rows": [
+            { "value": "Colchones ", "text": "Colchones " },
+            { "value": "Almohadas", "text": "Almohadas" }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FlattenedFormDefinition/Fixtures/trailing-whitespace-choices-definition.json
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FlattenedFormDefinition/Fixtures/trailing-whitespace-choices-definition.json
@@ -24,7 +24,10 @@
             { "value": "Precio\t", "text": "Precio\t" }
           ],
           "rows": [
-            { "value": "Colchones ", "text": "Colchones " },
+            {
+              "value": "Colchones ",
+              "text": "Mattresses (display)"
+            },
             { "value": "Almohadas", "text": "Almohadas" }
           ]
         }

--- a/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FormSchema/FormSchemaCompilerTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FormSchema/FormSchemaCompilerTests.cs
@@ -412,4 +412,50 @@ public class FormSchemaCompilerTests
       new KeyValuePair<string, string>("Tiendas en línea / Páginas web", "Tiendas en línea / Páginas web"));
     rowLabels.Values.Should().OnlyContain(label => !string.IsNullOrWhiteSpace(label));
   }
+
+  [Fact]
+  public void CompilePersisted_MatrixDropdownBlankTitle_FallsBackToColumnText()
+  {
+    // Arrange — blank localized title must not block usable text before columnValue fallback.
+    const string definitionJson = """
+        {
+          "pages": [
+            {
+              "elements": [
+                {
+                  "type": "matrixdropdown",
+                  "name": "orgCount",
+                  "columns": [
+                    {
+                      "name": "N_org",
+                      "title": { "default": "   " },
+                      "text": { "default": "Count from text" },
+                      "cellType": "text",
+                      "inputType": "number"
+                    }
+                  ],
+                  "rows": [
+                    { "value": "SPO_small", "text": "Small SPO" }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+        """;
+
+    // Act
+    FormSchemaCompileResult compiled = new FormSchemaCompiler().CompilePersisted(definitionJson);
+    using JsonDocument codebook = JsonDocument.Parse(compiled.CodebookJson);
+
+    // Assert
+    codebook.RootElement
+      .GetProperty("columns")
+      .GetProperty("orgCount__SPO_small__N_org")
+      .GetProperty("columnLabel")
+      .GetProperty("default")
+      .GetString()
+      .Should()
+      .Be("Count from text");
+  }
 }

--- a/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FormSchema/FormSchemaCompilerTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FormSchema/FormSchemaCompilerTests.cs
@@ -365,4 +365,51 @@ public class FormSchemaCompilerTests
 
     schema.Columns.Select(column => column.Key).Should().Equal("valid");
   }
+
+  [Fact]
+  public void CompilePersisted_MatrixValueOnlyRows_WritesRowLabelsFromValues()
+  {
+    // Arrange — endatix#914: SurveyJS value-only / blank-text matrix rows.
+    string definitionJson = FormSchemaFixtureLoader.LoadText("matrix-value-only-rows-definition.json");
+    FormSchemaCompiler compiler = new();
+
+    // Act
+    FormSchemaCompileResult compiled = compiler.CompilePersisted(definitionJson);
+    using JsonDocument codebook = JsonDocument.Parse(compiled.CodebookJson);
+
+    // Assert — question-level rows (default codebook path) keep non-empty text.
+    List<(string Value, string Text)> questionRows = codebook.RootElement
+      .GetProperty("questions")
+      .GetProperty("P7")
+      .GetProperty("rows")
+      .EnumerateArray()
+      .Select(row => (
+        row.GetProperty("value").GetString()!,
+        row.GetProperty("text").GetProperty("default").GetString()!))
+      .ToList();
+
+    questionRows.Should().Equal(
+      ("Deprati", "Deprati"),
+      ("Etafashion", "Etafashion"),
+      ("Sukasa", "Sukasa"),
+      ("Pycca", "Pycca Stores"),
+      ("Todo Hogar", "Todo Hogar"),
+      ("Tiendas en línea / Páginas web", "Tiendas en línea / Páginas web"));
+
+    // Assert — column metadata rowLabel used by Shoji categorical_array subvariables.
+    Dictionary<string, string> rowLabels = codebook.RootElement
+      .GetProperty("columns")
+      .EnumerateObject()
+      .Where(column => column.Name.StartsWith("P7__", StringComparison.Ordinal))
+      .ToDictionary(
+        column => column.Value.GetProperty("matrixRowValue").GetString()!,
+        column => column.Value.GetProperty("rowLabel").GetProperty("default").GetString()!);
+
+    rowLabels.Should().Contain(
+      new KeyValuePair<string, string>("Deprati", "Deprati"),
+      new KeyValuePair<string, string>("Sukasa", "Sukasa"),
+      new KeyValuePair<string, string>("Pycca", "Pycca Stores"),
+      new KeyValuePair<string, string>("Tiendas en línea / Páginas web", "Tiendas en línea / Páginas web"));
+    rowLabels.Values.Should().OnlyContain(label => !string.IsNullOrWhiteSpace(label));
+  }
 }


### PR DESCRIPTION
# fix(e914): Shoji codebook: matrix subvariable issues when row has no text populated

## Description
Improves overall support for matrix questions shoji export and choices support via:

- WriteMatrixRowLabel — fall back to row value (same pattern as choice labels).
- WriteMatrixRows — reuse that fallback for blank localized text.
- GetChoiceTextLabel — treat empty/whitespace text as missing (GetNonEmptyStringProperty).
- Shoji WriteSubvariablesForKeys — if rowLabel is blank, use matrixRowValue (covers pre-fix persisted artifacts).
- Trim path segments in ExportKeyTransformer / ExportPathBuilder (aliases + CSV headers)
- Normalize choice tokens at extraction + answer matching
-  Trim category/subvariable display names in Shoji

## Related Issues
- closes #914 

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved export key and answer matching by consistently trimming surrounding whitespace.
  - Fixed exported labels and category names that previously contained unwanted spaces.
  - Added fallback labels for matrix rows and columns when localized text is missing or blank.
  - Improved handling of choice, checkbox, and matrix values in reporting exports.
  - Ensured blank localized values fall back to meaningful source values instead of appearing empty or incorrectly formatted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->