### PR TITLE
feat(e941): Add locale add/remove/set-default support to Data List management APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,8 @@ Clean Architecture + vertical slices in `oss/`. Architecture/testing rules of re
 
 | Layer | Project | Folder | Reference |
 | --- | --- | --- | --- |
-| FastEndpoints | `Endatix.Api.Tests` | `Endpoints/{Feature}/` | `Forms/DeleteTests.cs`, `DataLists/AddLocaleTests.cs` |
-| Handlers / commands | `Endatix.Core.Tests` | `UseCases/{Feature}/{Action}/` | `Forms/Delete/DeleteFormHandlerTests.cs`, `DataLists/Locales/AddDataListLocale*Tests.cs` |
+| FastEndpoints | `Endatix.Api.Tests` | `Endpoints/{Feature}/` | `Forms/DeleteTests.cs`, `DataLists/*LocaleTests.cs` |
+| Handlers / commands | `Endatix.Core.Tests` | `UseCases/{Feature}/{Action}/` | `Forms/Delete/DeleteFormHandlerTests.cs`, `DataLists/Locales/*Locale*Tests.cs` |
 | Domain | `Endatix.Core.Tests` | `Entities/` | `DataListLocaleCatalogTests.cs` |
 | Infrastructure | `Endatix.Infrastructure.Tests` | Mirror source | `Data/Querying/...` |
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,43 +1,53 @@
-# Endatix OSS - Agent Instructions
+# Endatix API (OSS) — Agent Instructions
 
-## 1. Architecture stance
+Clean Architecture + vertical slices in `oss/`. Architecture/testing rules of record: [`.cursor/rules/endatix-api-rules.mdc`](../.cursor/rules/endatix-api-rules.mdc). Integration suite ops: [`tests/README.md`](tests/README.md).
 
-Use practical Vertical Slices inside Clean Architecture.
+## Unit vs integration
 
-* Keep the project boundaries: `Endatix.Api`, `Endatix.Core`, `Endatix.Infrastructure`.
-* Inside each project, organize by **feature first**, not by technical bucket first.
-* Prefer cohesive slice paths, for example:
-  * `Endatix.Api/Endpoints/Access/...`
-  * `Endatix.Core/Authorization/Access/...`
-  * `Endatix.Infrastructure/Features/AccessControl/...`
+**Do not duplicate the full decision tree here.** Use:
 
+| Need | Doc |
+| --- | --- |
+| When unit vs integration, naming (`UnitOfWork_Scenario_ExpectedBehavior`), AAA | [endatix-api-rules.mdc → Testing](../.cursor/rules/endatix-api-rules.mdc) |
+| Testcontainers, Respawn, traits (`Category` / `Priority` / `DbSpecific`), how to run | [`tests/README.md`](tests/README.md) |
 
-* **Commands/Writes:** enforce invariants through Core use cases/domain.
-* **Queries/Reads:** for single-slice read models, API endpoints may depend directly on Infrastructure query services.
-* Use MediatR where it adds real value (cross-slice orchestration, reusable flows), not as mandatory ceremony.
+**Short rule of thumb**
 
-## 3. Anti-fake-abstraction rules
+* **Unit** — domain, handlers, validators, mappers, endpoint `ExecuteAsync` mapping; mocks/substitutes only.
+* **Integration** — HTTP + auth + EF + real DB (`WebApplicationFactory` / Testcontainers). Prefer `CriticalPaths/` · `FeatureFlows/` · `Infrastructure/`.
 
-Avoid creating abstractions that exist only to satisfy layering.
+## Unit test placement (OSS)
 
-* Do not introduce Core interfaces for a read-only path with a single implementation and single consumer.
-* Keep query contracts in Infrastructure feature folders when the concern is implementation-centric read composition.
-* Move contracts to Core only when they represent stable domain policy or need multiple implementations/reuse.
+| Layer | Project | Folder | Reference |
+| --- | --- | --- | --- |
+| FastEndpoints | `Endatix.Api.Tests` | `Endpoints/{Feature}/` | `Forms/DeleteTests.cs`, `DataLists/AddLocaleTests.cs` |
+| Handlers / commands | `Endatix.Core.Tests` | `UseCases/{Feature}/{Action}/` | `Forms/Delete/DeleteFormHandlerTests.cs`, `DataLists/Locales/AddDataListLocale*Tests.cs` |
+| Domain | `Endatix.Core.Tests` | `Entities/` | `DataListLocaleCatalogTests.cs` |
+| Infrastructure | `Endatix.Infrastructure.Tests` | Mirror source | `Data/Querying/...` |
 
-## 4. Access feature conventions
+* **Class:** `{Sut}Tests`. **Methods:** `Method_State_ExpectedBehavior`.
+* Always `// Arrange` · `// Act` · `// Assert`.
 
-* Treat Access as its own feature umbrella for now.
-* Keep shared access types under `Core/Authorization/Access`:
-  * contexts
-  * access data DTOs
-  * permission/resource constants
-* Keep read execution under `Infrastructure/Features/AccessControl`:
-  * queries
-  * policies
-  * mapping/caching orchestration
+### FastEndpoints (`Endatix.Api.Tests`)
 
-## 5. Naming and testing
+Pattern: substitute `IMediator` → `Factory.Create<TEndpoint>(_mediator)` → assert `response.Result`.
 
-* Endpoint, validator, and test names must describe the exact access mode (`Public`, `Management`, etc.).
-* Follow AAA in tests with explicit `Arrange`, `Act`, `Assert` sections.
-* Prefer integration tests for endpoint behavior and focused unit tests for access policy/query logic.
+Minimum cases: invalid → 400 · not found → 404 (if applicable) · success payload · request→command via `Received`/`Arg.Is`. Skip FluentValidation re-tests unless validation is the SUT.
+
+### Handlers (`Endatix.Core.Tests`)
+
+Substitute `IRepository<T>` (+ `IMediator` if publishing). Cover: not found · happy path + persist · domain `Invalid` (no persist) · event reason/payload. Prefer real aggregates. Thin command-ctor tests when `Guard.Against.*` matters.
+
+## Run (examples)
+
+```bash
+# From oss/
+dotnet test tests/Endatix.Api.Tests/Endatix.Api.Tests.csproj --filter "FullyQualifiedName~AddLocaleTests"
+dotnet test tests/Endatix.Core.Tests/Endatix.Core.Tests.csproj --filter "FullyQualifiedName~AddDataListLocale"
+# Integration: see tests/README.md
+```
+
+## Related
+
+* SaaS / Hub agent rules: [`../.cursor/AGENTS.md`](../.cursor/AGENTS.md)
+* Integration contributor notes: `tests/Endatix.IntegrationTests/AGENTS.md` (linked from `tests/README.md`)

--- a/src/Endatix.Api/Endpoints/DataLists/AddLocale.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/AddLocale.cs
@@ -1,0 +1,98 @@
+using Endatix.Api.Infrastructure;
+using Endatix.Core.Abstractions.Authorization;
+using Endatix.Core.UseCases.DataLists.Locales;
+using FastEndpoints;
+using FluentValidation;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Endatix.Api.Endpoints.DataLists;
+
+/// <summary>
+/// Adds a locale to a data list catalog.
+/// </summary>
+public sealed class AddLocale(IMediator mediator)
+    : Endpoint<AddDataListLocaleRequest, Results<Ok<DataListDetailsModel>, ProblemHttpResult>>
+{
+    /// <summary>
+    /// Configures the endpoint settings.
+    /// </summary>
+    public override void Configure()
+    {
+        Post("data-lists/{dataListId}/locales");
+        Permissions(Actions.Forms.Edit);
+        Summary(s =>
+        {
+            s.Summary = "Add a data list locale";
+            s.Description = "Adds a locale code to the data list AvailableLocales catalog.";
+            s.ExampleRequest = new AddDataListLocaleRequest
+            {
+                DataListId = 1,
+                Locale = "es"
+            };
+            s.ResponseExamples[200] = new DataListDetailsModel
+            {
+                Id = 1,
+                Name = "Cities",
+                IsActive = true,
+                CreatedAt = DateTime.UtcNow,
+                ItemsCount = 0,
+                DefaultLocale = "en",
+                AvailableLocales = ["es"],
+                Items = []
+            };
+            s.Responses[200] = "Locale added successfully.";
+            s.Responses[400] = "Invalid input data.";
+            s.Responses[404] = "Data list not found.";
+        });
+        Description(builder => builder
+            .Produces<DataListDetailsModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
+    }
+
+    /// <inheritdoc />
+    public override async Task<Results<Ok<DataListDetailsModel>, ProblemHttpResult>> ExecuteAsync(
+        AddDataListLocaleRequest request,
+        CancellationToken ct)
+    {
+        AddDataListLocaleCommand command = new(request.DataListId, request.Locale!);
+        var result = await mediator.Send(command, ct);
+        
+        return TypedResultsBuilder
+            .MapResult(result, DataListMapper.MapDetails)
+            .SetTypedResults<Ok<DataListDetailsModel>, ProblemHttpResult>();
+    }
+}
+
+/// <summary>
+/// Validator for the AddDataListLocaleRequest.
+/// </summary>
+public sealed class AddDataListLocaleValidator : Validator<AddDataListLocaleRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AddDataListLocaleValidator"/> class.
+    /// </summary>
+    public AddDataListLocaleValidator()
+    {
+        RuleFor(x => x.DataListId).GreaterThan(0);
+        RuleFor(x => x.Locale).NotEmpty().MaximumLength(16);
+    }
+}
+
+/// <summary>
+/// Request to add a locale to a data list catalog.
+/// </summary>
+public sealed class AddDataListLocaleRequest
+{
+    /// <summary>
+    /// The ID of the data list.
+    /// </summary>
+    public long DataListId { get; init; }
+
+    /// <summary>
+    /// Locale code to add (for example <c>es</c> or <c>en-US</c>).
+    /// </summary>
+    public string? Locale { get; init; }
+}

--- a/src/Endatix.Api/Endpoints/DataLists/Create.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/Create.cs
@@ -6,6 +6,7 @@ using Endatix.Infrastructure.Data.Config;
 using FastEndpoints;
 using FluentValidation;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.DataLists;
@@ -17,18 +18,40 @@ public sealed class Create(
     IMediator mediator)
     : Endpoint<CreateDataListRequest, Results<Created<DataListDetailsModel>, ProblemHttpResult>>
 {
-    /// <inheritdoc />
+    /// <summary>
+    /// Configures the endpoint settings.
+    /// </summary>
     public override void Configure()
     {
         Post("data-lists");
         Permissions(Actions.Forms.Create);
         Summary(s =>
         {
-            s.Summary = "Create data list";
-            s.Description = "Creates a data list for current tenant.";
-            s.Responses[201] = "Data list created.";
-            s.Responses[400] = "Validation failed.";
+            s.Summary = "Create a data list";
+            s.Description = "Creates a data list for the current tenant.";
+            s.ExampleRequest = new CreateDataListRequest
+            {
+                Name = "Cities",
+                Description = "Major cities used in forms"
+            };
+            s.ResponseExamples[201] = new DataListDetailsModel
+            {
+                Id = 1,
+                Name = "Cities",
+                Description = "Major cities used in forms",
+                IsActive = true,
+                CreatedAt = DateTime.UtcNow,
+                ItemsCount = 0,
+                DefaultLocale = "en",
+                AvailableLocales = [],
+                Items = []
+            };
+            s.Responses[201] = "Data list created successfully.";
+            s.Responses[400] = "Invalid input data.";
         });
+        Description(builder => builder
+            .Produces<DataListDetailsModel>(StatusCodes.Status201Created, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc />

--- a/src/Endatix.Api/Endpoints/DataLists/DataListModel.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/DataListModel.cs
@@ -45,7 +45,7 @@ public class DataListModel
     public string DefaultLocale { get; init; } = "en";
 
     /// <summary>
-    /// Added cultures for this list (culture catalog).
+    /// Added locales for this list (catalog; excludes the synthetic <c>default</c> key).
     /// </summary>
     public IReadOnlyList<string> AvailableLocales { get; init; } = [];
 }

--- a/src/Endatix.Api/Endpoints/DataLists/Delete.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/Delete.cs
@@ -4,6 +4,7 @@ using Endatix.Core.UseCases.DataLists.Delete;
 using FastEndpoints;
 using FluentValidation;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.DataLists;
@@ -15,7 +16,9 @@ public sealed class Delete(
     IMediator mediator)
     : Endpoint<DeleteDataListRequest, Results<Ok<string>, ProblemHttpResult>>
 {
-    /// <inheritdoc />
+    /// <summary>
+    /// Configures the endpoint settings.
+    /// </summary>
     public override void Configure()
     {
         Delete("data-lists/{dataListId}");
@@ -24,10 +27,16 @@ public sealed class Delete(
         {
             s.Summary = "Delete a data list";
             s.Description = "Deletes a data list by its ID.";
+            s.ExampleRequest = new DeleteDataListRequest { DataListId = 1 };
+            s.ResponseExamples[200] = "1";
             s.Responses[200] = "Data list deleted successfully.";
-            s.Responses[400] = "Invalid request or access data.";
+            s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Data list not found.";
         });
+        Description(builder => builder
+            .Produces<string>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc />
@@ -67,4 +76,3 @@ public sealed class DeleteDataListRequest
     /// </summary>
     public long DataListId { get; init; }
 }
-

--- a/src/Endatix.Api/Endpoints/DataLists/GetById.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/GetById.cs
@@ -4,6 +4,7 @@ using Endatix.Core.UseCases.DataLists.GetById;
 using FastEndpoints;
 using FluentValidation;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.DataLists;
@@ -16,7 +17,9 @@ public sealed class GetById(
     )
     : Endpoint<GetDataListRequest, Results<Ok<DataListDetailsModel>, ProblemHttpResult>>
 {
-    /// <inheritdoc />
+    /// <summary>
+    /// Configures the endpoint settings.
+    /// </summary>
     public override void Configure()
     {
         Get("data-lists/{dataListId}");
@@ -24,11 +27,41 @@ public sealed class GetById(
         Summary(s =>
         {
             s.Summary = "Get a data list by ID";
-            s.Description = "Gets a data list by its ID.";
+            s.Description = "Gets a data list by its ID, including catalog locales and items.";
+            s.ExampleRequest = new GetDataListRequest { DataListId = 1 };
+            s.ResponseExamples[200] = new DataListDetailsModel
+            {
+                Id = 1,
+                Name = "Cities",
+                Description = "Major cities used in forms",
+                IsActive = true,
+                CreatedAt = DateTime.UtcNow,
+                ItemsCount = 1,
+                DefaultLocale = "en",
+                AvailableLocales = ["es"],
+                Items =
+                [
+                    new DataListItemModel
+                    {
+                        Id = 10,
+                        Labels = new Dictionary<string, string>(StringComparer.Ordinal)
+                        {
+                            ["default"] = "New York",
+                            ["es"] = "Nueva York"
+                        },
+                        Label = "New York",
+                        Value = "NYC"
+                    }
+                ]
+            };
             s.Responses[200] = "Data list retrieved successfully.";
-            s.Responses[400] = "Invalid request or access data.";
+            s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Data list not found.";
         });
+        Description(builder => builder
+            .Produces<DataListDetailsModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc />

--- a/src/Endatix.Api/Endpoints/DataLists/List.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/List.cs
@@ -17,7 +17,9 @@ public sealed class List(
     IMediator mediator)
     : Endpoint<DataListsListRequest, Results<Ok<Paged<DataListModel>>, ProblemHttpResult>>
 {
-    /// <inheritdoc />
+    /// <summary>
+    /// Configures the endpoint settings.
+    /// </summary>
     public override void Configure()
     {
         Get("data-lists");
@@ -25,17 +27,41 @@ public sealed class List(
         Summary(s =>
         {
             s.Summary = "List data lists";
-            s.Description = "Lists the data lists for the current tenant.";
-            s.Responses[200] = "Data lists listed successfully.";
-            s.Responses[400] = "Invalid request or access data.";
+            s.Description = "Lists data lists for the current tenant with paging and an optional locale filter.";
+            s.ExampleRequest = new DataListsListRequest
+            {
+                Page = 1,
+                PageSize = 20,
+                HasLocale = "es"
+            };
+            s.ResponseExamples[200] = new Paged<DataListModel>(
+                page: 1,
+                pageSize: 20,
+                totalRecords: 1,
+                totalPages: 1,
+                items:
+                [
+                    new DataListModel
+                    {
+                        Id = 1,
+                        Name = "Cities",
+                        Description = "Major cities used in forms",
+                        IsActive = true,
+                        CreatedAt = DateTime.UtcNow,
+                        ItemsCount = 2,
+                        DefaultLocale = "en",
+                        AvailableLocales = ["es"]
+                    }
+                ]);
+            s.Responses[200] = "Data lists retrieved successfully.";
+            s.Responses[400] = "Invalid input data.";
         });
+        Description(builder => builder
+            .Produces<Paged<DataListModel>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
-    /// <summary>
-    /// Executes the endpoint.
-    /// </summary>
-    /// <param name="request">The request.</param>
-    /// <param name="ct">The cancellation token.</param>
-    /// <returns>The result.</returns>
+
+    /// <inheritdoc />
     public override async Task<Results<Ok<Paged<DataListModel>>, ProblemHttpResult>> ExecuteAsync(DataListsListRequest request, CancellationToken ct)
     {
         var result = await mediator.Send(new ListDataListsQuery(request.Page, request.PageSize, request.HasLocale), ct);
@@ -77,8 +103,7 @@ public sealed class DataListsListRequest : IPagedRequest
     public int? PageSize { get; set; }
 
     /// <summary>
-    /// Optional culture code; returns only lists whose AvailableLocales contain this code.
+    /// Optional locale code; returns only lists whose AvailableLocales contain this code.
     /// </summary>
     public string? HasLocale { get; set; }
 }
-

--- a/src/Endatix.Api/Endpoints/DataLists/ListFormDependencies.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/ListFormDependencies.cs
@@ -5,6 +5,7 @@ using Endatix.Core.UseCases.DataLists.ListFormDependencies;
 using FastEndpoints;
 using FluentValidation;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.DataLists;
@@ -16,7 +17,9 @@ public sealed class ListFormDependencies(
     IMediator mediator)
     : Endpoint<ListFormDependenciesRequest, Results<Ok<IEnumerable<FormModel>>, ProblemHttpResult>>
 {
-    /// <inheritdoc />
+    /// <summary>
+    /// Configures the endpoint settings.
+    /// </summary>
     public override void Configure()
     {
         Get("data-lists/{dataListId}/forms");
@@ -24,11 +27,27 @@ public sealed class ListFormDependencies(
         Summary(s =>
         {
             s.Summary = "List form dependencies for a data list";
-            s.Description = "Lists the form dependencies for a data list.";
+            s.Description = "Lists forms that depend on the specified data list.";
+            s.ExampleRequest = new ListFormDependenciesRequest { DataListId = 1 };
+            s.ResponseExamples[200] = new[]
+            {
+                new FormModel
+                {
+                    Id = "42",
+                    Name = "Customer satisfaction",
+                    IsEnabled = true,
+                    IsPublic = false,
+                    SubmissionsCount = 4
+                }
+            };
             s.Responses[200] = "Form dependencies listed successfully.";
-            s.Responses[400] = "Invalid request or access data.";
+            s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Data list not found.";
         });
+        Description(builder => builder
+            .Produces<IEnumerable<FormModel>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc />
@@ -38,7 +57,7 @@ public sealed class ListFormDependencies(
     {
         ListFormDependenciesQuery query = new(request.DataListId);
         var result = await mediator.Send(query, ct);
-        
+
         return TypedResultsBuilder
             .MapResult(result, forms => forms.ToFormModelList())
             .SetTypedResults<Ok<IEnumerable<FormModel>>, ProblemHttpResult>();

--- a/src/Endatix.Api/Endpoints/DataLists/RemoveLocale.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/RemoveLocale.cs
@@ -1,0 +1,98 @@
+using Endatix.Api.Infrastructure;
+using Endatix.Core.Abstractions.Authorization;
+using Endatix.Core.UseCases.DataLists.Locales;
+using FastEndpoints;
+using FluentValidation;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Endatix.Api.Endpoints.DataLists;
+
+/// <summary>
+/// Removes a locale from a data list catalog.
+/// </summary>
+public sealed class RemoveLocale(IMediator mediator)
+    : Endpoint<RemoveDataListLocaleRequest, Results<Ok<DataListDetailsModel>, ProblemHttpResult>>
+{
+    /// <summary>
+    /// Configures the endpoint settings.
+    /// </summary>
+    public override void Configure()
+    {
+        Delete("data-lists/{dataListId}/locales/{locale}");
+        Permissions(Actions.Forms.Edit);
+        Summary(s =>
+        {
+            s.Summary = "Remove a data list locale";
+            s.Description = "Removes a locale from AvailableLocales and strips that key from all item Labels.";
+            s.ExampleRequest = new RemoveDataListLocaleRequest
+            {
+                DataListId = 1,
+                Locale = "es"
+            };
+            s.ResponseExamples[200] = new DataListDetailsModel
+            {
+                Id = 1,
+                Name = "Cities",
+                IsActive = true,
+                CreatedAt = DateTime.UtcNow,
+                ItemsCount = 0,
+                DefaultLocale = "en",
+                AvailableLocales = [],
+                Items = []
+            };
+            s.Responses[200] = "Locale removed successfully.";
+            s.Responses[400] = "Invalid input data.";
+            s.Responses[404] = "Data list not found.";
+        });
+        Description(builder => builder
+            .Produces<DataListDetailsModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
+    }
+
+    /// <inheritdoc />
+    public override async Task<Results<Ok<DataListDetailsModel>, ProblemHttpResult>> ExecuteAsync(
+        RemoveDataListLocaleRequest request,
+        CancellationToken ct)
+    {
+        RemoveDataListLocaleCommand command = new(request.DataListId, request.Locale!);
+        var result = await mediator.Send(command, ct);
+
+        return TypedResultsBuilder
+            .MapResult(result, DataListMapper.MapDetails)
+            .SetTypedResults<Ok<DataListDetailsModel>, ProblemHttpResult>();
+    }
+}
+
+/// <summary>
+/// Validator for the RemoveDataListLocaleRequest.
+/// </summary>
+public sealed class RemoveDataListLocaleValidator : Validator<RemoveDataListLocaleRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RemoveDataListLocaleValidator"/> class.
+    /// </summary>
+    public RemoveDataListLocaleValidator()
+    {
+        RuleFor(x => x.DataListId).GreaterThan(0);
+        RuleFor(x => x.Locale).NotEmpty().MaximumLength(16);
+    }
+}
+
+/// <summary>
+/// Request to remove a locale from a data list catalog.
+/// </summary>
+public sealed class RemoveDataListLocaleRequest
+{
+    /// <summary>
+    /// The ID of the data list.
+    /// </summary>
+    public long DataListId { get; init; }
+
+    /// <summary>
+    /// Locale code to remove.
+    /// </summary>
+    public string? Locale { get; init; }
+}

--- a/src/Endatix.Api/Endpoints/DataLists/ReplaceItems.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/ReplaceItems.cs
@@ -6,6 +6,7 @@ using Endatix.Infrastructure.Data.Config;
 using FastEndpoints;
 using FluentValidation;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.DataLists;
@@ -17,7 +18,9 @@ public sealed class ReplaceItems(
     IMediator mediator)
     : Endpoint<ReplaceDataListItemsRequest, Results<Ok<DataListDetailsModel>, ProblemHttpResult>>
 {
-    /// <inheritdoc />
+    /// <summary>
+    /// Configures the endpoint settings.
+    /// </summary>
     public override void Configure()
     {
         Put("data-lists/{dataListId}/items");
@@ -25,11 +28,70 @@ public sealed class ReplaceItems(
         Summary(s =>
         {
             s.Summary = "Replace items in a data list";
-            s.Description = "Replaces the items in a data list. Prefer Labels maps; Label is accepted as shorthand for { default: Label }.";
+            s.Description = "Replaces all items in a data list. Prefer Labels maps; Label is accepted as shorthand for { default: Label }.";
+            s.ExampleRequest = new ReplaceDataListItemsRequest
+            {
+                DataListId = 1,
+                Items =
+                [
+                    new ReplaceDataListItemRequest
+                    {
+                        Labels = new Dictionary<string, string>(StringComparer.Ordinal)
+                        {
+                            ["default"] = "New York",
+                            ["es"] = "Nueva York"
+                        },
+                        Value = "NYC"
+                    },
+                    new ReplaceDataListItemRequest
+                    {
+                        Label = "Los Angeles",
+                        Value = "LA"
+                    }
+                ]
+            };
+            s.ResponseExamples[200] = new DataListDetailsModel
+            {
+                Id = 1,
+                Name = "Cities",
+                IsActive = true,
+                CreatedAt = DateTime.UtcNow,
+                ItemsCount = 2,
+                DefaultLocale = "en",
+                AvailableLocales = ["es"],
+                Items =
+                [
+                    new DataListItemModel
+                    {
+                        Id = 10,
+                        Labels = new Dictionary<string, string>(StringComparer.Ordinal)
+                        {
+                            ["default"] = "New York",
+                            ["es"] = "Nueva York"
+                        },
+                        Label = "New York",
+                        Value = "NYC"
+                    },
+                    new DataListItemModel
+                    {
+                        Id = 11,
+                        Labels = new Dictionary<string, string>(StringComparer.Ordinal)
+                        {
+                            ["default"] = "Los Angeles"
+                        },
+                        Label = "Los Angeles",
+                        Value = "LA"
+                    }
+                ]
+            };
             s.Responses[200] = "Items replaced successfully.";
-            s.Responses[400] = "Invalid request or access data.";
+            s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Data list not found.";
         });
+        Description(builder => builder
+            .Produces<DataListDetailsModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc />

--- a/src/Endatix.Api/Endpoints/DataLists/SetDefaultLocale.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/SetDefaultLocale.cs
@@ -1,0 +1,98 @@
+using Endatix.Api.Infrastructure;
+using Endatix.Core.Abstractions.Authorization;
+using Endatix.Core.UseCases.DataLists.Locales;
+using FastEndpoints;
+using FluentValidation;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Endatix.Api.Endpoints.DataLists;
+
+/// <summary>
+/// Sets the default locale for a data list.
+/// </summary>
+public sealed class SetDefaultLocale(IMediator mediator)
+    : Endpoint<SetDataListDefaultLocaleRequest, Results<Ok<DataListDetailsModel>, ProblemHttpResult>>
+{
+    /// <summary>
+    /// Configures the endpoint settings.
+    /// </summary>
+    public override void Configure()
+    {
+        Put("data-lists/{dataListId}/default-locale");
+        Permissions(Actions.Forms.Edit);
+        Summary(s =>
+        {
+            s.Summary = "Set the data list default locale";
+            s.Description = "Sets which real locale the SurveyJS default label key represents.";
+            s.ExampleRequest = new SetDataListDefaultLocaleRequest
+            {
+                DataListId = 1,
+                DefaultLocale = "en"
+            };
+            s.ResponseExamples[200] = new DataListDetailsModel
+            {
+                Id = 1,
+                Name = "Cities",
+                IsActive = true,
+                CreatedAt = DateTime.UtcNow,
+                ItemsCount = 0,
+                DefaultLocale = "en",
+                AvailableLocales = ["es"],
+                Items = []
+            };
+            s.Responses[200] = "Default locale updated successfully.";
+            s.Responses[400] = "Invalid input data.";
+            s.Responses[404] = "Data list not found.";
+        });
+        Description(builder => builder
+            .Produces<DataListDetailsModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
+    }
+
+    /// <inheritdoc />
+    public override async Task<Results<Ok<DataListDetailsModel>, ProblemHttpResult>> ExecuteAsync(
+        SetDataListDefaultLocaleRequest request,
+        CancellationToken ct)
+    {
+        SetDataListDefaultLocaleCommand command = new(request.DataListId, request.DefaultLocale!);
+        var result = await mediator.Send(command, ct);
+
+        return TypedResultsBuilder
+            .MapResult(result, DataListMapper.MapDetails)
+            .SetTypedResults<Ok<DataListDetailsModel>, ProblemHttpResult>();
+    }
+}
+
+/// <summary>
+/// Validator for the SetDataListDefaultLocaleRequest.
+/// </summary>
+public sealed class SetDataListDefaultLocaleValidator : Validator<SetDataListDefaultLocaleRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SetDataListDefaultLocaleValidator"/> class.
+    /// </summary>
+    public SetDataListDefaultLocaleValidator()
+    {
+        RuleFor(x => x.DataListId).GreaterThan(0);
+        RuleFor(x => x.DefaultLocale).NotEmpty().MaximumLength(16);
+    }
+}
+
+/// <summary>
+/// Request to set the default locale for a data list.
+/// </summary>
+public sealed class SetDataListDefaultLocaleRequest
+{
+    /// <summary>
+    /// The ID of the data list.
+    /// </summary>
+    public long DataListId { get; init; }
+
+    /// <summary>
+    /// Real locale represented by the SurveyJS <c>default</c> label key (for example <c>en</c>).
+    /// </summary>
+    public string? DefaultLocale { get; init; }
+}

--- a/src/Endatix.Core/Entities/DataList.cs
+++ b/src/Endatix.Core/Entities/DataList.cs
@@ -111,6 +111,8 @@ public class DataList : TenantEntity, IAggregateRoot, IHasTranslations
     }
 
     /// <inheritdoc />
+    /// <exception cref="ArgumentException">Thrown when the culture code is the synthetic 'default' key.</exception>
+    /// <exception cref="InvalidOperationException">Thrown when the data list has more than the maximum allowed cultures.</exception>
     public void AddCulture(string cultureCode)
     {
         var normalized = TranslationCultureNormalizer.Normalize(cultureCode);

--- a/src/Endatix.Core/Entities/DataList.cs
+++ b/src/Endatix.Core/Entities/DataList.cs
@@ -97,6 +97,7 @@ public class DataList : TenantEntity, IAggregateRoot, IHasTranslations
     }
 
     /// <inheritdoc />
+    /// <exception cref="ArgumentException">Thrown when the culture code is the synthetic 'default' key.</exception>
     public void SetDefaultCulture(string cultureCode)
     {
         var normalized = TranslationCultureNormalizer.Normalize(cultureCode);

--- a/src/Endatix.Core/UseCases/DataLists/List/ListDataListsQuery.cs
+++ b/src/Endatix.Core/UseCases/DataLists/List/ListDataListsQuery.cs
@@ -8,6 +8,6 @@ namespace Endatix.Core.UseCases.DataLists.List;
 /// </summary>
 /// <param name="Page">The page number for pagination.</param>
 /// <param name="PageSize">The number of items per page for pagination.</param>
-/// <param name="HasLocale">Optional culture code; filters parent rows whose AvailableLocales contain this code.</param>
+/// <param name="HasLocale">Optional locale code; filters parent rows whose AvailableLocales contain this code.</param>
 public sealed record ListDataListsQuery(int? Page, int? PageSize, string? HasLocale = null)
     : IQuery<Result<Paged<DataListDto>>>;

--- a/src/Endatix.Core/UseCases/DataLists/Locales/AddDataListLocaleCommand.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Locales/AddDataListLocaleCommand.cs
@@ -1,0 +1,23 @@
+using Ardalis.GuardClauses;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.DataLists.Locales;
+
+/// <summary>
+/// Adds a culture to a data list catalog.
+/// </summary>
+public sealed record AddDataListLocaleCommand : ICommand<Result<DataListDto>>
+{
+    public long DataListId { get; }
+    public string Locale { get; }
+
+    public AddDataListLocaleCommand(long dataListId, string locale)
+    {
+        Guard.Against.NegativeOrZero(dataListId);
+        Guard.Against.NullOrWhiteSpace(locale);
+        
+        DataListId = dataListId;
+        Locale = locale;
+    }
+}

--- a/src/Endatix.Core/UseCases/DataLists/Locales/AddDataListLocaleHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Locales/AddDataListLocaleHandler.cs
@@ -1,0 +1,50 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Events;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
+using MediatR;
+
+namespace Endatix.Core.UseCases.DataLists.Locales;
+
+/// <summary>
+/// Handler for <see cref="AddDataListLocaleCommand"/>.
+/// </summary>
+public sealed class AddDataListLocaleHandler(
+    IRepository<DataList> repository,
+    IMediator mediator)
+    : ICommandHandler<AddDataListLocaleCommand, Result<DataListDto>>
+{
+    /// <inheritdoc />
+    public async Task<Result<DataListDto>> Handle(AddDataListLocaleCommand request, CancellationToken cancellationToken)
+    {
+        var spec = new DataListsSpecifications.ByIdWithItemsSpec(request.DataListId);
+        var dataList = await repository.SingleOrDefaultAsync(spec, cancellationToken);
+        if (dataList is null)
+        {
+            return Result.NotFound("Data list not found.");
+        }
+
+        try
+        {
+            dataList.AddCulture(request.Locale);
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            ValidationError error = new()
+            {
+                Identifier = nameof(request.Locale),
+                ErrorMessage = ex.Message
+            };
+            return Result.Invalid(error);
+        }
+
+        await repository.UpdateAsync(dataList, cancellationToken);
+        await mediator.Publish(
+            new DataListUpdatedEvent(dataList, DataListUpdateReasons.LocalesUpdated),
+            cancellationToken);
+
+        return Result.Success(DataListDtoMapper.FromEntity(dataList));
+    }
+}

--- a/src/Endatix.Core/UseCases/DataLists/Locales/RemoveDataListLocaleCommand.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Locales/RemoveDataListLocaleCommand.cs
@@ -1,0 +1,23 @@
+using Ardalis.GuardClauses;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.DataLists.Locales;
+
+/// <summary>
+/// Removes a culture from a data list catalog and strips that key from item labels.
+/// </summary>
+public sealed record RemoveDataListLocaleCommand : ICommand<Result<DataListDto>>
+{
+    public long DataListId { get; }
+    public string Locale { get; }
+
+    public RemoveDataListLocaleCommand(long dataListId, string locale)
+    {
+        Guard.Against.NegativeOrZero(dataListId);
+        Guard.Against.NullOrWhiteSpace(locale);
+
+        DataListId = dataListId;
+        Locale = locale;
+    }
+}

--- a/src/Endatix.Core/UseCases/DataLists/Locales/RemoveDataListLocaleCommand.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Locales/RemoveDataListLocaleCommand.cs
@@ -5,7 +5,7 @@ using Endatix.Core.Infrastructure.Result;
 namespace Endatix.Core.UseCases.DataLists.Locales;
 
 /// <summary>
-/// Removes a culture from a data list catalog and strips that key from item labels.
+/// Removes a locale from a data list catalog and strips that key from item labels.
 /// </summary>
 public sealed record RemoveDataListLocaleCommand : ICommand<Result<DataListDto>>
 {

--- a/src/Endatix.Core/UseCases/DataLists/Locales/RemoveDataListLocaleHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Locales/RemoveDataListLocaleHandler.cs
@@ -1,0 +1,50 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Events;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
+using MediatR;
+
+namespace Endatix.Core.UseCases.DataLists.Locales;
+
+/// <summary>
+/// Handler for <see cref="RemoveDataListLocaleCommand"/>.
+/// </summary>
+public sealed class RemoveDataListLocaleHandler(
+    IRepository<DataList> repository,
+    IMediator mediator)
+    : ICommandHandler<RemoveDataListLocaleCommand, Result<DataListDto>>
+{
+    /// <inheritdoc />
+    public async Task<Result<DataListDto>> Handle(RemoveDataListLocaleCommand request, CancellationToken cancellationToken)
+    {
+        var spec = new DataListsSpecifications.ByIdWithItemsSpec(request.DataListId);
+        var dataList = await repository.SingleOrDefaultAsync(spec, cancellationToken);
+        if (dataList is null)
+        {
+            return Result.NotFound("Data list not found.");
+        }
+
+        try
+        {
+            dataList.RemoveCulture(request.Locale);
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            ValidationError error = new()
+            {
+                Identifier = nameof(request.Locale),
+                ErrorMessage = ex.Message
+            };
+            return Result.Invalid(error);
+        }
+
+        await repository.UpdateAsync(dataList, cancellationToken);
+        await mediator.Publish(
+            new DataListUpdatedEvent(dataList, DataListUpdateReasons.LocalesUpdated),
+            cancellationToken);
+
+        return Result.Success(DataListDtoMapper.FromEntity(dataList));
+    }
+}

--- a/src/Endatix.Core/UseCases/DataLists/Locales/SetDataListDefaultLocaleCommand.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Locales/SetDataListDefaultLocaleCommand.cs
@@ -1,0 +1,23 @@
+using Ardalis.GuardClauses;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.DataLists.Locales;
+
+/// <summary>
+/// Sets the real locale represented by the SurveyJS <c>default</c> label key.
+/// </summary>
+public sealed record SetDataListDefaultLocaleCommand : ICommand<Result<DataListDto>>
+{
+    public long DataListId { get; }
+    public string DefaultLocale { get; }
+
+    public SetDataListDefaultLocaleCommand(long dataListId, string defaultLocale)
+    {
+        Guard.Against.NegativeOrZero(dataListId);
+        Guard.Against.NullOrWhiteSpace(defaultLocale);
+        
+        DataListId = dataListId;
+        DefaultLocale = defaultLocale;
+    }
+}

--- a/src/Endatix.Core/UseCases/DataLists/Locales/SetDataListDefaultLocaleHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Locales/SetDataListDefaultLocaleHandler.cs
@@ -1,0 +1,50 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Events;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
+using MediatR;
+
+namespace Endatix.Core.UseCases.DataLists.Locales;
+
+/// <summary>
+/// Handler for <see cref="SetDataListDefaultLocaleCommand"/>.
+/// </summary>
+public sealed class SetDataListDefaultLocaleHandler(
+    IRepository<DataList> repository,
+    IMediator mediator)
+    : ICommandHandler<SetDataListDefaultLocaleCommand, Result<DataListDto>>
+{
+    /// <inheritdoc />
+    public async Task<Result<DataListDto>> Handle(SetDataListDefaultLocaleCommand request, CancellationToken cancellationToken)
+    {
+        var spec = new DataListsSpecifications.ByIdWithItemsSpec(request.DataListId);
+        var dataList = await repository.SingleOrDefaultAsync(spec, cancellationToken);
+        if (dataList is null)
+        {
+            return Result.NotFound("Data list not found.");
+        }
+
+        try
+        {
+            dataList.SetDefaultCulture(request.DefaultLocale);
+        }
+        catch (ArgumentException ex)
+        {
+            ValidationError error = new()
+            {
+                Identifier = nameof(request.DefaultLocale),
+                ErrorMessage = ex.Message
+            };
+            return Result.Invalid(error);
+        }
+
+        await repository.UpdateAsync(dataList, cancellationToken);
+        await mediator.Publish(
+            new DataListUpdatedEvent(dataList, DataListUpdateReasons.LocalesUpdated),
+            cancellationToken);
+
+        return Result.Success(DataListDtoMapper.FromEntity(dataList));
+    }
+}

--- a/src/Endatix.Core/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsHandler.cs
@@ -119,7 +119,7 @@ public sealed class ReplaceDataListItemsHandler(
                 errors.Add(new()
                 {
                     Identifier = $"Items[{index}].Labels.{cultureKey}",
-                    ErrorMessage = $"Culture '{cultureKey}' is not in the data list culture catalog."
+                    ErrorMessage = $"Locale '{cultureKey}' is not in the data list AvailableLocales catalog."
                 });
             }
         }

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/AddLocaleTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/AddLocaleTests.cs
@@ -1,0 +1,106 @@
+using Endatix.Api.Endpoints.DataLists;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.DataLists;
+using Endatix.Core.UseCases.DataLists.Locales;
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Endatix.Api.Tests.Endpoints.DataLists;
+
+public class AddLocaleTests
+{
+    private readonly IMediator _mediator;
+    private readonly AddLocale _endpoint;
+
+    public AddLocaleTests()
+    {
+        _mediator = Substitute.For<IMediator>();
+        _endpoint = Factory.Create<AddLocale>(_mediator);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_InvalidRequest_ReturnsProblemDetails()
+    {
+        // Arrange
+        var request = new AddDataListLocaleRequest { DataListId = 1, Locale = "es" };
+        _mediator.Send(Arg.Any<AddDataListLocaleCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Invalid());
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DataListNotFound_ReturnsProblemDetails()
+    {
+        // Arrange
+        var request = new AddDataListLocaleRequest { DataListId = 1, Locale = "es" };
+        _mediator.Send(Arg.Any<AddDataListLocaleCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.NotFound("Data list not found."));
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ValidRequest_ReturnsOkWithDetails()
+    {
+        // Arrange
+        var request = new AddDataListLocaleRequest { DataListId = 1, Locale = "es" };
+        DataListDto dto = new(
+            1,
+            "Cities",
+            null,
+            DateTime.UtcNow,
+            null,
+            true,
+            0,
+            "en",
+            ["es"],
+            []);
+        _mediator.Send(Arg.Any<AddDataListLocaleCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(dto));
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        var okResult = response.Result as Ok<DataListDetailsModel>;
+        okResult.Should().NotBeNull();
+        okResult!.Value.Should().NotBeNull();
+        okResult.Value!.Id.Should().Be(1);
+        okResult.Value.AvailableLocales.Should().Equal("es");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldMapRequestToCommandCorrectly()
+    {
+        // Arrange
+        var request = new AddDataListLocaleRequest { DataListId = 123, Locale = "fr" };
+        DataListDto dto = new(123, "Cities", null, DateTime.UtcNow, null, true, 0, "en", ["fr"], []);
+        _mediator.Send(Arg.Any<AddDataListLocaleCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(dto));
+
+        // Act
+        await _endpoint.ExecuteAsync(request, CancellationToken.None);
+
+        // Assert
+        await _mediator.Received(1).Send(
+            Arg.Is<AddDataListLocaleCommand>(cmd =>
+                cmd.DataListId == request.DataListId
+                && cmd.Locale == request.Locale),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/RemoveLocaleTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/RemoveLocaleTests.cs
@@ -1,0 +1,106 @@
+using Endatix.Api.Endpoints.DataLists;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.DataLists;
+using Endatix.Core.UseCases.DataLists.Locales;
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Endatix.Api.Tests.Endpoints.DataLists;
+
+public class RemoveLocaleTests
+{
+    private readonly IMediator _mediator;
+    private readonly RemoveLocale _endpoint;
+
+    public RemoveLocaleTests()
+    {
+        _mediator = Substitute.For<IMediator>();
+        _endpoint = Factory.Create<RemoveLocale>(_mediator);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_InvalidRequest_ReturnsProblemDetails()
+    {
+        // Arrange
+        var request = new RemoveDataListLocaleRequest { DataListId = 1, Locale = "es" };
+        _mediator.Send(Arg.Any<RemoveDataListLocaleCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Invalid());
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DataListNotFound_ReturnsProblemDetails()
+    {
+        // Arrange
+        var request = new RemoveDataListLocaleRequest { DataListId = 1, Locale = "es" };
+        _mediator.Send(Arg.Any<RemoveDataListLocaleCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.NotFound("Data list not found."));
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ValidRequest_ReturnsOkWithDetails()
+    {
+        // Arrange
+        var request = new RemoveDataListLocaleRequest { DataListId = 1, Locale = "es" };
+        DataListDto dto = new(
+            1,
+            "Cities",
+            null,
+            DateTime.UtcNow,
+            null,
+            true,
+            0,
+            "en",
+            [],
+            []);
+        _mediator.Send(Arg.Any<RemoveDataListLocaleCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(dto));
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        var okResult = response.Result as Ok<DataListDetailsModel>;
+        okResult.Should().NotBeNull();
+        okResult!.Value.Should().NotBeNull();
+        okResult.Value!.Id.Should().Be(1);
+        okResult.Value.AvailableLocales.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldMapRequestToCommandCorrectly()
+    {
+        // Arrange
+        var request = new RemoveDataListLocaleRequest { DataListId = 123, Locale = "fr" };
+        DataListDto dto = new(123, "Cities", null, DateTime.UtcNow, null, true, 0, "en", [], []);
+        _mediator.Send(Arg.Any<RemoveDataListLocaleCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(dto));
+
+        // Act
+        await _endpoint.ExecuteAsync(request, CancellationToken.None);
+
+        // Assert
+        await _mediator.Received(1).Send(
+            Arg.Is<RemoveDataListLocaleCommand>(cmd =>
+                cmd.DataListId == request.DataListId
+                && cmd.Locale == request.Locale),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/SetDefaultLocaleTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/SetDefaultLocaleTests.cs
@@ -1,0 +1,106 @@
+using Endatix.Api.Endpoints.DataLists;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.DataLists;
+using Endatix.Core.UseCases.DataLists.Locales;
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Endatix.Api.Tests.Endpoints.DataLists;
+
+public class SetDefaultLocaleTests
+{
+    private readonly IMediator _mediator;
+    private readonly SetDefaultLocale _endpoint;
+
+    public SetDefaultLocaleTests()
+    {
+        _mediator = Substitute.For<IMediator>();
+        _endpoint = Factory.Create<SetDefaultLocale>(_mediator);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_InvalidRequest_ReturnsProblemDetails()
+    {
+        // Arrange
+        var request = new SetDataListDefaultLocaleRequest { DataListId = 1, DefaultLocale = "en" };
+        _mediator.Send(Arg.Any<SetDataListDefaultLocaleCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Invalid());
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DataListNotFound_ReturnsProblemDetails()
+    {
+        // Arrange
+        var request = new SetDataListDefaultLocaleRequest { DataListId = 1, DefaultLocale = "en" };
+        _mediator.Send(Arg.Any<SetDataListDefaultLocaleCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.NotFound("Data list not found."));
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ValidRequest_ReturnsOkWithDetails()
+    {
+        // Arrange
+        var request = new SetDataListDefaultLocaleRequest { DataListId = 1, DefaultLocale = "fr" };
+        DataListDto dto = new(
+            1,
+            "Cities",
+            null,
+            DateTime.UtcNow,
+            null,
+            true,
+            0,
+            "fr",
+            ["es"],
+            []);
+        _mediator.Send(Arg.Any<SetDataListDefaultLocaleCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(dto));
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        var okResult = response.Result as Ok<DataListDetailsModel>;
+        okResult.Should().NotBeNull();
+        okResult!.Value.Should().NotBeNull();
+        okResult.Value!.Id.Should().Be(1);
+        okResult.Value.DefaultLocale.Should().Be("fr");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldMapRequestToCommandCorrectly()
+    {
+        // Arrange
+        var request = new SetDataListDefaultLocaleRequest { DataListId = 123, DefaultLocale = "de" };
+        DataListDto dto = new(123, "Cities", null, DateTime.UtcNow, null, true, 0, "de", [], []);
+        _mediator.Send(Arg.Any<SetDataListDefaultLocaleCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(dto));
+
+        // Act
+        await _endpoint.ExecuteAsync(request, CancellationToken.None);
+
+        // Assert
+        await _mediator.Received(1).Send(
+            Arg.Is<SetDataListDefaultLocaleCommand>(cmd =>
+                cmd.DataListId == request.DataListId
+                && cmd.DefaultLocale == request.DefaultLocale),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/Locales/AddDataListLocaleCommandTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/Locales/AddDataListLocaleCommandTests.cs
@@ -1,0 +1,42 @@
+using Endatix.Core.UseCases.DataLists.Locales;
+
+namespace Endatix.Core.Tests.UseCases.DataLists.Locales;
+
+public class AddDataListLocaleCommandTests
+{
+    [Fact]
+    public void Ctor_ValidArgs_AssignsProperties()
+    {
+        // Arrange & Act
+        AddDataListLocaleCommand command = new(42, "es");
+
+        // Assert
+        command.DataListId.Should().Be(42);
+        command.Locale.Should().Be("es");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Ctor_NonPositiveDataListId_Throws(long dataListId)
+    {
+        // Act
+        Action act = () => _ = new AddDataListLocaleCommand(dataListId, "es");
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Ctor_NullOrWhitespaceLocale_Throws(string? locale)
+    {
+        // Act
+        Action act = () => _ = new AddDataListLocaleCommand(1, locale!);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/Locales/AddDataListLocaleHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/Locales/AddDataListLocaleHandlerTests.cs
@@ -1,0 +1,154 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Events;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
+using Endatix.Core.UseCases.DataLists.Locales;
+using MediatR;
+
+namespace Endatix.Core.Tests.UseCases.DataLists.Locales;
+
+public class AddDataListLocaleHandlerTests
+{
+    private readonly IRepository<DataList> _repository;
+    private readonly IMediator _mediator;
+    private readonly AddDataListLocaleHandler _sut;
+
+    public AddDataListLocaleHandlerTests()
+    {
+        _repository = Substitute.For<IRepository<DataList>>();
+        _mediator = Substitute.For<IMediator>();
+        _sut = new AddDataListLocaleHandler(_repository, _mediator);
+    }
+
+    [Fact]
+    public async Task Handle_DataListNotFound_ReturnsNotFound()
+    {
+        // Arrange
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns((DataList?)null);
+
+        // Act
+        var result = await _sut.Handle(
+            new AddDataListLocaleCommand(1, "es"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.NotFound);
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_AddsLocaleAndReturnsDto()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        // Act
+        var result = await _sut.Handle(
+            new AddDataListLocaleCommand(1, "ES"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().NotBeNull();
+        result.Value!.AvailableLocales.Should().Equal("es");
+        dataList.AvailableLocales.Should().Equal("es");
+
+        await _repository.Received(1).UpdateAsync(dataList, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_PublishesLocalesUpdatedEvent()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        // Act
+        await _sut.Handle(
+            new AddDataListLocaleCommand(1, "es"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await _mediator.Received(1).Publish(
+            Arg.Is<DataListUpdatedEvent>(e =>
+                e.DataList.Id == 1
+                && e.Reason == DataListUpdateReasons.LocalesUpdated),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_SyntheticDefaultKey_ReturnsInvalid()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        // Act
+        var result = await _sut.Handle(
+            new AddDataListLocaleCommand(1, "default"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().Contain(e => e.Identifier == "Locale");
+        dataList.AvailableLocales.Should().BeEmpty();
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_InvalidCultureCode_ReturnsInvalid()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        // Act
+        var result = await _sut.Handle(
+            new AddDataListLocaleCommand(1, "not a culture!"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().Contain(e => e.Identifier == "Locale");
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ExistingLocale_IsIdempotent()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        dataList.AddCulture("es");
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        // Act
+        var result = await _sut.Handle(
+            new AddDataListLocaleCommand(1, "es"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value!.AvailableLocales.Should().Equal("es");
+        await _repository.Received(1).UpdateAsync(dataList, Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/Locales/RemoveDataListLocaleCommandTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/Locales/RemoveDataListLocaleCommandTests.cs
@@ -1,0 +1,42 @@
+using Endatix.Core.UseCases.DataLists.Locales;
+
+namespace Endatix.Core.Tests.UseCases.DataLists.Locales;
+
+public class RemoveDataListLocaleCommandTests
+{
+    [Fact]
+    public void Ctor_ValidArgs_AssignsProperties()
+    {
+        // Arrange & Act
+        RemoveDataListLocaleCommand command = new(42, "es");
+
+        // Assert
+        command.DataListId.Should().Be(42);
+        command.Locale.Should().Be("es");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Ctor_NonPositiveDataListId_Throws(long dataListId)
+    {
+        // Act
+        Action act = () => _ = new RemoveDataListLocaleCommand(dataListId, "es");
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Ctor_NullOrWhitespaceLocale_Throws(string? locale)
+    {
+        // Act
+        Action act = () => _ = new RemoveDataListLocaleCommand(1, locale!);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/Locales/RemoveDataListLocaleHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/Locales/RemoveDataListLocaleHandlerTests.cs
@@ -1,0 +1,166 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Events;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
+using Endatix.Core.UseCases.DataLists.Locales;
+using MediatR;
+
+namespace Endatix.Core.Tests.UseCases.DataLists.Locales;
+
+public class RemoveDataListLocaleHandlerTests
+{
+    private readonly IRepository<DataList> _repository;
+    private readonly IMediator _mediator;
+    private readonly RemoveDataListLocaleHandler _sut;
+
+    public RemoveDataListLocaleHandlerTests()
+    {
+        _repository = Substitute.For<IRepository<DataList>>();
+        _mediator = Substitute.For<IMediator>();
+        _sut = new RemoveDataListLocaleHandler(_repository, _mediator);
+    }
+
+    [Fact]
+    public async Task Handle_DataListNotFound_ReturnsNotFound()
+    {
+        // Arrange
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns((DataList?)null);
+
+        // Act
+        var result = await _sut.Handle(
+            new RemoveDataListLocaleCommand(1, "es"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.NotFound);
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_RemovesLocaleAndStripsItemLabels()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        dataList.AddCulture("es");
+        dataList.AddItem(
+            new Dictionary<string, string>
+            {
+                ["default"] = "Apple",
+                ["es"] = "Manzana"
+            },
+            "apple");
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        // Act
+        var result = await _sut.Handle(
+            new RemoveDataListLocaleCommand(1, "ES"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().NotBeNull();
+        result.Value!.AvailableLocales.Should().BeEmpty();
+        dataList.AvailableLocales.Should().BeEmpty();
+        dataList.Items.Single().Labels.Should().NotContainKey("es");
+        dataList.Items.Single().Labels["default"].Should().Be("Apple");
+
+        await _repository.Received(1).UpdateAsync(dataList, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_PublishesLocalesUpdatedEvent()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        dataList.AddCulture("es");
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        // Act
+        await _sut.Handle(
+            new RemoveDataListLocaleCommand(1, "es"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await _mediator.Received(1).Publish(
+            Arg.Is<DataListUpdatedEvent>(e =>
+                e.DataList.Id == 1
+                && e.Reason == DataListUpdateReasons.LocalesUpdated),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_SyntheticDefaultKey_ReturnsInvalid()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        dataList.AddCulture("es");
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        // Act
+        var result = await _sut.Handle(
+            new RemoveDataListLocaleCommand(1, "default"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().Contain(e => e.Identifier == "Locale");
+        dataList.AvailableLocales.Should().Equal("es");
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_InvalidCultureCode_ReturnsInvalid()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        // Act
+        var result = await _sut.Handle(
+            new RemoveDataListLocaleCommand(1, "not a culture!"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().Contain(e => e.Identifier == "Locale");
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_MissingLocale_IsIdempotent()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        dataList.AddCulture("fr");
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        // Act
+        var result = await _sut.Handle(
+            new RemoveDataListLocaleCommand(1, "es"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value!.AvailableLocales.Should().Equal("fr");
+        await _repository.Received(1).UpdateAsync(dataList, Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/Locales/SetDataListDefaultLocaleCommandTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/Locales/SetDataListDefaultLocaleCommandTests.cs
@@ -1,0 +1,42 @@
+using Endatix.Core.UseCases.DataLists.Locales;
+
+namespace Endatix.Core.Tests.UseCases.DataLists.Locales;
+
+public class SetDataListDefaultLocaleCommandTests
+{
+    [Fact]
+    public void Ctor_ValidArgs_AssignsProperties()
+    {
+        // Arrange & Act
+        SetDataListDefaultLocaleCommand command = new(42, "en");
+
+        // Assert
+        command.DataListId.Should().Be(42);
+        command.DefaultLocale.Should().Be("en");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Ctor_NonPositiveDataListId_Throws(long dataListId)
+    {
+        // Act
+        Action act = () => _ = new SetDataListDefaultLocaleCommand(dataListId, "en");
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Ctor_NullOrWhitespaceDefaultLocale_Throws(string? defaultLocale)
+    {
+        // Act
+        Action act = () => _ = new SetDataListDefaultLocaleCommand(1, defaultLocale!);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/Locales/SetDataListDefaultLocaleHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/Locales/SetDataListDefaultLocaleHandlerTests.cs
@@ -1,0 +1,136 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Events;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
+using Endatix.Core.UseCases.DataLists.Locales;
+using MediatR;
+
+namespace Endatix.Core.Tests.UseCases.DataLists.Locales;
+
+public class SetDataListDefaultLocaleHandlerTests
+{
+    private readonly IRepository<DataList> _repository;
+    private readonly IMediator _mediator;
+    private readonly SetDataListDefaultLocaleHandler _sut;
+
+    public SetDataListDefaultLocaleHandlerTests()
+    {
+        _repository = Substitute.For<IRepository<DataList>>();
+        _mediator = Substitute.For<IMediator>();
+        _sut = new SetDataListDefaultLocaleHandler(_repository, _mediator);
+    }
+
+    [Fact]
+    public async Task Handle_DataListNotFound_ReturnsNotFound()
+    {
+        // Arrange
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns((DataList?)null);
+
+        // Act
+        var result = await _sut.Handle(
+            new SetDataListDefaultLocaleCommand(1, "en"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.NotFound);
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_SetsDefaultLocaleAndReturnsDto()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        // Act
+        var result = await _sut.Handle(
+            new SetDataListDefaultLocaleCommand(1, "FR"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().NotBeNull();
+        result.Value!.DefaultLocale.Should().Be("fr");
+        dataList.DefaultLocale.Should().Be("fr");
+        dataList.DefaultCulture.Should().Be("fr");
+
+        await _repository.Received(1).UpdateAsync(dataList, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_PublishesLocalesUpdatedEvent()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        // Act
+        await _sut.Handle(
+            new SetDataListDefaultLocaleCommand(1, "de"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await _mediator.Received(1).Publish(
+            Arg.Is<DataListUpdatedEvent>(e =>
+                e.DataList.Id == 1
+                && e.Reason == DataListUpdateReasons.LocalesUpdated),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_SyntheticDefaultKey_ReturnsInvalid()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        string originalDefault = dataList.DefaultLocale;
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        // Act
+        var result = await _sut.Handle(
+            new SetDataListDefaultLocaleCommand(1, "default"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().Contain(e => e.Identifier == "DefaultLocale");
+        dataList.DefaultLocale.Should().Be(originalDefault);
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_InvalidCultureCode_ReturnsInvalid()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        string originalDefault = dataList.DefaultLocale;
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        // Act
+        var result = await _sut.Handle(
+            new SetDataListDefaultLocaleCommand(1, "not a culture!"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().Contain(e => e.Identifier == "DefaultLocale");
+        dataList.DefaultLocale.Should().Be(originalDefault);
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
# feat(e941): Add locale add/remove/set-default support to Data List management APIs

## Description
- Add the add locale endpoint + test coverage; agent changes for better test and api endpoint styles
- Update data list endpoints to follow new rich open api docs and clean up culture vs locale usage
- Add remove data list locale endpoint + tests. DataList domain clean up and docs
- Push SetDefaultLocale implementation and tests

## Related Issues
- closes #941

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Dependency update
- [x] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for adding and removing data-list locales.
  - Added support for setting a data-list’s default locale.
  - Added validation and clear success, validation, and not-found responses.

- **Documentation**
  - Improved API descriptions, examples, response details, paging, and locale-filtering guidance.
  - Clarified locale terminology and behavior around the default locale.

- **Tests**
  - Added coverage for locale management, validation, error handling, idempotent operations, and response mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->