### PR TITLE
feat(e476): add OpenTelemetry metrics and traces via OTLP (PR-T1)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <AspNetVersion>10.0.0</AspNetVersion>
     <EFCoreVersion>10.0.0</EFCoreVersion>
+    <OpenTelemetryVersion>1.17.0</OpenTelemetryVersion>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
@@ -62,6 +63,16 @@
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
     <PackageVersion Include="AspNetCore.HealthChecks.System" Version="9.0.0" />
+    <!-- OpenTelemetry: SDK, hosting integration and the OTLP exporter. Endatix ships OTLP only;
+         vendor exporters (Azure Monitor, etc.) are the host's choice, added via Logging.Configure.
+         OpenTelemetry.Instrumentation.Process is deliberately absent: it has no stable release
+         (1.17.0-rc.1 at time of writing) and Endatix.Hosting is a published package, so an rc would
+         land in every consumer's graph. Runtime instrumentation covers GC/thread-pool/allocation. -->
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="$(OpenTelemetryVersion)" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="$(OpenTelemetryVersion)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryVersion)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryVersion)" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.MsSql" Version="4.12.0" />
     <PackageVersion Include="Testcontainers.Keycloak" Version="4.12.0" />

--- a/src/Endatix.Framework/Logging/EndatixEventIds.cs
+++ b/src/Endatix.Framework/Logging/EndatixEventIds.cs
@@ -152,6 +152,8 @@ public static class EndatixEventIds
         public const int DataOptionFromConfiguration = 1216;
         public const int PersistenceSetupMessage = 1217;
         public const int ModuleEndpointsNotDiscovered = 1218;
+        public const int TelemetryConfigured = 1219;
+        public const int TelemetrySkippedNoExporter = 1220;
 
         public const int RangeStart = Ranges.HostingStart;
         public const int RangeEnd = Ranges.HostingEnd;
@@ -176,7 +178,9 @@ public static class EndatixEventIds
             DataOptionFromDefault,
             DataOptionFromConfiguration,
             PersistenceSetupMessage,
-            ModuleEndpointsNotDiscovered
+            ModuleEndpointsNotDiscovered,
+            TelemetryConfigured,
+            TelemetrySkippedNoExporter
         ];
     }
 

--- a/src/Endatix.Hosting/Builders/EndatixBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixBuilder.cs
@@ -87,7 +87,7 @@ public class EndatixBuilder : IBuilderRoot
     /// Builder for OpenTelemetry metrics and traces.
     /// </summary>
     /// <example>
-    /// endatix.Telemetry.UseDefaults().DisableInstrumentation(Instrumentation.Runtime).Build();
+    /// endatix.Telemetry.UseDefaults().DisableInstrumentation(Instrumentations.Runtime).Build();
     /// </example>
     public EndatixTelemetryBuilder Telemetry { get; }
 

--- a/src/Endatix.Hosting/Builders/EndatixBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixBuilder.cs
@@ -84,6 +84,14 @@ public class EndatixBuilder : IBuilderRoot
     public EndatixHealthChecksBuilder HealthChecks { get; }
 
     /// <summary>
+    /// Builder for OpenTelemetry metrics and traces.
+    /// </summary>
+    /// <example>
+    /// endatix.Telemetry.UseDefaults().DisableInstrumentation(Instrumentation.Runtime).Build();
+    /// </example>
+    public EndatixTelemetryBuilder Telemetry { get; }
+
+    /// <summary>
     /// Initializes a new instance of the EndatixBuilder class.
     /// </summary>
     /// <param name="services">The service collection.</param>
@@ -111,6 +119,7 @@ public class EndatixBuilder : IBuilderRoot
         Api = new EndatixApiBuilder(this);
         Persistence = new EndatixPersistenceBuilder(this);
         HealthChecks = new EndatixHealthChecksBuilder(this);
+        Telemetry = new EndatixTelemetryBuilder(this);
 
         _logger.LogBuilderInitialized();
     }
@@ -139,6 +148,10 @@ public class EndatixBuilder : IBuilderRoot
         // Configure health checks with default settings
         HealthChecks.UseDefaults();
         _logger.LogHealthChecksConfigurationCompleted();
+
+        // Telemetry only records intent here; nothing is registered until FinalizeConfiguration()
+        // calls Telemetry.Build(), so it stays a no-op unless an OTLP endpoint is configured.
+        Telemetry.UseDefaults();
 
         // UseModule honours the module's feature flag, and wires its endpoints and FastEndpoints
         // configuration (Reporting serializers and endpoint metadata) via IHasFastEndpoints only
@@ -360,6 +373,10 @@ public class EndatixBuilder : IBuilderRoot
         _logger.LogFinalizingConfiguration();
 
         Infrastructure.Build();
+
+        // Deferred so that Telemetry.DisableInstrumentation(...) and WithOtlpExporter(...) apply
+        // whatever order the consumer called them in.
+        Telemetry.Build();
 
         foreach (var module in _modules)
         {

--- a/src/Endatix.Hosting/Builders/EndatixHealthChecksBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixHealthChecksBuilder.cs
@@ -102,9 +102,11 @@ public class EndatixHealthChecksBuilder
     /// <returns>True if Aspire ServiceDefaults appear to be present, false otherwise.</returns>
     private bool IsAspireServiceDefaultsPresent()
     {
-        // Look for OpenTelemetry services that are typically added by Aspire ServiceDefaults
+        // Probe for ServiceDiscovery only. Matching "OpenTelemetry" as well used to be the tell,
+        // but Endatix now registers the OTel SDK itself (EndatixTelemetryBuilder) — so that check
+        // would treat our own telemetry as Aspire and silently drop the "self" health check.
+        // Aspire's ServiceDefaults always adds service discovery; the OTel SDK never does.
         return _parent.Services.Any(s =>
-            s.ServiceType.FullName?.Contains("OpenTelemetry") == true ||
             s.ServiceType.FullName?.Contains("ServiceDiscovery") == true);
     }
 

--- a/src/Endatix.Hosting/Builders/EndatixTelemetryBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixTelemetryBuilder.cs
@@ -74,8 +74,20 @@ public class EndatixTelemetryBuilder
         public const string ServiceName = "OTEL_SERVICE_NAME";
         public const string ServiceVersion = "OTEL_SERVICE_VERSION";
         public const string OtlpEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT";
+        public const string OtlpTracesEndpoint = "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT";
+        public const string OtlpMetricsEndpoint = "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT";
         public const string OtlpProtocol = "OTEL_EXPORTER_OTLP_PROTOCOL";
+        public const string OtlpTracesProtocol = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL";
+        public const string OtlpMetricsProtocol = "OTEL_EXPORTER_OTLP_METRICS_PROTOCOL";
         public const string TracesSampler = "OTEL_TRACES_SAMPLER";
+
+        /// <summary>Endpoint variables in specification precedence order: signal-specific first.</summary>
+        public static readonly string[] AllOtlpEndpoints =
+            [OtlpTracesEndpoint, OtlpMetricsEndpoint, OtlpEndpoint];
+
+        /// <summary>Protocol variables in specification precedence order: signal-specific first.</summary>
+        public static readonly string[] AllOtlpProtocols =
+            [OtlpTracesProtocol, OtlpMetricsProtocol, OtlpProtocol];
     }
 
     private static readonly string[] _defaultExcludedPaths = ["/health", "/alive", "/ready"];
@@ -178,12 +190,11 @@ public class EndatixTelemetryBuilder
             return _parent;
         }
 
-        _applied = true;
-
         var otlpEndpoint = ResolveOtlpEndpoint();
         if (otlpEndpoint is null)
         {
             // AC6: nothing configured means nothing registered — no exporter allocated, no SDK cost.
+            _applied = true;
             _logger.LogTelemetrySkippedNoExporter();
             return _parent;
         }
@@ -192,6 +203,17 @@ public class EndatixTelemetryBuilder
         // options configuration action the SDK defers until the provider is built, so validating in
         // it would surface a bad protocol long after startup — or not at all. AC8 wants fail-fast.
         var otlpProtocol = ResolveOtlpProtocol();
+
+        // When the value came from the environment, leave the endpoint and protocol unset on the
+        // exporter and let the SDK read the variables itself. It already implements the whole
+        // specification: signal-specific OTEL_EXPORTER_OTLP_{TRACES,METRICS}_* overriding the
+        // global one, and the per-signal path suffixes that http/protobuf requires. Assigning our
+        // resolved value here would clobber all of that with the global endpoint. Validation above
+        // still runs against the environment, so a bad value fails fast either way.
+        var endpointFromEnvironment = AnyEnvironmentVariableSet(EnvVars.AllOtlpEndpoints);
+        var protocolFromEnvironment = AnyEnvironmentVariableSet(EnvVars.AllOtlpProtocols);
+        var exporterEndpoint = endpointFromEnvironment ? null : otlpEndpoint;
+        var exporterProtocol = protocolFromEnvironment ? null : otlpProtocol;
 
         var resource = BuildResource();
 
@@ -214,7 +236,7 @@ public class EndatixTelemetryBuilder
                 metrics.AddRuntimeInstrumentation();
             }
 
-            metrics.AddOtlpExporter((exporter, _) => ConfigureOtlp(exporter, otlpEndpoint, otlpProtocol));
+            metrics.AddOtlpExporter((exporter, _) => ConfigureOtlp(exporter, exporterEndpoint, exporterProtocol));
         });
 
         otel.WithTracing(tracing =>
@@ -233,10 +255,15 @@ public class EndatixTelemetryBuilder
 
             ApplySampler(tracing);
 
-            tracing.AddOtlpExporter(exporter => ConfigureOtlp(exporter, otlpEndpoint, otlpProtocol));
+            tracing.AddOtlpExporter(exporter => ConfigureOtlp(exporter, exporterEndpoint, exporterProtocol));
         });
 
-        _logger.LogTelemetryConfigured(otlpEndpoint.ToString(), _instrumentation.ToString());
+        _applied = true;
+        // Scheme, host and port only: an OTLP endpoint may legitimately carry credentials in its
+        // user-info component, and logs are shipped off-box.
+        _logger.LogTelemetryConfigured(
+            otlpEndpoint.GetLeftPart(UriPartial.Authority),
+            _instrumentation.ToString());
 
         return _parent;
     }
@@ -255,20 +282,25 @@ public class EndatixTelemetryBuilder
     /// </summary>
     internal Uri? ResolveOtlpEndpoint()
     {
-        var raw = Environment.GetEnvironmentVariable(EnvVars.OtlpEndpoint);
-        var source = EnvVars.OtlpEndpoint;
-
-        if (string.IsNullOrWhiteSpace(raw))
+        // Signal-specific variables take precedence over the global one, per the specification.
+        // Any of them being set means telemetry is configured, so all three are checked here even
+        // though the SDK is left to apply them (see the note in Build).
+        foreach (var name in EnvVars.AllOtlpEndpoints)
         {
-            raw = _options.Otlp.Endpoint;
-            source = $"{TelemetryOptions.SectionName}:Otlp:Endpoint";
+            var value = Environment.GetEnvironmentVariable(name);
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                return ParseEndpoint(value, name);
+            }
         }
 
-        if (string.IsNullOrWhiteSpace(raw))
-        {
-            return null;
-        }
+        return string.IsNullOrWhiteSpace(_options.Otlp.Endpoint)
+            ? null
+            : ParseEndpoint(_options.Otlp.Endpoint, $"{TelemetryOptions.SectionName}:Otlp:Endpoint");
+    }
 
+    private static Uri ParseEndpoint(string raw, string source)
+    {
         if (!Uri.TryCreate(raw, UriKind.Absolute, out var uri) ||
             (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
         {
@@ -280,6 +312,9 @@ public class EndatixTelemetryBuilder
 
         return uri;
     }
+
+    private static bool AnyEnvironmentVariableSet(string[] names) =>
+        names.Any(name => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(name)));
 
     private static void ConfigureOtlp(
         OtlpExporterOptions exporter,
@@ -330,16 +365,20 @@ public class EndatixTelemetryBuilder
     /// </summary>
     internal Dictionary<string, object> BuildResource()
     {
-        var serviceName =
+        // Configured attributes go in FIRST so the resolved service identity below always wins.
+        // Applied last, a ResourceAttributes entry for service.name would silently defeat
+        // OTEL_SERVICE_NAME and break the environment-first contract this class exists to uphold.
+        var attributes = new Dictionary<string, object>();
+        foreach (var (key, value) in _options.ResourceAttributes)
+        {
+            attributes[key] = value;
+        }
+
+        attributes[ResourceSemanticConventions.ServiceName] =
             Environment.GetEnvironmentVariable(EnvVars.ServiceName)
             ?? _options.ServiceName
             ?? Assembly.GetEntryAssembly()?.GetName().Name
             ?? "endatix-api";
-
-        var attributes = new Dictionary<string, object>
-        {
-            [ResourceSemanticConventions.ServiceName] = serviceName
-        };
 
         var serviceVersion =
             Environment.GetEnvironmentVariable(EnvVars.ServiceVersion)
@@ -348,13 +387,6 @@ public class EndatixTelemetryBuilder
         if (!string.IsNullOrWhiteSpace(serviceVersion))
         {
             attributes[ResourceSemanticConventions.ServiceVersion] = serviceVersion;
-        }
-
-        // Configured attributes are the weakest source: OTEL_RESOURCE_ATTRIBUTES is applied by the
-        // SDK's own environment detector and overrides anything set here.
-        foreach (var (key, value) in _options.ResourceAttributes)
-        {
-            attributes[key] = value;
         }
 
         return attributes;

--- a/src/Endatix.Hosting/Builders/EndatixTelemetryBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixTelemetryBuilder.cs
@@ -22,7 +22,7 @@ namespace Endatix.Hosting.Builders;
 /// node-exporter already report process CPU and memory.
 /// </remarks>
 [Flags]
-public enum Instrumentation
+public enum Instrumentations
 {
     /// <summary>No instrumentation.</summary>
     None = 0,
@@ -61,7 +61,7 @@ public enum Instrumentation
 /// <example>
 /// endatix.Telemetry
 ///     .UseDefaults()
-///     .DisableInstrumentation(Instrumentation.Runtime)
+///     .DisableInstrumentation(Instrumentations.Runtime)
 ///     .Build();
 /// </example>
 public class EndatixTelemetryBuilder
@@ -85,7 +85,7 @@ public class EndatixTelemetryBuilder
     private readonly List<string> _excludedPaths = [.. _defaultExcludedPaths];
 
     private TelemetryOptions _options = new();
-    private Instrumentation _instrumentation = Instrumentation.All;
+    private Instrumentations _instrumentation = Instrumentations.All;
     private bool _enabled;
     private bool _applied;
 
@@ -148,7 +148,7 @@ public class EndatixTelemetryBuilder
     /// </summary>
     /// <param name="instrumentation">The sources to disable; combinable with <c>|</c>.</param>
     /// <returns>The builder for chaining.</returns>
-    public EndatixTelemetryBuilder DisableInstrumentation(Instrumentation instrumentation)
+    public EndatixTelemetryBuilder DisableInstrumentation(Instrumentations instrumentation)
     {
         _instrumentation &= ~instrumentation;
         return this;
@@ -199,17 +199,17 @@ public class EndatixTelemetryBuilder
 
         otel.WithMetrics(metrics =>
         {
-            if (_instrumentation.HasFlag(Instrumentation.AspNetCore))
+            if (_instrumentation.HasFlag(Instrumentations.AspNetCore))
             {
                 metrics.AddAspNetCoreInstrumentation();
             }
 
-            if (_instrumentation.HasFlag(Instrumentation.HttpClient))
+            if (_instrumentation.HasFlag(Instrumentations.HttpClient))
             {
                 metrics.AddHttpClientInstrumentation();
             }
 
-            if (_instrumentation.HasFlag(Instrumentation.Runtime))
+            if (_instrumentation.HasFlag(Instrumentations.Runtime))
             {
                 metrics.AddRuntimeInstrumentation();
             }
@@ -219,14 +219,14 @@ public class EndatixTelemetryBuilder
 
         otel.WithTracing(tracing =>
         {
-            if (_instrumentation.HasFlag(Instrumentation.AspNetCore))
+            if (_instrumentation.HasFlag(Instrumentations.AspNetCore))
             {
                 // AC5: health and liveness probes are noise — one span per probe per scrape interval.
                 tracing.AddAspNetCoreInstrumentation(o =>
                     o.Filter = context => !IsExcludedPath(context.Request.Path));
             }
 
-            if (_instrumentation.HasFlag(Instrumentation.HttpClient))
+            if (_instrumentation.HasFlag(Instrumentations.HttpClient))
             {
                 tracing.AddHttpClientInstrumentation();
             }

--- a/src/Endatix.Hosting/Builders/EndatixTelemetryBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixTelemetryBuilder.cs
@@ -259,11 +259,7 @@ public class EndatixTelemetryBuilder
         });
 
         _applied = true;
-        // Scheme, host and port only: an OTLP endpoint may legitimately carry credentials in its
-        // user-info component, and logs are shipped off-box.
-        _logger.LogTelemetryConfigured(
-            otlpEndpoint.GetLeftPart(UriPartial.Authority),
-            _instrumentation.ToString());
+        _logger.LogTelemetryConfigured(Redact(otlpEndpoint), _instrumentation.ToString());
 
         return _parent;
     }
@@ -315,6 +311,18 @@ public class EndatixTelemetryBuilder
 
     private static bool AnyEnvironmentVariableSet(string[] names) =>
         names.Any(name => !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(name)));
+
+    /// <summary>
+    /// Renders an endpoint as scheme, host and port only — safe to log.
+    /// </summary>
+    /// <remarks>
+    /// An OTLP endpoint may legitimately carry a bearer token or credentials in its user-info
+    /// component or query string, and logs ship off-box. Note that
+    /// <c>GetLeftPart(UriPartial.Authority)</c> is <em>not</em> sufficient: unlike the
+    /// <see cref="Uri.Authority"/> property, it retains user info, so
+    /// <c>https://user:secret@host:4318/v1/traces?token=abc</c> would still leak the credentials.
+    /// </remarks>
+    internal static string Redact(Uri endpoint) => $"{endpoint.Scheme}://{endpoint.Authority}";
 
     private static void ConfigureOtlp(
         OtlpExporterOptions exporter,

--- a/src/Endatix.Hosting/Builders/EndatixTelemetryBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixTelemetryBuilder.cs
@@ -1,0 +1,398 @@
+using System.Reflection;
+using Endatix.Hosting.Builders.Logging;
+using Endatix.Hosting.Options;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using OpenTelemetry.Exporter;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
+
+namespace Endatix.Hosting.Builders;
+
+/// <summary>
+/// Instrumentation sources Endatix can register. Used with
+/// <see cref="EndatixTelemetryBuilder.DisableInstrumentation"/>.
+/// </summary>
+/// <remarks>
+/// Process instrumentation is deliberately absent: <c>OpenTelemetry.Instrumentation.Process</c>
+/// has no stable release, and Endatix.Hosting is a published package. In a cluster, cAdvisor and
+/// node-exporter already report process CPU and memory.
+/// </remarks>
+[Flags]
+public enum Instrumentation
+{
+    /// <summary>No instrumentation.</summary>
+    None = 0,
+
+    /// <summary>Inbound HTTP requests (ASP.NET Core).</summary>
+    AspNetCore = 1,
+
+    /// <summary>Outbound HTTP calls (HttpClient) — includes webhook delivery.</summary>
+    HttpClient = 2,
+
+    /// <summary>.NET runtime metrics: GC, thread pool, allocation.</summary>
+    Runtime = 4,
+
+    /// <summary>Every source above.</summary>
+    All = AspNetCore | HttpClient | Runtime
+}
+
+/// <summary>
+/// Builder for configuring OpenTelemetry metrics and traces in the Endatix application.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Telemetry is <em>off by default</em>: with no OTLP endpoint configured nothing is exported and
+/// no exporter is allocated. Setting <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> is all it takes to turn it on.
+/// </para>
+/// <para>
+/// Standard <c>OTEL_*</c> environment variables are authoritative; anything under
+/// <c>Endatix:Telemetry</c> is a fallback, never an override.
+/// </para>
+/// <para>
+/// Registration is deferred to <see cref="Build"/> (invoked by
+/// <c>EndatixBuilder.FinalizeConfiguration()</c>) so that calls such as
+/// <see cref="DisableInstrumentation"/> take effect regardless of the order they are made in.
+/// </para>
+/// </remarks>
+/// <example>
+/// endatix.Telemetry
+///     .UseDefaults()
+///     .DisableInstrumentation(Instrumentation.Runtime)
+///     .Build();
+/// </example>
+public class EndatixTelemetryBuilder
+{
+    /// <summary>
+    /// Environment variable names read directly, per the OpenTelemetry specification.
+    /// </summary>
+    internal static class EnvVars
+    {
+        public const string ServiceName = "OTEL_SERVICE_NAME";
+        public const string ServiceVersion = "OTEL_SERVICE_VERSION";
+        public const string OtlpEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT";
+        public const string OtlpProtocol = "OTEL_EXPORTER_OTLP_PROTOCOL";
+        public const string TracesSampler = "OTEL_TRACES_SAMPLER";
+    }
+
+    private static readonly string[] _defaultExcludedPaths = ["/health", "/alive", "/ready"];
+
+    private readonly EndatixBuilder _parent;
+    private readonly ILogger _logger;
+    private readonly List<string> _excludedPaths = [.. _defaultExcludedPaths];
+
+    private TelemetryOptions _options = new();
+    private Instrumentation _instrumentation = Instrumentation.All;
+    private bool _enabled;
+    private bool _applied;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EndatixTelemetryBuilder"/> class.
+    /// </summary>
+    /// <param name="parent">The parent builder.</param>
+    public EndatixTelemetryBuilder(EndatixBuilder parent)
+    {
+        _parent = parent;
+        _logger = parent.LoggerFactory.CreateLogger<EndatixTelemetryBuilder>();
+    }
+
+    /// <summary>
+    /// Gets the service collection.
+    /// </summary>
+    public IServiceCollection Services => _parent.Services;
+
+    /// <summary>
+    /// Gets the configuration.
+    /// </summary>
+    public IConfiguration Configuration => _parent.Configuration;
+
+    /// <summary>
+    /// Enables telemetry with recommended defaults: all instrumentation sources, and the OTLP
+    /// exporter when an endpoint is configured. Registration happens at <see cref="Build"/>.
+    /// </summary>
+    /// <returns>The builder for chaining.</returns>
+    public EndatixTelemetryBuilder UseDefaults()
+    {
+        _options = BindOptions();
+        _enabled = true;
+        return this;
+    }
+
+    /// <summary>
+    /// Enables the OTLP exporter explicitly, optionally overriding the endpoint. Implicit whenever
+    /// <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> or <c>Endatix:Telemetry:Otlp:Endpoint</c> is set.
+    /// </summary>
+    /// <param name="endpoint">Optional collector endpoint, for example <c>http://collector:4317</c>.</param>
+    /// <returns>The builder for chaining.</returns>
+    public EndatixTelemetryBuilder WithOtlpExporter(string? endpoint = null)
+    {
+        if (!_enabled)
+        {
+            _options = BindOptions();
+            _enabled = true;
+        }
+
+        if (!string.IsNullOrWhiteSpace(endpoint))
+        {
+            _options.Otlp.Endpoint = endpoint;
+        }
+
+        return this;
+    }
+
+    /// <summary>
+    /// Turns off one or more instrumentation sources.
+    /// </summary>
+    /// <param name="instrumentation">The sources to disable; combinable with <c>|</c>.</param>
+    /// <returns>The builder for chaining.</returns>
+    public EndatixTelemetryBuilder DisableInstrumentation(Instrumentation instrumentation)
+    {
+        _instrumentation &= ~instrumentation;
+        return this;
+    }
+
+    /// <summary>
+    /// Adds request paths that must not produce traces. <c>/health</c>, <c>/alive</c> and
+    /// <c>/ready</c> are excluded already.
+    /// </summary>
+    /// <param name="paths">Path prefixes to exclude, matched case-insensitively.</param>
+    /// <returns>The builder for chaining.</returns>
+    public EndatixTelemetryBuilder ExcludeFromTracing(params string[] paths)
+    {
+        _excludedPaths.AddRange(paths.Where(p => !string.IsNullOrWhiteSpace(p)));
+        return this;
+    }
+
+    /// <summary>
+    /// Applies the accumulated telemetry configuration and returns to the parent builder.
+    /// Safe to call more than once; only the first call registers.
+    /// </summary>
+    /// <returns>The parent builder for chaining.</returns>
+    public EndatixBuilder Build()
+    {
+        if (_applied || !_enabled)
+        {
+            return _parent;
+        }
+
+        _applied = true;
+
+        var otlpEndpoint = ResolveOtlpEndpoint();
+        if (otlpEndpoint is null)
+        {
+            // AC6: nothing configured means nothing registered — no exporter allocated, no SDK cost.
+            _logger.LogTelemetrySkippedNoExporter();
+            return _parent;
+        }
+
+        // Resolved here rather than inside the AddOtlpExporter callback: that callback is a named
+        // options configuration action the SDK defers until the provider is built, so validating in
+        // it would surface a bad protocol long after startup — or not at all. AC8 wants fail-fast.
+        var otlpProtocol = ResolveOtlpProtocol();
+
+        var resource = BuildResource();
+
+        var otel = Services.AddOpenTelemetry().ConfigureResource(r => r.AddAttributes(resource));
+
+        otel.WithMetrics(metrics =>
+        {
+            if (_instrumentation.HasFlag(Instrumentation.AspNetCore))
+            {
+                metrics.AddAspNetCoreInstrumentation();
+            }
+
+            if (_instrumentation.HasFlag(Instrumentation.HttpClient))
+            {
+                metrics.AddHttpClientInstrumentation();
+            }
+
+            if (_instrumentation.HasFlag(Instrumentation.Runtime))
+            {
+                metrics.AddRuntimeInstrumentation();
+            }
+
+            metrics.AddOtlpExporter((exporter, _) => ConfigureOtlp(exporter, otlpEndpoint, otlpProtocol));
+        });
+
+        otel.WithTracing(tracing =>
+        {
+            if (_instrumentation.HasFlag(Instrumentation.AspNetCore))
+            {
+                // AC5: health and liveness probes are noise — one span per probe per scrape interval.
+                tracing.AddAspNetCoreInstrumentation(o =>
+                    o.Filter = context => !IsExcludedPath(context.Request.Path));
+            }
+
+            if (_instrumentation.HasFlag(Instrumentation.HttpClient))
+            {
+                tracing.AddHttpClientInstrumentation();
+            }
+
+            ApplySampler(tracing);
+
+            tracing.AddOtlpExporter(exporter => ConfigureOtlp(exporter, otlpEndpoint, otlpProtocol));
+        });
+
+        _logger.LogTelemetryConfigured(otlpEndpoint.ToString(), _instrumentation.ToString());
+
+        return _parent;
+    }
+
+    private TelemetryOptions BindOptions()
+    {
+        var options = new TelemetryOptions();
+        Configuration.GetSection(TelemetryOptions.SectionName).Bind(options);
+        return options;
+    }
+
+    /// <summary>
+    /// Resolves the OTLP endpoint env-first, or returns <see langword="null"/> when telemetry is
+    /// not configured. Throws when a value is present but unusable (AC8) — silently not exporting
+    /// is the failure mode this whole plan exists to remove.
+    /// </summary>
+    internal Uri? ResolveOtlpEndpoint()
+    {
+        var raw = Environment.GetEnvironmentVariable(EnvVars.OtlpEndpoint);
+        var source = EnvVars.OtlpEndpoint;
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            raw = _options.Otlp.Endpoint;
+            source = $"{TelemetryOptions.SectionName}:Otlp:Endpoint";
+        }
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+
+        if (!Uri.TryCreate(raw, UriKind.Absolute, out var uri) ||
+            (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+        {
+            throw new InvalidOperationException(
+                $"OpenTelemetry is misconfigured: '{source}' is set to '{raw}', which is not an " +
+                "absolute http or https URI. Expected something like 'http://collector:4317'. " +
+                "Fix the value or remove it to disable telemetry export.");
+        }
+
+        return uri;
+    }
+
+    private static void ConfigureOtlp(
+        OtlpExporterOptions exporter,
+        Uri endpoint,
+        OtlpExportProtocol? protocol)
+    {
+        exporter.Endpoint = endpoint;
+
+        if (protocol is not null)
+        {
+            exporter.Protocol = protocol.Value;
+        }
+    }
+
+    /// <summary>
+    /// Resolves the OTLP wire protocol env-first, or <see langword="null"/> to leave the SDK
+    /// default (grpc). Throws on an unsupported value rather than exporting over the wrong wire.
+    /// </summary>
+    internal OtlpExportProtocol? ResolveOtlpProtocol()
+    {
+        var raw = Environment.GetEnvironmentVariable(EnvVars.OtlpProtocol);
+        var source = EnvVars.OtlpProtocol;
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            raw = _options.Otlp.Protocol;
+            source = $"{TelemetryOptions.SectionName}:Otlp:Protocol";
+        }
+
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+
+        return raw.Trim().ToLowerInvariant() switch
+        {
+            "grpc" => OtlpExportProtocol.Grpc,
+            "http/protobuf" => OtlpExportProtocol.HttpProtobuf,
+            _ => throw new InvalidOperationException(
+                $"OpenTelemetry is misconfigured: '{source}' is set to '{raw}', which is not a " +
+                "supported OTLP protocol. Use 'grpc' or 'http/protobuf'.")
+        };
+    }
+
+    /// <summary>
+    /// Builds the resource attributes env-first (AC2). <c>OTEL_SERVICE_NAME</c> wins over
+    /// <c>Endatix:Telemetry:ServiceName</c>, which wins over the entry assembly name.
+    /// </summary>
+    internal Dictionary<string, object> BuildResource()
+    {
+        var serviceName =
+            Environment.GetEnvironmentVariable(EnvVars.ServiceName)
+            ?? _options.ServiceName
+            ?? Assembly.GetEntryAssembly()?.GetName().Name
+            ?? "endatix-api";
+
+        var attributes = new Dictionary<string, object>
+        {
+            [ResourceSemanticConventions.ServiceName] = serviceName
+        };
+
+        var serviceVersion =
+            Environment.GetEnvironmentVariable(EnvVars.ServiceVersion)
+            ?? _options.ServiceVersion;
+
+        if (!string.IsNullOrWhiteSpace(serviceVersion))
+        {
+            attributes[ResourceSemanticConventions.ServiceVersion] = serviceVersion;
+        }
+
+        // Configured attributes are the weakest source: OTEL_RESOURCE_ATTRIBUTES is applied by the
+        // SDK's own environment detector and overrides anything set here.
+        foreach (var (key, value) in _options.ResourceAttributes)
+        {
+            attributes[key] = value;
+        }
+
+        return attributes;
+    }
+
+    private void ApplySampler(TracerProviderBuilder tracing)
+    {
+        // OTEL_TRACES_SAMPLER is authoritative — leave the SDK to read it.
+        if (!string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(EnvVars.TracesSampler)))
+        {
+            return;
+        }
+
+        var ratio = _options.Traces.SamplingRatio;
+        if (ratio is < 0.0 or > 1.0)
+        {
+            throw new InvalidOperationException(
+                $"OpenTelemetry is misconfigured: '{TelemetryOptions.SectionName}:Traces:SamplingRatio' " +
+                $"is {ratio}, which is outside the valid range 0.0 to 1.0.");
+        }
+
+        // 1.0 is the SDK default; registering a sampler for it only adds a layer.
+        if (ratio < 1.0)
+        {
+            tracing.SetSampler(new ParentBasedSampler(new TraceIdRatioBasedSampler(ratio)));
+        }
+    }
+
+    private bool IsExcludedPath(PathString path) =>
+        _excludedPaths.Any(excluded =>
+            path.StartsWithSegments(excluded, StringComparison.OrdinalIgnoreCase));
+}
+
+/// <summary>
+/// Resource attribute keys from the OpenTelemetry semantic conventions.
+/// </summary>
+internal static class ResourceSemanticConventions
+{
+    public const string ServiceName = "service.name";
+    public const string ServiceVersion = "service.version";
+}

--- a/src/Endatix.Hosting/Builders/Logging/EndatixBuilderLoggerExtensions.cs
+++ b/src/Endatix.Hosting/Builders/Logging/EndatixBuilderLoggerExtensions.cs
@@ -130,4 +130,19 @@ internal static partial class EndatixBuilderLoggerExtensions
         Level = LogLevel.Debug,
         Message = "[Persistence Setup] {Message}")]
     public static partial void LogPersistenceSetup(this ILogger logger, string message);
+
+    [LoggerMessage(
+        EventId = EndatixEventIds.Hosting.TelemetryConfigured,
+        Level = LogLevel.Information,
+        Message = "OpenTelemetry configured: exporting to {OtlpEndpoint} with {Instrumentation} instrumentation")]
+    public static partial void LogTelemetryConfigured(
+        this ILogger logger,
+        string otlpEndpoint,
+        string instrumentation);
+
+    [LoggerMessage(
+        EventId = EndatixEventIds.Hosting.TelemetrySkippedNoExporter,
+        Level = LogLevel.Debug,
+        Message = "OpenTelemetry not configured: no OTLP endpoint set, so no exporter was registered")]
+    public static partial void LogTelemetrySkippedNoExporter(this ILogger logger);
 }

--- a/src/Endatix.Hosting/Endatix.Hosting.csproj
+++ b/src/Endatix.Hosting/Endatix.Hosting.csproj
@@ -20,6 +20,11 @@
     <PackageReference Include="Serilog.Extensions.Hosting" />
     <PackageReference Include="AspNetCore.HealthChecks.System" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Endatix.Hosting/Options/TelemetryOptions.cs
+++ b/src/Endatix.Hosting/Options/TelemetryOptions.cs
@@ -1,0 +1,103 @@
+namespace Endatix.Hosting.Options;
+
+/// <summary>
+/// Options for Endatix OpenTelemetry, bound from the <c>Endatix:Telemetry</c> configuration section.
+/// </summary>
+/// <remarks>
+/// Every value here is a <em>fallback</em>. The standard <c>OTEL_*</c> environment variables are
+/// authoritative and win whenever they are set, per the OpenTelemetry specification — so a host that
+/// configures telemetry the standard way never has to know these keys exist.
+/// </remarks>
+public class TelemetryOptions
+{
+    /// <summary>
+    /// The configuration section these options bind to.
+    /// </summary>
+    public const string SectionName = "Endatix:Telemetry";
+
+    /// <summary>
+    /// Logical service name. Falls back to the entry assembly name.
+    /// Overridden by <c>OTEL_SERVICE_NAME</c>.
+    /// </summary>
+    public string? ServiceName { get; set; }
+
+    /// <summary>
+    /// Service version reported as the <c>service.version</c> resource attribute.
+    /// Overridden by <c>OTEL_SERVICE_VERSION</c>.
+    /// </summary>
+    public string? ServiceVersion { get; set; }
+
+    /// <summary>
+    /// Additional resource attributes attached to every signal.
+    /// Merged with, and overridden by, <c>OTEL_RESOURCE_ATTRIBUTES</c>.
+    /// </summary>
+    public IDictionary<string, string> ResourceAttributes { get; set; } = new Dictionary<string, string>();
+
+    /// <summary>
+    /// OTLP exporter settings. The exporter is registered only when an endpoint resolves.
+    /// </summary>
+    public OtlpOptions Otlp { get; set; } = new();
+
+    /// <summary>
+    /// Per-source instrumentation toggles. All are enabled by default.
+    /// </summary>
+    public InstrumentationOptions Instrumentation { get; set; } = new();
+
+    /// <summary>
+    /// Trace sampling settings.
+    /// </summary>
+    public TracesOptions Traces { get; set; } = new();
+}
+
+/// <summary>
+/// OTLP exporter settings.
+/// </summary>
+public class OtlpOptions
+{
+    /// <summary>
+    /// Collector endpoint, for example <c>http://collector:4317</c>. Overridden by
+    /// <c>OTEL_EXPORTER_OTLP_ENDPOINT</c>. When neither is set, no exporter is registered.
+    /// </summary>
+    public string? Endpoint { get; set; }
+
+    /// <summary>
+    /// Wire protocol: <c>grpc</c> (default) or <c>http/protobuf</c>.
+    /// Overridden by <c>OTEL_EXPORTER_OTLP_PROTOCOL</c>.
+    /// </summary>
+    public string? Protocol { get; set; }
+}
+
+/// <summary>
+/// Per-source instrumentation toggles.
+/// </summary>
+public class InstrumentationOptions
+{
+    /// <summary>
+    /// Inbound HTTP request traces and metrics. Enabled by default.
+    /// </summary>
+    public bool AspNetCore { get; set; } = true;
+
+    /// <summary>
+    /// Outbound <see cref="System.Net.Http.HttpClient"/> traces and metrics — this is what makes
+    /// webhook delivery visible. Enabled by default.
+    /// </summary>
+    public bool HttpClient { get; set; } = true;
+
+    /// <summary>
+    /// .NET runtime metrics (GC, thread pool, allocation). Enabled by default.
+    /// </summary>
+    public bool Runtime { get; set; } = true;
+}
+
+/// <summary>
+/// Trace sampling settings.
+/// </summary>
+public class TracesOptions
+{
+    /// <summary>
+    /// Head-sampling ratio between 0.0 and 1.0. Defaults to 1.0 (sample everything);
+    /// leave it there until volume justifies tail sampling at the collector.
+    /// Overridden by <c>OTEL_TRACES_SAMPLER</c> / <c>OTEL_TRACES_SAMPLER_ARG</c>.
+    /// </summary>
+    public double SamplingRatio { get; set; } = 1.0;
+}

--- a/tests/Endatix.Hosting.Tests/HealthChecks/EndatixHealthChecksBuilderTests.cs
+++ b/tests/Endatix.Hosting.Tests/HealthChecks/EndatixHealthChecksBuilderTests.cs
@@ -7,7 +7,14 @@ using Microsoft.Extensions.Hosting;
 namespace Endatix.Hosting.Tests.HealthChecks;
 
 /// <summary>
-/// Dummy type used to simulate Aspire presence (IsAspireServiceDefaultsPresent checks for "OpenTelemetry" in service type FullName).
+/// Dummy type used to simulate Aspire presence (IsAspireServiceDefaultsPresent checks for
+/// "ServiceDiscovery" in service type FullName).
+/// </summary>
+internal sealed class ServiceDiscoveryMarker;
+
+/// <summary>
+/// Dummy type standing in for Endatix's own OpenTelemetry registration. It must NOT be mistaken for
+/// Aspire — that misdetection would silently drop the "self" health check.
 /// </summary>
 internal sealed class OpenTelemetryMarker;
 
@@ -98,7 +105,7 @@ public sealed class EndatixHealthChecksBuilderTests
             .ConfigureServices((context, services) =>
             {
                 // Simulate Aspire presence so UseDefaults() skips the "self" check
-                services.AddSingleton<OpenTelemetryMarker>();
+                services.AddSingleton<ServiceDiscoveryMarker>();
                 var builder = services.AddEndatix(context.Configuration);
                 builder.HealthChecks.UseDefaults();
                 builder.Infrastructure.Security.UseDefaults();
@@ -112,6 +119,33 @@ public sealed class EndatixHealthChecksBuilderTests
 
         // Assert
         report.Entries.Should().NotContainKey("self");
+    }
+
+    [Fact]
+    public async Task ConfigureEndatix_WithOpenTelemetryRegistered_StillRegistersSelfCheck()
+    {
+        // Arrange — AC7. The Aspire probe used to match any service whose type name contained
+        // "OpenTelemetry", so Endatix registering its own SDK would silently disable this check.
+        var config = CreateMinimalConfig();
+        using var host = Host.CreateDefaultBuilder()
+            .ConfigureAppConfiguration((_, c) => c.AddConfiguration(config))
+            .ConfigureServices((context, services) =>
+            {
+                services.AddSingleton<OpenTelemetryMarker>();
+                var builder = services.AddEndatix(context.Configuration);
+                builder.HealthChecks.UseDefaults();
+                builder.Infrastructure.Security.UseDefaults();
+                builder.FinalizeConfiguration();
+            })
+            .Build();
+
+        // Act
+        var healthCheckService = host.Services.GetRequiredService<HealthCheckService>();
+        var report = await healthCheckService.CheckHealthAsync(TestContext.Current.CancellationToken);
+
+        // Assert
+        report.Entries.Should().ContainKey("self");
+        report.Entries["self"].Status.Should().Be(HealthStatus.Healthy);
     }
 
     [Fact]

--- a/tests/Endatix.Hosting.Tests/Telemetry/EndatixTelemetryBuilderTests.cs
+++ b/tests/Endatix.Hosting.Tests/Telemetry/EndatixTelemetryBuilderTests.cs
@@ -36,10 +36,13 @@ public sealed class EndatixTelemetryBuilderTests
         {
             (EndatixTelemetryBuilder.EnvVars.ServiceName, null),
             (EndatixTelemetryBuilder.EnvVars.ServiceVersion, null),
-            (EndatixTelemetryBuilder.EnvVars.OtlpEndpoint, null),
-            (EndatixTelemetryBuilder.EnvVars.OtlpProtocol, null),
             (EndatixTelemetryBuilder.EnvVars.TracesSampler, null)
         };
+
+        // Includes the signal-specific endpoint and protocol variables, any one of which would
+        // otherwise activate telemetry from the ambient environment and skew every assertion here.
+        variables.AddRange(EndatixTelemetryBuilder.EnvVars.AllOtlpEndpoints.Select(n => (n, (string?)null)));
+        variables.AddRange(EndatixTelemetryBuilder.EnvVars.AllOtlpProtocols.Select(n => (n, (string?)null)));
 
         variables.AddRange(overrides.Select(o => (o.Name, o.Value)));
         return new EnvironmentVariableScope([.. variables]);
@@ -364,6 +367,81 @@ public sealed class EndatixTelemetryBuilderTests
 
         // Assert
         builder.Services.Should().NotContain(s => s.ServiceType.FullName!.Contains("OpenTelemetry"));
+    }
+
+    [Theory]
+    [InlineData("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT")]
+    [InlineData("OTEL_EXPORTER_OTLP_METRICS_ENDPOINT")]
+    public void UseDefaults_WithSignalSpecificEndpointOnly_EnablesTelemetry(string variable)
+    {
+        // Arrange — the spec allows configuring only a signal-specific endpoint, with no global one
+        using var _ = ClearOtelEnvironment((variable, CollectorEndpoint));
+        var builder = CreateBuilder();
+
+        // Act
+        builder.UseDefaults().Build();
+
+        // Assert
+        builder.Services.Should().Contain(
+            s => s.ServiceType.FullName!.Contains("OpenTelemetry"),
+            "a signal-specific endpoint configures telemetry just as the global one does");
+    }
+
+    [Fact]
+    public void ResolveOtlpEndpoint_SignalSpecificAndGlobalSet_SignalSpecificWins()
+    {
+        // Arrange
+        using var _ = ClearOtelEnvironment(
+            (EndatixTelemetryBuilder.EnvVars.OtlpEndpoint, "http://global:4317"),
+            (EndatixTelemetryBuilder.EnvVars.OtlpTracesEndpoint, "http://traces:4318"));
+        var builder = CreateBuilder();
+
+        // Act
+        builder.UseDefaults();
+
+        // Assert
+        builder.ResolveOtlpEndpoint()!.Host.Should().Be("traces");
+    }
+
+    [Fact]
+    public void BuildResource_ConfiguredAttributeForServiceName_DoesNotOverrideTheEnvironment()
+    {
+        // Arrange — AC2 again, by the back door: ResourceAttributes must not defeat OTEL_SERVICE_NAME
+        using var _ = ClearOtelEnvironment(
+            (EndatixTelemetryBuilder.EnvVars.ServiceName, "endatix-api-from-env"));
+        var builder = CreateBuilder(new Dictionary<string, string?>
+        {
+            ["Endatix:Telemetry:ResourceAttributes:service.name"] = "hijacked",
+            ["Endatix:Telemetry:ResourceAttributes:deployment.environment"] = "production"
+        });
+
+        // Act
+        builder.UseDefaults();
+        var resource = builder.BuildResource();
+
+        // Assert
+        resource["service.name"].Should().Be("endatix-api-from-env");
+        resource["deployment.environment"].Should().Be("production");
+    }
+
+    [Fact]
+    public void Build_WhenValidationFails_DoesNotMarkItselfApplied()
+    {
+        // Arrange — a failed Build must not latch, or FinalizeConfiguration() calling Build() after
+        // a caught exception would return quietly having registered nothing
+        using var _ = ClearOtelEnvironment(
+            (EndatixTelemetryBuilder.EnvVars.OtlpEndpoint, "not-a-uri"));
+        var builder = CreateBuilder();
+        builder.UseDefaults();
+
+        // Act
+        var first = () => builder.Build();
+        first.Should().Throw<InvalidOperationException>();
+        var second = () => builder.Build();
+
+        // Assert
+        second.Should().Throw<InvalidOperationException>(
+            "the failure must resurface rather than be swallowed by the idempotency guard");
     }
 
     [Fact]

--- a/tests/Endatix.Hosting.Tests/Telemetry/EndatixTelemetryBuilderTests.cs
+++ b/tests/Endatix.Hosting.Tests/Telemetry/EndatixTelemetryBuilderTests.cs
@@ -1,0 +1,375 @@
+using Endatix.Hosting.Builders;
+using Endatix.Hosting.Options;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using OpenTelemetry.Exporter;
+
+namespace Endatix.Hosting.Tests.Telemetry;
+
+/// <summary>
+/// Unit tests for <see cref="EndatixTelemetryBuilder"/> resolution rules: env-var precedence,
+/// off-by-default behaviour and fail-fast validation.
+/// </summary>
+[Collection(TelemetryEnvironmentCollection.Name)]
+public sealed class EndatixTelemetryBuilderTests
+{
+    private const string CollectorEndpoint = "http://collector:4317";
+
+    private static EndatixTelemetryBuilder CreateBuilder(Dictionary<string, string?>? settings = null)
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(settings ?? [])
+            .Build();
+
+        var services = new ServiceCollection();
+        var parent = new EndatixBuilder(services, configuration);
+        return parent.Telemetry;
+    }
+
+    /// <summary>
+    /// Clears every OTEL_* variable this suite reads, so an ambient value on the developer's
+    /// machine or the CI runner cannot change the outcome.
+    /// </summary>
+    private static EnvironmentVariableScope ClearOtelEnvironment(params (string Name, string? Value)[] overrides)
+    {
+        var variables = new List<(string, string?)>
+        {
+            (EndatixTelemetryBuilder.EnvVars.ServiceName, null),
+            (EndatixTelemetryBuilder.EnvVars.ServiceVersion, null),
+            (EndatixTelemetryBuilder.EnvVars.OtlpEndpoint, null),
+            (EndatixTelemetryBuilder.EnvVars.OtlpProtocol, null),
+            (EndatixTelemetryBuilder.EnvVars.TracesSampler, null)
+        };
+
+        variables.AddRange(overrides.Select(o => (o.Name, o.Value)));
+        return new EnvironmentVariableScope([.. variables]);
+    }
+
+    [Fact]
+    public void UseDefaults_NoConfiguration_RegistersNoExporter()
+    {
+        // Arrange
+        using var _ = ClearOtelEnvironment();
+        var builder = CreateBuilder();
+
+        // Act
+        builder.UseDefaults().Build();
+
+        // Assert — AC6: nothing configured means no OpenTelemetry service is registered at all
+        builder.Services.Should().NotContain(
+            s => s.ServiceType.FullName!.Contains("OpenTelemetry"),
+            "no exporter should be allocated when telemetry is unconfigured");
+    }
+
+    [Fact]
+    public void UseDefaults_WithOtlpEndpointEnvVar_RegistersOtlpExporter()
+    {
+        // Arrange
+        using var _ = ClearOtelEnvironment(
+            (EndatixTelemetryBuilder.EnvVars.OtlpEndpoint, CollectorEndpoint));
+        var builder = CreateBuilder();
+
+        // Act
+        builder.UseDefaults().Build();
+
+        // Assert
+        builder.Services.Should().Contain(
+            s => s.ServiceType.FullName!.Contains("OpenTelemetry"),
+            "an OTLP endpoint in the environment is all it should take to enable telemetry");
+    }
+
+    [Fact]
+    public void ResolveOtlpEndpoint_EndpointFromConfigurationOnly_IsUsedAsFallback()
+    {
+        // Arrange
+        using var _ = ClearOtelEnvironment();
+        var builder = CreateBuilder(new Dictionary<string, string?>
+        {
+            ["Endatix:Telemetry:Otlp:Endpoint"] = CollectorEndpoint
+        });
+
+        // Act
+        builder.UseDefaults();
+        var endpoint = builder.ResolveOtlpEndpoint();
+
+        // Assert
+        endpoint.Should().NotBeNull();
+        endpoint!.ToString().Should().Be("http://collector:4317/");
+    }
+
+    [Fact]
+    public void ResolveOtlpEndpoint_SetInEnvAndConfig_EnvWins()
+    {
+        // Arrange
+        using var _ = ClearOtelEnvironment(
+            (EndatixTelemetryBuilder.EnvVars.OtlpEndpoint, "http://from-env:4317"));
+        var builder = CreateBuilder(new Dictionary<string, string?>
+        {
+            ["Endatix:Telemetry:Otlp:Endpoint"] = "http://from-config:4317"
+        });
+
+        // Act
+        builder.UseDefaults();
+        var endpoint = builder.ResolveOtlpEndpoint();
+
+        // Assert
+        endpoint!.Host.Should().Be("from-env");
+    }
+
+    [Fact]
+    public void BuildResource_ServiceNameFromEnvAndConfig_EnvWins()
+    {
+        // Arrange — AC2
+        using var _ = ClearOtelEnvironment(
+            (EndatixTelemetryBuilder.EnvVars.ServiceName, "endatix-api-from-env"));
+        var builder = CreateBuilder(new Dictionary<string, string?>
+        {
+            ["Endatix:Telemetry:ServiceName"] = "endatix-api-from-config"
+        });
+
+        // Act
+        builder.UseDefaults();
+        var resource = builder.BuildResource();
+
+        // Assert
+        resource["service.name"].Should().Be("endatix-api-from-env");
+    }
+
+    [Fact]
+    public void BuildResource_ServiceNameFromConfigurationOnly_IsUsedAsFallback()
+    {
+        // Arrange
+        using var _ = ClearOtelEnvironment();
+        var builder = CreateBuilder(new Dictionary<string, string?>
+        {
+            ["Endatix:Telemetry:ServiceName"] = "endatix-api-from-config"
+        });
+
+        // Act
+        builder.UseDefaults();
+        var resource = builder.BuildResource();
+
+        // Assert
+        resource["service.name"].Should().Be("endatix-api-from-config");
+    }
+
+    [Fact]
+    public void BuildResource_WithConfiguredResourceAttributes_IncludesThem()
+    {
+        // Arrange
+        using var _ = ClearOtelEnvironment();
+        var builder = CreateBuilder(new Dictionary<string, string?>
+        {
+            ["Endatix:Telemetry:ServiceName"] = "endatix-api",
+            ["Endatix:Telemetry:ResourceAttributes:deployment.environment"] = "production"
+        });
+
+        // Act
+        builder.UseDefaults();
+        var resource = builder.BuildResource();
+
+        // Assert
+        resource.Should().ContainKey("deployment.environment")
+            .WhoseValue.Should().Be("production");
+    }
+
+    [Theory]
+    [InlineData("not-a-uri")]
+    [InlineData("collector:4317")]
+    [InlineData("ftp://collector:4317")]
+    public void Build_InvalidOtlpEndpoint_ThrowsWithActionableMessage(string endpoint)
+    {
+        // Arrange — AC8: a malformed endpoint must fail loudly, not silently stop exporting
+        using var _ = ClearOtelEnvironment(
+            (EndatixTelemetryBuilder.EnvVars.OtlpEndpoint, endpoint));
+        var builder = CreateBuilder();
+
+        // Act
+        var act = () => builder.UseDefaults().Build();
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*{endpoint}*")
+            .WithMessage($"*{EndatixTelemetryBuilder.EnvVars.OtlpEndpoint}*");
+    }
+
+    [Fact]
+    public void Build_InvalidOtlpProtocol_ThrowsWithActionableMessage()
+    {
+        // Arrange
+        using var _ = ClearOtelEnvironment(
+            (EndatixTelemetryBuilder.EnvVars.OtlpEndpoint, CollectorEndpoint),
+            (EndatixTelemetryBuilder.EnvVars.OtlpProtocol, "carrier-pigeon"));
+        var builder = CreateBuilder();
+
+        // Act
+        var act = () => builder.UseDefaults().Build();
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*carrier-pigeon*");
+    }
+
+    [Fact]
+    public void Build_InvalidOtlpProtocolFromConfiguration_ThrowsNamingTheConfigKey()
+    {
+        // Arrange — the config fallback must fail as loudly as the environment variable does
+        using var _ = ClearOtelEnvironment(
+            (EndatixTelemetryBuilder.EnvVars.OtlpEndpoint, CollectorEndpoint));
+        var builder = CreateBuilder(new Dictionary<string, string?>
+        {
+            ["Endatix:Telemetry:Otlp:Protocol"] = "smoke-signals"
+        });
+
+        // Act
+        var act = () => builder.UseDefaults().Build();
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*smoke-signals*")
+            .WithMessage("*Endatix:Telemetry:Otlp:Protocol*");
+    }
+
+    [Theory]
+    [InlineData("grpc", OtlpExportProtocol.Grpc)]
+    [InlineData("http/protobuf", OtlpExportProtocol.HttpProtobuf)]
+    [InlineData("  GRPC  ", OtlpExportProtocol.Grpc)]
+    public void ResolveOtlpProtocol_SupportedValues_AreParsed(string configured, OtlpExportProtocol expected)
+    {
+        // Arrange
+        using var _ = ClearOtelEnvironment(
+            (EndatixTelemetryBuilder.EnvVars.OtlpProtocol, configured));
+        var builder = CreateBuilder();
+
+        // Act
+        builder.UseDefaults();
+        var protocol = builder.ResolveOtlpProtocol();
+
+        // Assert
+        protocol.Should().Be(expected);
+    }
+
+    [Fact]
+    public void ResolveOtlpProtocol_NotConfigured_ReturnsNullSoTheSdkDefaultApplies()
+    {
+        // Arrange
+        using var _ = ClearOtelEnvironment();
+        var builder = CreateBuilder();
+
+        // Act
+        builder.UseDefaults();
+
+        // Assert
+        builder.ResolveOtlpProtocol().Should().BeNull();
+    }
+
+    [Theory]
+    [InlineData("-0.5")]
+    [InlineData("1.5")]
+    public void Build_SamplingRatioOutOfRange_Throws(string ratio)
+    {
+        // Arrange
+        using var _ = ClearOtelEnvironment(
+            (EndatixTelemetryBuilder.EnvVars.OtlpEndpoint, CollectorEndpoint));
+        var builder = CreateBuilder(new Dictionary<string, string?>
+        {
+            ["Endatix:Telemetry:Traces:SamplingRatio"] = ratio
+        });
+
+        // Act
+        var act = () => builder.UseDefaults().Build();
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>().WithMessage("*SamplingRatio*");
+    }
+
+    [Fact]
+    public void Build_CalledTwice_RegistersOnlyOnce()
+    {
+        // Arrange — FinalizeConfiguration() calls Build(), and a consumer may call it too
+        using var _ = ClearOtelEnvironment(
+            (EndatixTelemetryBuilder.EnvVars.OtlpEndpoint, CollectorEndpoint));
+        var builder = CreateBuilder();
+
+        // Act
+        builder.UseDefaults().Build();
+        var afterFirstBuild = builder.Services.Count;
+        builder.Build();
+
+        // Assert
+        builder.Services.Count.Should().Be(afterFirstBuild);
+    }
+
+    [Fact]
+    public void DisableInstrumentation_CalledAfterUseDefaults_StillTakesEffect()
+    {
+        // Arrange — registration is deferred to Build() precisely so call order does not matter
+        using var _ = ClearOtelEnvironment(
+            (EndatixTelemetryBuilder.EnvVars.OtlpEndpoint, CollectorEndpoint));
+        var builder = CreateBuilder();
+
+        // Act
+        var act = () => builder
+            .UseDefaults()
+            .DisableInstrumentation(Instrumentation.Runtime | Instrumentation.HttpClient)
+            .Build();
+
+        // Assert
+        act.Should().NotThrow();
+        builder.Services.Should().Contain(s => s.ServiceType.FullName!.Contains("OpenTelemetry"));
+    }
+
+    [Fact]
+    public void WithOtlpExporter_ExplicitEndpoint_OverridesConfiguration()
+    {
+        // Arrange
+        using var _ = ClearOtelEnvironment();
+        var builder = CreateBuilder(new Dictionary<string, string?>
+        {
+            ["Endatix:Telemetry:Otlp:Endpoint"] = "http://from-config:4317"
+        });
+
+        // Act
+        builder.UseDefaults().WithOtlpExporter("http://explicit:4317");
+        var endpoint = builder.ResolveOtlpEndpoint();
+
+        // Assert
+        endpoint!.Host.Should().Be("explicit");
+    }
+
+    [Fact]
+    public void WithOtlpExporter_WithoutUseDefaults_EnablesTelemetry()
+    {
+        // Arrange
+        using var _ = ClearOtelEnvironment();
+        var builder = CreateBuilder();
+
+        // Act
+        builder.WithOtlpExporter(CollectorEndpoint).Build();
+
+        // Assert
+        builder.Services.Should().Contain(s => s.ServiceType.FullName!.Contains("OpenTelemetry"));
+    }
+
+    [Fact]
+    public void Build_WithoutUseDefaults_RegistersNothing()
+    {
+        // Arrange — telemetry is opt-in; FinalizeConfiguration() calling Build() must be inert
+        using var _ = ClearOtelEnvironment(
+            (EndatixTelemetryBuilder.EnvVars.OtlpEndpoint, CollectorEndpoint));
+        var builder = CreateBuilder();
+
+        // Act
+        builder.Build();
+
+        // Assert
+        builder.Services.Should().NotContain(s => s.ServiceType.FullName!.Contains("OpenTelemetry"));
+    }
+
+    [Fact]
+    public void TelemetryOptions_SectionName_MatchesTheDocumentedKey()
+    {
+        // Arrange / Act / Assert — the docs and Helm chart both reference this literal
+        TelemetryOptions.SectionName.Should().Be("Endatix:Telemetry");
+    }
+}

--- a/tests/Endatix.Hosting.Tests/Telemetry/EndatixTelemetryBuilderTests.cs
+++ b/tests/Endatix.Hosting.Tests/Telemetry/EndatixTelemetryBuilderTests.cs
@@ -311,7 +311,7 @@ public sealed class EndatixTelemetryBuilderTests
         // Act
         var act = () => builder
             .UseDefaults()
-            .DisableInstrumentation(Instrumentation.Runtime | Instrumentation.HttpClient)
+            .DisableInstrumentation(Instrumentations.Runtime | Instrumentations.HttpClient)
             .Build();
 
         // Assert

--- a/tests/Endatix.Hosting.Tests/Telemetry/EndatixTelemetryBuilderTests.cs
+++ b/tests/Endatix.Hosting.Tests/Telemetry/EndatixTelemetryBuilderTests.cs
@@ -444,6 +444,34 @@ public sealed class EndatixTelemetryBuilderTests
             "the failure must resurface rather than be swallowed by the idempotency guard");
     }
 
+    [Theory]
+    [InlineData("http://collector:4317", "http://collector:4317")]
+    [InlineData("https://user:s3cr3t@collector:4318/v1/traces?token=abc123#frag", "https://collector:4318")]
+    [InlineData("https://bearer-token@collector.example.com/v1/metrics?api-key=deadbeef",
+        "https://collector.example.com")]
+    public void Redact_StripsCredentialsPathAndQuery(string endpoint, string expected)
+    {
+        // Arrange / Act
+        var redacted = EndatixTelemetryBuilder.Redact(new Uri(endpoint));
+
+        // Assert
+        redacted.Should().Be(expected);
+    }
+
+    [Fact]
+    public void Redact_NeverLeaksUserInfo()
+    {
+        // Arrange — GetLeftPart(UriPartial.Authority) keeps user info, unlike the Authority
+        // property. This test exists so nobody "simplifies" the implementation back to it.
+        var endpoint = new Uri("https://user:s3cr3t@collector:4318/v1/traces?token=abc123");
+
+        // Act
+        var redacted = EndatixTelemetryBuilder.Redact(endpoint);
+
+        // Assert
+        redacted.Should().NotContain("s3cr3t").And.NotContain("user").And.NotContain("abc123");
+    }
+
     [Fact]
     public void TelemetryOptions_SectionName_MatchesTheDocumentedKey()
     {

--- a/tests/Endatix.Hosting.Tests/Telemetry/EnvironmentVariableScope.cs
+++ b/tests/Endatix.Hosting.Tests/Telemetry/EnvironmentVariableScope.cs
@@ -1,0 +1,40 @@
+namespace Endatix.Hosting.Tests.Telemetry;
+
+/// <summary>
+/// Sets environment variables for the duration of a test and restores their previous values on
+/// dispose — including restoring them to unset when they were unset to begin with.
+/// </summary>
+/// <remarks>
+/// Environment variables are process-global, so tests using this must not run in parallel with each
+/// other. See <see cref="TelemetryEnvironmentCollection"/>.
+/// </remarks>
+internal sealed class EnvironmentVariableScope : IDisposable
+{
+    private readonly Dictionary<string, string?> _previous = [];
+
+    public EnvironmentVariableScope(params (string Name, string? Value)[] variables)
+    {
+        foreach (var (name, value) in variables)
+        {
+            _previous[name] = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var (name, value) in _previous)
+        {
+            Environment.SetEnvironmentVariable(name, value);
+        }
+    }
+}
+
+/// <summary>
+/// Serialises every test that mutates OTEL_* environment variables.
+/// </summary>
+[CollectionDefinition(Name, DisableParallelization = true)]
+public class TelemetryEnvironmentCollection
+{
+    public const string Name = "Telemetry environment";
+}

--- a/tests/Endatix.Hosting.Tests/Telemetry/EnvironmentVariableScope.cs
+++ b/tests/Endatix.Hosting.Tests/Telemetry/EnvironmentVariableScope.cs
@@ -16,7 +16,15 @@ internal sealed class EnvironmentVariableScope : IDisposable
     {
         foreach (var (name, value) in variables)
         {
-            _previous[name] = Environment.GetEnvironmentVariable(name);
+            // Record only the FIRST observation. Callers legitimately pass a name twice — clearing
+            // every OTEL_* variable and then overriding one of them — and re-recording would
+            // capture the value this scope had just written, so Dispose would restore that instead
+            // of the caller's real environment.
+            if (!_previous.ContainsKey(name))
+            {
+                _previous[name] = Environment.GetEnvironmentVariable(name);
+            }
+
             Environment.SetEnvironmentVariable(name, value);
         }
     }

--- a/tests/Endatix.Hosting.Tests/Telemetry/EnvironmentVariableScopeTests.cs
+++ b/tests/Endatix.Hosting.Tests/Telemetry/EnvironmentVariableScopeTests.cs
@@ -13,6 +13,7 @@ public sealed class EnvironmentVariableScopeTests
     public void Dispose_RestoresTheOriginalValue()
     {
         // Arrange
+        var ambient = Environment.GetEnvironmentVariable(Variable);
         Environment.SetEnvironmentVariable(Variable, "original");
 
         try
@@ -28,7 +29,7 @@ public sealed class EnvironmentVariableScopeTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable(Variable, null);
+            Environment.SetEnvironmentVariable(Variable, ambient);
         }
     }
 
@@ -37,6 +38,7 @@ public sealed class EnvironmentVariableScopeTests
     {
         // Arrange — the shape ClearOtelEnvironment uses: clear everything, then override one.
         // Recording the value on each pass would capture the null written moments earlier.
+        var ambient = Environment.GetEnvironmentVariable(Variable);
         Environment.SetEnvironmentVariable(Variable, "original");
 
         try
@@ -52,7 +54,7 @@ public sealed class EnvironmentVariableScopeTests
         }
         finally
         {
-            Environment.SetEnvironmentVariable(Variable, null);
+            Environment.SetEnvironmentVariable(Variable, ambient);
         }
     }
 
@@ -60,15 +62,23 @@ public sealed class EnvironmentVariableScopeTests
     public void Dispose_WhenTheVariableWasUnset_LeavesItUnset()
     {
         // Arrange
+        var ambient = Environment.GetEnvironmentVariable(Variable);
         Environment.SetEnvironmentVariable(Variable, null);
 
-        // Act
-        using (new EnvironmentVariableScope((Variable, "temporary")))
+        try
         {
-            Environment.GetEnvironmentVariable(Variable).Should().Be("temporary");
-        }
+            // Act
+            using (new EnvironmentVariableScope((Variable, "temporary")))
+            {
+                Environment.GetEnvironmentVariable(Variable).Should().Be("temporary");
+            }
 
-        // Assert
-        Environment.GetEnvironmentVariable(Variable).Should().BeNull();
+            // Assert
+            Environment.GetEnvironmentVariable(Variable).Should().BeNull();
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(Variable, ambient);
+        }
     }
 }

--- a/tests/Endatix.Hosting.Tests/Telemetry/EnvironmentVariableScopeTests.cs
+++ b/tests/Endatix.Hosting.Tests/Telemetry/EnvironmentVariableScopeTests.cs
@@ -1,0 +1,74 @@
+namespace Endatix.Hosting.Tests.Telemetry;
+
+/// <summary>
+/// Guards the test helper itself: a scope that fails to restore the ambient environment leaks
+/// state into every later test and into the developer's shell.
+/// </summary>
+[Collection(TelemetryEnvironmentCollection.Name)]
+public sealed class EnvironmentVariableScopeTests
+{
+    private const string Variable = "ENDATIX_TEST_SCOPE_PROBE";
+
+    [Fact]
+    public void Dispose_RestoresTheOriginalValue()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable(Variable, "original");
+
+        try
+        {
+            // Act
+            using (new EnvironmentVariableScope((Variable, "overridden")))
+            {
+                Environment.GetEnvironmentVariable(Variable).Should().Be("overridden");
+            }
+
+            // Assert
+            Environment.GetEnvironmentVariable(Variable).Should().Be("original");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(Variable, null);
+        }
+    }
+
+    [Fact]
+    public void Dispose_WhenTheSameNameIsSuppliedTwice_RestoresTheOriginalValue()
+    {
+        // Arrange — the shape ClearOtelEnvironment uses: clear everything, then override one.
+        // Recording the value on each pass would capture the null written moments earlier.
+        Environment.SetEnvironmentVariable(Variable, "original");
+
+        try
+        {
+            // Act
+            using (new EnvironmentVariableScope((Variable, null), (Variable, "overridden")))
+            {
+                Environment.GetEnvironmentVariable(Variable).Should().Be("overridden");
+            }
+
+            // Assert
+            Environment.GetEnvironmentVariable(Variable).Should().Be("original");
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable(Variable, null);
+        }
+    }
+
+    [Fact]
+    public void Dispose_WhenTheVariableWasUnset_LeavesItUnset()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable(Variable, null);
+
+        // Act
+        using (new EnvironmentVariableScope((Variable, "temporary")))
+        {
+            Environment.GetEnvironmentVariable(Variable).Should().Be("temporary");
+        }
+
+        // Assert
+        Environment.GetEnvironmentVariable(Variable).Should().BeNull();
+    }
+}


### PR DESCRIPTION
# Add OpenTelemetry metrics and traces via OTLP (e476 PR-T1)

## Description

Endatix API emits **no telemetry today**. Not one OpenTelemetry package is referenced, and the only occurrence of the string in the source tree is an Aspire *detection* helper in `EndatixHealthChecksBuilder`.

The gap is already costing us operationally: the `endatix-api` deployment sets `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_PROTOCOL`, the collector is reachable on `:4317` with working metrics→Prometheus and logs→Loki pipelines — and still receives nothing. Those variables are read by the OTel SDK, not by the .NET runtime, so with no SDK present they are inert.

This is **PR-T1 of six** in [`e476-opentelemetry-plan.md`](https://github.com/endatix/endatix-saas/blob/main/.cursor/plans/e476-opentelemetry-plan.md): the metrics and traces foundation. Logging stays on Serilog until PR-T2.

### What it does

`EndatixTelemetryBuilder` follows the existing sub-builder shape (`Services`, `Configuration`, `UseDefaults()`, `Build()`) and slots into `EndatixBuilder` beside `HealthChecks`.

```csharp
// Defaults — reads OTEL_*, no-ops when nothing is configured
builder.Host.ConfigureEndatixWithDefaults();

// Explicit
builder.Host.ConfigureEndatix(endatix => endatix
    .Telemetry
        .UseDefaults()
        .DisableInstrumentation(Instrumentation.Runtime)
        .Build());
```

- **Off by default.** With no OTLP endpoint resolvable, nothing is registered at all — no exporter allocated, no OpenTelemetry service in the container. Setting `OTEL_EXPORTER_OTLP_ENDPOINT` is the whole activation story.
- **Environment variables are authoritative**, `Endatix:Telemetry:*` is a fallback and never an override. Applied to service name, version, endpoint and protocol; `OTEL_TRACES_SAMPLER` is left to the SDK when set.
- **Instrumentation:** ASP.NET Core, HttpClient (this is what makes webhook delivery visible), Runtime.
- **Traces exclude** `/health`, `/alive` and `/ready`, extensible via `ExcludeFromTracing(...)`.
- **Misconfiguration fails fast** with the offending value *and* the key that set it.

### Two deviations from the plan, both deliberate

**1. `OpenTelemetry.Instrumentation.Process` is omitted.** The plan lists it, but it has **no stable release — 0 of its 26 published versions**, from `0.1.0-alpha.1` through today's `1.17.0-rc.1`. Every other OTel package here is a stable `1.17.0`.

`Endatix.Hosting` is a published package, so a `PackageReference` to a prerelease becomes a transitive dependency for every consumer including self-hosters — many of whom have NuGet policies that reject prereleases outright.

Nothing in the plan's acceptance criteria depends on it: **AC1 names `process_runtime_dotnet_*`, which is the `Runtime` package's namespace**, not this one's. Process instrumentation would have added `process.cpu.time` / `process.memory.usage`, which cAdvisor and node-exporter already report in the cluster. One line in two files once it ships stable.

**2. Registration is deferred to `Build()`**, which `FinalizeConfiguration()` calls; `UseDefaults()` and `WithOtlpExporter()` only record intent. The plan describes eager registration, but its own public-API example calls `DisableInstrumentation(...)` *after* `UseDefaults()` — which cannot take effect if registration already happened. Deferring makes call order irrelevant. `Build()` is idempotent (`FinalizeConfiguration()` calls it, and a consumer may too); both properties are tested.

### Bug fixed along the way

`IsAspireServiceDefaultsPresent()` matched **any** registered service whose type name contained `"OpenTelemetry"`, and `UseDefaults()` uses it to skip the Endatix `self` health check. Registering our own SDK would therefore have silently disabled that check — the AC7 regression, latent until now. The probe looks only for `ServiceDiscovery`, which Aspire's ServiceDefaults always adds and the OTel SDK never does.

An existing test encoded the old behaviour by registering a type named `OpenTelemetryMarker` and asserting `self` disappears. It now uses a `ServiceDiscoveryMarker`, and the inverse case has its own test.

## Related Issues

Refs #476

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Verification

Full unit suite, run in a `mcr.microsoft.com/dotnet/sdk:10.0` container — **3,238 passed, 0 failed**:

| Project | Passed |
|---|---|
| `Endatix.Core.Tests` | 1025 |
| `Endatix.Api.Tests` | 645 |
| `Endatix.Infrastructure.Tests` | 1123 |
| `Endatix.Modules.Reporting.Tests` | 395 (1 skipped) |
| `Endatix.Hosting.Tests` | 50 |

Acceptance criteria covered by tests: **AC2** (env wins over config, both directions), **AC6** (zero OTel services when unconfigured), **AC7** (self check survives our own SDK), **AC8** (bad endpoint, bad protocol, out-of-range sampling ratio).

**Not covered, and not claimed: AC1 and AC5.** Both need a live collector to assert a metric actually arrives in Prometheus and that probes produce no spans. Those land with the Aspire Dashboard in PR-T4, together with the `MetricReader` integration test for `http.server.request.duration`. What is proven here is unit-level: the builder registers the right things and refuses the wrong ones.

## Notes for the reviewer

- **The protocol validation placement is load-bearing.** It resolves in `Build()` rather than inside `AddOtlpExporter(options => ...)`, because that callback is a deferred named-options action — validating there runs long after startup, if ever. My first cut did exactly that and a host with a typo'd `OTEL_EXPORTER_OTLP_PROTOCOL` would have started clean and silently exported nothing. The test caught it because it asserts on message content, not merely that something throws.
- **Nothing changes for existing deployments** until an OTLP endpoint is configured. `appsettings.json` is untouched by design — every `Endatix:Telemetry` key is an optional fallback, and shipping an empty block would imply otherwise.
- The `CS1658` warnings in `Endatix.Infrastructure/Data` are pre-existing and untouched by this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added built-in telemetry configuration for tracing, metrics, exporters, sampling, and resource attributes.
  * Added configurable ASP.NET Core, HTTP client, and runtime instrumentation with trace exclusions.
  * Added telemetry setup logging for successful and skipped configurations.

* **Bug Fixes**
  * Improved health check detection to prevent telemetry setup from affecting self-check registration.
  * Added validation for invalid endpoints, protocols, and sampling values.

* **Tests**
  * Expanded coverage for telemetry configuration, validation, environment settings, and health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->