### PR TITLE
fix(ci): publish to nuget.org from this repo so OIDC claims match

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -4,10 +4,17 @@ name: Publish Stable Artifacts
 # reviewed draft release (that's when GitHub creates the vX.Y.Z tag).
 # promotion: rebuild — NuGet packages bake the version string into the artifact
 # and cannot be retagged, so the stable packages are rebuilt at the tagged
-# commit and pushed to GitHub Packages + nuget.org (release scripts).
-# nuget.org auth is OIDC trusted publishing (nuget-login): a short-lived API
-# key is minted per run — no long-lived key stored anywhere. fetch-secrets
-# provides the nuget.org username (ENDATIX_NUGET_ORG_USERNAME via Infisical).
+# commit and pushed to GitHub Packages (release scripts).
+#
+# nuget.org publishing happens in the SECOND job below, not in the shared
+# workflow. OIDC's job_workflow_ref claim names the workflow where the job is
+# defined, so a NuGet/login inside the reusable workflow presents
+# endatix/release-workflows and a policy scoped to endatix/endatix rejects it.
+# The minted key cannot be handed back to a caller job either — NuGet/login
+# marks it a secret and GitHub redacts secrets from job outputs — so the push
+# moves to the key rather than the key to the push. This keeps the trusted
+# publishing policy scoped to this repo instead of to the shared workflow.
+#
 # Canary prereleases are filtered out — ci.yml already shipped their packages.
 
 on:
@@ -21,10 +28,73 @@ jobs:
       contents: read
       packages: write # GitHub Packages push
       id-token: write # OIDC for Infisical (fetch-secrets)
-    uses: endatix/release-workflows/.github/workflows/release-artifacts.yml@cca02534258a68b196f9295afe9fd855ad9eee83 # v1
+    uses: endatix/release-workflows/.github/workflows/release-artifacts.yml@7056fe678e52a4a50af23d14cef11a5a2b4dcd27 # v1 + upload-nuget-artifacts
     with:
       docker-image: ghcr.io/endatix/endatix-api
       promotion: rebuild # NuGet versions are baked in — the image is rebuilt at the tag too
-      fetch-secrets: true # ENDATIX_NUGET_ORG_USERNAME + ENDATIX_DOCKERHUB_* via Infisical (prod)
-      nuget-login: true # OIDC trusted publishing → short-lived NUGET_API_KEY
+      fetch-secrets: true # ENDATIX_DOCKERHUB_* via Infisical (prod)
+      nuget-login: false # nuget.org auth happens in publish-nuget-org below
+      upload-nuget-artifacts: true # hand the .nupkg files to that job
       dotnet-version: "10.x"
+
+  # Runs in THIS repo, so the OIDC token carries
+  # job_workflow_ref = endatix/endatix/.github/workflows/release-artifacts.yml —
+  # which is what the nuget.org trusted publishing policy is scoped to.
+  # Mirrors the arrangement already proven in endatix/endatix-relay, where the
+  # login runs in the repo's own workflow.
+  publish-nuget-org:
+    name: Publish packages to nuget.org
+    needs: promote
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-latest
+    environment:
+      name: Production # matches the Infisical OIDC identity binding
+    permissions:
+      contents: read
+      id-token: write # OIDC for Infisical + NuGet trusted publishing
+    steps:
+      - name: 🔐 Fetch secrets (Infisical, OIDC)
+        uses: Infisical/secrets-action@03d3fa38607956c493f53c6633f94006a13c47ae # v1.0.7
+        with:
+          method: "oidc"
+          env-slug: "prod"
+          project-slug: "github-actions-for-endatix"
+          identity-id: "403af1ed-7046-480f-a100-c4482b8a89ac"
+          recursive: true
+
+      # Must run AFTER Infisical: the nuget.org username (an individual profile
+      # name — the policy creator — not an organization) is injected by it.
+      - name: 🔑 NuGet login (OIDC → temp API key)
+        id: nuget-login
+        uses: NuGet/login@8d196754b4036150537f80ac539e15c2f1028841 # v1.2.0
+        with:
+          user: ${{ env.ENDATIX_NUGET_ORG_USERNAME }}
+
+      - name: 📥 Download packages built by the promote job
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: nuget-packages-${{ github.event.release.tag_name }}
+          path: packages
+
+      - name: 🚀 Push to nuget.org
+        env:
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          VERSION="${TAG#v}"
+
+          # Fail loud rather than "succeeding" with nothing pushed — the failure
+          # mode that left v0.7.1 tagged and announced with no packages anywhere.
+          shopt -s nullglob
+          pkgs=(packages/*."${VERSION}".nupkg)
+          if [ ${#pkgs[@]} -eq 0 ]; then
+            echo "::error::No .nupkg files matching version ${VERSION} in the artifact" >&2
+            exit 1
+          fi
+          echo "Pushing ${#pkgs[@]} package(s) to nuget.org"
+
+          dotnet nuget push "packages/*.${VERSION}.nupkg" \
+            -k "$NUGET_API_KEY" \
+            -s https://api.nuget.org/v3/index.json \
+            --skip-duplicate

--- a/scripts/release-publish.sh
+++ b/scripts/release-publish.sh
@@ -19,6 +19,12 @@
 #   maintenance                   yes                      yes              no
 #   stable                        yes                      yes              yes
 #
+# NOTE: the nuget.org half of that column is no longer this script's job — it is
+# published by the publish-nuget-org job in .github/workflows/release-artifacts.yml,
+# which must run in THIS repo so its OIDC claim matches the trusted publishing
+# policy. This script still BUILDS the packages into build/packages/nuget/, which
+# that job consumes as a workflow artifact. Docker Hub mirroring stays here.
+#
 # The Helm chart ships to GHCR on every channel: OCI charts are addressed by
 # exact version with no floating pointer to protect, and the prerelease version
 # already keeps canaries out of `helm upgrade` unless --devel is passed.
@@ -31,8 +37,6 @@
 #   HELM_OCI_REPO      OCI chart repo (oci://ghcr.io/endatix/charts)
 #   DOCKER_IMAGE       GHCR image name, from the caller's docker-image input
 #                      (the shared workflows do the ghcr.io login)
-#   NUGET_API_KEY      short-lived nuget.org key minted per run via OIDC
-#                      trusted publishing (NuGet/login) — promoted releases only
 #   ENDATIX_DOCKERHUB_USERNAME / ENDATIX_DOCKERHUB_TOKEN
 #                      Docker Hub credentials via Infisical (fetch-secrets:
 #                      true on the caller) — promoted releases only
@@ -69,14 +73,14 @@ dotnet nuget push "build/packages/nuget/*.${VERSION}.nupkg" \
   -s "$NUGET_SOURCE" \
   --skip-duplicate
 
-if [[ "$PUBLISH_PUBLIC" = true ]]; then
-  : "${NUGET_API_KEY:?NUGET_API_KEY env var is required for promoted releases (minted by NuGet/login — is nuget-login: true set?)}"
-  echo "──── Pushing NuGet packages to nuget.org ────"
-  dotnet nuget push "build/packages/nuget/*.${VERSION}.nupkg" \
-    -k "$NUGET_API_KEY" \
-    -s https://api.nuget.org/v3/index.json \
-    --skip-duplicate
-fi
+# nuget.org is deliberately NOT pushed here. It is done by the publish-nuget-org
+# job in .github/workflows/release-artifacts.yml, which runs in this repo so its
+# OIDC job_workflow_ref claim matches the nuget.org trusted publishing policy.
+# A NuGet/login inside the shared reusable workflow presents
+# endatix/release-workflows instead and is rejected; the minted key cannot be
+# passed back to a caller job because GitHub redacts secrets from job outputs.
+# That job consumes build/packages/nuget/*.nupkg via the upload-nuget-artifacts
+# input on the shared workflow — so this script must keep producing them there.
 
 # The per-arch tags are what release-prepare.sh built and loaded into the local
 # daemon; the plain version tag is a manifest list stitched from them once they


### PR DESCRIPTION
# Publish to nuget.org from this repo so OIDC claims match

## Description of changes

`v0.7.1` was tagged and marked **Latest** but shipped **nothing** — not to nuget.org, not even to GitHub Packages. The shared workflow's `NuGet/login` step failed, and because it gates everything after it, the GitHub Packages push (which needs no nuget.org credential at all) never ran either.

```
Token exchange failed (HTTP 401) at https://www.nuget.org/api/v2/token.
Claim 'job_workflow_ref' has value
  'endatix/release-workflows/.github/workflows/release-artifacts.yml@cca0253...'
which does not start with endatix/endatix/.github/workflows/.
```

### Why it cannot be fixed inside the shared workflow

OIDC's `job_workflow_ref` claim names the workflow where the job is **defined**. A `NuGet/login` inside `endatix/release-workflows` therefore always presents that repository — never `endatix/endatix` — so a trusted publishing policy scoped to this repo is rejected. Re-scoping the policy to the shared workflow does make the claim match, but widens the trust boundary to *every* consumer of it.

Handing the minted key back to a caller job doesn't work either: `NuGet/login` calls `core.setSecret(apiKey)` before setting the output, and GitHub redacts registered secrets from job outputs.

So the push moves to the key rather than the key to the push.

### What changed

- `promote` job: `nuget-login: false`, `upload-nuget-artifacts: true` — the shared workflow now hands over the built `.nupkg` files as an artifact.
- New `publish-nuget-org` job, running **in this repo**: Infisical → `NuGet/login` → download artifact → `dotnet nuget push` to nuget.org. Its claim is `endatix/endatix/...`, matching a per-repo policy.
- `scripts/release-publish.sh` no longer pushes to nuget.org. It still builds the packages into `build/packages/nuget/` and pushes them to GitHub Packages, and still mirrors the image to Docker Hub.

This mirrors the arrangement already working in [endatix/endatix-relay](https://github.com/endatix/endatix-relay), where the login runs in the repo's own workflow and nuget.org publishing succeeds.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Other

## Dependencies

Requires `endatix/release-workflows@7056fe6` (already on `main`) for the new `upload-nuget-artifacts` input — the pin in this PR points at that commit.

The `v1` floating tag was deliberately **not** moved: `api-contracts` tracks `@v1`, and moving it would change that repo's releases as a side effect of this work. This repo pins by SHA, so it takes the change directly.

## Verification

Cannot be exercised until merged — the workflow only triggers on `release: published`. After merge:

1. Confirm the nuget.org trusted publishing policy is scoped to **`endatix/endatix`** + `release-artifacts.yml` + environment `Production`. It was re-scoped to `release-workflows` while diagnosing; this change requires it back on this repo.
2. Re-run the failed `v0.7.1` job — it re-checks out the tag and rebuilds, so no re-cut is needed.
3. `curl -s https://api.nuget.org/v3-flatcontainer/endatix.core/index.json | grep 0.7.1` should return the version. It currently stops at `0.7.0`.

## Notes for the reviewer

- **The release is now two-phase.** A nuget.org failure leaves GitHub Packages already published. That is a better failure mode than today's, where a nuget.org credential problem blocked everything — but it is a change in behaviour worth knowing.
- **The new job fails loudly** if the artifact contains no `.nupkg` matching the version, rather than reporting success having pushed nothing. That silent-success shape is exactly how `v0.7.1` went out empty.
- **Trust boundary is unchanged** — per-repo, as before. The alternative (scoping the policy to the shared workflow) would have extended publish rights for `Endatix.*` to every repo that can call it.
