### PR TITLE
feat(e917): Shoji codebook: set body name/description from Form entity

### DIFF
--- a/src/Endatix.Modules.Reporting/Domain/SurveyJs/SurveyJsElementType.cs
+++ b/src/Endatix.Modules.Reporting/Domain/SurveyJs/SurveyJsElementType.cs
@@ -8,6 +8,11 @@ namespace Endatix.Modules.Reporting.Domain.SurveyJs;
 /// </summary>
 internal sealed record SurveyJsElementType
 {
+    /// <summary>
+    /// SurveyJS default locale catalog key (localized title/description objects and form locale lists).
+    /// </summary>
+    public const string DefaultLocale = "default";
+
     private SurveyJsElementType(string name, SurveyJsElementCategory category, SurveyJsFlattening flattening)
     {
         Guard.Against.NullOrWhiteSpace(name);

--- a/src/Endatix.Modules.Reporting/Endpoints/Forms/CompileSchema.cs
+++ b/src/Endatix.Modules.Reporting/Endpoints/Forms/CompileSchema.cs
@@ -27,7 +27,8 @@ public sealed class CompileSchema(
             summary.Summary = "Compile reporting form schema";
             summary.Description =
                 "Compiles and persists the export schema for the active form definition. " +
-                "Use before exporting when the form predates the reporting pipeline or outbox processing has not run.";
+                "Use before exporting when the form predates the reporting pipeline or outbox processing has not run. " +
+                "Set replace=true to force Replace mode and clear flattened submissions even when real submissions exist.";
             summary.Responses[200] = "Form schema compiled.";
             summary.Responses[404] = "Form or active definition not found.";
         });
@@ -42,7 +43,7 @@ public sealed class CompileSchema(
         CompileFormSchemaRequest request,
         CancellationToken cancellationToken)
     {
-        CompileFormSchemaCommand command = new(request.FormId, tenantContext.TenantId);
+        CompileFormSchemaCommand command = new(request.FormId, tenantContext.TenantId, request.Replace);
 
         var result = await mediator.Send(command, cancellationToken);
 
@@ -73,6 +74,12 @@ public sealed class CompileFormSchemaValidator : Validator<CompileFormSchemaRequ
 public sealed class CompileFormSchemaRequest
 {
     public long FormId { get; init; }
+
+    /// <summary>
+    /// When <c>true</c>, always replace the schema and clear flattened rows.
+    /// Defaults to <c>false</c> (auto Merge vs Replace from real submission count).
+    /// </summary>
+    public bool Replace { get; init; }
 }
 
 /// <summary>

--- a/src/Endatix.Modules.Reporting/Features/Export/ExportColumnPlanBuilder.cs
+++ b/src/Endatix.Modules.Reporting/Features/Export/ExportColumnPlanBuilder.cs
@@ -19,7 +19,7 @@ internal static class ExportColumnPlanBuilder
     /// </summary>
     internal static IExportColumnPlan Build(
         FormSchemaEntity schema,
-        string locale = "default",
+        string locale = FormSchemaCodebookPropertyNames.Default,
         ColumnAliasProfile aliasProfile = ColumnAliasProfile.Native,
         IReadOnlySet<string>? columnScope = null,
         string keySeparator = ExportFormatSettings.DefaultKeySeparator,
@@ -334,7 +334,8 @@ internal static class ExportColumnPlanBuilder
             return localized.GetString();
         }
 
-        if (property.TryGetProperty("default", out var defaultValue) && defaultValue.ValueKind == JsonValueKind.String)
+        if (property.TryGetProperty(FormSchemaCodebookPropertyNames.Default, out var defaultValue) &&
+            defaultValue.ValueKind == JsonValueKind.String)
         {
             return defaultValue.GetString();
         }

--- a/src/Endatix.Modules.Reporting/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookExportDataSource.cs
+++ b/src/Endatix.Modules.Reporting/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookExportDataSource.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using Endatix.Core.Abstractions.Exporting;
+using Endatix.Core.Abstractions.Repositories;
 using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Modules.Reporting.Contracts.Export;
@@ -12,8 +13,11 @@ namespace Endatix.Modules.Reporting.Features.Export.Integrations.Crunch.Shoji;
 /// </summary>
 internal sealed class ShojiCodebookExportDataSource(
     IFormSchemaRepository formSchemaRepository,
+    IFormsRepository formsRepository,
     ExportFormatSettingsParser exportFormatSettingsParser) : IExportDataSource
 {
+    private const string DefaultDatasetName = "Form export";
+
     internal static IReadOnlyList<ExportCapability> Capabilities { get; } =
     [
         new(
@@ -79,12 +83,41 @@ internal sealed class ShojiCodebookExportDataSource(
 
         var settings = ResolveSettings(context.Options);
         var requestLocale = ReportingExportSchemaHelper.ResolveLocaleOrDefault(settings.Locale);
+        var (datasetName, datasetDescription) = await ResolveDatasetMetadataAsync(
+            context.FormId,
+            requestLocale,
+            cancellationToken);
         var codebookJson = ShojiCodebookGenerator.Generate(
             schema.FlatteningMap,
             schema.Codebook,
             settings.KeySeparator,
-            requestLocale);
+            requestLocale,
+            datasetName,
+            datasetDescription);
         yield return new DynamicExportRow { Data = codebookJson };
+    }
+
+    private async Task<(string? DatasetName, string DatasetDescription)> ResolveDatasetMetadataAsync(
+        long formId,
+        string locale,
+        CancellationToken cancellationToken)
+    {
+        var form = await formsRepository.GetByIdAsync(formId, cancellationToken);
+        var datasetName = form is not null && !string.IsNullOrWhiteSpace(form.Name)
+            ? form.Name.Trim()
+            : null;
+        var datasetDescription = form is not null && !string.IsNullOrWhiteSpace(form.Description)
+            ? form.Description.Trim()
+            : $"Exported shoji codebook for formID {formId}";
+
+        if (!ReportingExportSchemaHelper.IsDefaultLocale(locale))
+        {
+            datasetName = ReportingExportSchemaHelper.FormatTitleWithLocale(
+                datasetName ?? DefaultDatasetName,
+                locale);
+        }
+
+        return (datasetName, datasetDescription);
     }
 
     private ExportFormatSettings ResolveSettings(ExportOptions options)

--- a/src/Endatix.Modules.Reporting/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookGenerator.cs
+++ b/src/Endatix.Modules.Reporting/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookGenerator.cs
@@ -40,7 +40,9 @@ internal static class ShojiCodebookGenerator
         string flatteningMapJson,
         string codebookJson,
         string keySeparator = ExportFormatSettings.DefaultKeySeparator,
-        string locale = FormSchemaCodebookPropertyNames.Default)
+        string locale = FormSchemaCodebookPropertyNames.Default,
+        string? datasetName = null,
+        string? datasetDescription = null)
     {
         var previousLocale = _activeLocale.Value;
         _activeLocale.Value = string.IsNullOrWhiteSpace(locale)
@@ -66,7 +68,9 @@ internal static class ShojiCodebookGenerator
                     questions,
                     groupedColumnKeys,
                     codebookColumns,
-                    keySeparator);
+                    keySeparator,
+                    datasetName,
+                    datasetDescription);
             }
 
             return System.Text.Encoding.UTF8.GetString(buffer.WrittenSpan);
@@ -83,14 +87,24 @@ internal static class ShojiCodebookGenerator
         IReadOnlyDictionary<string, JsonElement> questions,
         IReadOnlyDictionary<string, List<string>> groupedColumnKeys,
         IReadOnlyDictionary<string, JsonElement> codebookColumns,
-        string keySeparator)
+        string keySeparator,
+        string? datasetName,
+        string? datasetDescription)
     {
         writer.WriteStartObject();
         writer.WriteString(ShojiCodebookPropertyNames.Element, ShojiCodebookPropertyNames.ShojiEntity);
         writer.WritePropertyName(ShojiCodebookPropertyNames.Body);
         writer.WriteStartObject();
-        writer.WriteString(ShojiCodebookPropertyNames.Name, ShojiCodebookPropertyNames.DefaultDatasetName);
-        writer.WriteString(ShojiCodebookPropertyNames.Description, ShojiCodebookPropertyNames.DefaultDatasetDescription);
+        writer.WriteString(
+            ShojiCodebookPropertyNames.Name,
+            string.IsNullOrWhiteSpace(datasetName)
+                ? ShojiCodebookPropertyNames.DefaultDatasetName
+                : datasetName.Trim());
+        writer.WriteString(
+            ShojiCodebookPropertyNames.Description,
+            string.IsNullOrWhiteSpace(datasetDescription)
+                ? ShojiCodebookPropertyNames.DefaultDatasetDescription
+                : datasetDescription.Trim());
         writer.WritePropertyName(ShojiCodebookPropertyNames.Table);
         writer.WriteStartObject();
         writer.WriteString(ShojiCodebookPropertyNames.Element, ShojiCodebookPropertyNames.CrunchTable);

--- a/src/Endatix.Modules.Reporting/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookGenerator.cs
+++ b/src/Endatix.Modules.Reporting/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookGenerator.cs
@@ -64,13 +64,14 @@ internal static class ShojiCodebookGenerator
             {
                 WriteShojiCodebook(
                     writer,
-                    flatteningMap,
-                    questions,
-                    groupedColumnKeys,
-                    codebookColumns,
-                    keySeparator,
-                    datasetName,
-                    datasetDescription);
+                    new ShojiCodebookWriteArgs(
+                        flatteningMap,
+                        questions,
+                        groupedColumnKeys,
+                        codebookColumns,
+                        keySeparator,
+                        datasetName,
+                        datasetDescription));
             }
 
             return System.Text.Encoding.UTF8.GetString(buffer.WrittenSpan);
@@ -81,15 +82,16 @@ internal static class ShojiCodebookGenerator
         }
     }
 
-    private static void WriteShojiCodebook(
-        Utf8JsonWriter writer,
-        MergedFormSchema flatteningMap,
-        IReadOnlyDictionary<string, JsonElement> questions,
-        IReadOnlyDictionary<string, List<string>> groupedColumnKeys,
-        IReadOnlyDictionary<string, JsonElement> codebookColumns,
-        string keySeparator,
-        string? datasetName,
-        string? datasetDescription)
+    private sealed record ShojiCodebookWriteArgs(
+        MergedFormSchema FlatteningMap,
+        IReadOnlyDictionary<string, JsonElement> Questions,
+        IReadOnlyDictionary<string, List<string>> GroupedColumnKeys,
+        IReadOnlyDictionary<string, JsonElement> CodebookColumns,
+        string KeySeparator,
+        string? DatasetName,
+        string? DatasetDescription);
+
+    private static void WriteShojiCodebook(Utf8JsonWriter writer, ShojiCodebookWriteArgs args)
     {
         writer.WriteStartObject();
         writer.WriteString(ShojiCodebookPropertyNames.Element, ShojiCodebookPropertyNames.ShojiEntity);
@@ -97,14 +99,14 @@ internal static class ShojiCodebookGenerator
         writer.WriteStartObject();
         writer.WriteString(
             ShojiCodebookPropertyNames.Name,
-            string.IsNullOrWhiteSpace(datasetName)
+            string.IsNullOrWhiteSpace(args.DatasetName)
                 ? ShojiCodebookPropertyNames.DefaultDatasetName
-                : datasetName.Trim());
+                : args.DatasetName.Trim());
         writer.WriteString(
             ShojiCodebookPropertyNames.Description,
-            string.IsNullOrWhiteSpace(datasetDescription)
+            string.IsNullOrWhiteSpace(args.DatasetDescription)
                 ? ShojiCodebookPropertyNames.DefaultDatasetDescription
-                : datasetDescription.Trim());
+                : args.DatasetDescription.Trim());
         writer.WritePropertyName(ShojiCodebookPropertyNames.Table);
         writer.WriteStartObject();
         writer.WriteString(ShojiCodebookPropertyNames.Element, ShojiCodebookPropertyNames.CrunchTable);
@@ -113,14 +115,20 @@ internal static class ShojiCodebookGenerator
         List<string> writtenAliases = [];
         WriteShojiVariables(
             writer,
-            flatteningMap,
-            questions,
-            groupedColumnKeys,
-            codebookColumns,
-            keySeparator,
+            args.FlatteningMap,
+            args.Questions,
+            args.GroupedColumnKeys,
+            args.CodebookColumns,
+            args.KeySeparator,
             writtenAliases);
         writer.WriteEndObject();
-        WriteOrder(writer, BuildAppearanceOrder(flatteningMap, questions, writtenAliases, keySeparator));
+        WriteOrder(
+            writer,
+            BuildAppearanceOrder(
+                args.FlatteningMap,
+                args.Questions,
+                writtenAliases,
+                args.KeySeparator));
         writer.WriteEndObject();
         writer.WriteEndObject();
         writer.WriteEndObject();

--- a/src/Endatix.Modules.Reporting/Features/Export/ReportingExportSchemaHelper.cs
+++ b/src/Endatix.Modules.Reporting/Features/Export/ReportingExportSchemaHelper.cs
@@ -1,4 +1,5 @@
 using Endatix.Core.Infrastructure.Result;
+using Endatix.Modules.Reporting.Domain.SurveyJs;
 using Endatix.Modules.Reporting.Features.FormSchema;
 using FormSchemaEntity = Endatix.Modules.Reporting.Domain.FormSchema;
 
@@ -24,7 +25,32 @@ internal static class ReportingExportSchemaHelper
         FormSchemaLocales.Contains(localesJson, locale);
 
     internal static string ResolveLocaleOrDefault(string? locale) =>
-        string.IsNullOrWhiteSpace(locale) ? "default" : locale.Trim();
+        string.IsNullOrWhiteSpace(locale) ? SurveyJsElementType.DefaultLocale : locale.Trim();
+
+    /// <summary>
+    /// Returns <c>true</c> when <paramref name="locale"/> resolves to the default catalog key.
+    /// </summary>
+    internal static bool IsDefaultLocale(string? locale) =>
+        string.Equals(
+            ResolveLocaleOrDefault(locale),
+            SurveyJsElementType.DefaultLocale,
+            StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Appends <c> - {locale}</c> to a title when the locale is not the default catalog key.
+    /// </summary>
+    internal static string FormatTitleWithLocale(string title, string? locale)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(title);
+
+        var resolvedLocale = ResolveLocaleOrDefault(locale);
+        if (IsDefaultLocale(resolvedLocale))
+        {
+            return title.Trim();
+        }
+
+        return $"{title.Trim()} - {resolvedLocale}";
+    }
 
     internal static Result<T> InvalidLocaleResult<T>(string localesJson, string locale)
     {

--- a/src/Endatix.Modules.Reporting/Features/FormSchema/Codebook/FormSchemaCodebookPropertyNames.cs
+++ b/src/Endatix.Modules.Reporting/Features/FormSchema/Codebook/FormSchemaCodebookPropertyNames.cs
@@ -22,7 +22,9 @@ internal static class FormSchemaCodebookPropertyNames
     public const string ColumnLabel = "columnLabel";
 
     public const string Id = "id";
-    public const string Default = "default";
+
+    /// <inheritdoc cref="Domain.SurveyJs.SurveyJsElementType.DefaultLocale"/>
+    public const string Default = Domain.SurveyJs.SurveyJsElementType.DefaultLocale;
 
     public const string UnknownSurveyJsType = "unknown";
 }

--- a/src/Endatix.Modules.Reporting/Features/FormSchema/CompileFormSchemaCommand.cs
+++ b/src/Endatix.Modules.Reporting/Features/FormSchema/CompileFormSchemaCommand.cs
@@ -6,9 +6,16 @@ namespace Endatix.Modules.Reporting.Features.FormSchema;
 /// <summary>
 /// Command to compile the form schema.
 /// </summary>
+/// <param name="FormId">The form to compile.</param>
+/// <param name="TenantId">The tenant that owns the form.</param>
+/// <param name="Replace">
+/// When <c>true</c>, always replace the schema and clear flattened rows.
+/// When <c>false</c> (default), auto-pick Replace vs Merge from real submission count.
+/// </param>
 public sealed record CompileFormSchemaCommand(
     long FormId,
-    long TenantId) : ICommand<Result<CompileFormSchemaResult>>;
+    long TenantId,
+    bool Replace = false) : ICommand<Result<CompileFormSchemaResult>>;
 
 /// <summary>
 /// Result of the compile form schema command.

--- a/src/Endatix.Modules.Reporting/Features/FormSchema/CompileFormSchemaHandler.cs
+++ b/src/Endatix.Modules.Reporting/Features/FormSchema/CompileFormSchemaHandler.cs
@@ -36,6 +36,7 @@ public sealed class CompileFormSchemaHandler(
             request.TenantId,
             request.FormId,
             formDefinitionId,
+            request.Replace,
             cancellationToken);
 
         return Result.Success(

--- a/src/Endatix.Modules.Reporting/Features/FormSchema/FormSchemaLocales.cs
+++ b/src/Endatix.Modules.Reporting/Features/FormSchema/FormSchemaLocales.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Endatix.Modules.Reporting.Domain.SurveyJs;
 
 namespace Endatix.Modules.Reporting.Features.FormSchema;
 
@@ -7,8 +8,6 @@ namespace Endatix.Modules.Reporting.Features.FormSchema;
 /// </summary>
 public static class FormSchemaLocales
 {
-    private const string DEFAULT_LOCALE_KEY = "default";
-
     /// <summary>
     /// Parses the <c>FormSchema.Locales</c> JSON into a list of locale keys.
     /// </summary>
@@ -18,7 +17,7 @@ public static class FormSchemaLocales
     {
         if (string.IsNullOrWhiteSpace(localesJson))
         {
-            return [DEFAULT_LOCALE_KEY];
+            return [SurveyJsElementType.DefaultLocale];
         }
 
         try
@@ -26,7 +25,7 @@ public static class FormSchemaLocales
             using var document = JsonDocument.Parse(localesJson);
             if (document.RootElement.ValueKind != JsonValueKind.Array)
             {
-                return [DEFAULT_LOCALE_KEY];
+                return [SurveyJsElementType.DefaultLocale];
             }
 
             List<string> locales = [];
@@ -42,11 +41,11 @@ public static class FormSchemaLocales
                 }
             }
 
-            return locales.Count > 0 ? locales : [DEFAULT_LOCALE_KEY];
+            return locales.Count > 0 ? locales : [SurveyJsElementType.DefaultLocale];
         }
         catch (JsonException)
         {
-            return [DEFAULT_LOCALE_KEY];
+            return [SurveyJsElementType.DefaultLocale];
         }
     }
 

--- a/src/Endatix.Modules.Reporting/Features/FormSchema/FormSchemaProcessor.cs
+++ b/src/Endatix.Modules.Reporting/Features/FormSchema/FormSchemaProcessor.cs
@@ -10,7 +10,7 @@ namespace Endatix.Modules.Reporting.Features.FormSchema;
 
 /// <summary>
 /// Compiles and persists the export schema for a form definition.
-/// Uses replace mode when the form has no real (non-test) submissions; otherwise merge.
+/// Uses replace mode when forced via <c>replace</c> or when the form has no real (non-test) submissions; otherwise merge.
 /// </summary>
 internal sealed class FormSchemaProcessor(
     IFormsRepository formsRepository,
@@ -26,7 +26,8 @@ internal sealed class FormSchemaProcessor(
         long tenantId,
         long formId,
         long formDefinitionId,
-        CancellationToken cancellationToken)
+        bool replace = false,
+        CancellationToken cancellationToken = default)
     {
         DefinitionByFormAndDefinitionIdSpec spec = new(formId, formDefinitionId);
         var formDefinition = await formsRepository.SingleOrDefaultAsync(spec, cancellationToken);
@@ -53,7 +54,7 @@ internal sealed class FormSchemaProcessor(
                 formId,
                 cancellationToken);
             var realSubmissionCount = await CountRealSubmissionsAsync(tenantId, formId, cancellationToken);
-            var compileMode = realSubmissionCount == 0
+            var compileMode = replace || realSubmissionCount == 0
                 ? FormSchemaCompileMode.Replace
                 : FormSchemaCompileMode.Merge;
 
@@ -65,6 +66,7 @@ internal sealed class FormSchemaProcessor(
                     formDefinitionId,
                     formDefinition.JsonData,
                     existingSchema,
+                    forceClearFlattenedRows: replace,
                     cancellationToken);
             }
             else
@@ -79,10 +81,11 @@ internal sealed class FormSchemaProcessor(
             }
 
             logger.LogInformation(
-                "Compiled form schema for form {FormId} (definition {FormDefinitionId}, compileMode={CompileMode}, realSubmissionCount={RealSubmissionCount})",
+                "Compiled form schema for form {FormId} (definition {FormDefinitionId}, compileMode={CompileMode}, replace={Replace}, realSubmissionCount={RealSubmissionCount})",
                 formId,
                 formDefinitionId,
                 compileMode,
+                replace,
                 realSubmissionCount);
         }
         catch (SchemaCompilationLimitExceededException ex)
@@ -99,6 +102,7 @@ internal sealed class FormSchemaProcessor(
         long formDefinitionId,
         string definitionJson,
         FormSchemaEntity? existingSchema,
+        bool forceClearFlattenedRows,
         CancellationToken cancellationToken)
     {
         var compiled = compiler.CompilePersisted(
@@ -110,12 +114,19 @@ internal sealed class FormSchemaProcessor(
         {
             await PersistAsync(tenantId, formId, formDefinitionId, existingSchema, compiled, cancellationToken);
 
-            // Count lives on App DB and cannot join this Reporting transaction; re-check
-            // immediately before delete so a concurrent first real submission is not wiped.
-            var realSubmissionCount = await CountRealSubmissionsAsync(tenantId, formId, cancellationToken);
-            if (realSubmissionCount == 0)
+            if (forceClearFlattenedRows)
             {
                 await flattenedSubmissionRepository.DeleteByFormIdAsync(tenantId, formId, cancellationToken);
+            }
+            else
+            {
+                // Count lives on App DB and cannot join this Reporting transaction; re-check
+                // immediately before delete so a concurrent first real submission is not wiped.
+                var realSubmissionCount = await CountRealSubmissionsAsync(tenantId, formId, cancellationToken);
+                if (realSubmissionCount == 0)
+                {
+                    await flattenedSubmissionRepository.DeleteByFormIdAsync(tenantId, formId, cancellationToken);
+                }
             }
 
             await unitOfWork.CommitTransactionAsync(cancellationToken);

--- a/src/Endatix.Modules.Reporting/Features/FormSchema/FormSchemaProvider.cs
+++ b/src/Endatix.Modules.Reporting/Features/FormSchema/FormSchemaProvider.cs
@@ -23,7 +23,7 @@ internal sealed class FormSchemaProvider(
             return schema;
         }
 
-        await schemaProcessor.ProcessAsync(tenantId, formId, formDefinitionId, cancellationToken);
+        await schemaProcessor.ProcessAsync(tenantId, formId, formDefinitionId, cancellationToken: cancellationToken);
 
         schema = await schemaRepository.GetByFormIdAsync(tenantId, formId, cancellationToken);
         if (schema is null || schema.FormDefinitionRevision < formDefinitionId)

--- a/src/Endatix.Modules.Reporting/Features/FormSchema/IFormSchemaProcessor.cs
+++ b/src/Endatix.Modules.Reporting/Features/FormSchema/IFormSchemaProcessor.cs
@@ -11,7 +11,16 @@ public interface IFormSchemaProcessor
     /// <param name="tenantId">The ID of the tenant.</param>
     /// <param name="formId">The ID of the form.</param>
     /// <param name="formDefinitionId">The ID of the form definition.</param>
+    /// <param name="replace">
+    /// When <c>true</c>, always replace the schema and clear flattened rows even if real submissions exist.
+    /// When <c>false</c> (default), replace only when the form has no real submissions; otherwise merge.
+    /// </param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task representing the asynchronous operation.</returns>
-    Task ProcessAsync(long tenantId, long formId, long formDefinitionId, CancellationToken cancellationToken);
+    Task ProcessAsync(
+        long tenantId,
+        long formId,
+        long formDefinitionId,
+        bool replace = false,
+        CancellationToken cancellationToken = default);
 }

--- a/src/Endatix.Modules.Reporting/Features/Outbox/CompileFormSchemaOutboxHandler.cs
+++ b/src/Endatix.Modules.Reporting/Features/Outbox/CompileFormSchemaOutboxHandler.cs
@@ -24,6 +24,6 @@ internal sealed class CompileFormSchemaOutboxHandler(
         var formId = message.GetRequiredIdProp(payload, "formId");
         var formDefinitionId = message.GetRequiredIdProp(payload, "formDefinitionId");
 
-        await schemaProcessor.ProcessAsync(tenantId, formId, formDefinitionId, cancellationToken);
+        await schemaProcessor.ProcessAsync(tenantId, formId, formDefinitionId, cancellationToken: cancellationToken);
     }
 }

--- a/src/Endatix.Modules.Reporting/Shared/SurveyJs/SurveyJsPropertyNames.cs
+++ b/src/Endatix.Modules.Reporting/Shared/SurveyJs/SurveyJsPropertyNames.cs
@@ -40,5 +40,7 @@ internal static class SurveyJsPropertyNames
     public const string MultiSelect = "multiSelect";
     public const string SliderType = "sliderType";
     public const string SliderTypeRange = "range";
-    public const string DefaultLocale = "default";
+
+    /// <inheritdoc cref="Domain.SurveyJs.SurveyJsElementType.DefaultLocale"/>
+    public const string DefaultLocale = Domain.SurveyJs.SurveyJsElementType.DefaultLocale;
 }

--- a/tests/Endatix.IntegrationTests/Infrastructure/FormSchemaProcessorReplaceMergeIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/FormSchemaProcessorReplaceMergeIntegrationTests.cs
@@ -79,7 +79,7 @@ public sealed class FormSchemaProcessorReplaceMergeIntegrationTests
         FormSchemaProcessor processor = CreateProcessor(formsRepository, reportingDb, appDb);
 
         // Act
-        await processor.ProcessAsync(TenantId, seed.FormId, seed.FormDefinitionId, cancellationToken);
+        await processor.ProcessAsync(TenantId, seed.FormId, seed.FormDefinitionId, cancellationToken: cancellationToken);
 
         // Assert
         reportingDb.ChangeTracker.Clear();
@@ -122,7 +122,7 @@ public sealed class FormSchemaProcessorReplaceMergeIntegrationTests
         FormSchemaProcessor processor = CreateProcessor(formsRepository, reportingDb, appDb);
 
         // Act
-        await processor.ProcessAsync(TenantId, seed.FormId, seed.FormDefinitionId, cancellationToken);
+        await processor.ProcessAsync(TenantId, seed.FormId, seed.FormDefinitionId, cancellationToken: cancellationToken);
 
         // Assert
         reportingDb.ChangeTracker.Clear();
@@ -156,7 +156,7 @@ public sealed class FormSchemaProcessorReplaceMergeIntegrationTests
         FormSchemaProcessor processor = CreateProcessor(formsRepository, reportingDb, appDb);
 
         // Act
-        await processor.ProcessAsync(TenantId, seed.FormId, seed.FormDefinitionId, cancellationToken);
+        await processor.ProcessAsync(TenantId, seed.FormId, seed.FormDefinitionId, cancellationToken: cancellationToken);
 
         // Assert
         reportingDb.ChangeTracker.Clear();
@@ -169,6 +169,50 @@ public sealed class FormSchemaProcessorReplaceMergeIntegrationTests
             .IgnoreQueryFilters()
             .CountAsync(row => row.TenantId == TenantId && row.FormId == seed.FormId, cancellationToken);
         flattenedForForm.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_WithReplaceTrueAndRealSubmissions_ReplacesSchemaAndDeletesFlattenedRows()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        SeededForm seed = await SeedFormAsync(seedRealSubmission: true, seedTestSubmission: false, cancellationToken);
+        await SeedReportingStateWithOrphanAsync(seed, cancellationToken);
+
+        FormDefinition currentDefinition = new(TenantId, jsonData: DefinitionWithoutOrphan) { Id = seed.FormDefinitionId };
+        IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
+        formsRepository
+            .SingleOrDefaultAsync(Arg.Any<DefinitionByFormAndDefinitionIdSpec>(), cancellationToken)
+            .Returns(currentDefinition);
+
+        await using ReportingDbContext reportingDb = CreateReportingDbContext();
+        await using AppDbContext appDb = CreateAppDbContext();
+        FormSchemaProcessor processor = CreateProcessor(formsRepository, reportingDb, appDb);
+
+        // Act
+        await processor.ProcessAsync(
+            TenantId,
+            seed.FormId,
+            seed.FormDefinitionId,
+            replace: true,
+            cancellationToken);
+
+        // Assert
+        reportingDb.ChangeTracker.Clear();
+        FormSchema schema = await reportingDb.FormSchemas
+            .SingleAsync(row => row.TenantId == TenantId && row.FormId == seed.FormId, cancellationToken);
+        schema.FlatteningMap.Should().Contain("keep");
+        schema.FlatteningMap.Should().NotContain("orphan");
+
+        int flattenedForForm = await reportingDb.FlattenedSubmissions
+            .IgnoreQueryFilters()
+            .CountAsync(row => row.TenantId == TenantId && row.FormId == seed.FormId, cancellationToken);
+        flattenedForForm.Should().Be(0);
+
+        int otherFormRows = await reportingDb.FlattenedSubmissions
+            .IgnoreQueryFilters()
+            .CountAsync(row => row.SubmissionId == OtherFormFlattenedSubmissionId, cancellationToken);
+        otherFormRows.Should().Be(1);
     }
 
     private async Task<SeededForm> SeedFormAsync(

--- a/tests/Endatix.Modules.Reporting.Tests/Endpoints/Forms/CompileSchemaTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Endpoints/Forms/CompileSchemaTests.cs
@@ -64,7 +64,32 @@ public sealed class CompileSchemaTests
         await _mediator.Received(1).Send(
             Arg.Is<CompileFormSchemaCommand>(command =>
                 command.FormId == formId &&
-                command.TenantId == SampleData.TENANT_ID),
+                command.TenantId == SampleData.TENANT_ID &&
+                command.Replace == false),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_WhenReplaceTrue_PassesReplaceToCommand()
+    {
+        const long formId = 100;
+        const long formDefinitionId = 200;
+        CompileFormSchemaRequest request = new() { FormId = formId, Replace = true };
+
+        _mediator.Send(Arg.Any<CompileFormSchemaCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new CompileFormSchemaResult(formId, formDefinitionId)));
+
+        Results<Ok<CompileFormSchemaResponse>, ProblemHttpResult> response =
+            await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        Ok<CompileFormSchemaResponse>? ok = response.Result as Ok<CompileFormSchemaResponse>;
+        ok.Should().NotBeNull();
+
+        await _mediator.Received(1).Send(
+            Arg.Is<CompileFormSchemaCommand>(command =>
+                command.FormId == formId &&
+                command.TenantId == SampleData.TENANT_ID &&
+                command.Replace),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Endatix.Modules.Reporting.Tests/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookExportDataSourceTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookExportDataSourceTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Endatix.Core.Abstractions.Exporting;
+using Endatix.Core.Abstractions.Repositories;
 using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Modules.Reporting.Contracts.Export;
@@ -22,8 +23,13 @@ public sealed class ShojiCodebookExportDataSourceTests
     private static readonly ExportFormatSettingsParser ExportFormatSettingsParser =
         new(NullLogger<ExportFormatSettingsParser>.Instance);
 
-    private static ShojiCodebookExportDataSource CreateDataSource(IFormSchemaRepository formSchemaRepository) =>
-        new(formSchemaRepository, ExportFormatSettingsParser);
+    private static ShojiCodebookExportDataSource CreateDataSource(
+        IFormSchemaRepository formSchemaRepository,
+        IFormsRepository? formsRepository = null) =>
+        new(
+            formSchemaRepository,
+            formsRepository ?? Substitute.For<IFormsRepository>(),
+            ExportFormatSettingsParser);
 
     [Fact]
     public async Task PrepareOptionsAsync_WithMissingSchema_ReturnsMissingSchemaMessage()
@@ -97,17 +103,24 @@ public sealed class ShojiCodebookExportDataSourceTests
         FormSchemaCompiler compiler = new();
         FormSchemaCompileResult compiled = compiler.CompilePersisted(definitionJson);
         FormSchemaEntity schema = new(TenantId, FormId, 1, compiled.FlatteningMapJson, compiled.CodebookJson);
+        Form form = new(TenantId, "Customer Satisfaction Survey", "Annual wave");
+        form.Id = FormId;
         string expectedCodebookJson = ShojiCodebookGenerator.Generate(
             schema.FlatteningMap,
             schema.Codebook,
-            ExportFormatSettings.InterimCrunchKeySeparator);
+            ExportFormatSettings.InterimCrunchKeySeparator,
+            datasetName: form.Name,
+            datasetDescription: form.Description);
 
         IFormSchemaRepository formSchemaRepository = Substitute.For<IFormSchemaRepository>();
         formSchemaRepository
             .GetByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>())
             .Returns(schema);
 
-        ShojiCodebookExportDataSource dataSource = CreateDataSource(formSchemaRepository);
+        IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
+        formsRepository.GetByIdAsync(FormId, Arg.Any<CancellationToken>()).Returns(form);
+
+        ShojiCodebookExportDataSource dataSource = CreateDataSource(formSchemaRepository, formsRepository);
         ExportDataSourceContext context = CreateContext(
             settingsJson: """{"keySeparator":"--"}""");
 
@@ -130,6 +143,117 @@ public sealed class ShojiCodebookExportDataSourceTests
             actualDocument.RootElement,
             expectedDocument.RootElement,
             because: "Shoji data source should generate codebook from persisted schema artifacts");
+    }
+
+    [Fact]
+    public async Task StreamAsync_WithFormMissingDescription_UsesFormIdFallbackDescription()
+    {
+        string definitionJson = FormSchemaFixtureLoader.LoadText("simple-definition.json");
+        FormSchemaCompileResult compiled = new FormSchemaCompiler().CompilePersisted(definitionJson);
+        FormSchemaEntity schema = new(TenantId, FormId, 1, compiled.FlatteningMapJson, compiled.CodebookJson);
+        Form form = new(TenantId, "Datanium Panel");
+        form.Id = FormId;
+
+        IFormSchemaRepository formSchemaRepository = Substitute.For<IFormSchemaRepository>();
+        formSchemaRepository
+            .GetByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>())
+            .Returns(schema);
+
+        IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
+        formsRepository.GetByIdAsync(FormId, Arg.Any<CancellationToken>()).Returns(form);
+
+        ShojiCodebookExportDataSource dataSource = CreateDataSource(formSchemaRepository, formsRepository);
+        ExportDataSourceContext context = CreateContext();
+        await dataSource.PrepareOptionsAsync(context, TestContext.Current.CancellationToken);
+
+        DynamicExportRow row = null!;
+        await foreach (IExportItem item in dataSource.StreamAsync(context, TestContext.Current.CancellationToken))
+        {
+            row = (DynamicExportRow)item;
+        }
+
+        using JsonDocument document = JsonDocument.Parse(row.Data!);
+        JsonElement body = document.RootElement.GetProperty("body");
+        body.GetProperty("name").GetString().Should().Be("Datanium Panel");
+        body.GetProperty("description").GetString().Should().Be($"Exported shoji codebook for formID {FormId}");
+    }
+
+    [Fact]
+    public async Task StreamAsync_WithNonDefaultLocale_AppendsCultureCodeToDatasetName()
+    {
+        string definitionJson = FormSchemaFixtureLoader.LoadText("simple-definition.json");
+        FormSchemaCompileResult compiled = new FormSchemaCompiler().CompilePersisted(definitionJson);
+        FormSchemaEntity schema = new(
+            TenantId,
+            FormId,
+            1,
+            compiled.FlatteningMapJson,
+            compiled.CodebookJson,
+            locales: """["default","es"]""");
+        Form form = new(TenantId, "Datanium Panel", "Wave 1");
+        form.Id = FormId;
+
+        IFormSchemaRepository formSchemaRepository = Substitute.For<IFormSchemaRepository>();
+        formSchemaRepository
+            .GetByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>())
+            .Returns(schema);
+
+        IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
+        formsRepository.GetByIdAsync(FormId, Arg.Any<CancellationToken>()).Returns(form);
+
+        ShojiCodebookExportDataSource dataSource = CreateDataSource(formSchemaRepository, formsRepository);
+        ExportDataSourceContext context = CreateContext(
+            settingsJson: """{"locale":"es","keySeparator":"--"}""");
+
+        Result<ExportOptions> prepareResult = await dataSource.PrepareOptionsAsync(
+            context,
+            TestContext.Current.CancellationToken);
+        prepareResult.IsSuccess.Should().BeTrue();
+
+        DynamicExportRow row = null!;
+        await foreach (IExportItem item in dataSource.StreamAsync(context, TestContext.Current.CancellationToken))
+        {
+            row = (DynamicExportRow)item;
+        }
+
+        using JsonDocument document = JsonDocument.Parse(row.Data!);
+        JsonElement body = document.RootElement.GetProperty("body");
+        body.GetProperty("name").GetString().Should().Be("Datanium Panel - es");
+        body.GetProperty("description").GetString().Should().Be("Wave 1");
+    }
+
+    [Fact]
+    public async Task StreamAsync_WithDefaultLocale_DoesNotAppendCultureCodeToDatasetName()
+    {
+        string definitionJson = FormSchemaFixtureLoader.LoadText("simple-definition.json");
+        FormSchemaCompileResult compiled = new FormSchemaCompiler().CompilePersisted(definitionJson);
+        FormSchemaEntity schema = new(TenantId, FormId, 1, compiled.FlatteningMapJson, compiled.CodebookJson);
+        Form form = new(TenantId, "Datanium Panel");
+        form.Id = FormId;
+
+        IFormSchemaRepository formSchemaRepository = Substitute.For<IFormSchemaRepository>();
+        formSchemaRepository
+            .GetByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>())
+            .Returns(schema);
+
+        IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
+        formsRepository.GetByIdAsync(FormId, Arg.Any<CancellationToken>()).Returns(form);
+
+        ShojiCodebookExportDataSource dataSource = CreateDataSource(formSchemaRepository, formsRepository);
+        ExportDataSourceContext context = CreateContext(
+            settingsJson: """{"locale":"default"}""");
+
+        await dataSource.PrepareOptionsAsync(context, TestContext.Current.CancellationToken);
+
+        DynamicExportRow row = null!;
+        await foreach (IExportItem item in dataSource.StreamAsync(context, TestContext.Current.CancellationToken))
+        {
+            row = (DynamicExportRow)item;
+        }
+
+        using JsonDocument document = JsonDocument.Parse(row.Data!);
+        document.RootElement.GetProperty("body").GetProperty("name").GetString()
+            .Should().Be("Datanium Panel");
     }
 
     [Fact]

--- a/tests/Endatix.Modules.Reporting.Tests/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookExportDataSourceTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookExportDataSourceTests.cs
@@ -179,6 +179,37 @@ public sealed class ShojiCodebookExportDataSourceTests
     }
 
     [Fact]
+    public async Task StreamAsync_WithUnloadedForm_UsesDefaultDatasetNameAndFormIdFallbackDescription()
+    {
+        string definitionJson = FormSchemaFixtureLoader.LoadText("simple-definition.json");
+        FormSchemaCompileResult compiled = new FormSchemaCompiler().CompilePersisted(definitionJson);
+        FormSchemaEntity schema = new(TenantId, FormId, 1, compiled.FlatteningMapJson, compiled.CodebookJson);
+
+        IFormSchemaRepository formSchemaRepository = Substitute.For<IFormSchemaRepository>();
+        formSchemaRepository
+            .GetByFormIdAsync(TenantId, FormId, Arg.Any<CancellationToken>())
+            .Returns(schema);
+
+        IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
+        formsRepository.GetByIdAsync(FormId, Arg.Any<CancellationToken>()).Returns((Form?)null);
+
+        ShojiCodebookExportDataSource dataSource = CreateDataSource(formSchemaRepository, formsRepository);
+        ExportDataSourceContext context = CreateContext();
+        await dataSource.PrepareOptionsAsync(context, TestContext.Current.CancellationToken);
+
+        DynamicExportRow row = null!;
+        await foreach (IExportItem item in dataSource.StreamAsync(context, TestContext.Current.CancellationToken))
+        {
+            row = (DynamicExportRow)item;
+        }
+
+        using JsonDocument document = JsonDocument.Parse(row.Data!);
+        JsonElement body = document.RootElement.GetProperty("body");
+        body.GetProperty("name").GetString().Should().Be("Form export");
+        body.GetProperty("description").GetString().Should().Be($"Exported shoji codebook for formID {FormId}");
+    }
+
+    [Fact]
     public async Task StreamAsync_WithNonDefaultLocale_AppendsCultureCodeToDatasetName()
     {
         string definitionJson = FormSchemaFixtureLoader.LoadText("simple-definition.json");

--- a/tests/Endatix.Modules.Reporting.Tests/Features/Export/ShojiCodebookGeneratorTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/Export/ShojiCodebookGeneratorTests.cs
@@ -33,6 +33,42 @@ public sealed class ShojiCodebookGeneratorTests
     }
 
     [Fact]
+    public void Generate_WithDatasetMetadata_WritesBodyNameAndDescription()
+    {
+        string definitionJson = FormSchemaFixtureLoader.LoadText("simple-definition.json");
+        FormSchemaCompileResult compiled = new FormSchemaCompiler().CompilePersisted(definitionJson);
+
+        using JsonDocument document = JsonDocument.Parse(
+            ShojiCodebookGenerator.Generate(
+                compiled.FlatteningMapJson,
+                compiled.CodebookJson,
+                ExportFormatSettings.InterimCrunchKeySeparator,
+                datasetName: "ACME Wave 1",
+                datasetDescription: "Panel export for ACME"));
+        JsonElement body = document.RootElement.GetProperty("body");
+
+        body.GetProperty("name").GetString().Should().Be("ACME Wave 1");
+        body.GetProperty("description").GetString().Should().Be("Panel export for ACME");
+    }
+
+    [Fact]
+    public void Generate_WithoutDatasetMetadata_KeepsDefaultBodyNameAndDescription()
+    {
+        string definitionJson = FormSchemaFixtureLoader.LoadText("simple-definition.json");
+        FormSchemaCompileResult compiled = new FormSchemaCompiler().CompilePersisted(definitionJson);
+
+        using JsonDocument document = JsonDocument.Parse(
+            ShojiCodebookGenerator.Generate(
+                compiled.FlatteningMapJson,
+                compiled.CodebookJson,
+                ExportFormatSettings.InterimCrunchKeySeparator));
+        JsonElement body = document.RootElement.GetProperty("body");
+
+        body.GetProperty("name").GetString().Should().Be("Form export");
+        body.GetProperty("description").GetString().Should().Be("Shoji codebook metadata");
+    }
+
+    [Fact]
     public void Generate_Order_FollowsSystemColumnsThenSurveyAppearance()
     {
         // Arrange

--- a/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/CompileFormSchemaHandlerTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/CompileFormSchemaHandlerTests.cs
@@ -30,7 +30,12 @@ public sealed class CompileFormSchemaHandlerTests
 
         result.Status.Should().Be(ResultStatus.NotFound);
         await schemaProcessor.DidNotReceive()
-            .ProcessAsync(Arg.Any<long>(), Arg.Any<long>(), Arg.Any<long>(), Arg.Any<CancellationToken>());
+            .ProcessAsync(
+                Arg.Any<long>(),
+                Arg.Any<long>(),
+                Arg.Any<long>(),
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -59,6 +64,34 @@ public sealed class CompileFormSchemaHandlerTests
         result.IsSuccess.Should().BeTrue();
         result.Value!.FormDefinitionId.Should().Be(FormDefinitionId);
         await schemaProcessor.Received(1)
-            .ProcessAsync(TenantId, FormId, FormDefinitionId, Arg.Any<CancellationToken>());
+            .ProcessAsync(TenantId, FormId, FormDefinitionId, replace: false, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WhenReplaceTrue_PassesReplaceToProcessor()
+    {
+        Form form = new(TenantId, "Test form") { Id = FormId };
+        FormDefinition definition = new(TenantId, isDraft: false, """{"pages":[]}""")
+        {
+            Id = FormDefinitionId,
+        };
+        form.AddFormDefinition(definition);
+        form.SetActiveFormDefinition(definition);
+
+        IRepository<Form> formsRepository = Substitute.For<IRepository<Form>>();
+        formsRepository
+            .SingleOrDefaultAsync(Arg.Any<ActiveFormDefinitionByFormIdSpec>(), Arg.Any<CancellationToken>())
+            .Returns(form);
+
+        IFormSchemaProcessor schemaProcessor = Substitute.For<IFormSchemaProcessor>();
+        CompileFormSchemaHandler handler = new(formsRepository, schemaProcessor);
+
+        Result<CompileFormSchemaResult> result = await handler.Handle(
+            new CompileFormSchemaCommand(FormId, TenantId, Replace: true),
+            TestContext.Current.CancellationToken);
+
+        result.IsSuccess.Should().BeTrue();
+        await schemaProcessor.Received(1)
+            .ProcessAsync(TenantId, FormId, FormDefinitionId, replace: true, Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FormSchemaProcessorTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FormSchemaProcessorTests.cs
@@ -17,65 +17,65 @@ namespace Endatix.Modules.Reporting.Tests.Features.FormSchema;
 /// </summary>
 public class FormSchemaProcessorTests
 {
-  private const long TenantId = 1;
-  private const long FormId = 100;
-  private const long FormDefinitionId = 200;
+    private const long TenantId = 1;
+    private const long FormId = 100;
+    private const long FormDefinitionId = 200;
 
-  [Fact]
-  public async Task FormSchemaProcessor_ProcessAsync_WithMissingDefinition_DoesNotPersistSchema()
-  {
-    IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
-    IFormSchemaRepository schemaRepository = Substitute.For<IFormSchemaRepository>();
-    IFlattenedSubmissionRepository flattenedRepository = Substitute.For<IFlattenedSubmissionRepository>();
-    formsRepository.SingleOrDefaultAsync(Arg.Any<DefinitionByFormAndDefinitionIdSpec>(), Arg.Any<CancellationToken>())
-        .Returns((FormDefinition?)null);
+    [Fact]
+    public async Task FormSchemaProcessor_ProcessAsync_WithMissingDefinition_DoesNotPersistSchema()
+    {
+        IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
+        IFormSchemaRepository schemaRepository = Substitute.For<IFormSchemaRepository>();
+        IFlattenedSubmissionRepository flattenedRepository = Substitute.For<IFlattenedSubmissionRepository>();
+        formsRepository.SingleOrDefaultAsync(Arg.Any<DefinitionByFormAndDefinitionIdSpec>(), Arg.Any<CancellationToken>())
+            .Returns((FormDefinition?)null);
 
-    FormSchemaProcessor processor = CreateProcessor(
-        formsRepository,
-        schemaRepository,
-        flattenedRepository);
+        FormSchemaProcessor processor = CreateProcessor(
+            formsRepository,
+            schemaRepository,
+            flattenedRepository);
 
-    await processor.ProcessAsync(TenantId, FormId, formDefinitionId: 999, TestContext.Current.CancellationToken);
+        await processor.ProcessAsync(TenantId, FormId, formDefinitionId: 999, cancellationToken: TestContext.Current.CancellationToken);
 
-    await schemaRepository.DidNotReceive().GetByFormIdAsync(Arg.Any<long>(), Arg.Any<long>(), Arg.Any<CancellationToken>());
-    await schemaRepository.DidNotReceive().SaveAsync(Arg.Any<FormSchemaEntity>(), Arg.Any<CancellationToken>());
-    await flattenedRepository.DidNotReceive()
-        .DeleteByFormIdAsync(Arg.Any<long>(), Arg.Any<long>(), Arg.Any<CancellationToken>());
-  }
+        await schemaRepository.DidNotReceive().GetByFormIdAsync(Arg.Any<long>(), Arg.Any<long>(), Arg.Any<CancellationToken>());
+        await schemaRepository.DidNotReceive().SaveAsync(Arg.Any<FormSchemaEntity>(), Arg.Any<CancellationToken>());
+        await flattenedRepository.DidNotReceive()
+            .DeleteByFormIdAsync(Arg.Any<long>(), Arg.Any<long>(), Arg.Any<CancellationToken>());
+    }
 
-  [Fact]
-  public async Task FormSchemaProcessor_ProcessAsync_WithTenantMismatch_ThrowsInvalidOperationException()
-  {
-    IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
-    IFormSchemaRepository schemaRepository = Substitute.For<IFormSchemaRepository>();
-    IFlattenedSubmissionRepository flattenedRepository = Substitute.For<IFlattenedSubmissionRepository>();
-    FormDefinition definition = new(tenantId: 2, jsonData: """{"pages":[]}""") { Id = FormDefinitionId };
-    formsRepository.SingleOrDefaultAsync(Arg.Any<DefinitionByFormAndDefinitionIdSpec>(), Arg.Any<CancellationToken>())
-        .Returns(definition);
+    [Fact]
+    public async Task FormSchemaProcessor_ProcessAsync_WithTenantMismatch_ThrowsInvalidOperationException()
+    {
+        IFormsRepository formsRepository = Substitute.For<IFormsRepository>();
+        IFormSchemaRepository schemaRepository = Substitute.For<IFormSchemaRepository>();
+        IFlattenedSubmissionRepository flattenedRepository = Substitute.For<IFlattenedSubmissionRepository>();
+        FormDefinition definition = new(tenantId: 2, jsonData: """{"pages":[]}""") { Id = FormDefinitionId };
+        formsRepository.SingleOrDefaultAsync(Arg.Any<DefinitionByFormAndDefinitionIdSpec>(), Arg.Any<CancellationToken>())
+            .Returns(definition);
 
-    FormSchemaProcessor processor = CreateProcessor(
-        formsRepository,
-        schemaRepository,
-        flattenedRepository);
+        FormSchemaProcessor processor = CreateProcessor(
+            formsRepository,
+            schemaRepository,
+            flattenedRepository);
 
-    Func<Task> act = () => processor.ProcessAsync(TenantId, FormId, FormDefinitionId, TestContext.Current.CancellationToken);
+        Func<Task> act = () => processor.ProcessAsync(TenantId, FormId, FormDefinitionId, cancellationToken: TestContext.Current.CancellationToken);
 
-    await act.Should().ThrowAsync<InvalidOperationException>()
-        .WithMessage("*Tenant mismatch*");
-    await schemaRepository.DidNotReceive().SaveAsync(Arg.Any<FormSchemaEntity>(), Arg.Any<CancellationToken>());
-  }
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("*Tenant mismatch*");
+        await schemaRepository.DidNotReceive().SaveAsync(Arg.Any<FormSchemaEntity>(), Arg.Any<CancellationToken>());
+    }
 
-  private static FormSchemaProcessor CreateProcessor(
-      IFormsRepository formsRepository,
-      IFormSchemaRepository schemaRepository,
-      IFlattenedSubmissionRepository flattenedRepository) =>
-      new(
-          formsRepository,
-          schemaRepository,
-          flattenedRepository,
-          Substitute.For<IReportingUnitOfWork>(),
-          // Early-exit tests never query submissions.
-          Substitute.For<AppDbContext>(),
-          new FormSchemaCompiler(),
-          NullLogger<FormSchemaProcessor>.Instance);
+    private static FormSchemaProcessor CreateProcessor(
+        IFormsRepository formsRepository,
+        IFormSchemaRepository schemaRepository,
+        IFlattenedSubmissionRepository flattenedRepository) =>
+        new(
+            formsRepository,
+            schemaRepository,
+            flattenedRepository,
+            Substitute.For<IReportingUnitOfWork>(),
+            // Early-exit tests never query submissions.
+            Substitute.For<AppDbContext>(),
+            new FormSchemaCompiler(),
+            NullLogger<FormSchemaProcessor>.Instance);
 }

--- a/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FormSchemaProviderTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/FormSchemaProviderTests.cs
@@ -41,6 +41,7 @@ public class FormSchemaProviderTests
             Arg.Any<long>(),
             Arg.Any<long>(),
             Arg.Any<long>(),
+            Arg.Any<bool>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -74,7 +75,11 @@ public class FormSchemaProviderTests
             TestContext.Current.CancellationToken);
 
         result.Should().BeSameAs(refreshed);
-        await schemaProcessor.Received(1).ProcessAsync(TenantId, FormId, FormDefinitionId, Arg.Any<CancellationToken>());
+        await schemaProcessor.Received(1).ProcessAsync(
+            TenantId,
+            FormId,
+            FormDefinitionId,
+            cancellationToken: Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -111,7 +116,7 @@ public class FormSchemaProviderTests
             TenantId,
             FormId,
             HistoricalFormDefinitionId,
-            Arg.Any<CancellationToken>());
+            cancellationToken: Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -138,6 +143,10 @@ public class FormSchemaProviderTests
             TestContext.Current.CancellationToken);
 
         result.Should().BeNull();
-        await schemaProcessor.Received(1).ProcessAsync(TenantId, FormId, FormDefinitionId, Arg.Any<CancellationToken>());
+        await schemaProcessor.Received(1).ProcessAsync(
+            TenantId,
+            FormId,
+            FormDefinitionId,
+            cancellationToken: Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Endatix.Modules.Reporting.Tests/Features/Outbox/CompileFormSchemaOutboxHandlerTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/Outbox/CompileFormSchemaOutboxHandlerTests.cs
@@ -43,7 +43,7 @@ public sealed class CompileFormSchemaOutboxHandlerTests
             TenantId,
             FormId,
             FormDefinitionId,
-            Arg.Any<CancellationToken>());
+            cancellationToken: Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -64,6 +64,7 @@ public sealed class CompileFormSchemaOutboxHandlerTests
             Arg.Any<long>(),
             Arg.Any<long>(),
             Arg.Any<long>(),
+            Arg.Any<bool>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -85,6 +86,7 @@ public sealed class CompileFormSchemaOutboxHandlerTests
             Arg.Any<long>(),
             Arg.Any<long>(),
             Arg.Any<long>(),
+            Arg.Any<bool>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -101,7 +103,12 @@ public sealed class CompileFormSchemaOutboxHandlerTests
             Payload: payload,
             TenantId: TenantId);
         _schemaProcessor
-            .ProcessAsync(Arg.Any<long>(), Arg.Any<long>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .ProcessAsync(
+                Arg.Any<long>(),
+                Arg.Any<long>(),
+                Arg.Any<long>(),
+                Arg.Any<bool>(),
+                Arg.Any<CancellationToken>())
             .Returns(Task.FromException(new InvalidOperationException("compile failed")));
 
         Func<Task> act = () => CreateSut().HandleAsync(message, TestContext.Current.CancellationToken);


### PR DESCRIPTION
# feat(e917): Shoji codebook: set body name/description from Form entity

## Description
- Adding ability for form schema compiler to replace records instead of just appending them.
- Add ability to populate Shoji title/description fields from form Add logic to update shoji title with locale key
- Update tests

## Related Issues
- closes #917 

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to explicitly replace compiled form schemas and clear flattened submissions.
  * Exported Shoji codebooks now include form-specific dataset names and descriptions.
  * Dataset names automatically include the selected locale when applicable.

* **Bug Fixes**
  * Improved default-locale handling and fallback behavior across schema compilation and exports.
  * Preserved existing submission data unless replacement is explicitly requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->