### PR TITLE
fix(featureflags): shut OpenFeature down once per process

### DIFF
--- a/src/Endatix.Infrastructure/FeatureFlags/SingleShutdownFeatureLifecycleManager.cs
+++ b/src/Endatix.Infrastructure/FeatureFlags/SingleShutdownFeatureLifecycleManager.cs
@@ -1,0 +1,44 @@
+using OpenFeature.Hosting;
+
+namespace Endatix.Infrastructure.FeatureFlags;
+
+/// <summary>
+/// Wraps OpenFeature's lifecycle manager so that shutdown runs at most once per process.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>OpenFeature.Api</c> is a process-wide singleton, but the hosted lifecycle service that shuts
+/// it down is registered per host. <c>Api.ShutdownAsync()</c> completes the SDK's event channel, and
+/// a completed channel cannot be reopened, so a second host stopping in the same process throws
+/// <c>ChannelClosedException</c> out of <c>IHostedLifecycleService.StoppedAsync</c>.
+/// </para>
+/// <para>
+/// A single application host never notices — there is nothing to shut down twice. Anything that
+/// builds more than one host in a process does: the integration test suite creates several
+/// <c>WebApplicationFactory</c> instances, and whichever stops second fails on teardown even though
+/// the test itself passed.
+/// </para>
+/// <para>
+/// The guard is static because the resource it protects is static. Shutting OpenFeature down is a
+/// process-wide, one-way operation, so the second and later calls have nothing left to do.
+/// </para>
+/// </remarks>
+internal sealed class SingleShutdownFeatureLifecycleManager(IFeatureLifecycleManager inner)
+    : IFeatureLifecycleManager
+{
+    private static int _shutdownStarted;
+
+    public ValueTask EnsureInitializedAsync(CancellationToken cancellationToken = default) =>
+        inner.EnsureInitializedAsync(cancellationToken);
+
+    public ValueTask ShutdownAsync(CancellationToken cancellationToken = default) =>
+        Interlocked.Exchange(ref _shutdownStarted, 1) == 0
+            ? inner.ShutdownAsync(cancellationToken)
+            : ValueTask.CompletedTask;
+
+    /// <summary>
+    /// Clears the process-wide guard. Exists so tests can exercise the first-shutdown path more
+    /// than once; nothing in the application resets it.
+    /// </summary>
+    internal static void ResetForTests() => Interlocked.Exchange(ref _shutdownStarted, 0);
+}

--- a/src/Endatix.Infrastructure/Features/Outbox/OutboxRelayServiceCollectionExtensions.cs
+++ b/src/Endatix.Infrastructure/Features/Outbox/OutboxRelayServiceCollectionExtensions.cs
@@ -1,8 +1,10 @@
+using Endatix.Infrastructure.FeatureFlags;
 using Endatix.Outbox.Engine;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using OpenFeature;
+using OpenFeature.Hosting;
 using OpenFeature.Hosting.Providers.Memory;
 using OpenFeature.Providers.Memory;
 
@@ -51,9 +53,10 @@ public static class OutboxRelayServiceCollectionExtensions
     /// </summary>
     public static IServiceCollection AddEndatixOpenFeature(this IServiceCollection services)
     {
+        // AddOpenFeature registers the hosted lifecycle service itself; calling
+        // AddHostedFeatureLifecycle() as well is obsolete as of OpenFeature 2.14.
         services.AddOpenFeature((OpenFeature.Hosting.OpenFeatureBuilder builder) =>
         {
-            builder.AddHostedFeatureLifecycle();
             builder.AddInMemoryProvider(serviceProvider =>
             {
                 var runInProcess = serviceProvider.GetService<IConfiguration>()?
@@ -68,6 +71,35 @@ public static class OutboxRelayServiceCollectionExtensions
             });
         });
 
+        UseSingleProcessShutdown(services);
+
         return services;
+    }
+
+    /// <summary>
+    /// Decorates OpenFeature's <see cref="IFeatureLifecycleManager"/> with
+    /// <see cref="SingleShutdownFeatureLifecycleManager"/>, so the process-wide
+    /// <c>OpenFeature.Api</c> is shut down at most once no matter how many hosts stop.
+    /// Idempotent: a second call finds the decorator already in place and does nothing.
+    /// </summary>
+    private static void UseSingleProcessShutdown(IServiceCollection services)
+    {
+        var descriptor = services.LastOrDefault(d => d.ServiceType == typeof(IFeatureLifecycleManager));
+
+        // The decorator registers itself through a factory, so a null ImplementationType means
+        // either that it is already installed or that OpenFeature changed how it registers the
+        // manager — in both cases there is nothing safe to wrap.
+        if (descriptor?.ImplementationType is null)
+        {
+            return;
+        }
+
+        var innerType = descriptor.ImplementationType;
+        services.Remove(descriptor);
+        services.Add(ServiceDescriptor.Describe(
+            typeof(IFeatureLifecycleManager),
+            serviceProvider => new SingleShutdownFeatureLifecycleManager(
+                (IFeatureLifecycleManager)ActivatorUtilities.CreateInstance(serviceProvider, innerType)),
+            descriptor.Lifetime));
     }
 }

--- a/tests/Endatix.Infrastructure.Tests/FeatureFlags/SingleShutdownFeatureLifecycleManagerTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/FeatureFlags/SingleShutdownFeatureLifecycleManagerTests.cs
@@ -1,0 +1,145 @@
+using System.Threading.Channels;
+using Endatix.Infrastructure.FeatureFlags;
+using Endatix.Infrastructure.Features.Outbox;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenFeature.Hosting;
+
+namespace Endatix.Infrastructure.Tests.FeatureFlags;
+
+public sealed class SingleShutdownFeatureLifecycleManagerTests
+{
+    public SingleShutdownFeatureLifecycleManagerTests()
+    {
+        // The guard is process-wide by design, so each test has to start from a clean slate.
+        SingleShutdownFeatureLifecycleManager.ResetForTests();
+    }
+
+    [Fact]
+    public async Task ShutdownAsync_FirstCall_ShutsDownTheInnerManager()
+    {
+        // Arrange
+        var inner = new RecordingFeatureLifecycleManager();
+        var manager = new SingleShutdownFeatureLifecycleManager(inner);
+
+        // Act
+        await manager.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        inner.ShutdownCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ShutdownAsync_CalledTwice_ReachesTheInnerManagerOnce()
+    {
+        // Arrange
+        var inner = new RecordingFeatureLifecycleManager();
+        var manager = new SingleShutdownFeatureLifecycleManager(inner);
+
+        // Act
+        await manager.ShutdownAsync(TestContext.Current.CancellationToken);
+        await manager.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        inner.ShutdownCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ShutdownAsync_SecondHostInTheSameProcess_DoesNotThrow()
+    {
+        // Arrange
+        // OpenFeature.Api is a process-wide singleton whose event channel cannot be reopened, so a
+        // real second shutdown throws ChannelClosedException. Two decorator instances stand in for
+        // the two hosts, each with its own inner manager, sharing the same static guard.
+        var firstHost = new SingleShutdownFeatureLifecycleManager(new RecordingFeatureLifecycleManager());
+        var secondInner = new RecordingFeatureLifecycleManager(throwOnShutdown: true);
+        var secondHost = new SingleShutdownFeatureLifecycleManager(secondInner);
+
+        await firstHost.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        // Act
+        var secondShutdown = async () => await secondHost.ShutdownAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        await secondShutdown.Should().NotThrowAsync();
+        secondInner.ShutdownCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task EnsureInitializedAsync_EveryCall_ReachesTheInnerManager()
+    {
+        // Arrange
+        // Initialization is per host and must never be suppressed — only shutdown is one-way.
+        var inner = new RecordingFeatureLifecycleManager();
+        var manager = new SingleShutdownFeatureLifecycleManager(inner);
+
+        // Act
+        await manager.EnsureInitializedAsync(TestContext.Current.CancellationToken);
+        await manager.EnsureInitializedAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        inner.InitializeCallCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void AddEndatixOpenFeature_DecoratesTheLifecycleManager()
+    {
+        // Arrange
+        var services = CreateServices();
+
+        // Act
+        services.AddEndatixOpenFeature();
+
+        // Assert
+        var manager = services.BuildServiceProvider().GetRequiredService<IFeatureLifecycleManager>();
+        manager.Should().BeOfType<SingleShutdownFeatureLifecycleManager>();
+    }
+
+    [Fact]
+    public void AddEndatixOpenFeature_CalledTwice_RegistersASingleDecorator()
+    {
+        // Arrange
+        var services = CreateServices();
+
+        // Act
+        services.AddEndatixOpenFeature();
+        services.AddEndatixOpenFeature();
+
+        // Assert
+        services.Count(service => service.ServiceType == typeof(IFeatureLifecycleManager))
+            .Should().Be(1);
+    }
+
+    private static ServiceCollection CreateServices()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<IConfiguration>(new ConfigurationBuilder().Build());
+        return services;
+    }
+
+    private sealed class RecordingFeatureLifecycleManager(bool throwOnShutdown = false)
+        : IFeatureLifecycleManager
+    {
+        public int InitializeCallCount { get; private set; }
+
+        public int ShutdownCallCount { get; private set; }
+
+        public ValueTask EnsureInitializedAsync(CancellationToken cancellationToken = default)
+        {
+            InitializeCallCount++;
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask ShutdownAsync(CancellationToken cancellationToken = default)
+        {
+            if (throwOnShutdown)
+            {
+                throw new ChannelClosedException();
+            }
+
+            ShutdownCallCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## The problem

`Endatix.IntegrationTests.ReportingModuleStartupMigrationTests` has been failing on unrelated PRs — roughly **two runs in three** — with a failure that has nothing to do with the test's assertion:

```
System.Threading.Channels.ChannelClosedException : The channel has been closed.
   at System.Threading.Channels.ChannelWriter`1.Complete(Exception error)
   at OpenFeature.EventExecutor.ShutdownAsync()
   at OpenFeature.Api.ShutdownAsync()
   at OpenFeature.Hosting.Internal.FeatureLifecycleManager.ShutdownAsync(CancellationToken)
   at OpenFeature.Hosting.HostedFeatureLifecycleService.StoppedAsync(CancellationToken)
   at Microsoft.Extensions.Hosting.Internal.Host.StopAsync(CancellationToken)
   at Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory`1.DisposeAsync()
```

The assertion passed — a failed `Assert.True` raises `TrueException`, not this. The host blew up during **teardown**.

## Cause

`OpenFeature.Api` is a **process-wide singleton**. The hosted service that shuts it down is registered **per host**.

`EventExecutor.ShutdownAsync` (OpenFeature 2.14.0) is:

```csharp
public async Task ShutdownAsync()
{
    this.EventChannel.Writer.Complete();
    await this.EventChannel.Reader.Completion.ConfigureAwait(false);
}
```

No guard, and a completed `Channel` cannot be reopened. The first host to stop closes it; the next host's `StoppedAsync` calls `Complete()` on a closed channel and throws.

A single application host never notices — there is nothing to shut down twice. Anything that builds more than one host in a process does. The integration suite builds three `EndatixWebApplicationFactory` instances (the collection fixture, plus one each in `ReportingModuleStartupMigrationTests` and `HealthCheckTests`), so whichever stops second fails on teardown. Which one that is depends on ordering, which is why it looks like flake.

## The fix

Decorate OpenFeature's `IFeatureLifecycleManager` so shutdown reaches the SDK at most once per process:

```csharp
public ValueTask ShutdownAsync(CancellationToken cancellationToken = default) =>
    Interlocked.Exchange(ref _shutdownStarted, 1) == 0
        ? inner.ShutdownAsync(cancellationToken)
        : ValueTask.CompletedTask;
```

Three deliberate choices:

- **Decorate rather than replace.** `FeatureLifecycleManager.EnsureInitializedAsync` does real work — default provider, named providers, hooks, event handlers. Only `ShutdownAsync` needed changing, so the rest is delegated untouched, along with OpenFeature's own lifecycle timing and its configurable `FeatureStartState`/`FeatureStopState`.
- **Initialization is not guarded.** It is per host and must run for every one; only shutdown is one-way.
- **The guard is static** because the resource it protects is static. Shutting OpenFeature down is a process-wide, one-way operation, so the second and later calls have nothing left to do.

Registration hooks in after `AddOpenFeature` and is idempotent — a second `AddEndatixOpenFeature()` finds the decorator already installed and does nothing.

### Also: an obsolete call removed

`builder.AddHostedFeatureLifecycle()` has been obsolete since OpenFeature 2.14 and was emitting `CS0618`:

> Calling AddHostedFeatureLifecycle() is no longer necessary. OpenFeature will inject this automatically when you call AddOpenFeature().

Removed. **This is not the fix** — the lifecycle service is registered either way, and `AddHostedService` de-duplicates by implementation type, so the call was redundant rather than harmful.

## Verification

`dotnet build` → 0 errors, and the `CS0618` warning is gone.

`Endatix.Infrastructure.Tests` → **1117 passed, 1 failed**. The one failure is the pre-existing culture-dependent CSV export bug, unrelated to this change and fixed separately in #919. Six new tests:

| Test | Covers |
|---|---|
| `ShutdownAsync_FirstCall_ShutsDownTheInnerManager` | the first shutdown still reaches OpenFeature |
| `ShutdownAsync_CalledTwice_ReachesTheInnerManagerOnce` | the guard |
| `ShutdownAsync_SecondHostInTheSameProcess_DoesNotThrow` | the reported failure, with an inner manager that throws `ChannelClosedException` like the real one |
| `EnsureInitializedAsync_EveryCall_ReachesTheInnerManager` | initialization is *not* suppressed |
| `AddEndatixOpenFeature_DecoratesTheLifecycleManager` | wiring |
| `AddEndatixOpenFeature_CalledTwice_RegistersASingleDecorator` | idempotent registration |

Verified non-vacuous: dropping the `Interlocked` guard fails the two shutdown tests.

**On the end-to-end proof, being precise:** the integration suite passes locally on this branch (65/65) — but it also passes locally *without* this change, so the local run proves nothing on its own. The failure only reproduces on CI hardware. The real check is CI, and #918 has been rebased onto this branch to run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application shutdown handling to prevent duplicate shutdown attempts when multiple hosts run in the same process.
  * Preserved feature initialization behavior across repeated calls.
  * Improved resilience when shutdown is triggered more than once.

* **Tests**
  * Added coverage for repeated shutdowns, multiple hosts, initialization, and feature lifecycle registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->