### PR TITLE
ci: pin all release-workflows callers to one SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,7 +149,7 @@ jobs:
       contents: read # release writes use the App token inside the shared workflow
       packages: write # GitHub Packages push + GHCR image push
       id-token: write # OIDC for Infisical inside the shared workflow
-    uses: endatix/release-workflows/.github/workflows/canary.yml@cca02534258a68b196f9295afe9fd855ad9eee83 # v1
+    uses: endatix/release-workflows/.github/workflows/canary.yml@8e04473b8951790b94f7a4486e47d4e714dac9a3 # v1
     with:
       docker-image: ghcr.io/endatix/endatix-api
       dotnet-version: "10.x" # global.json rolls forward within 10.0.x

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
       packages: write # GitHub Packages push
       id-token: write # OIDC for Infisical (fetch-secrets)
-    uses: endatix/release-workflows/.github/workflows/release-artifacts.yml@7056fe678e52a4a50af23d14cef11a5a2b4dcd27 # v1 + upload-nuget-artifacts
+    uses: endatix/release-workflows/.github/workflows/release-artifacts.yml@8e04473b8951790b94f7a4486e47d4e714dac9a3 # v1
     with:
       docker-image: ghcr.io/endatix/endatix-api
       promotion: rebuild # NuGet versions are baked in — the image is rebuilt at the tag too

--- a/.github/workflows/release-hotfix.yml
+++ b/.github/workflows/release-hotfix.yml
@@ -39,7 +39,7 @@ jobs:
     needs: validate
     permissions:
       contents: write # create the draft release (no tag exists until a human publishes it)
-    uses: endatix/release-workflows/.github/workflows/release-start.yml@cca02534258a68b196f9295afe9fd855ad9eee83 # v1
+    uses: endatix/release-workflows/.github/workflows/release-start.yml@8e04473b8951790b94f7a4486e47d4e714dac9a3 # v1
     with:
       ref: ${{ inputs.branch }}
       bump: patch

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -23,7 +23,7 @@ jobs:
   draft:
     permissions:
       contents: write # create the draft release (no tag exists until a human publishes it)
-    uses: endatix/release-workflows/.github/workflows/release-start.yml@cca02534258a68b196f9295afe9fd855ad9eee83 # v1
+    uses: endatix/release-workflows/.github/workflows/release-start.yml@8e04473b8951790b94f7a4486e47d4e714dac9a3 # v1
     with:
       canary-tag: ${{ inputs.canary_tag }}
       bump: ${{ inputs.bump }}


### PR DESCRIPTION
## Description of changes

Three callers still referenced `cca0253` while `release-artifacts.yml` had moved to `7056fe6` for the nuget.org fix (#929), so this repo was straddling two versions of the shared contract. All four now pin the current `v1`.

| Workflow | Before | After |
|---|---|---|
| `ci.yml` | `cca0253` | `8e04473` |
| `release-start.yml` | `cca0253` | `8e04473` |
| `release-hotfix.yml` | `cca0253` | `8e04473` |
| `release-artifacts.yml` | `7056fe6` | `8e04473` |

**No behaviour change.** Only `release-artifacts.yml` differs between those commits in the shared repo; the rest of the range is documentation. The caller already sets the new inputs it needs.

## Why SHA rather than `@v1`

`v1` is force-moved whenever `release-workflows` changes, so tracking it means picking up new workflow code on the next release with no diff, no review, and no record in the caller of which version ran. A SHA is immutable and surfaces in a pull request when it changes — the same reasoning that already has every third-party action here pinned.

`v1` remains as a human-readable pointer for resolving what to pin to:

```bash
git ls-remote https://github.com/endatix/release-workflows refs/tags/v1
```

Documented in [release-workflows README + AGENTS.md](https://github.com/endatix/release-workflows), updated in the same pass. `api-contracts` has been repinned identically.