### PR TITLE
fix(е922): keep CSV number and date formatting culture-invariant

### DIFF
--- a/src/Endatix.Infrastructure/Exporting/Formatters/DefaultCsvFormatter.cs
+++ b/src/Endatix.Infrastructure/Exporting/Formatters/DefaultCsvFormatter.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Endatix.Core.Abstractions.Exporting;
@@ -35,9 +36,22 @@ public class DefaultCsvFormatter : IValueFormatter
             JsonObject obj => obj.ToJsonString(),
             JsonElement el => FormatJsonElement(el),
 
-            _ => value.ToString()
+            _ => FormatFallback(value)
         };
     }
+
+    /// <summary>
+    /// Renders any value the switch above does not special-case. Formattable values (decimal,
+    /// double, int, TimeSpan, …) are rendered with the invariant culture: the export is written by
+    /// a <c>CsvWriter</c> configured with <see cref="CultureInfo.InvariantCulture"/>, but that
+    /// setting never applies to values the formatter has already turned into strings. Using the
+    /// ambient culture here would emit "12,5" instead of "12.5" on any host whose locale uses a
+    /// decimal comma, silently changing the exported data with the server's regional settings.
+    /// </summary>
+    private static string? FormatFallback(object value) =>
+        value is IFormattable formattable
+            ? formattable.ToString(null, CultureInfo.InvariantCulture)
+            : value.ToString();
 
     private static string FormatJsonArray(JsonArray array)
     {
@@ -141,5 +155,8 @@ public class DefaultCsvFormatter : IValueFormatter
         return boolean.ToString().ToLowerInvariant();
     }
 
-    private static string FormatDateTime(DateTime dateTime) => dateTime.ToString(DATE_TIME_FORMAT);
+    // The ':' in a custom format string is the culture's time separator placeholder, not a
+    // literal, so this pattern is only stable when bound to the invariant culture.
+    private static string FormatDateTime(DateTime dateTime) =>
+        dateTime.ToString(DATE_TIME_FORMAT, CultureInfo.InvariantCulture);
 }

--- a/tests/Endatix.Infrastructure.Tests/Exporting/DefaultCsvFormatterTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Exporting/DefaultCsvFormatterTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Endatix.Core.Abstractions.Exporting;
@@ -73,6 +74,37 @@ public class DefaultCsvFormatterTests
         // Act & Assert
         Assert.Equal("1", formatter.Format(trueDocument.RootElement, _context));
         Assert.Equal("0", formatter.Format(falseDocument.RootElement, _context));
+    }
+
+    [Theory]
+    [InlineData("bg-BG")]
+    [InlineData("de-DE")]
+    [InlineData("fr-FR")]
+    public void Format_UnderCommaDecimalCulture_StillWritesInvariantNumbers(string culture)
+    {
+        // Arrange
+        // The CSV is written by a CsvWriter bound to InvariantCulture, but that never applies to
+        // values the formatter has already stringified. Exported numbers must therefore not drift
+        // with the host's regional settings.
+        var originalCulture = CultureInfo.CurrentCulture;
+        CultureInfo.CurrentCulture = new CultureInfo(culture);
+
+        try
+        {
+            // Act
+            var decimalResult = _formatter.Format(12.5m, _context);
+            var doubleResult = _formatter.Format(1234.75d, _context);
+            var dateResult = _formatter.Format(new DateTime(2023, 10, 05, 14, 30, 05), _context);
+
+            // Assert
+            decimalResult.Should().Be("12.5");
+            doubleResult.Should().Be("1234.75");
+            dateResult.Should().Be("2023-10-05 14:30:05");
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = originalCulture;
+        }
     }
 
     // --- Data Generators ---


### PR DESCRIPTION
## The problem (issue#922)

CSV submission exports render numbers and dates using the **ambient culture** of the host process. On any server whose locale uses a decimal comma, an exported value of `12.5` comes out as `12,5`.

This shows up today as a test failure on developer machines with such a locale:

```
Failed DefaultCsvFormatterTests.Format_ShouldReturnExpectedString_ForPrimitives(input: 12,5, expected: "12.5")
```

The tempting fix is to make the test read the current culture and assert accordingly. That would be wrong — it would pin the bug in place. The test was asserting the correct contract; the formatter is what is broken.

## Why `"12.5"` is the correct expectation

`SubmissionCsvExporter` writes the file through a `CsvWriter` constructed with `CultureInfo.InvariantCulture`:

```csharp
using var csv = new CsvWriter(streamWriter, new CsvConfiguration(CultureInfo.InvariantCulture));
```

So the export's intended contract is unambiguously invariant. The rest of the codebase agrees — `LongToStringConverter`, `FormDefinitionFlattener`, `ExportPathBuilder` and friends all format machine-readable values with `InvariantCulture`.

But that configuration only governs values **CsvHelper formats itself**. The pipeline is:

```csharp
csv.WriteField(formatter.Format(value, context));
```

`DefaultCsvFormatter` runs first and hands `CsvWriter` an **already-formatted string**, so the invariant setting is silently bypassed for precisely the values that need it. `DefaultCsvFormatter` has no numeric branch, so numbers fell through to `value.ToString()` — ambient culture.

## The fix

- Formattable values are rendered with `CultureInfo.InvariantCulture`.
- The date pattern is bound to the invariant culture too. `':'` in a custom format string is the culture's **time separator placeholder**, not a literal, so `"yyyy-MM-dd HH:mm:ss"` was only stable by luck on cultures that happen to use `:`.

The existing `"12.5"` expectation is **left untouched** — it now passes on decimal-comma machines because the production code was fixed, which is the real proof the bug is gone.

A new theory pins the invariant output under three comma-decimal cultures:

```csharp
[Theory]
[InlineData("bg-BG")]
[InlineData("de-DE")]
[InlineData("fr-FR")]
public void Format_UnderCommaDecimalCulture_StillWritesInvariantNumbers(string culture)
```

## Impact

Any deployment whose host locale uses a decimal comma has been emitting CSV exports with locale-specific decimal separators. BI consumers reading those columns as numeric would misparse them, and the output changed depending on which machine produced it.

## Verification

| Suite | Result |
|---|---|
| `Endatix.Infrastructure.Tests` | 1115 passed, 0 failed |
| `Endatix.Core.Tests` | 1022 passed, 0 failed |
| `Endatix.Api.Tests` | 637 passed, 0 failed |
| `Endatix.Modules.Reporting.Tests` | 382 passed, 0 failed, 1 skipped |

`dotnet build -c Release` → 0 errors.

Full `Endatix.Infrastructure.Tests` run repeated under three locales, all green:

```
LANG=en_US.UTF-8   Passed!  - Failed: 0, Passed: 1115
LANG=de_DE.UTF-8   Bestanden! : Fehler: 0, erfolgreich: 1115
LANG=bg_BG.UTF-8   Passed!  - Failed: 0, Passed: 1115
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
