### PR TITLE
refactor(e934): Migrate all constructor usages to the new FormCreateArgs based factory

### DIFF
--- a/src/Endatix.Core/UseCases/Forms/Create/CreateFormHandler.cs
+++ b/src/Endatix.Core/UseCases/Forms/Create/CreateFormHandler.cs
@@ -27,7 +27,7 @@ public class CreateFormHandler(
             return folderCheck.ToErrorResult<Form>();
         }
 
-        var newForm = Form.Create(new FormCreateArgs(
+        FormCreateArgs createArgs = new(
             TenantId: tenantContext.TenantId,
             Name: request.Name,
             Description: request.Description,
@@ -37,7 +37,8 @@ public class CreateFormHandler(
             Metadata: request.Metadata,
             WebHookSettingsJson: request.WebHookSettingsJson,
             FolderId: request.FolderId,
-            SubmissionTokenExpiryHours: request.SubmissionTokenExpiryHours));
+            SubmissionTokenExpiryHours: request.SubmissionTokenExpiryHours);
+        var newForm = Form.Create(createArgs);
         var newFormDefinition = new FormDefinition(tenantContext.TenantId, isDraft: true, jsonData: request.FormDefinitionJsonData);
 
         // form.created is captured to the outbox (→ webhook) inside CreateFormWithDefinitionAsync via

--- a/src/Endatix.Infrastructure/Data/DataSeeder.cs
+++ b/src/Endatix.Infrastructure/Data/DataSeeder.cs
@@ -82,10 +82,11 @@ public class DataSeeder(ILogger<DataSeeder> logger, IIdGenerator<long> idGenerat
 
     private Form CreateForm(string name, long? id = null)
     {
-        var form = Form.Create(new FormCreateArgs(
+        FormCreateArgs args = new(
             TenantId: 1,
             Name: name,
-            IsEnabled: true));
+            IsEnabled: true);
+        var form = Form.Create(args);
         form.Id = id ?? idGenerator.CreateId();
         return form;
     }

--- a/tests/Endatix.Api.Tests/Endpoints/Forms/CreateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Forms/CreateTests.cs
@@ -29,9 +29,9 @@ public class CreateTests
             IsEnabled = true,
             FormDefinitionJsonData = """{ "type": "object" }"""
         };
-        
+
         var result = Result.Invalid();
-        
+
         _mediator.Send(Arg.Any<CreateFormCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);
 
@@ -47,15 +47,17 @@ public class CreateTests
     public async Task ExecuteAsync_ValidRequest_ReturnsCreatedWithForm()
     {
         // Arrange
-        var request = new CreateFormRequest 
-        { 
+        var request = new CreateFormRequest
+        {
             Name = "Test Form",
             Description = "Test Description",
             IsEnabled = true,
             FormDefinitionJsonData = """{ "type": "object" }"""
         };
-        
-        var form = new Form(SampleData.TENANT_ID, request.Name) { Id = 1 };
+
+        FormCreateArgs args = new(TenantId: SampleData.TENANT_ID, Name: request.Name);
+        var form = Form.Create(args);
+        form.Id = 1;
         var result = Result<Form>.Created(form);
 
         _mediator.Send(Arg.Any<CreateFormCommand>(), Arg.Any<CancellationToken>())
@@ -83,8 +85,8 @@ public class CreateTests
             IsEnabled = true,
             FormDefinitionJsonData = """{ "type": "object" }"""
         };
-        var result = Result<Form>.Created(new Form(SampleData.TENANT_ID, "Test Form"));
-        
+        var result = Result<Form>.Created(Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form")));
+
         _mediator.Send(Arg.Any<CreateFormCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);
 
@@ -129,7 +131,7 @@ public class CreateTests
             IsEnabled = true,
             FormDefinitionSchema = jsonSchema
         };
-        var result = Result<Form>.Created(new Form(SampleData.TENANT_ID, "Test Form"));
+        var result = Result<Form>.Created(Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form")));
 
         _mediator.Send(Arg.Any<CreateFormCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);
@@ -173,7 +175,7 @@ public class CreateTests
             FormDefinitionJsonData = """{ "type": "object" }""",
             WebHookSettings = webhookSettings
         };
-        var result = Result<Form>.Created(new Form(SampleData.TENANT_ID, "Test Form"));
+        var result = Result<Form>.Created(Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form")));
 
         _mediator.Send(Arg.Any<CreateFormCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);
@@ -218,7 +220,7 @@ public class CreateTests
             FormDefinitionJsonData = """{ "type": "old" }""",  // Old string format
             FormDefinitionSchema = newJsonSchema  // New object format (should win)
         };
-        var result = Result<Form>.Created(new Form(SampleData.TENANT_ID, "Test Form"));
+        var result = Result<Form>.Created(Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form")));
 
         _mediator.Send(Arg.Any<CreateFormCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);
@@ -258,7 +260,7 @@ public class CreateTests
             WebHookSettingsJson = """{ "events": {} }""",  // Old string format
             WebHookSettings = newWebhookSettings  // New object format (should win)
         };
-        var result = Result<Form>.Created(new Form(SampleData.TENANT_ID, "Test Form"));
+        var result = Result<Form>.Created(Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form")));
 
         _mediator.Send(Arg.Any<CreateFormCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);
@@ -288,7 +290,7 @@ public class CreateTests
             FormDefinitionJsonData = """{ "type": "object" }""",
             WebHookSettingsJson = """{ "events": {} }"""
         };
-        var result = Result<Form>.Created(new Form(SampleData.TENANT_ID, "Test Form"));
+        var result = Result<Form>.Created(Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form")));
 
         _mediator.Send(Arg.Any<CreateFormCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);

--- a/tests/Endatix.Api.Tests/Endpoints/Forms/DeleteTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Forms/DeleteTests.cs
@@ -66,7 +66,8 @@ public class DeleteTests
         // Arrange
         var formId = 1L;
         var request = new DeleteFormRequest { FormId = formId };
-        var form = new Form(SampleData.TENANT_ID, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        form.Id = formId;
         var result = Result.Success(form);
 
         _mediator.Send(Arg.Any<DeleteFormCommand>(), Arg.Any<CancellationToken>())
@@ -86,7 +87,7 @@ public class DeleteTests
     {
         // Arrange
         var request = new DeleteFormRequest { FormId = 123 };
-        var result = Result.Success(new Form(SampleData.TENANT_ID, "Test Form"));
+        var result = Result.Success(Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form")));
 
         _mediator.Send(Arg.Any<DeleteFormCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);

--- a/tests/Endatix.Api.Tests/Endpoints/Forms/PartialUpdateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Forms/PartialUpdateTests.cs
@@ -120,7 +120,7 @@ public class PartialUpdateTests
             Description = "Updated Description",
             IsEnabled = true
         };
-        FormCreateArgs args = new(TenantId: SampleData.TENANT_ID, Name: "Updated Form"))
+        FormCreateArgs args = new(TenantId: SampleData.TENANT_ID, Name: "Updated Form");
         var result = Result.Success(Form.Createargs);
 
         _mediator.Send(Arg.Any<PartialUpdateFormCommand>(), Arg.Any<CancellationToken>())

--- a/tests/Endatix.Api.Tests/Endpoints/Forms/PartialUpdateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Forms/PartialUpdateTests.cs
@@ -121,7 +121,7 @@ public class PartialUpdateTests
             IsEnabled = true
         };
         FormCreateArgs args = new(TenantId: SampleData.TENANT_ID, Name: "Updated Form");
-        var result = Result.Success(Form.Createargs);
+        var result = Result.Success(Form.Create(args));
 
         _mediator.Send(Arg.Any<PartialUpdateFormCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);

--- a/tests/Endatix.Api.Tests/Endpoints/Forms/PartialUpdateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Forms/PartialUpdateTests.cs
@@ -26,7 +26,7 @@ public class PartialUpdateTests
         var formId = 1L;
         var request = new PartialUpdateFormRequest { FormId = formId };
         var result = Result.Invalid();
-        
+
         _mediator.Send(Arg.Any<PartialUpdateFormCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);
 
@@ -64,15 +64,17 @@ public class PartialUpdateTests
     {
         // Arrange
         var formId = 1L;
-        var request = new PartialUpdateFormRequest 
-        { 
+        var request = new PartialUpdateFormRequest
+        {
             FormId = formId,
             Name = "Updated Form",
             Description = "Updated Description",
             IsEnabled = true
         };
-        
-        var form = new Form(SampleData.TENANT_ID, request.Name) { Id = formId };
+
+        FormCreateArgs args = new(TenantId: SampleData.TENANT_ID, Name: request.Name);
+        var form = Form.Create(args);
+        form.Id = formId;
         var result = Result.Success(form);
 
         _mediator.Send(Arg.Any<PartialUpdateFormCommand>(), Arg.Any<CancellationToken>())
@@ -118,8 +120,9 @@ public class PartialUpdateTests
             Description = "Updated Description",
             IsEnabled = true
         };
-        var result = Result.Success(new Form(SampleData.TENANT_ID, "Updated Form"));
-        
+        FormCreateArgs args = new(TenantId: SampleData.TENANT_ID, Name: "Updated Form"))
+        var result = Result.Success(Form.Createargs);
+
         _mediator.Send(Arg.Any<PartialUpdateFormCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);
 

--- a/tests/Endatix.Api.Tests/Endpoints/Forms/UpdateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Forms/UpdateTests.cs
@@ -137,8 +137,8 @@ public class UpdateTests
             Description = "Updated Description",
             IsEnabled = true
         };
-        FormCreateArgs args = new(TenantId: SampleData.TENANT_ID, Name: "Updated Form"))
-                var result = Result.Success(Form.Create(args);
+        FormCreateArgs args = new(TenantId: SampleData.TENANT_ID, Name: "Updated Form");
+        var result = Result.Success(Form.Create(args));
 
         _mediator.Send(Arg.Any<UpdateFormCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);

--- a/tests/Endatix.Api.Tests/Endpoints/Forms/UpdateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Forms/UpdateTests.cs
@@ -32,7 +32,7 @@ public class UpdateTests
             IsEnabled = true
         };
         var result = Result.Invalid();
-        
+
         _mediator.Send(Arg.Any<UpdateFormCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);
 
@@ -76,15 +76,17 @@ public class UpdateTests
     {
         // Arrange
         var formId = 1L;
-        var request = new UpdateFormRequest 
-        { 
+        var request = new UpdateFormRequest
+        {
             FormId = formId,
             Name = "Updated Form",
             Description = "Updated Description",
             IsEnabled = true
         };
-        
-        var form = new Form(SampleData.TENANT_ID, request.Name) { Id = formId };
+
+        FormCreateArgs args = new(TenantId: SampleData.TENANT_ID, Name: request.Name);
+        var form = Form.Create(args);
+        form.Id = formId;
         var result = Result.Success(form);
 
         _mediator.Send(Arg.Any<UpdateFormCommand>(), Arg.Any<CancellationToken>())
@@ -135,8 +137,9 @@ public class UpdateTests
             Description = "Updated Description",
             IsEnabled = true
         };
-        var result = Result.Success(new Form(SampleData.TENANT_ID, "Updated Form"));
-        
+        FormCreateArgs args = new(TenantId: SampleData.TENANT_ID, Name: "Updated Form"))
+                var result = Result.Success(Form.Create(args);
+
         _mediator.Send(Arg.Any<UpdateFormCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);
 
@@ -167,7 +170,7 @@ public class UpdateTests
             IsEnabled = true,
             LimitOnePerUser = null
         };
-        var result = Result.Success(new Form(SampleData.TENANT_ID, "Updated Form"));
+        var result = Result.Success(Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Updated Form")));
 
         _mediator.Send(Arg.Any<UpdateFormCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);

--- a/tests/Endatix.Api.Tests/Endpoints/Submissions/ExportTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Submissions/ExportTests.cs
@@ -160,7 +160,8 @@ public class ExportTests
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId, ExportId = exportId };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var tenantSettings = new TenantSettingsEntity(tenantId);
         var exportConfig = new CustomExportConfiguration
         {
@@ -211,7 +212,8 @@ public class ExportTests
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId, ExportId = exportId };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var tenantSettings = new TenantSettingsEntity(tenantId);
         tenantSettings.CustomExports.Add(new CustomExportConfiguration
         {
@@ -262,7 +264,8 @@ public class ExportTests
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId, ExportId = exportId };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
 
         _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>())
             .Returns(form);
@@ -286,7 +289,8 @@ public class ExportTests
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId, ExportId = exportId };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var tenantSettings = new TenantSettingsEntity(tenantId);
 
         _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>())
@@ -311,7 +315,8 @@ public class ExportTests
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId, ExportId = exportId };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var tenantSettings = new TenantSettingsEntity(tenantId);
         var exportConfig = new CustomExportConfiguration
         {
@@ -344,7 +349,8 @@ public class ExportTests
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId, ExportId = exportId };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var tenantSettings = new TenantSettingsEntity(tenantId);
         var exportConfig = new CustomExportConfiguration
         {
@@ -378,7 +384,8 @@ public class ExportTests
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId, ExportId = exportId };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var tenantSettings = new TenantSettingsEntity(tenantId);
         var exportConfig = new CustomExportConfiguration
         {
@@ -409,7 +416,8 @@ public class ExportTests
         var formId = 1L;
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId, ExportFormat = "json" };
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var exporter = CreateMockExporter("json", typeof(SubmissionExportRow));
         var fileExport = new FileExport("application/json", "submissions-1.json");
 
@@ -451,7 +459,8 @@ public class ExportTests
             ColumnScope = ["q1"],
         };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var exporter = CreateMockExporter("csv", typeof(SubmissionExportRow));
         var fileExport = new FileExport("text/csv", "submissions-1.csv");
 
@@ -489,7 +498,8 @@ public class ExportTests
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId, ExportFormatId = exportFormatId };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
 
         _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>())
             .Returns(form);
@@ -510,7 +520,8 @@ public class ExportTests
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var exporter = CreateMockExporter("csv", typeof(SubmissionExportRow));
         var fileExport = new FileExport("text/csv", "submissions-1.csv");
 
@@ -548,7 +559,8 @@ public class ExportTests
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var exporter = CreateMockExporter("csv", typeof(SubmissionExportRow));
         var fileExport = new FileExport("text/csv", "submissions-1.csv");
 
@@ -587,7 +599,8 @@ public class ExportTests
             ColumnScope = ["q1"],
         };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var exporter = CreateMockExporter("csv", typeof(SubmissionExportRow));
         var fileExport = new FileExport("text/csv", "submissions-1.csv");
 
@@ -623,7 +636,8 @@ public class ExportTests
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId, ExportFormat = "unsupported" };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
 
         _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>())
             .Returns(form);
@@ -643,7 +657,8 @@ public class ExportTests
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId, ExportFormatId = 100L };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var exporter = CreateMockExporter("csv", typeof(SubmissionExportRow));
 
         _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>())
@@ -668,7 +683,8 @@ public class ExportTests
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId, ExportFormatId = 100L };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var exporter = CreateMockExporter("csv", typeof(SubmissionExportRow));
         var fileExport = new FileExport("text/csv", "submissions-1.csv");
 
@@ -698,7 +714,8 @@ public class ExportTests
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId, ExportId = exportId };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var tenantSettings = new TenantSettingsEntity(tenantId);
         var exportConfig = new CustomExportConfiguration
         {
@@ -742,7 +759,8 @@ public class ExportTests
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId, ExportId = exportId };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var tenantSettings = new TenantSettingsEntity(tenantId);
         var exportConfig = new CustomExportConfiguration
         {
@@ -807,7 +825,8 @@ public class ExportTests
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId, ExportFormatId = 100L };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var exporter = CreateMockExporter("csv", typeof(SubmissionExportRow));
         var fileExport = new FileExport("text/csv", "submissions-1.csv");
 
@@ -836,7 +855,8 @@ public class ExportTests
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId, ExportFormatId = 100L };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var exporter = CreateMockExporter("csv", typeof(SubmissionExportRow));
         var fileExport = new FileExport("text/csv", "submissions-1.csv");
 
@@ -891,7 +911,8 @@ public class ExportTests
             ColumnScope = ["q1"],
         };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var exporter = CreateMockExporter("csv", typeof(SubmissionExportRow));
         var fileExport = new FileExport("text/csv", "submissions-1.csv");
 
@@ -936,7 +957,8 @@ public class ExportTests
             Locale = "es",
         };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
 
         _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>()).Returns(form);
         _tenantContext.TenantId.Returns(tenantId);
@@ -966,7 +988,8 @@ public class ExportTests
             CompletionStatus = completionStatus,
         };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var exporter = CreateMockExporter("csv", typeof(SubmissionExportRow));
         var fileExport = new FileExport("text/csv", "submissions-1.csv");
 
@@ -1003,7 +1026,8 @@ public class ExportTests
             CompletionStatus = ExportCompletionStatus.All,
         };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var exporter = CreateMockExporter("csv", typeof(SubmissionExportRow));
         var fileExport = new FileExport("text/csv", "submissions-1.csv");
 
@@ -1039,7 +1063,8 @@ public class ExportTests
             ExportFormatId = exportFormatId,
         };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var exporter = CreateMockExporter("csv", typeof(SubmissionExportRow));
         var fileExport = new FileExport("text/csv", "submissions-1.csv");
 
@@ -1076,7 +1101,8 @@ public class ExportTests
             CompletionStatus = ExportCompletionStatus.Completed,
         };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
 
         _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>()).Returns(form);
         _tenantContext.TenantId.Returns(tenantId);
@@ -1103,7 +1129,8 @@ public class ExportTests
             Locale = "es",
         };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
 
         _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>()).Returns(form);
         _tenantContext.TenantId.Returns(tenantId);
@@ -1130,7 +1157,8 @@ public class ExportTests
             CreatedAfter = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
         };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
 
         _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>()).Returns(form);
         _tenantContext.TenantId.Returns(tenantId);
@@ -1156,7 +1184,8 @@ public class ExportTests
             Locale = "es",
         };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var exporter = CreateMockExporter("codebook-shoji", typeof(DynamicExportRow));
         var fileExport = new FileExport("application/json", "codebook-1.json");
 
@@ -1192,7 +1221,8 @@ public class ExportTests
             IncludeTestSubmissions = true,
         };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
 
         _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>()).Returns(form);
         _tenantContext.TenantId.Returns(tenantId);
@@ -1211,7 +1241,8 @@ public class ExportTests
         var tenantId = SampleData.TENANT_ID;
         var request = new ExportRequest { FormId = formId, ExportFormatId = 100L };
 
-        var form = new Form(tenantId, "Test Form") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "Test Form"));
+        form.Id = formId;
         var exporter = CreateMockExporter("csv", typeof(SubmissionExportRow));
         var fileExport = new FileExport("text/csv", "submissions-1.csv");
 

--- a/tests/Endatix.Core.Tests/Entities/FormIntegrationEventTests.cs
+++ b/tests/Endatix.Core.Tests/Entities/FormIntegrationEventTests.cs
@@ -10,8 +10,13 @@ namespace Endatix.Core.Tests.Entities;
 /// </summary>
 public class FormIntegrationEventTests
 {
-    private static Form CreateForm(bool isEnabled = false) =>
-        new(tenantId: 1, name: "Test Form", isEnabled: isEnabled) { Id = 100 };
+    private static Form CreateForm(bool isEnabled = false)
+    {
+        FormCreateArgs args = new(TenantId: 1, Name: "Test Form", IsEnabled: isEnabled);
+        var form = Form.Create(args);
+        form.Id = 100;
+        return form;
+    }
 
     [Fact]
     public void RaiseCreated_registers_FormCreatedEvent_and_keeps_revision_at_1()

--- a/tests/Endatix.Core.Tests/Entities/FormTests.cs
+++ b/tests/Endatix.Core.Tests/Entities/FormTests.cs
@@ -8,7 +8,7 @@ public class FormTests
     [Fact]
     public void MoveToFolder_WhenAllowed_UpdatesFolderId()
     {
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1);
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
 
         var moved = form.MoveToFolder(42);
 
@@ -19,7 +19,7 @@ public class FormTests
     [Fact]
     public void ClearFolder_WhenAssigned_RemovesFolderId()
     {
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, folderId: 24);
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, FolderId: 24));
 
         var cleared = form.ClearFolder();
 
@@ -31,7 +31,7 @@ public class FormTests
     public void AddFormDefinition_WhenFirstDefinition_SetsItAsActive()
     {
         // Arrange & Act
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1);
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1);
         form.AddFormDefinition(formDefinition);
 
@@ -45,7 +45,8 @@ public class FormTests
     public void SetActiveFormDefinition_WhenChangingActive_UpdatesActiveDefinitionCorrectly()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
         var formDefinition1 = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1)
         {
             Id = 1
@@ -70,7 +71,8 @@ public class FormTests
     [Fact]
     public void SetActiveFormDefinition_WhenAlreadyActiveReference_DoesNotRaiseReportingEvent()
     {
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1)
         {
             Id = 10
@@ -88,7 +90,8 @@ public class FormTests
     [Fact]
     public void SetActiveFormDefinition_WhenActivatingDraftDefinition_DoesNotRaiseReportingEvent()
     {
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
         var published = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1)
         {
             Id = 1
@@ -110,7 +113,8 @@ public class FormTests
     [Fact]
     public void UpdateActiveDefinitionSchema_WhenJsonChanges_RaisesReportingEvent()
     {
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1)
         {
             Id = 10
@@ -128,7 +132,8 @@ public class FormTests
     [Fact]
     public void UpdateActiveDefinitionSchema_WhenPublishingDraftWithoutJsonChange_RaisesReportingEvent()
     {
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, isDraft: true, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1)
         {
             Id = 10
@@ -146,7 +151,8 @@ public class FormTests
     [Fact]
     public void UpdateActiveDefinitionSchema_WhenDraftSaveWithoutPublish_DoesNotRaiseReportingEvent()
     {
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, isDraft: true, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1)
         {
             Id = 10
@@ -165,8 +171,8 @@ public class FormTests
     public void SetActiveFormDefinition_WithNonExistingDefinition_ThrowsException()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1);
-        var externalForm = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_2);
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        var externalForm = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_2));
         var externalDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1);
         externalForm.AddFormDefinition(externalDefinition);
 
@@ -181,7 +187,7 @@ public class FormTests
     public void UpdateWebHookSettings_WithValidConfiguration_UpdatesSettings()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1);
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
         var webHookConfig = new WebHookConfiguration
         {
             Events = new Dictionary<string, WebHookEventConfig>
@@ -212,7 +218,7 @@ public class FormTests
     public void UpdateWebHookSettings_WithNull_ClearsSettings()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1);
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
         var webHookConfig = new WebHookConfiguration
         {
             Events = new Dictionary<string, WebHookEventConfig>
@@ -235,7 +241,7 @@ public class FormTests
     public void WebHookSettings_WhenNoSettingsSet_ReturnsEmptyConfiguration()
     {
         // Arrange & Act
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1);
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
 
         // Assert
         form.WebHookSettings.Should().NotBeNull();
@@ -262,7 +268,7 @@ public class FormTests
         """;
 
         // Act
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, webHookSettingsJson: webHookJson);
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, WebHookSettingsJson: webHookJson));
 
         // Assert
         form.WebHookSettings.Should().NotBeNull();

--- a/tests/Endatix.Core.Tests/Entities/SubmissionConstructorTests.cs
+++ b/tests/Endatix.Core.Tests/Entities/SubmissionConstructorTests.cs
@@ -43,10 +43,8 @@ public class SubmissionConstructorTests
     {
         // Arrange
         const long invalidFormDefinitionId = -1;
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1)
-        {
-            Id = 123
-        };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 123;
         const string jsonData = SampleData.SUBMISSION_JSON_DATA_1;
 
         // Act
@@ -68,10 +66,8 @@ public class SubmissionConstructorTests
     public void Constructor_ValidInput_SetsPropertiesCorrectly()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1)
-        {
-            Id = 123
-        };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 123;
         var jsonData = SampleData.SUBMISSION_JSON_DATA_1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1)
         {
@@ -97,10 +93,8 @@ public class SubmissionConstructorTests
     public void Constructor_CompleteSubmission_SetsCompletedAt()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1)
-        {
-            Id = 123
-        };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 123;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1)
         {
             Id = 456

--- a/tests/Endatix.Core.Tests/Events/IntegrationEventPayloadTests.cs
+++ b/tests/Endatix.Core.Tests/Events/IntegrationEventPayloadTests.cs
@@ -19,7 +19,8 @@ public class IntegrationEventPayloadTests
     [Fact]
     public void FormCreatedEvent_has_dotted_type_and_form_payload_with_revision_and_folderId()
     {
-        var form = new Form(tenantId: 1, name: "Test", description: "d", isEnabled: true) { Id = 555 };
+        var form = Form.Create(new FormCreateArgs(TenantId: 1, Name: "Test", Description: "d", IsEnabled: true));
+        form.Id = 555;
         var evt = new FormCreatedEvent(form);
 
         evt.EventType.Should().Be("form.created");
@@ -36,7 +37,8 @@ public class IntegrationEventPayloadTests
     {
         // The live form is still disabled; the event captured isEnabled: true. The payload must reflect the
         // captured (event-creation-time) value, not the live form.
-        var form = new Form(tenantId: 1, name: "Test") { Id = 7 };
+        var form = Form.Create(new FormCreateArgs(TenantId: 1, Name: "Test"));
+        form.Id = 7;
         var evt = new FormEnabledStateChangedEvent(form, isEnabled: true);
 
         evt.EventType.Should().Be("form.enabled_state_changed");
@@ -50,7 +52,8 @@ public class IntegrationEventPayloadTests
     [Fact]
     public void FormDeletedEvent_has_dotted_type_and_includes_folderId()
     {
-        var form = new Form(tenantId: 1, name: "Test") { Id = 9 };
+        var form = Form.Create(new FormCreateArgs(TenantId: 1, Name: "Test"));
+        form.Id = 9;
         var evt = new FormDeletedEvent(form);
 
         evt.EventType.Should().Be("form.deleted");
@@ -64,7 +67,8 @@ public class IntegrationEventPayloadTests
         // An update that toggles enabled raises two events: enabled_state_changed (revision 2) then
         // updated (revision 3). Each payload must keep the revision captured when it was raised, not the
         // final live value — otherwise an order-sensitive consumer can't distinguish/order them.
-        var form = new Form(tenantId: 1, name: "Test") { Id = 1 }; // revision 1
+        var form = Form.Create(new FormCreateArgs(TenantId: 1, Name: "Test"));
+        form.Id = 1; // revision 1
         form.SetEnabled(true); // revision 2, raises enabled_state_changed
         form.UpdateDetails("New", null, isPublic: true, limitOnePerUser: false, metadata: null); // revision 3, raises updated
 

--- a/tests/Endatix.Core.Tests/UseCases/Folders/Delete/DeleteFolderHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Folders/Delete/DeleteFolderHandlerTests.cs
@@ -90,11 +90,11 @@ public class DeleteFolderHandlerTests
     {
         _tenantContext.TenantId.Returns(1L);
         var folder = new Folder(1L, "Test", "test", "TEST") { Id = 10L };
-        var forms = new List<Form>
-        {
-            new Form(1L, "Form 1", folderId: 10L) { Id = 1 },
-            new Form(1L, "Form 2", folderId: 10L) { Id = 2 }
-        };
+        var form1 = Form.Create(new FormCreateArgs(TenantId: 1L, Name: "Form 1", FolderId: 10L));
+        form1.Id = 1;
+        var form2 = Form.Create(new FormCreateArgs(TenantId: 1L, Name: "Form 2", FolderId: 10L));
+        form2.Id = 2;
+        var forms = new List<Form> { form1, form2 };
 
         _folderRepository.FirstOrDefaultAsync(
                 Arg.Any<FolderSpecifications.FolderByIdSpec>(),

--- a/tests/Endatix.Core.Tests/UseCases/FormDefinitions/Create/CreateFormDefinitionHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/FormDefinitions/Create/CreateFormDefinitionHandlerTests.cs
@@ -46,15 +46,13 @@ public class CreateFormDefinitionHandlerTests
     {
         // Arrange
         var request = new CreateFormDefinitionCommand(SampleData.TENANT_ID, isDraft: false, SampleData.FORM_DEFINITION_JSON_DATA_1);
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1)
-        {
-            Id = request.FormId
-        };
-          var formDefinition = FormDefinitionFactory.CreateForTesting(
-            isDraft: false,
-            jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1,
-            formDefinitionId: 123
-        );
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = request.FormId;
+        var formDefinition = FormDefinitionFactory.CreateForTesting(
+          isDraft: false,
+          jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1,
+          formDefinitionId: 123
+      );
         form.AddFormDefinition(formDefinition);
 
         _formsRepository.GetByIdAsync(
@@ -85,10 +83,8 @@ public class CreateFormDefinitionHandlerTests
     {
         // Arrange
         var request = new CreateFormDefinitionCommand(SampleData.TENANT_ID, isDraft: true, SampleData.FORM_DEFINITION_JSON_DATA_1);
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1)
-        {
-            Id = request.FormId
-        };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = request.FormId;
         var formDefinition = FormDefinitionFactory.CreateForTesting(
             isDraft: false,
             jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1,

--- a/tests/Endatix.Core.Tests/UseCases/FormDefinitions/GetActive/GetActiveFormDefinitionHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/FormDefinitions/GetActive/GetActiveFormDefinitionHandlerTests.cs
@@ -47,10 +47,8 @@ public class GetActiveFormDefinitionHandlerTests
     public async Task Handle_ValidRequest_ReturnsActiveFormDefinition()
     {
         // Arrange
-        var formWithActiveDefinition = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, isEnabled: true, isPublic: true)
-        {
-            Id = 1
-        };
+        var formWithActiveDefinition = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, IsEnabled: true, IsPublic: true));
+        formWithActiveDefinition.Id = 1;
         var activeDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1);
         formWithActiveDefinition.AddFormDefinition(activeDefinition);
 
@@ -82,10 +80,8 @@ public class GetActiveFormDefinitionHandlerTests
     public async Task Handle_ValidRequestWithCustomQuestions_ReturnsActiveFormDefinitionWithCustomQuestions()
     {
         // Arrange
-        var formWithActiveDefinition = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, isEnabled: true, isPublic: true)
-        {
-            Id = 1
-        };
+        var formWithActiveDefinition = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, IsEnabled: true, IsPublic: true));
+        formWithActiveDefinition.Id = 1;
         var activeDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1);
         formWithActiveDefinition.AddFormDefinition(activeDefinition);
 
@@ -124,10 +120,8 @@ public class GetActiveFormDefinitionHandlerTests
     public async Task Handle_ValidRequestWithTheme_ReturnsActiveFormDefinitionWithTheme()
     {
         // Arrange
-        var formWithActiveDefinition = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, isEnabled: true, isPublic: true)
-        {
-            Id = 1
-        };
+        var formWithActiveDefinition = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, IsEnabled: true, IsPublic: true));
+        formWithActiveDefinition.Id = 1;
         var activeDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1);
         var theme = new Theme(SampleData.TENANT_ID, "Test Theme", "{ \"colors\": { \"primary\": \"#000000\" } }");
         formWithActiveDefinition.AddFormDefinition(activeDefinition);
@@ -162,10 +156,8 @@ public class GetActiveFormDefinitionHandlerTests
     public async Task Handle_PrivateFormWithAnonymousUser_ReturnsUnauthorizedResult()
     {
         // Arrange
-        var formWithActiveDefinition = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, isEnabled: true, isPublic: false)
-        {
-            Id = 1
-        };
+        var formWithActiveDefinition = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, IsEnabled: true, IsPublic: false));
+        formWithActiveDefinition.Id = 1;
         var activeDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1);
         formWithActiveDefinition.AddFormDefinition(activeDefinition);
 
@@ -191,10 +183,8 @@ public class GetActiveFormDefinitionHandlerTests
     public async Task Handle_PrivateFormWithUserWithoutPermission_ReturnsForbiddenResult()
     {
         // Arrange
-        var formWithActiveDefinition = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, isEnabled: true, isPublic: false)
-        {
-            Id = 1
-        };
+        var formWithActiveDefinition = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, IsEnabled: true, IsPublic: false));
+        formWithActiveDefinition.Id = 1;
         var activeDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1);
         formWithActiveDefinition.AddFormDefinition(activeDefinition);
 
@@ -220,10 +210,8 @@ public class GetActiveFormDefinitionHandlerTests
     public async Task Handle_PrivateFormWithUserWithPermission_ReturnsActiveFormDefinition()
     {
         // Arrange
-        var formWithActiveDefinition = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, isEnabled: true, isPublic: false)
-        {
-            Id = 1
-        };
+        var formWithActiveDefinition = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, IsEnabled: true, IsPublic: false));
+        formWithActiveDefinition.Id = 1;
         var activeDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1);
         formWithActiveDefinition.AddFormDefinition(activeDefinition);
 
@@ -256,10 +244,8 @@ public class GetActiveFormDefinitionHandlerTests
     public async Task Handle_PublicForm_ReturnsActiveFormDefinitionWithoutPermissionCheck()
     {
         // Arrange
-        var formWithActiveDefinition = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, isEnabled: true, isPublic: true)
-        {
-            Id = 1
-        };
+        var formWithActiveDefinition = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, IsEnabled: true, IsPublic: true));
+        formWithActiveDefinition.Id = 1;
         var activeDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1);
         formWithActiveDefinition.AddFormDefinition(activeDefinition);
 
@@ -293,15 +279,13 @@ public class GetActiveFormDefinitionHandlerTests
     {
         // Arrange
         const string userId = "user-123";
-        var formWithActiveDefinition = new Form(
-            SampleData.TENANT_ID,
-            SampleData.FORM_NAME_1,
-            isEnabled: true,
-            isPublic: false,
-            limitOnePerUser: true)
-        {
-            Id = 1
-        };
+        var formWithActiveDefinition = Form.Create(new FormCreateArgs(
+            TenantId: SampleData.TENANT_ID,
+            Name: SampleData.FORM_NAME_1,
+            IsEnabled: true,
+            IsPublic: false,
+            LimitOnePerUser: true));
+        formWithActiveDefinition.Id = 1;
         var activeDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1);
         formWithActiveDefinition.AddFormDefinition(activeDefinition);
 

--- a/tests/Endatix.Core.Tests/UseCases/FormDefinitions/GetById/GetFormDefinitionByIdHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/FormDefinitions/GetById/GetFormDefinitionByIdHandlerTests.cs
@@ -42,7 +42,8 @@ public class GetFormDefinitionByIdHandlerTests
     {
         // Arrange
         var formDefinitionIdToReturn = 123;
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
         var formDefinition = FormDefinitionFactory.CreateForTesting(
             isDraft: false,
             jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1,
@@ -70,7 +71,8 @@ public class GetFormDefinitionByIdHandlerTests
     public async Task Handle_ValidRequest_ReturnsFormDefinition()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form") { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        form.Id = 1;
         var formDefinition = FormDefinitionFactory.CreateForTesting(
             isDraft: false,
             jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1,

--- a/tests/Endatix.Core.Tests/UseCases/FormDefinitions/GetFields/GetFormDefinitionFieldsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/FormDefinitions/GetFields/GetFormDefinitionFieldsHandlerTests.cs
@@ -27,8 +27,10 @@ public class GetFormDefinitionFieldsHandlerTests
 
     private void ArrangeFormExists(long formId = 1)
     {
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test form"));
+        form.Id = formId;
         _formsRepository.SingleOrDefaultAsync(Arg.Any<FormSpecifications.ByIdReadOnly>(), Arg.Any<CancellationToken>())
-            .Returns(new Form(SampleData.TENANT_ID, "Test form") { Id = formId });
+            .Returns(form);
     }
 
     [Fact]

--- a/tests/Endatix.Core.Tests/UseCases/FormDefinitions/List/ListFormDefinitionsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/FormDefinitions/List/ListFormDefinitionsHandlerTests.cs
@@ -21,9 +21,10 @@ public class ListFormDefinitionsHandlerTests
     public async Task Handle_ValidRequest_ReturnsFormDefinitions()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form") { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        form.Id = 1;
         var formDefinition1 = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1);
-        var formDefinition2 =  new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_2);
+        var formDefinition2 = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_2);
         form.AddFormDefinition(formDefinition1);
         form.AddFormDefinition(formDefinition2);
         var formDefinitions = new List<FormDefinition>

--- a/tests/Endatix.Core.Tests/UseCases/FormDefinitions/PartialUpdate/PartialUpdateFormDefinitionHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/FormDefinitions/PartialUpdate/PartialUpdateFormDefinitionHandlerTests.cs
@@ -42,7 +42,8 @@ public class PartialUpdateFormDefinitionHandlerTests
     {
         // Arrange
         var nonExistingFormId = 2;
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1);
         form.AddFormDefinition(formDefinition);
         var request = new PartialUpdateFormDefinitionCommand(nonExistingFormId, 1, null, null);
@@ -62,7 +63,8 @@ public class PartialUpdateFormDefinitionHandlerTests
     public async Task Handle_ValidRequest_UpdatesFormDefinition()
     {
         // Arrange
-        var testForm = new Form(SampleData.TENANT_ID, "Test Form") { Id = 1 };
+        var testForm = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        testForm.Id = 1;
         var formDefinition = FormDefinitionFactory.CreateForTesting(
             jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1,
             formId: 1,
@@ -95,15 +97,13 @@ public class PartialUpdateFormDefinitionHandlerTests
     public async Task Handle_PartialUpdate_UpdatesOnlySpecifiedFields()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form")
-        {
-            Id = 1
-        };
-         var formDefinition = FormDefinitionFactory.CreateForTesting(
-            jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1,
-            formId: 1,
-            formDefinitionId: 2
-        );
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        form.Id = 1;
+        var formDefinition = FormDefinitionFactory.CreateForTesting(
+           jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1,
+           formId: 1,
+           formDefinitionId: 2
+       );
         var request = new PartialUpdateFormDefinitionCommand(1, 1, null, SampleData.FORM_DEFINITION_JSON_DATA_2);
         _repository.GetByIdAsync(
             request.DefinitionId,

--- a/tests/Endatix.Core.Tests/UseCases/FormDefinitions/PartialUpdateActive/PartialUpdateActiveFormDefinitionHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/FormDefinitions/PartialUpdateActive/PartialUpdateActiveFormDefinitionHandlerTests.cs
@@ -46,7 +46,8 @@ public class PartialUpdateActiveFormDefinitionHandlerTests
     public async Task Handle_ValidRequest_UpdatesFormDefinition()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form") { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1);
         form.AddFormDefinition(formDefinition);
 
@@ -72,7 +73,8 @@ public class PartialUpdateActiveFormDefinitionHandlerTests
     public async Task Handle_PartialUpdate_UpdatesOnlySpecifiedFields()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form") { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1);
         form.AddFormDefinition(formDefinition);
 
@@ -99,7 +101,8 @@ public class PartialUpdateActiveFormDefinitionHandlerTests
     public async Task Handle_WithSubmissionsAndChangedJsonData_CreatesNewPublishedDefinitionAndSetsItActive()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form") { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        form.Id = 1;
         var originalDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1)
         {
             Id = 10
@@ -133,7 +136,8 @@ public class PartialUpdateActiveFormDefinitionHandlerTests
     public async Task Handle_WithSubmissionsAndChangedJsonData_CreatesDraftWithoutChangingActiveDefinition()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form") { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        form.Id = 1;
         var originalDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1)
         {
             Id = 10
@@ -166,7 +170,8 @@ public class PartialUpdateActiveFormDefinitionHandlerTests
     public async Task Handle_WithoutSubmissionsAndChangedJsonData_UpdatesActiveDefinitionInPlace()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form") { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1)
         {
             Id = 10
@@ -198,7 +203,8 @@ public class PartialUpdateActiveFormDefinitionHandlerTests
     public async Task Handle_WithSubmissionsAndUnchangedJsonData_UpdatesActiveDefinitionInPlace()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form") { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1)
         {
             Id = 10
@@ -232,7 +238,8 @@ public class PartialUpdateActiveFormDefinitionHandlerTests
     [Fact]
     public async Task Handle_PublishingDraftWithUnchangedJsonData_RaisesFormDefinitionUpdatedEvent()
     {
-        var form = new Form(SampleData.TENANT_ID, "Test Form") { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, isDraft: true, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1)
         {
             Id = 10

--- a/tests/Endatix.Core.Tests/UseCases/FormDefinitions/Update/UpdateFormDefinitionHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/FormDefinitions/Update/UpdateFormDefinitionHandlerTests.cs
@@ -45,7 +45,8 @@ public class UpdateFormDefinitionHandlerTests
         var notFoundFormDefinitionId = 2;
         var request = new UpdateFormDefinitionCommand(notFoundFormId, notFoundFormDefinitionId, true, SampleData.FORM_DEFINITION_JSON_DATA_1);
 
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 123 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 123;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1)
         {
             Id = 456
@@ -70,7 +71,8 @@ public class UpdateFormDefinitionHandlerTests
     public async Task Handle_ValidRequest_UpdatesFormDefinition()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
         var formDefinition = FormDefinitionFactory.CreateForTesting(
             jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1,
             formId: 1,

--- a/tests/Endatix.Core.Tests/UseCases/FormDefinitions/UpdateActive/UpdateActiveFormDefinitionHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/FormDefinitions/UpdateActive/UpdateActiveFormDefinitionHandlerTests.cs
@@ -41,7 +41,7 @@ public class UpdateActiveFormDefinitionHandlerTests
     public async Task Handle_ValidRequest_UpdatesFormDefinition()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1);
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1)
         {
             Id = 1

--- a/tests/Endatix.Core.Tests/UseCases/Forms/Create/CreateFormHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/Create/CreateFormHandlerTests.cs
@@ -28,10 +28,8 @@ public class CreateFormHandlerTests
         // Arrange
         var request = new CreateFormCommand("Form Name", "Description", true, SampleData.FORM_DEFINITION_JSON_DATA_1);
 
-        var createdForm = new Form(SampleData.TENANT_ID, "Form Name", request.Description, request.IsEnabled)
-        {
-            Id = 123
-        };
+        var createdForm = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Form Name", Description: request.Description, IsEnabled: request.IsEnabled));
+        createdForm.Id = 123;
         var createdFormDefinition = new FormDefinition(SampleData.TENANT_ID, jsonData: SampleData.FORM_DEFINITION_JSON_DATA_1)
         {
             Id = 456

--- a/tests/Endatix.Core.Tests/UseCases/Forms/Delete/DeleteFormHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/Delete/DeleteFormHandlerTests.cs
@@ -44,9 +44,10 @@ public class DeleteFormHandlerTests
     public async Task Handle_ValidRequest_DeletesForm()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form") { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        form.Id = 1;
         var request = new DeleteFormCommand(1);
-        
+
         _repository.SingleOrDefaultAsync(
             Arg.Any<FormWithDefinitionsAndSubmissionsSpec>(),
             Arg.Any<CancellationToken>())
@@ -60,7 +61,7 @@ public class DeleteFormHandlerTests
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().NotBeNull();
         result.Value.Should().Be(form);
-        
+
         await _repository.Received(1).UpdateAsync(
             Arg.Is<Form>(f => f.Id == form.Id),
             Arg.Any<CancellationToken>()
@@ -71,9 +72,10 @@ public class DeleteFormHandlerTests
     public async Task Handle_ValidRequest_CallsDeleteOnForm()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form") { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        form.Id = 1;
         var request = new DeleteFormCommand(1);
-        
+
         _repository.SingleOrDefaultAsync(
             Arg.Any<FormWithDefinitionsAndSubmissionsSpec>(),
             Arg.Any<CancellationToken>())
@@ -90,9 +92,10 @@ public class DeleteFormHandlerTests
     public async Task Handle_ValidRequest_PublishesFormDeletedEvent()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form") { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        form.Id = 1;
         var request = new DeleteFormCommand(1);
-        
+
         _repository.SingleOrDefaultAsync(
             Arg.Any<FormWithDefinitionsAndSubmissionsSpec>(),
             Arg.Any<CancellationToken>())
@@ -107,4 +110,4 @@ public class DeleteFormHandlerTests
             Arg.Any<CancellationToken>()
         );
     }
-} 
+}

--- a/tests/Endatix.Core.Tests/UseCases/Forms/PartialUpdate/PartialUpdateFormHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/PartialUpdate/PartialUpdateFormHandlerTests.cs
@@ -50,13 +50,11 @@ public class PartialUpdateFormHandlerTests
     public async Task Handle_ValidRequest_UpdatesForm()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form")
-        {
-            Id = 1,
-            Name = SampleData.FORM_NAME_1,
-            Description = SampleData.FORM_DESCRIPTION_1,
-            IsEnabled = true
-        };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        form.Id = 1;
+        form.Name = SampleData.FORM_NAME_1;
+        form.Description = SampleData.FORM_DESCRIPTION_1;
+        form.IsEnabled = true;
         var theme = new Theme(SampleData.TENANT_ID, "Test Theme", "{ \"background\": \"#FFFFFF\" }") { Id = 4 };
         form.SetTheme(theme);
         var request = new PartialUpdateFormCommand(1)
@@ -86,7 +84,11 @@ public class PartialUpdateFormHandlerTests
     public async Task Handle_PartialUpdate_UpdatesOnlySpecifiedFields()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form") { Id = 1, Name = SampleData.FORM_NAME_1, Description = SampleData.FORM_DESCRIPTION_1, IsEnabled = true };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        form.Id = 1;
+        form.Name = SampleData.FORM_NAME_1;
+        form.Description = SampleData.FORM_DESCRIPTION_1;
+        form.IsEnabled = true;
         var oldTheme = new Theme(SampleData.TENANT_ID, "Test Theme", "{ \"background\": \"#FFFFFF\" }") { Id = 3 };
         var newTheme = new Theme(SampleData.TENANT_ID, "Test Theme", "{ \"background\": \"#000000\" }") { Id = 4 };
         var request = new PartialUpdateFormCommand(1)
@@ -118,13 +120,11 @@ public class PartialUpdateFormHandlerTests
     public async Task Handle_ValidRequest_PublishesFormUpdatedEvent()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form")
-        {
-            Id = 1,
-            Name = SampleData.FORM_NAME_1,
-            Description = SampleData.FORM_DESCRIPTION_1,
-            IsEnabled = true
-        };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        form.Id = 1;
+        form.Name = SampleData.FORM_NAME_1;
+        form.Description = SampleData.FORM_DESCRIPTION_1;
+        form.IsEnabled = true;
         var request = new PartialUpdateFormCommand(1)
         {
             Name = SampleData.FORM_NAME_2,
@@ -146,13 +146,11 @@ public class PartialUpdateFormHandlerTests
     {
         // Arrange — the enabled-state change is now captured to the outbox via the aggregate (SetEnabled),
         // not published in-process.
-        var form = new Form(SampleData.TENANT_ID, "Test Form")
-        {
-            Id = 1,
-            Name = SampleData.FORM_NAME_1,
-            Description = SampleData.FORM_DESCRIPTION_1,
-            IsEnabled = true
-        };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
+        form.Id = 1;
+        form.Name = SampleData.FORM_NAME_1;
+        form.Description = SampleData.FORM_DESCRIPTION_1;
+        form.IsEnabled = true;
         var request = new PartialUpdateFormCommand(1)
         {
             IsEnabled = false
@@ -174,7 +172,8 @@ public class PartialUpdateFormHandlerTests
     public async Task Handle_WithWebHookSettingsJson_UpdatesWebHookConfiguration()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
         var webHookJson = """
         {
             "Events": {
@@ -219,7 +218,8 @@ public class PartialUpdateFormHandlerTests
                 ["SubmissionCompleted"] = new WebHookEventConfig { IsEnabled = true }
             }
         };
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
         form.UpdateWebHookSettings(webHookConfig);
 
         var request = new PartialUpdateFormCommand(1)
@@ -243,12 +243,10 @@ public class PartialUpdateFormHandlerTests
     public async Task Handle_PartialUpdateWithOtherFieldsAndWebHookSettings_UpdatesBothCorrectly()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1)
-        {
-            Id = 1,
-            Description = SampleData.FORM_DESCRIPTION_1,
-            IsEnabled = true
-        };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
+        form.Description = SampleData.FORM_DESCRIPTION_1;
+        form.IsEnabled = true;
         var webHookJson = """
         {
             "Events": {
@@ -303,7 +301,8 @@ public class PartialUpdateFormHandlerTests
                 }
             }
         };
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
         form.UpdateWebHookSettings(webHookConfig);
 
         // Create request with only Name updated, WebHookSettingsJson is null
@@ -343,7 +342,8 @@ public class PartialUpdateFormHandlerTests
                 ["SubmissionCompleted"] = new WebHookEventConfig { IsEnabled = true }
             }
         };
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
         form.UpdateWebHookSettings(webHookConfig);
 
         var request = new PartialUpdateFormCommand(1)
@@ -367,7 +367,8 @@ public class PartialUpdateFormHandlerTests
     public async Task Handle_DisablingLimitOnePerUserAfterEnabled_ReturnsConflict()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, isPublic: false, limitOnePerUser: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, IsPublic: false, LimitOnePerUser: true));
+        form.Id = 1;
         var request = new PartialUpdateFormCommand(1)
         {
             LimitOnePerUser = false
@@ -387,7 +388,8 @@ public class PartialUpdateFormHandlerTests
     public async Task Handle_EnablingLimitOnePerUserWithDuplicateEligibleSubmissions_ReturnsConflict()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, isPublic: false, limitOnePerUser: false) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, IsPublic: false, LimitOnePerUser: false));
+        form.Id = 1;
         var request = new PartialUpdateFormCommand(1)
         {
             LimitOnePerUser = true
@@ -411,7 +413,8 @@ public class PartialUpdateFormHandlerTests
     public async Task Handle_EnablingLimitOnePerUserWithWhitespaceSubmittedByValues_Succeeds()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, isPublic: false, limitOnePerUser: false) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, IsPublic: false, LimitOnePerUser: false));
+        form.Id = 1;
         var request = new PartialUpdateFormCommand(1)
         {
             LimitOnePerUser = true
@@ -435,7 +438,8 @@ public class PartialUpdateFormHandlerTests
     public async Task Handle_SettingFormPublicWhileSingleSubmissionEnabled_ReturnsConflict()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, isPublic: false, limitOnePerUser: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, IsPublic: false, LimitOnePerUser: true));
+        form.Id = 1;
         var request = new PartialUpdateFormCommand(1)
         {
             IsPublic = true
@@ -474,7 +478,8 @@ public class PartialUpdateFormHandlerTests
             .Returns((TenantSettingsEntity?)null);
 
         var handler = new PartialUpdateFormHandler(_repository, _themeRepository, _submissionRepository, _mediator, helper);
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, folderId: 7) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, FolderId: 7));
+        form.Id = 1;
         var request = new PartialUpdateFormCommand(1) { ClearFolderId = true };
         _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
             .Returns(form);

--- a/tests/Endatix.Core.Tests/UseCases/Forms/Update/UpdateFormHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/Update/UpdateFormHandlerTests.cs
@@ -47,7 +47,10 @@ public class UpdateFormHandlerTests
     public async Task Handle_ValidRequest_UpdatesForm()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1, Description = SampleData.FORM_DESCRIPTION_1, IsEnabled = true };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
+        form.Description = SampleData.FORM_DESCRIPTION_1;
+        form.IsEnabled = true;
         var request = new UpdateFormCommand(1, SampleData.FORM_NAME_2, SampleData.FORM_DESCRIPTION_2, false);
         _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
                    .Returns(form);
@@ -69,7 +72,10 @@ public class UpdateFormHandlerTests
     public async Task Handle_ValidRequest_PublishesFormUpdatedEvent()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1, Description = SampleData.FORM_DESCRIPTION_1, IsEnabled = true };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
+        form.Description = SampleData.FORM_DESCRIPTION_1;
+        form.IsEnabled = true;
         var request = new UpdateFormCommand(1, SampleData.FORM_NAME_2, SampleData.FORM_DESCRIPTION_2, false);
         _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
                    .Returns(form);
@@ -86,7 +92,10 @@ public class UpdateFormHandlerTests
     {
         // Arrange — the enabled-state change is now captured to the outbox via the aggregate (SetEnabled),
         // not published in-process. The handler keeps the FormUpdated publish for cache invalidation.
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1, Description = SampleData.FORM_DESCRIPTION_1, IsEnabled = true };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
+        form.Description = SampleData.FORM_DESCRIPTION_1;
+        form.IsEnabled = true;
         var request = new UpdateFormCommand(1, SampleData.FORM_NAME_1, SampleData.FORM_DESCRIPTION_1, false);
         _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
                    .Returns(form);
@@ -105,7 +114,8 @@ public class UpdateFormHandlerTests
     public async Task Handle_WithWebHookSettingsJson_UpdatesWebHookConfiguration()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
         var webHookJson = """
         {
             "Events": {
@@ -147,7 +157,8 @@ public class UpdateFormHandlerTests
                 ["SubmissionCompleted"] = new WebHookEventConfig { IsEnabled = true }
             }
         };
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
         form.UpdateWebHookSettings(webHookConfig);
 
         var request = new UpdateFormCommand(1, SampleData.FORM_NAME_1, SampleData.FORM_DESCRIPTION_1, true, "");
@@ -175,7 +186,8 @@ public class UpdateFormHandlerTests
                 ["SubmissionCompleted"] = new WebHookEventConfig { IsEnabled = true }
             }
         };
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1));
+        form.Id = 1;
         form.UpdateWebHookSettings(webHookConfig);
 
         var request = new UpdateFormCommand(1, SampleData.FORM_NAME_1, SampleData.FORM_DESCRIPTION_1, true, null);
@@ -196,7 +208,8 @@ public class UpdateFormHandlerTests
     public async Task Handle_DisablingLimitOnePerUserAfterEnabled_ReturnsConflict()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, isPublic: false, limitOnePerUser: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, IsPublic: false, LimitOnePerUser: true));
+        form.Id = 1;
         var request = new UpdateFormCommand(1, SampleData.FORM_NAME_1, SampleData.FORM_DESCRIPTION_1, true, null, false);
         _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
                    .Returns(form);
@@ -213,7 +226,8 @@ public class UpdateFormHandlerTests
     public async Task Handle_EnablingLimitOnePerUserWithDuplicateEligibleSubmissions_ReturnsConflict()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, isPublic: false, limitOnePerUser: false) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, IsPublic: false, LimitOnePerUser: false));
+        form.Id = 1;
         var request = new UpdateFormCommand(1, SampleData.FORM_NAME_1, SampleData.FORM_DESCRIPTION_1, true, null, true);
         _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
             .Returns(form);
@@ -234,7 +248,8 @@ public class UpdateFormHandlerTests
     public async Task Handle_EnablingLimitOnePerUserWithOnlyTestDuplicates_Succeeds()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, isPublic: false, limitOnePerUser: false) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, IsPublic: false, LimitOnePerUser: false));
+        form.Id = 1;
         var request = new UpdateFormCommand(1, SampleData.FORM_NAME_1, SampleData.FORM_DESCRIPTION_1, true, null, true);
         _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
             .Returns(form);
@@ -255,7 +270,8 @@ public class UpdateFormHandlerTests
     public async Task Handle_EnablingLimitOnePerUserWithWhitespaceSubmittedByValues_Succeeds()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, isPublic: false, limitOnePerUser: false) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, IsPublic: false, LimitOnePerUser: false));
+        form.Id = 1;
         var request = new UpdateFormCommand(1, SampleData.FORM_NAME_1, SampleData.FORM_DESCRIPTION_1, true, null, true);
         _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
             .Returns(form);
@@ -276,7 +292,8 @@ public class UpdateFormHandlerTests
     public async Task Handle_EnablingLimitOnePerUserOnPublicForm_ReturnsConflict()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, isPublic: true, limitOnePerUser: false) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, IsPublic: true, LimitOnePerUser: false));
+        form.Id = 1;
         var request = new UpdateFormCommand(1, SampleData.FORM_NAME_1, SampleData.FORM_DESCRIPTION_1, true, null, true);
         _repository.GetByIdAsync(request.FormId, Arg.Any<CancellationToken>())
             .Returns(form);
@@ -293,7 +310,8 @@ public class UpdateFormHandlerTests
     public async Task Handle_OmittedLimitOnePerUser_PreservesExistingEnabledValue()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, isPublic: false, limitOnePerUser: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, IsPublic: false, LimitOnePerUser: true));
+        form.Id = 1;
         var request = new UpdateFormCommand(
             formId: 1,
             name: SampleData.FORM_NAME_1,
@@ -335,7 +353,8 @@ public class UpdateFormHandlerTests
             .Returns((TenantSettingsEntity?)null);
 
         var handler = new UpdateFormHandler(_repository, _submissionRepository, _mediator, helper);
-        var form = new Form(SampleData.TENANT_ID, SampleData.FORM_NAME_1, folderId: 7) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: SampleData.FORM_NAME_1, FolderId: 7));
+        form.Id = 1;
         var request = new UpdateFormCommand(
             1,
             SampleData.FORM_NAME_1,

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/Create/CreateSubmissionHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/Create/CreateSubmissionHandlerTests.cs
@@ -68,7 +68,8 @@ public class CreateSubmissionHandlerTests
     public async Task Handle_ValidRequest_CreatesSubmission()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -117,7 +118,8 @@ public class CreateSubmissionHandlerTests
     public async Task Handle_ValidRequest_GeneratesAndSetsToken()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -151,7 +153,8 @@ public class CreateSubmissionHandlerTests
     public async Task Handle_IncompleteSubmission_DoesNotPublishSubmissionCompletedEvent()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -189,7 +192,8 @@ public class CreateSubmissionHandlerTests
     public async Task Handle_ValidRequestAndSubmissionIsCompleted_PublishesSubmissionCreatedEvent()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -232,7 +236,8 @@ public class CreateSubmissionHandlerTests
     {
         // Arrange
         const string DEFAULT_JSON_DATA = "{}";
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -271,7 +276,8 @@ public class CreateSubmissionHandlerTests
     {
         // Arrange
         const int DEFAULT_CURRENT_PAGE = 0;
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -309,7 +315,8 @@ public class CreateSubmissionHandlerTests
     public async Task Handle_ReCaptchaValidationFailed_ReturnsBadRequestResult()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -341,7 +348,8 @@ public class CreateSubmissionHandlerTests
         // Arrange
         const long userId = 123;
         SetupSubmitterResolution(userId);
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -395,7 +403,8 @@ public class CreateSubmissionHandlerTests
         const long submitterId = 123;
         const string profileSnapshot = """{"department":"sales"}""";
         SetupSubmitterResolution(submitterId, profileSnapshot);
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -438,7 +447,8 @@ public class CreateSubmissionHandlerTests
     public async Task Handle_AnonymousUser_SetsSubmittedByToNull()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true, isPublic: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true, IsPublic: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -490,7 +500,8 @@ public class CreateSubmissionHandlerTests
     public async Task Handle_PrivateFormWithAnonymousUser_ReturnsUnauthorizedResult()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true, isPublic: false) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true, IsPublic: false));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -524,7 +535,8 @@ public class CreateSubmissionHandlerTests
     public async Task Handle_PrivateFormWithUserWithoutPermission_ReturnsForbiddenResult()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true, isPublic: false) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true, IsPublic: false));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -558,7 +570,8 @@ public class CreateSubmissionHandlerTests
     public async Task Handle_PrivateFormWithUserWithPermission_CreatesSubmission()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true, isPublic: false) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true, IsPublic: false));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -598,7 +611,8 @@ public class CreateSubmissionHandlerTests
     public async Task Handle_PublicForm_CreatesSubmissionWithoutPermissionCheck()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true, isPublic: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true, IsPublic: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -639,7 +653,8 @@ public class CreateSubmissionHandlerTests
     {
         // Arrange
         SetupSubmitterResolution(123);
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true, isPublic: false, limitOnePerUser: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true, IsPublic: false, LimitOnePerUser: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -679,7 +694,8 @@ public class CreateSubmissionHandlerTests
     {
         // Arrange
         SetupSubmitterResolution(123);
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true, isPublic: false, limitOnePerUser: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true, IsPublic: false, LimitOnePerUser: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -713,7 +729,8 @@ public class CreateSubmissionHandlerTests
     {
         // Arrange
         SetupSubmitterResolution(123);
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true, isPublic: false, limitOnePerUser: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true, IsPublic: false, LimitOnePerUser: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -770,7 +787,8 @@ public class CreateSubmissionHandlerTests
     {
         // Arrange
         SetupSubmitterResolution(123);
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true, isPublic: false, limitOnePerUser: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true, IsPublic: false, LimitOnePerUser: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -823,7 +841,8 @@ public class CreateSubmissionHandlerTests
     {
         // Arrange
         SetupSubmitterResolution(123);
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true, isPublic: false, limitOnePerUser: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true, IsPublic: false, LimitOnePerUser: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -862,7 +881,8 @@ public class CreateSubmissionHandlerTests
     {
         // Arrange
         SetupSubmitterResolution(123);
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true, isPublic: false, limitOnePerUser: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true, IsPublic: false, LimitOnePerUser: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -895,7 +915,8 @@ public class CreateSubmissionHandlerTests
     {
         // Arrange
         SetupSubmitterResolution(123);
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true, isPublic: true, limitOnePerUser: false) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true, IsPublic: true, LimitOnePerUser: false));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -923,7 +944,8 @@ public class CreateSubmissionHandlerTests
     {
         // Arrange
         SetupSubmitterResolution(123);
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true, isPublic: false, limitOnePerUser: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true, IsPublic: false, LimitOnePerUser: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -965,7 +987,8 @@ public class CreateSubmissionHandlerTests
     {
         // Arrange
         SetupSubmitterResolution(123);
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true, isPublic: false, limitOnePerUser: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true, IsPublic: false, LimitOnePerUser: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);
@@ -1088,7 +1111,8 @@ public class CreateSubmissionHandlerTests
 
     private void ArrangeSuccessfulCreatePath()
     {
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true) { Id = 1 };
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true));
+        form.Id = 1;
         var formDefinition = new FormDefinition(SampleData.TENANT_ID) { Id = 2 };
         form.AddFormDefinition(formDefinition);
         form.SetActiveFormDefinition(formDefinition);

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/GetByAccessToken/GetByAccessTokenHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/GetByAccessToken/GetByAccessTokenHandlerTests.cs
@@ -23,7 +23,7 @@ public class GetByAccessTokenHandlerTests
 
     private static Submission CreateSubmissionWithForm(long formId, long formDefinitionId, bool isFormEnabled = true)
     {
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: isFormEnabled);
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: isFormEnabled));
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, false, "{}");
         var submission = new Submission(SampleData.TENANT_ID, "{}", formId, formDefinitionId);
 

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/GetById/GetSubmissionByIdHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/GetById/GetSubmissionByIdHandlerTests.cs
@@ -44,7 +44,7 @@ public class GetSubmissionByIdHandlerTests
         var formDefinitionId = 1L;
         var submissionId = 1L;
 
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true);
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true));
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, false, "{}");
         var submission = new Submission(SampleData.TENANT_ID, "{ }", formId, formDefinitionId) { Id = submissionId };
 

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/GetByToken/GetByTokenHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/GetByToken/GetByTokenHandlerTests.cs
@@ -54,7 +54,7 @@ public class GetByTokenHandlerTests
         var request = new GetByTokenQuery(formId, token);
         var tokenResult = Result.Success(submissionId);
 
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true);
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true));
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, false, "{}");
         var submission = new Submission(SampleData.TENANT_ID, "{}", formId, formDefinitionId);
 
@@ -95,7 +95,7 @@ public class GetByTokenHandlerTests
         var request = new GetByTokenQuery(formId, token);
         var tokenResult = Result.Success(submissionId);
 
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: false);
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: false));
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, false, "{}");
         var submission = new Submission(SampleData.TENANT_ID, "{}", formId, formDefinitionId);
 

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/GetFiles/GetFilesHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/GetFiles/GetFilesHandlerTests.cs
@@ -60,7 +60,7 @@ public class GetFilesHandlerTests
         var query = new GetFilesQuery(formId, submissionId, prefix);
 
         var submission = new Submission(1, "{}", formId, 1) { Id = submissionId };
-        var form = new Form(1, "TestForm");
+        var form = Form.Create(new FormCreateArgs(TenantId: 1, Name: "TestForm"));
 
         _submissionRepo
             .SingleOrDefaultAsync(Arg.Is<SubmissionWithDefinitionSpec>(spec => true), Arg.Any<CancellationToken>())
@@ -97,7 +97,7 @@ public class GetFilesHandlerTests
         var query = new GetFilesQuery(formId, submissionId, null);
 
         var submission = new Submission(1, "{}", formId, 1) { Id = submissionId };
-        var form = new Form(1, "TestForm");
+        var form = Form.Create(new FormCreateArgs(TenantId: 1, Name: "TestForm"));
 
         _submissionRepo
             .SingleOrDefaultAsync(Arg.Is<SubmissionWithDefinitionSpec>(spec => true), Arg.Any<CancellationToken>())

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/PartialUpdateByAccessToken/PartialUpdateByAccessTokenHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/PartialUpdateByAccessToken/PartialUpdateByAccessTokenHandlerTests.cs
@@ -27,7 +27,7 @@ public class PartialUpdateByAccessTokenHandlerTests
 
     private static Submission CreateSubmissionWithForm(long formId, long formDefinitionId, bool isFormEnabled = true)
     {
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: isFormEnabled);
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: isFormEnabled));
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, false, "{}");
         var submission = new Submission(SampleData.TENANT_ID, "{}", formId, formDefinitionId);
 
@@ -60,7 +60,7 @@ public class PartialUpdateByAccessTokenHandlerTests
             new[] { "edit" },
             DateTime.UtcNow.AddHours(1));
 
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true);
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true));
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, false, "{}");
         var submission = new Submission(SampleData.TENANT_ID, "{}", formId, formDefinitionId);
 
@@ -128,7 +128,7 @@ public class PartialUpdateByAccessTokenHandlerTests
             new[] { "edit" },
             DateTime.UtcNow.AddHours(1));
 
-        var form = new Form(SampleData.TENANT_ID, "Test Form", isEnabled: false);
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: false));
         var formDefinition = new FormDefinition(SampleData.TENANT_ID, false, "{}");
         var submission = new Submission(SampleData.TENANT_ID, "{}", formId, formDefinitionId);
 

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/PartialUpdateByToken/PartialUpdateSubmissionByTokenHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/PartialUpdateByToken/PartialUpdateSubmissionByTokenHandlerTests.cs
@@ -92,8 +92,10 @@ public class PartialUpdateSubmissionByTokenHandlerTests
         _tokenService.ResolveTokenAsync(token, Arg.Any<CancellationToken>())
             .Returns(tokenResult);
 
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true));
+        form.Id = formId;
         _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>())
-            .Returns(new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true) { Id = formId });
+            .Returns(form);
 
         _recaptchaService.ValidateReCaptchaAsync(
             Arg.Any<SubmissionVerificationContext>(),
@@ -187,8 +189,10 @@ public class PartialUpdateSubmissionByTokenHandlerTests
         _tokenService.ResolveTokenAsync(token, Arg.Any<CancellationToken>())
             .Returns(Result.Success(submissionId));
 
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true));
+        form.Id = formId;
         _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>())
-            .Returns(new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true) { Id = formId });
+            .Returns(form);
 
         _recaptchaService.ValidateReCaptchaAsync(
             Arg.Any<SubmissionVerificationContext>(),
@@ -241,8 +245,10 @@ public class PartialUpdateSubmissionByTokenHandlerTests
         _tokenService.ResolveTokenAsync(token, Arg.Any<CancellationToken>())
             .Returns(Result.Success(submissionId));
 
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form", IsEnabled: true));
+        form.Id = formId;
         _formsRepository.GetByIdAsync(formId, Arg.Any<CancellationToken>())
-            .Returns(new Form(SampleData.TENANT_ID, "Test Form", isEnabled: true) { Id = formId });
+            .Returns(form);
 
         _recaptchaService.ValidateReCaptchaAsync(
             Arg.Any<SubmissionVerificationContext>(),

--- a/tests/Endatix.Core.Tests/UseCases/Themes/Delete/DeleteThemeHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Themes/Delete/DeleteThemeHandlerTests.cs
@@ -46,12 +46,13 @@ public class DeleteThemeHandlerTests
     {
         // Arrange
         var theme = new Theme(SampleData.TENANT_ID, "Test Theme") { Id = 1 };
-        var forms = new List<Form>
-        {
-            new Form(SampleData.TENANT_ID, "Test Form 1") { Id = 1 },
-            new Form(SampleData.TENANT_ID, "Test Form 2") { Id = 2 },
-            new Form(SampleData.TENANT_ID, "Test Form 3") { Id = 3 }
-        };
+        var form1 = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form 1"));
+        form1.Id = 1;
+        var form2 = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form 2"));
+        form2.Id = 2;
+        var form3 = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form 3"));
+        form3.Id = 3;
+        var forms = new List<Form> { form1, form2, form3 };
 
         forms.ForEach(f => f.SetTheme(theme));
 

--- a/tests/Endatix.Infrastructure.Tests/Caching/FormAccessCacheInvalidatorTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Caching/FormAccessCacheInvalidatorTests.cs
@@ -77,7 +77,7 @@ public sealed class FormAccessCacheInvalidatorTests
         // Arrange
         var invalidator = Substitute.For<IFormAccessCacheInvalidator>();
         var handler = new InvalidateFormAccessCacheOnFormUpdatedHandler(invalidator);
-        var form = new Form(1, "Test form", isPublic: false);
+        var form = Form.Create(new FormCreateArgs(TenantId: 1, Name: "Test form", IsPublic: false));
         var notification = new FormUpdatedEvent(form);
 
         // Act
@@ -93,7 +93,7 @@ public sealed class FormAccessCacheInvalidatorTests
         // Arrange
         var invalidator = Substitute.For<IFormAccessCacheInvalidator>();
         var handler = new InvalidateFormAccessCacheOnFormDeletedHandler(invalidator);
-        var form = new Form(1, "Test form", isPublic: false);
+        var form = Form.Create(new FormCreateArgs(TenantId: 1, Name: "Test form", IsPublic: false));
         var notification = new FormDeletedEvent(form);
 
         // Act

--- a/tests/Endatix.Infrastructure.Tests/Data/FormsRepositoryTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Data/FormsRepositoryTests.cs
@@ -24,7 +24,7 @@ public class FormsRepositoryTests
     public async Task CreateFormWithDefinitionAsync_ShouldCommitTransaction_WhenSuccessful()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "form", "description", true);
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "form", Description: "description", IsEnabled: true));
         var formDefinition = new FormDefinition(SampleData.TENANT_ID);
 
         // Act
@@ -40,7 +40,7 @@ public class FormsRepositoryTests
     public async Task CreateFormWithDefinitionAsync_ShouldRollbackTransaction_WhenExceptionThrown()
     {
         // Arrange
-        var form = new Form(SampleData.TENANT_ID, "form", "description", true);
+        var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "form", Description: "description", IsEnabled: true));
         var formDefinition = new FormDefinition(SampleData.TENANT_ID);
         _dbContext.Set<FormDefinition>().When(x => x.Add(formDefinition)).Do(x => { throw new Exception("Test exception"); });
 

--- a/tests/Endatix.Infrastructure.Tests/Features/AccessControl/PublicFormAccessPolicyTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/AccessControl/PublicFormAccessPolicyTests.cs
@@ -122,9 +122,11 @@ public partial class PublicFormAccessPolicyTests
             .AnyAsync(Arg.Any<SubmissionByFormIdAndSubmissionIdSpec>(), Arg.Any<CancellationToken>())
             .Returns(true);
 
+        var privateForm = Form.Create(new FormCreateArgs(TenantId: 1, Name: "Private form", IsEnabled: true, IsPublic: false));
+        privateForm.Id = 1;
         _formRepository
             .FirstOrDefaultAsync(Arg.Any<FormSpecifications.ByIdWithRelatedForPublicAccess>(), Arg.Any<CancellationToken>())
-            .Returns(new Form(1, "Private form", isEnabled: true, isPublic: false) { Id = 1 });
+            .Returns(privateForm);
 
         _cache
             .GetOrCreateAsync<Cached<PublicFormAccessData>>(
@@ -1180,10 +1182,9 @@ public partial class PublicFormAccessPolicyTests
         FormAccessTokenClaims claims = new(formId, tenantId, DateTime.UtcNow.AddMinutes(30));
         PublicFormAccessContext context = new(formId, rawJwt, SubmissionTokenType.FormToken);
 
-        Form form = new(tenantId, "Form token test")
-        {
-            Id = formId
-        };
+        FormCreateArgs formArgs = new(TenantId: tenantId, Name: "Form token test");
+        Form form = Form.Create(formArgs);
+        form.Id = formId;
         FormDefinition definition = new(tenantId, isDraft: false, jsonData: "{}");
         form.AddFormDefinition(definition, isActive: true);
 

--- a/tests/Endatix.Infrastructure.Tests/Features/Authorization/PublicForm/CreateFormAccessTokenHandlerTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Authorization/PublicForm/CreateFormAccessTokenHandlerTests.cs
@@ -66,7 +66,7 @@ public sealed class CreateFormAccessTokenHandlerTests
         policy.GetAccessData(Arg.Any<PublicFormAccessContext>(), Arg.Any<CancellationToken>())
             .Returns(Result.Success<ICachedData<PublicFormAccessData>>(cached));
 
-        var form = new Form(formTenantId, "Mint test");
+        var form = Form.Create(new FormCreateArgs(TenantId: formTenantId, Name: "Mint test"));
         form.Id = formId;
         var definition = new FormDefinition(formTenantId, isDraft: false, jsonData: "{}");
         form.AddFormDefinition(definition, isActive: true);

--- a/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxIntegrationEventDispatcherTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Outbox/OutboxIntegrationEventDispatcherTests.cs
@@ -113,7 +113,8 @@ public class OutboxIntegrationEventDispatcherTests
     [Fact]
     public void Capture_IncludesReportingLifecycleEvents_with_expected_event_types()
     {
-        var form = new Form(tenantId: 7, name: "f") { Id = 10 };
+        var form = Form.Create(new FormCreateArgs(TenantId: 7, Name: "f"));
+        form.Id = 10;
         var formDefinition = new FormDefinition(tenantId: 7, jsonData: """{"pages":[]}""") { Id = 99 };
         form.AddFormDefinition(formDefinition);
         form.ClearDomainEvents();

--- a/tests/Endatix.Infrastructure.Tests/Features/Outbox/WebHookIntegrationEventPublisherTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Outbox/WebHookIntegrationEventPublisherTests.cs
@@ -62,7 +62,8 @@ public class WebHookIntegrationEventPublisherTests
         // mapping derived from WebHookOperation.EventName (lookup side): a mismatch would silently skip
         // delivery. Drives the publisher with the EventType + payload the ACTUAL event classes produce.
         const long formId = 555L;
-        var form = new Form(tenantId: 42, name: "f") { Id = formId };
+        var form = Form.Create(new FormCreateArgs(TenantId: 42, Name: "f"));
+        form.Id = formId;
         var submission = Submission.Create(new SubmissionCreateArgs(
             TenantId: 42,
             FormId: formId,

--- a/tests/Endatix.Infrastructure.Tests/Features/ReCaptcha/GoogleReCaptchaServiceTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/ReCaptcha/GoogleReCaptchaServiceTests.cs
@@ -182,7 +182,7 @@ public class GoogleReCaptchaServiceTests
         var successResponse = GoogleReCaptchaResponses.Success();
         var reCaptchaHttpClient = new StubReCaptchaHttpClient(successResponse);
         var service = new GoogleReCaptchaService(reCaptchaHttpClient, _options, _userContext);
-        var form = new StubForm(1);
+        var form = StubForm.Create(1);
 
         // Act
         var result = service.RequiresReCaptcha(form);
@@ -200,7 +200,7 @@ public class GoogleReCaptchaServiceTests
         var successResponse = GoogleReCaptchaResponses.Success();
         var reCaptchaHttpClient = new StubReCaptchaHttpClient(successResponse);
         var service = new GoogleReCaptchaService(reCaptchaHttpClient, _options, _userContext);
-        var form = new StubForm(1);
+        var form = StubForm.Create(1);
 
         // Act
         var result = service.RequiresReCaptcha(form);
@@ -218,7 +218,7 @@ public class GoogleReCaptchaServiceTests
         var successResponse = GoogleReCaptchaResponses.Success();
         var reCaptchaHttpClient = new StubReCaptchaHttpClient(successResponse);
         var service = new GoogleReCaptchaService(reCaptchaHttpClient, _options, _userContext);
-        var form = new StubForm(1);
+        var form = StubForm.Create(1);
 
         // Act
         var result = service.RequiresReCaptcha(form);
@@ -236,7 +236,7 @@ public class GoogleReCaptchaServiceTests
         var successResponse = GoogleReCaptchaResponses.Success();
         var reCaptchaHttpClient = new StubReCaptchaHttpClient(successResponse);
         var service = new GoogleReCaptchaService(reCaptchaHttpClient, _options, _userContext);
-        var form = new StubForm(1);
+        var form = StubForm.Create(1);
 
         // Act
         var result = service.RequiresReCaptcha(form);
@@ -253,7 +253,7 @@ public class GoogleReCaptchaServiceTests
         var successResponse = GoogleReCaptchaResponses.Success();
         var reCaptchaHttpClient = new StubReCaptchaHttpClient(successResponse);
         var service = new GoogleReCaptchaService(reCaptchaHttpClient, _options, _userContext);
-        var form = new StubForm(999); // not in enabled list
+        var form = StubForm.Create(999); // not in enabled list
         var context = new SubmissionVerificationContext(form, false, null, null);
 
         // Act
@@ -271,7 +271,7 @@ public class GoogleReCaptchaServiceTests
         var successResponse = GoogleReCaptchaResponses.Success();
         var reCaptchaHttpClient = Substitute.For<IReCaptchaHttpClient>();
         var service = new GoogleReCaptchaService(reCaptchaHttpClient, _options, _userContext);
-        var form = new StubForm(1);
+        var form = StubForm.Create(1);
         var submissionIsComplete = false;
         var context = new SubmissionVerificationContext(form, submissionIsComplete, null, null);
 
@@ -296,7 +296,7 @@ public class GoogleReCaptchaServiceTests
         var reCaptchaHttpClient = new StubReCaptchaHttpClient(invalidResponse);
         var service = new GoogleReCaptchaService(reCaptchaHttpClient, _options, _userContext);
 
-        var formWithRecaptcha = new StubForm(_defaultOptions.EnabledForTenantIds!.FirstOrDefault());
+        var formWithRecaptcha = StubForm.Create(_defaultOptions.EnabledForTenantIds!.FirstOrDefault());
         _userContext.IsAuthenticated.Returns(true);
         var validationContext = new SubmissionVerificationContext(formWithRecaptcha, false, null, null);
 
@@ -315,7 +315,7 @@ public class GoogleReCaptchaServiceTests
         var invalidResponse = GoogleReCaptchaResponses.InvalidResponse();
         var reCaptchaHttpClient = new StubReCaptchaHttpClient(invalidResponse);
         var service = new GoogleReCaptchaService(reCaptchaHttpClient, _options, _userContext);
-        var form = new StubForm(_defaultOptions.EnabledForTenantIds!.FirstOrDefault());
+        var form = StubForm.Create(_defaultOptions.EnabledForTenantIds!.FirstOrDefault());
         var isComplete = true;
         string? token = null;
         var validationContext = new SubmissionVerificationContext(form, isComplete, null, token);
@@ -342,7 +342,7 @@ public class GoogleReCaptchaServiceTests
             .Returns(Task.FromResult(Result.Success(invalidResponse)));
 
         var service = new GoogleReCaptchaService(reCaptchaHttpClient, _options, _userContext);
-        var form = new StubForm(_defaultOptions.EnabledForTenantIds!.FirstOrDefault());
+        var form = StubForm.Create(_defaultOptions.EnabledForTenantIds!.FirstOrDefault());
         var token = "invalid_token";
         var isComplete = true;
         var validationContext = new SubmissionVerificationContext(form, isComplete, null, token);
@@ -367,7 +367,7 @@ public class GoogleReCaptchaServiceTests
         var successResponse = GoogleReCaptchaResponses.Success();
         var reCaptchaHttpClient = new StubReCaptchaHttpClient(successResponse);
         var service = new GoogleReCaptchaService(reCaptchaHttpClient, _options, _userContext);
-        var form = new StubForm(_defaultOptions.EnabledForTenantIds!.FirstOrDefault());
+        var form = StubForm.Create(_defaultOptions.EnabledForTenantIds!.FirstOrDefault());
         var token = "valid_token";
         var validationContext = new SubmissionVerificationContext(form, false, null, token);
 
@@ -401,7 +401,8 @@ internal static class GoogleReCaptchaResponses
     public static GoogleReCaptchaResponse ScoreTooLow(double score = 0.3) => new(true, DateTime.UtcNow, "localhost", score, "form_submit", null);
 }
 
-internal class StubForm : Form
+internal static class StubForm
 {
-    public StubForm(long tenantId) : base(tenantId, "TestForm") { }
+    public static Form Create(long tenantId) =>
+        Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "TestForm"));
 }

--- a/tests/Endatix.Infrastructure.Tests/Features/Submissions/SubmissionTokenServiceObtainTokenTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Submissions/SubmissionTokenServiceObtainTokenTests.cs
@@ -28,7 +28,8 @@ public class SubmissionTokenServiceObtainTokenTests
             Arg.Any<TenantSettingsByTenantIdSpec>(),
             Arg.Any<CancellationToken>()).Returns(tenantSettings);
 
-        var form = new Form(TENANT_ID, "Test form") { Id = FORM_ID };
+        var form = Form.Create(new FormCreateArgs(TenantId: TENANT_ID, Name: "Test form"));
+        form.Id = FORM_ID;
         _formRepository.FirstOrDefaultAsync(
             Arg.Any<FormProjections.SessionTokenExpiryDtoSpec>(),
             Arg.Any<CancellationToken>())

--- a/tests/Endatix.Infrastructure.Tests/Features/WebHooks/BackgroundTaskWebHookServiceTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/WebHooks/BackgroundTaskWebHookServiceTests.cs
@@ -346,10 +346,8 @@ public class BackgroundTaskWebHookServiceTests
             }
         };
 
-        var form = new Form(TEST_TENANT_ID, "Test Form")
-        {
-            Id = TEST_FORM_ID
-        };
+        var form = Form.Create(new FormCreateArgs(TenantId: TEST_TENANT_ID, Name: "Test Form"));
+        form.Id = TEST_FORM_ID;
         form.UpdateWebHookSettings(webHookConfig);
         return form;
     }

--- a/tests/Endatix.IntegrationTests.Shared/IntegrationSeedBuilder.cs
+++ b/tests/Endatix.IntegrationTests.Shared/IntegrationSeedBuilder.cs
@@ -104,7 +104,7 @@ public sealed class IntegrationSeedBuilder(IServiceProvider services)
             return;
         }
 
-        Form form = new(tenantId, name, isEnabled: isEnabled, isPublic: isPublic);
+        var form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: name, IsEnabled: isEnabled, IsPublic: isPublic));
         db.Forms.Add(form);
         await db.SaveChangesAsync(cancellationToken);
     }

--- a/tests/Endatix.IntegrationTests/Infrastructure/DatabaseMutationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/DatabaseMutationTests.cs
@@ -42,7 +42,7 @@ public sealed class DatabaseMutationTests
                 Tenant tenant = new("integration-mutation-tenant");
                 db.Set<Tenant>().Add(tenant);
                 await db.SaveChangesAsync(cancellationToken);
-                Form form = new(tenant.Id, "integration-test-form");
+                Form form = Form.Create(new FormCreateArgs(TenantId: tenant.Id, Name: "integration-test-form"));
                 db.Forms.Add(form);
                 await db.SaveChangesAsync(cancellationToken);
             }

--- a/tests/Endatix.IntegrationTests/Infrastructure/FormSchemaProcessorReplaceMergeIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/FormSchemaProcessorReplaceMergeIntegrationTests.cs
@@ -228,7 +228,7 @@ public sealed class FormSchemaProcessorReplaceMergeIntegrationTests
         appDb.Set<Tenant>().Add(tenant);
         await appDb.SaveChangesAsync(cancellationToken);
 
-        Form form = new(TenantId, "Replace/merge form");
+        Form form = Form.Create(new FormCreateArgs(TenantId: TenantId, Name: "Replace/merge form"));
         appDb.Forms.Add(form);
         await appDb.SaveChangesAsync(cancellationToken);
 

--- a/tests/Endatix.IntegrationTests/Infrastructure/OutboxCaptureTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/OutboxCaptureTests.cs
@@ -117,7 +117,7 @@ public sealed class OutboxCaptureTests
             await ctx.SaveChangesAsync(cancellationToken);
 
             FormsRepository repository = new(ctx, new AppUnitOfWork(ctx), new EndatixSpecificationEvaluator([]));
-            Form form = new(tenant.Id, "webhook-form", "desc", isEnabled: true);
+            Form form = Form.Create(new FormCreateArgs(TenantId: tenant.Id, Name: "webhook-form", Description: "desc", IsEnabled: true));
             FormDefinition formDefinition = new(tenant.Id);
 
             await repository.CreateFormWithDefinitionAsync(form, formDefinition, cancellationToken);
@@ -159,7 +159,7 @@ public sealed class OutboxCaptureTests
             await ctx.SaveChangesAsync(cancellationToken);
             tenantId = tenant.Id;
 
-            Form form = new(tenantId, "delete-outbox-form");
+            Form form = Form.Create(new FormCreateArgs(TenantId: tenantId, Name: "delete-outbox-form"));
             ctx.Forms.Add(form);
             await ctx.SaveChangesAsync(cancellationToken);
 
@@ -217,7 +217,7 @@ public sealed class OutboxCaptureTests
         // Align ambient tenant with the seeded tenant so query filters see the rows.
         _tenantContext.TenantId.Returns(tenant.Id);
 
-        Form form = new(tenant.Id, "restriction-reuse-form", isPublic: false, limitOnePerUser: true);
+        Form form = Form.Create(new FormCreateArgs(TenantId: tenant.Id, Name: "restriction-reuse-form", IsPublic: false, LimitOnePerUser: true));
         ctx.Forms.Add(form);
         await ctx.SaveChangesAsync(cancellationToken);
 

--- a/tests/Endatix.IntegrationTests/Infrastructure/ReportingExportRepositoryIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/ReportingExportRepositoryIntegrationTests.cs
@@ -448,7 +448,7 @@ public sealed class ReportingExportRepositoryIntegrationTests
         await appDb.SaveChangesAsync(cancellationToken);
 
         // Two-step form+definition save avoids Form ↔ ActiveDefinition circular insert.
-        Form form = new(TenantId, "Export filter form");
+        Form form = Form.Create(new FormCreateArgs(TenantId: TenantId, Name: "Export filter form"));
         appDb.Forms.Add(form);
         await appDb.SaveChangesAsync(cancellationToken);
 

--- a/tests/Endatix.IntegrationTests/Infrastructure/StandardSeedTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/StandardSeedTests.cs
@@ -63,7 +63,7 @@ public sealed class StandardSeedTests
                     .Select(x => x.Id)
                     .FirstAsync(token);
 
-                Form extraForm = new(firstTenantId, "custom-post-seed-form", isEnabled: true, isPublic: false);
+                Form extraForm = Form.Create(new FormCreateArgs(TenantId: firstTenantId, Name: "custom-post-seed-form", IsEnabled: true, IsPublic: false));
                 db.Forms.Add(extraForm);
                 await db.SaveChangesAsync(token);
             },

--- a/tests/Endatix.IntegrationTests/Infrastructure/SyncFormDeletionOutboxHandlerIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/SyncFormDeletionOutboxHandlerIntegrationTests.cs
@@ -143,7 +143,8 @@ public sealed class SyncFormDeletionOutboxHandlerIntegrationTests
 
     private static IOutboxMessage CreateMessage()
     {
-        Form form = new(TenantId, "to-delete") { Id = FormId };
+        Form form = Form.Create(new FormCreateArgs(TenantId: TenantId, Name: "to-delete"));
+        form.Id = FormId;
         object payloadObject = new FormDeletedEvent(form).GetPayload();
         string payload = JsonSerializer.Serialize(
             payloadObject,

--- a/tests/Endatix.Modules.Reporting.Tests/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookExportDataSourceTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/Export/Integrations/Crunch/Shoji/ShojiCodebookExportDataSourceTests.cs
@@ -103,7 +103,7 @@ public sealed class ShojiCodebookExportDataSourceTests
         FormSchemaCompiler compiler = new();
         FormSchemaCompileResult compiled = compiler.CompilePersisted(definitionJson);
         FormSchemaEntity schema = new(TenantId, FormId, 1, compiled.FlatteningMapJson, compiled.CodebookJson);
-        Form form = new(TenantId, "Customer Satisfaction Survey", "Annual wave");
+        Form form = Form.Create(new FormCreateArgs(TenantId: TenantId, Name: "Customer Satisfaction Survey", Description: "Annual wave"));
         form.Id = FormId;
         string expectedCodebookJson = ShojiCodebookGenerator.Generate(
             schema.FlatteningMap,
@@ -151,7 +151,7 @@ public sealed class ShojiCodebookExportDataSourceTests
         string definitionJson = FormSchemaFixtureLoader.LoadText("simple-definition.json");
         FormSchemaCompileResult compiled = new FormSchemaCompiler().CompilePersisted(definitionJson);
         FormSchemaEntity schema = new(TenantId, FormId, 1, compiled.FlatteningMapJson, compiled.CodebookJson);
-        Form form = new(TenantId, "Datanium Panel");
+        Form form = Form.Create(new FormCreateArgs(TenantId: TenantId, Name: "Datanium Panel"));
         form.Id = FormId;
 
         IFormSchemaRepository formSchemaRepository = Substitute.For<IFormSchemaRepository>();
@@ -221,7 +221,7 @@ public sealed class ShojiCodebookExportDataSourceTests
             compiled.FlatteningMapJson,
             compiled.CodebookJson,
             locales: """["default","es"]""");
-        Form form = new(TenantId, "Datanium Panel", "Wave 1");
+        Form form = Form.Create(new FormCreateArgs(TenantId: TenantId, Name: "Datanium Panel", Description: "Wave 1"));
         form.Id = FormId;
 
         IFormSchemaRepository formSchemaRepository = Substitute.For<IFormSchemaRepository>();
@@ -259,7 +259,7 @@ public sealed class ShojiCodebookExportDataSourceTests
         string definitionJson = FormSchemaFixtureLoader.LoadText("simple-definition.json");
         FormSchemaCompileResult compiled = new FormSchemaCompiler().CompilePersisted(definitionJson);
         FormSchemaEntity schema = new(TenantId, FormId, 1, compiled.FlatteningMapJson, compiled.CodebookJson);
-        Form form = new(TenantId, "Datanium Panel");
+        Form form = Form.Create(new FormCreateArgs(TenantId: TenantId, Name: "Datanium Panel"));
         form.Id = FormId;
 
         IFormSchemaRepository formSchemaRepository = Substitute.For<IFormSchemaRepository>();

--- a/tests/Endatix.Modules.Reporting.Tests/Features/FlattenedSubmission/BackfillSubmissionsHandlerTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/FlattenedSubmission/BackfillSubmissionsHandlerTests.cs
@@ -35,7 +35,8 @@ public sealed class BackfillSubmissionsHandlerTests
     [Fact]
     public async Task Handle_WhenFormBelongsToOtherTenant_ReturnsNotFound()
     {
-        Form form = new(OtherTenantId, "Other tenant form") { Id = FormId };
+        Form form = Form.Create(new FormCreateArgs(TenantId: OtherTenantId, Name: "Other tenant form"));
+        form.Id = FormId;
 
         IRepository<Form> formsRepository = Substitute.For<IRepository<Form>>();
         formsRepository
@@ -57,7 +58,8 @@ public sealed class BackfillSubmissionsHandlerTests
     [Fact]
     public async Task Handle_WhenFormExists_DelegatesToBackfillProcessor()
     {
-        Form form = new(TenantId, "Test form") { Id = FormId };
+        Form form = Form.Create(new FormCreateArgs(TenantId: TenantId, Name: "Test form"));
+        form.Id = FormId;
         SubmissionBackfillResult backfillResult = new(
             FormId,
             Scanned: 2,

--- a/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/CompileFormSchemaHandlerTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/FormSchema/CompileFormSchemaHandlerTests.cs
@@ -41,7 +41,8 @@ public sealed class CompileFormSchemaHandlerTests
     [Fact]
     public async Task Handle_WhenActiveDefinitionExists_CompilesSchema()
     {
-        Form form = new(TenantId, "Test form") { Id = FormId };
+        Form form = Form.Create(new FormCreateArgs(TenantId: TenantId, Name: "Test form"));
+        form.Id = FormId;
         FormDefinition definition = new(TenantId, isDraft: false, """{"pages":[]}""")
         {
             Id = FormDefinitionId,
@@ -70,7 +71,8 @@ public sealed class CompileFormSchemaHandlerTests
     [Fact]
     public async Task Handle_WhenReplaceTrue_PassesReplaceToProcessor()
     {
-        Form form = new(TenantId, "Test form") { Id = FormId };
+        Form form = Form.Create(new FormCreateArgs(TenantId: TenantId, Name: "Test form"));
+        form.Id = FormId;
         FormDefinition definition = new(TenantId, isDraft: false, """{"pages":[]}""")
         {
             Id = FormDefinitionId,

--- a/tests/Endatix.Modules.Reporting.Tests/Features/Outbox/CompileFormSchemaOutboxHandlerTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/Outbox/CompileFormSchemaOutboxHandlerTests.cs
@@ -27,7 +27,8 @@ public sealed class CompileFormSchemaOutboxHandlerTests
     [Fact]
     public async Task HandleAsync_WithValidPayload_CallsProcessorWithIds()
     {
-        Form form = new(TenantId, "Survey", isEnabled: true) { Id = FormId };
+        Form form = Form.Create(new FormCreateArgs(TenantId: TenantId, Name: "Survey", IsEnabled: true));
+        form.Id = FormId;
         FormDefinition definition = new(TenantId, jsonData: "{}") { Id = FormDefinitionId };
         form.AddFormDefinition(definition);
         string payload = ReportingOutboxTestHelpers.SerializePayload(new FormDefinitionUpdatedEvent(form, definition).GetPayload());
@@ -93,7 +94,8 @@ public sealed class CompileFormSchemaOutboxHandlerTests
     [Fact]
     public async Task HandleAsync_WhenProcessorThrows_PropagatesException()
     {
-        Form form = new(TenantId, "Survey", isEnabled: true) { Id = FormId };
+        Form form = Form.Create(new FormCreateArgs(TenantId: TenantId, Name: "Survey", IsEnabled: true));
+        form.Id = FormId;
         FormDefinition definition = new(TenantId, jsonData: "{}") { Id = FormDefinitionId };
         form.AddFormDefinition(definition);
         string payload = ReportingOutboxTestHelpers.SerializePayload(new FormDefinitionUpdatedEvent(form, definition).GetPayload());

--- a/tests/Endatix.Modules.Reporting.Tests/Features/Outbox/SyncFormDeletionOutboxHandlerTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Features/Outbox/SyncFormDeletionOutboxHandlerTests.cs
@@ -116,7 +116,8 @@ public sealed class SyncFormDeletionOutboxHandlerTests
 
     private static ReportingOutboxTestHelpers.FakeOutboxMessage CreateMessage()
     {
-        Form form = new(TenantId, "to-delete") { Id = FormId };
+        Form form = Form.Create(new FormCreateArgs(TenantId: TenantId, Name: "to-delete"));
+        form.Id = FormId;
         string payload = ReportingOutboxTestHelpers.SerializePayload(
             new FormDeletedEvent(form).GetPayload());
 


### PR DESCRIPTION
# refactor(e934): Migrate all constructor usages to the new FormCreateArgs based factory

## Description
- Migrate all constructor usages to the new FormCreateArgs based factory

## Related Issues
- closes #934 

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [x] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized form creation across application setup and test scenarios.
  * Preserved existing form properties, behavior, and validation outcomes.
* **Tests**
  * Updated unit, integration, repository, reporting, submission, access, and webhook test fixtures.
  * Existing assertions and covered scenarios remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->