### PR TITLE
fix(e920): register FastEndpoints once per service collection

### DIFF
--- a/src/Endatix.Api/Builders/ApiConfigurationBuilder.cs
+++ b/src/Endatix.Api/Builders/ApiConfigurationBuilder.cs
@@ -233,14 +233,23 @@ public class ApiConfigurationBuilder
     /// </summary>
     /// <remarks>
     /// Called by <see cref="UseDefaults"/>, so the common paths need not call it. Safe to call
-    /// again: the registration is replaced, never duplicated.
+    /// again: a call that changes nothing is a no-op, and otherwise the registration is replaced
+    /// rather than duplicated.
     /// </remarks>
     /// <returns>The builder for chaining.</returns>
     public virtual ApiConfigurationBuilder RegisterEndpointDiscovery()
     {
         var registration = EndpointDiscoveryRegistration.GetOrAdd(Services);
-        registration.Add([typeof(ApiConfigurationBuilder).Assembly]);
-        registration.Register(Services);
+        var added = registration.Add([typeof(ApiConfigurationBuilder).Assembly]);
+
+        // Re-registering is wasted work only when nothing changed *and* a registration already
+        // exists. "Nothing new was added" alone is not the test: ScanAssemblies may have
+        // accumulated assemblies without registering yet, and this method is the one that has to
+        // register them — it cannot defer to anyone else.
+        if (added || !registration.IsRegistered)
+        {
+            registration.Register(Services);
+        }
 
         LogSetupInfo($"Endpoint discovery registered for {registration.Assemblies.Count} assembly(ies)");
         return this;

--- a/src/Endatix.Api/Builders/ApiConfigurationBuilder.cs
+++ b/src/Endatix.Api/Builders/ApiConfigurationBuilder.cs
@@ -26,7 +26,6 @@ public class ApiConfigurationBuilder
     private readonly ILogger? _logger;
     private readonly IConfiguration? _configuration;
     private readonly IAppEnvironment? _environment;
-    private readonly List<Assembly> _endpointAssemblies = [];
 
     private const int JWT_CLOCK_SKEW_IN_SECONDS = 15;
 
@@ -84,7 +83,7 @@ public class ApiConfigurationBuilder
         // Register FastEndpoints for the core API assembly only.
         // Module assemblies are added via ScanAssemblies so feature-flagged modules
         // do not get endpoint discovery without their DI registrations.
-        ScanAssemblies(typeof(ApiConfigurationBuilder).Assembly);
+        RegisterEndpointDiscovery();
 
         // Add Swagger documentation
         AddSwagger();
@@ -206,34 +205,44 @@ public class ApiConfigurationBuilder
     /// <summary>
     /// Adds endpoint discovery from the specified assemblies.
     /// </summary>
+    /// <remarks>
+    /// Accumulates into the discovery set shared by every builder over this service collection.
+    /// FastEndpoints is registered by <see cref="RegisterEndpointDiscovery"/>; calling this after
+    /// that point replaces the existing registration rather than adding a second one.
+    /// </remarks>
     /// <param name="assemblies">The assemblies to scan for endpoints.</param>
     /// <returns>The builder for chaining.</returns>
     public virtual ApiConfigurationBuilder ScanAssemblies(params Assembly[] assemblies)
     {
-        LogSetupInfo($"Scanning {assemblies.Length} assemblies for endpoints");
+        LogSetupInfo($"Adding {assemblies.Length} assemblies to endpoint discovery");
 
-        var apiAssembly = typeof(ApiConfigurationBuilder).Assembly;
-        if (!_endpointAssemblies.Contains(apiAssembly))
+        var registration = EndpointDiscoveryRegistration.GetOrAdd(Services);
+        var added = registration.Add([typeof(ApiConfigurationBuilder).Assembly, .. assemblies]);
+
+        if (added && registration.IsRegistered)
         {
-            _endpointAssemblies.Add(apiAssembly);
+            registration.Register(Services);
         }
 
-        foreach (var assembly in assemblies)
-        {
-            if (!_endpointAssemblies.Contains(assembly))
-            {
-                _endpointAssemblies.Add(assembly);
-            }
-        }
+        LogSetupInfo($"Endpoint discovery covers {registration.Assemblies.Count} assembly(ies)");
+        return this;
+    }
 
-        Assembly[] endpointAssemblies = [.. _endpointAssemblies];
-        Services.AddFastEndpoints(options =>
-        {
-            options.DisableAutoDiscovery = true;
-            options.Assemblies = endpointAssemblies;
-        });
+    /// <summary>
+    /// Registers FastEndpoints for every assembly added through <see cref="ScanAssemblies"/>.
+    /// </summary>
+    /// <remarks>
+    /// Called by <see cref="UseDefaults"/>, so the common paths need not call it. Safe to call
+    /// again: the registration is replaced, never duplicated.
+    /// </remarks>
+    /// <returns>The builder for chaining.</returns>
+    public virtual ApiConfigurationBuilder RegisterEndpointDiscovery()
+    {
+        var registration = EndpointDiscoveryRegistration.GetOrAdd(Services);
+        registration.Add([typeof(ApiConfigurationBuilder).Assembly]);
+        registration.Register(Services);
 
-        LogSetupInfo($"Endpoint discovery limited to {endpointAssemblies.Length} assembly(ies)");
+        LogSetupInfo($"Endpoint discovery registered for {registration.Assemblies.Count} assembly(ies)");
         return this;
     }
 

--- a/src/Endatix.Api/Builders/EndpointDiscoveryRegistration.cs
+++ b/src/Endatix.Api/Builders/EndpointDiscoveryRegistration.cs
@@ -1,0 +1,112 @@
+using System.Reflection;
+using FastEndpoints;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Endatix.Api.Builders;
+
+/// <summary>
+/// Owns the set of assemblies FastEndpoints discovers endpoints from, and the single registration
+/// that set produces.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The state belongs to the <see cref="IServiceCollection"/> rather than to a builder instance:
+/// <c>AddApiEndpoints</c> and <c>GetApiBuilder</c> each hand out a fresh
+/// <see cref="ApiConfigurationBuilder"/> over the same services, and <c>AddFastEndpoints</c> is
+/// last-registration-wins. With the set held per builder, a second builder would re-register with
+/// only its own assemblies and silently drop the first builder's endpoints.
+/// </para>
+/// <para>
+/// Registration is replaced rather than repeated. <c>AddFastEndpoints</c> registers
+/// <c>EndpointData</c>, <c>CommandHandlerRegistry</c>, <c>EventBus&lt;&gt;</c> and <c>Cfg</c> with
+/// <c>AddSingleton</c> rather than <c>TryAdd</c>, so calling it repeatedly leaves a full set of
+/// descriptors behind each time — and discovery is eager, so every call also re-runs a reflection
+/// pass over every accumulated assembly.
+/// </para>
+/// </remarks>
+internal sealed class EndpointDiscoveryRegistration
+{
+    private readonly List<Assembly> _assemblies = [];
+    private readonly List<ServiceDescriptor> _ownedDescriptors = [];
+
+    /// <summary>
+    /// The assemblies accumulated so far, in the order they were added.
+    /// </summary>
+    public IReadOnlyList<Assembly> Assemblies => _assemblies;
+
+    /// <summary>
+    /// Whether FastEndpoints has been registered at least once.
+    /// </summary>
+    public bool IsRegistered => _ownedDescriptors.Count > 0;
+
+    /// <summary>
+    /// Returns the registration attached to <paramref name="services"/>, attaching a new one on
+    /// first use. Held as a singleton instance descriptor so every builder over the same service
+    /// collection shares it.
+    /// </summary>
+    public static EndpointDiscoveryRegistration GetOrAdd(IServiceCollection services)
+    {
+        var existing = services
+            .FirstOrDefault(descriptor => descriptor.ServiceType == typeof(EndpointDiscoveryRegistration))?
+            .ImplementationInstance;
+
+        if (existing is EndpointDiscoveryRegistration registration)
+        {
+            return registration;
+        }
+
+        registration = new EndpointDiscoveryRegistration();
+        services.AddSingleton(registration);
+        return registration;
+    }
+
+    /// <summary>
+    /// Adds assemblies to the discovery set, ignoring duplicates.
+    /// </summary>
+    /// <returns><c>true</c> when at least one assembly was new.</returns>
+    public bool Add(IEnumerable<Assembly> assemblies)
+    {
+        var added = false;
+
+        foreach (var assembly in assemblies)
+        {
+            if (_assemblies.Contains(assembly))
+            {
+                continue;
+            }
+
+            _assemblies.Add(assembly);
+            added = true;
+        }
+
+        return added;
+    }
+
+    /// <summary>
+    /// Registers FastEndpoints for the accumulated assemblies, first removing the descriptors a
+    /// previous call added so the container holds exactly one live registration.
+    /// </summary>
+    public void Register(IServiceCollection services)
+    {
+        foreach (var descriptor in _ownedDescriptors)
+        {
+            services.Remove(descriptor);
+        }
+
+        _ownedDescriptors.Clear();
+
+        // AddFastEndpoints only appends, so everything past this index is ours to own and to
+        // remove again on the next call. Descriptors are tracked by reference rather than by index
+        // because removing one shifts the rest.
+        var firstOwnedIndex = services.Count;
+        Assembly[] assemblies = [.. _assemblies];
+
+        services.AddFastEndpoints(options =>
+        {
+            options.DisableAutoDiscovery = true;
+            options.Assemblies = assemblies;
+        });
+
+        _ownedDescriptors.AddRange(services.Skip(firstOwnedIndex));
+    }
+}

--- a/tests/Endatix.Api.Tests/Builders/ApiConfigurationBuilderEndpointDiscoveryTests.cs
+++ b/tests/Endatix.Api.Tests/Builders/ApiConfigurationBuilderEndpointDiscoveryTests.cs
@@ -1,0 +1,121 @@
+using System.Reflection;
+using Endatix.Api.Builders;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Endatix.Api.Tests.Builders;
+
+public sealed class ApiConfigurationBuilderEndpointDiscoveryTests
+{
+    private static readonly Assembly ApiAssembly = typeof(ApiConfigurationBuilder).Assembly;
+    private static readonly Assembly ModuleAssembly = typeof(ApiConfigurationBuilderEndpointDiscoveryTests).Assembly;
+
+    [Fact]
+    public void UseDefaults_RegistersFastEndpointsExactlyOnce()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        new ApiConfigurationBuilder(services).UseDefaults();
+
+        // Assert
+        CountEndpointDataRegistrations(services).Should().Be(1);
+    }
+
+    [Fact]
+    public void ScanAssemblies_AfterUseDefaults_ReplacesTheRegistrationInsteadOfAddingOne()
+    {
+        // Arrange
+        // AddFastEndpoints registers EndpointData, CommandHandlerRegistry, EventBus<> and Cfg with
+        // AddSingleton rather than TryAdd, so a repeated call would leave a second set behind and
+        // re-run an eager reflection pass over every accumulated assembly.
+        var services = new ServiceCollection();
+        var builder = new ApiConfigurationBuilder(services);
+        builder.UseDefaults();
+
+        // Act
+        builder.ScanAssemblies(ModuleAssembly);
+
+        // Assert
+        CountEndpointDataRegistrations(services).Should().Be(1);
+        GetDiscoveryAssemblies(services).Should().Contain([ApiAssembly, ModuleAssembly]);
+    }
+
+    [Fact]
+    public void ScanAssemblies_SameAssemblyTwice_DoesNotReRegister()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var builder = new ApiConfigurationBuilder(services);
+        builder.UseDefaults();
+        builder.ScanAssemblies(ModuleAssembly);
+        var descriptorCount = services.Count;
+
+        // Act
+        builder.ScanAssemblies(ModuleAssembly);
+
+        // Assert
+        services.Count.Should().Be(descriptorCount);
+        CountEndpointDataRegistrations(services).Should().Be(1);
+    }
+
+    [Fact]
+    public void ScanAssemblies_FromASecondBuilder_KeepsTheFirstBuildersAssemblies()
+    {
+        // Arrange
+        // AddApiEndpoints and GetApiBuilder each hand out a fresh builder over the same services.
+        // With the assembly set held per builder, the second registration replaced the first and
+        // its endpoints silently disappeared.
+        var services = new ServiceCollection();
+        new ApiConfigurationBuilder(services).UseDefaults();
+
+        // Act
+        new ApiConfigurationBuilder(services).ScanAssemblies(ModuleAssembly);
+
+        // Assert
+        GetDiscoveryAssemblies(services).Should().Contain([ApiAssembly, ModuleAssembly]);
+        CountEndpointDataRegistrations(services).Should().Be(1);
+    }
+
+    [Fact]
+    public void ScanAssemblies_BeforeUseDefaults_IsIncludedInTheRegistration()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+        var builder = new ApiConfigurationBuilder(services);
+
+        // Act
+        builder.ScanAssemblies(ModuleAssembly);
+        builder.UseDefaults();
+
+        // Assert
+        GetDiscoveryAssemblies(services).Should().Contain([ApiAssembly, ModuleAssembly]);
+        CountEndpointDataRegistrations(services).Should().Be(1);
+    }
+
+    [Fact]
+    public void ScanAssemblies_WithoutRegistering_DoesNotRegisterFastEndpoints()
+    {
+        // Arrange
+        // Accumulating must stay side-effect free until something asks for the registration,
+        // otherwise the single-registration guarantee depends on call order.
+        var services = new ServiceCollection();
+
+        // Act
+        new ApiConfigurationBuilder(services).ScanAssemblies(ModuleAssembly);
+
+        // Assert
+        CountEndpointDataRegistrations(services).Should().Be(0);
+    }
+
+    /// <summary>
+    /// Counts the live FastEndpoints core registrations. EndpointData is internal to
+    /// FastEndpoints, so it is matched by name; the callers assert a non-zero count wherever a
+    /// registration is expected, so a rename fails the tests rather than passing vacuously.
+    /// </summary>
+    private static int CountEndpointDataRegistrations(IServiceCollection services) =>
+        services.Count(descriptor => descriptor.ServiceType.Name == "EndpointData");
+
+    private static IReadOnlyList<Assembly> GetDiscoveryAssemblies(IServiceCollection services) =>
+        EndpointDiscoveryRegistration.GetOrAdd(services).Assemblies;
+}

--- a/tests/Endatix.Api.Tests/Builders/ApiConfigurationBuilderEndpointDiscoveryTests.cs
+++ b/tests/Endatix.Api.Tests/Builders/ApiConfigurationBuilderEndpointDiscoveryTests.cs
@@ -94,6 +94,43 @@ public sealed class ApiConfigurationBuilderEndpointDiscoveryTests
     }
 
     [Fact]
+    public void RegisterEndpointDiscovery_CalledAgainWithNothingNew_DoesNotReRegister()
+    {
+        // Arrange
+        // Registration is eager: EndpointData's constructor reflects over every assembly. Repeating
+        // it with an unchanged set is a wasted reflection pass, so the descriptor should survive
+        // untouched rather than being removed and rebuilt.
+        var services = new ServiceCollection();
+        var builder = new ApiConfigurationBuilder(services);
+        builder.UseDefaults();
+        var descriptor = services.Single(d => d.ServiceType.Name == "EndpointData");
+
+        // Act
+        builder.RegisterEndpointDiscovery();
+
+        // Assert
+        services.Single(d => d.ServiceType.Name == "EndpointData").Should().BeSameAs(descriptor);
+    }
+
+    [Fact]
+    public void RegisterEndpointDiscovery_AfterScanAssembliesAccumulated_StillRegisters()
+    {
+        // Arrange
+        // Guards the tempting-but-wrong optimisation of skipping registration whenever no new
+        // assembly was added: ScanAssemblies has already accumulated this assembly, so Add returns
+        // false here, yet nothing is registered yet and this call must do it.
+        var services = new ServiceCollection();
+        var builder = new ApiConfigurationBuilder(services);
+        builder.ScanAssemblies(ApiAssembly);
+
+        // Act
+        builder.RegisterEndpointDiscovery();
+
+        // Assert
+        CountEndpointDataRegistrations(services).Should().Be(1);
+    }
+
+    [Fact]
     public void ScanAssemblies_WithoutRegistering_DoesNotRegisterFastEndpoints()
     {
         // Arrange

--- a/tests/Endatix.Hosting.Tests/Builders/EndatixBuilderUseModuleTests.cs
+++ b/tests/Endatix.Hosting.Tests/Builders/EndatixBuilderUseModuleTests.cs
@@ -191,11 +191,21 @@ public class EndatixBuilderUseModuleTests
     /// </summary>
     private static IReadOnlyList<Assembly> GetScannedAssemblies(EndatixBuilder builder)
     {
-        FieldInfo? apiConfigurationField = typeof(EndatixApiBuilder).GetField("_apiConfigurationBuilder", BindingFlags.Instance | BindingFlags.NonPublic);
-        var apiConfigurationBuilder = apiConfigurationField!.GetValue(builder.Api)!;
+        var registrationType = typeof(ApiConfigurationBuilder).Assembly
+            .GetType("Endatix.Api.Builders.EndpointDiscoveryRegistration")!;
 
-        FieldInfo? assembliesField = typeof(ApiConfigurationBuilder).GetField("_endpointAssemblies", BindingFlags.Instance | BindingFlags.NonPublic);
-        return (List<Assembly>)assembliesField!.GetValue(apiConfigurationBuilder)!;
+        var registration = builder.Services
+            .FirstOrDefault(descriptor => descriptor.ServiceType == registrationType)?
+            .ImplementationInstance;
+
+        if (registration is null)
+        {
+            return [];
+        }
+
+        return (IReadOnlyList<Assembly>)registrationType
+            .GetProperty("Assemblies", BindingFlags.Instance | BindingFlags.Public)!
+            .GetValue(registration)!;
     }
 
     private sealed class TrackingTestModule : IEndatixModule


### PR DESCRIPTION
Closes #920.

## The problem

`ApiConfigurationBuilder.ScanAssemblies` called `Services.AddFastEndpoints(...)` on **every** invocation. FastEndpoints registers its core singletons with `AddSingleton`, not `TryAdd`:

```csharp
services.AddSingleton(cmdHandlerRegistry);
services.AddSingleton(endpointData);
services.AddSingleton(typeof(EventBus<>));
services.AddSingleton<Cfg>();
```

So each call left another full set of descriptors behind. And discovery is **eager** — `EndpointData`'s constructor runs `BuildEndpointDefinitions` immediately, enumerating the assemblies and reflecting over their types — so each call also re-ran a reflection pass over everything accumulated so far. In a default host `Endatix.Api` was scanned twice.

It worked only because .NET DI resolves the last descriptor and the last call carried the cumulative list. Correctness rested on last-registration-wins.

## A second defect the issue did not cover

The assembly set lived in a **field on the builder**, but the thing it registers into is **shared**. `AddApiEndpoints` and `GetApiBuilder` each hand out a fresh `ApiConfigurationBuilder` over the same `IServiceCollection`:

```csharp
public static ApiConfigurationBuilder GetApiBuilder(this IServiceCollection services, ILoggerFactory? loggerFactory = null)
    => new ApiConfigurationBuilder(services, loggerFactory: loggerFactory);
```

Two builders each kept a private list, and since `AddFastEndpoints` is last-wins, the second registration narrowed discovery to its own assemblies and **silently dropped the first builder's endpoints**. No error — the endpoints just stopped existing.

`Endatix.Hosting` was safe because `EndatixApiBuilder` constructs one `ApiConfigurationBuilder` and reuses it. But both entry points are public API on a published package, so consumers could hit this.

## The fix

`EndpointDiscoveryRegistration` now owns the assembly set *and* the registration, attached to the service collection so every builder over those services shares one. `ScanAssemblies` accumulates; `RegisterEndpointDiscovery` registers and **replaces** the descriptors it previously added instead of appending a second set. `UseDefaults` calls it at the end, exactly where the old `ScanAssemblies` call sat, so no existing caller has to learn a new step.

Tracking is by descriptor reference, not index, because removing one shifts the rest:

```csharp
var firstOwnedIndex = services.Count;
services.AddFastEndpoints(options => { ... });
_ownedDescriptors.AddRange(services.Skip(firstOwnedIndex));
```

### Two things this deliberately does not do

**It does not defer registration to `EndatixBuilder.FinalizeConfiguration()`.** That would give the host path exactly one registration, but `UseDefaults` is reachable through the public `GetApiBuilder`, and a builder that registered nothing until an unrelated finalize step would be a silent breaking change for anyone using it standalone — the same class of failure this PR is removing.

**It leaves the host path at two registrations** — `UseDefaults`, then `UseModule`'s later `ScanAssemblies`. That is one extra reflection pass over a single assembly, and the descriptors are *replaced* rather than duplicated, so the container still holds exactly one live set. Trading that for a silent-breakage risk in public API was not worth it.

### Out of scope

`ApiConfigurationBuilder.ConfigureApplication` and `EndatixApiBuilder.ConfigureApplication` have **no callers** — the live path is `UseEndatix()` → `EndatixMiddlewareBuilder.UseDefaults()` → `UseEndatixApi(options)`. Both are `public virtual` on published types, so removing them is a breaking change and belongs in its own PR. Worth noting because #920 originally cited `ConfigureApplication`'s Swagger-descriptor check as an ordering constraint on this work; it is not one. The issue body has been corrected.

## Verification

`dotnet build` → 0 errors.

| Suite | Result |
|---|---|
| `Endatix.Api.Tests` | 643 passed, 0 failed |
| `Endatix.Hosting.Tests` | 25 passed, 0 failed |
| `Endatix.Infrastructure.Tests` | 1121 passed, 0 failed |
| `Endatix.Modules.Reporting.Tests` | 387 passed, 0 failed, 1 skipped |
| `Endatix.Core.Tests` | 1022 passed, 0 failed |
| `Endatix.IntegrationTests` (PostgreSql) | 65 passed, 0 failed |

The integration run matters most here: it exercises real endpoint discovery end to end, so a regression in what gets registered would surface as 404s rather than as a unit-test failure.

Six new tests in `ApiConfigurationBuilderEndpointDiscoveryTests`:

| Test | Covers |
|---|---|
| `UseDefaults_RegistersFastEndpointsExactlyOnce` | the baseline |
| `ScanAssemblies_AfterUseDefaults_ReplacesTheRegistrationInsteadOfAddingOne` | defect 1 |
| `ScanAssemblies_SameAssemblyTwice_DoesNotReRegister` | no work for a no-op call |
| `ScanAssemblies_FromASecondBuilder_KeepsTheFirstBuildersAssemblies` | defect 2 |
| `ScanAssemblies_BeforeUseDefaults_IsIncludedInTheRegistration` | order independence |
| `ScanAssemblies_WithoutRegistering_DoesNotRegisterFastEndpoints` | accumulation stays side-effect free |

Verified non-vacuous: making `Register` skip removing its previous descriptors — i.e. restoring the old append behaviour — fails three of the six.

`EndpointData` is internal to FastEndpoints so the count assertions match it by type name; every such assertion is paired with a non-zero expectation somewhere in the suite, so a rename fails the tests rather than passing vacuously.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized endpoint discovery registration.
  * Assembly scanning now supports multiple builders while preserving previously discovered assemblies.
  * Duplicate scans no longer create duplicate endpoint registrations.

* **Bug Fixes**
  * Improved registration consistency regardless of whether scanning occurs before or after default setup.
  * Prevented endpoint registration when defaults have not been configured.

* **Tests**
  * Added coverage for registration order, duplicate scans, and shared assembly discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->