### PR TITLE
feat(e476): optional rotating file logging (PR-T6)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -70,6 +70,11 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="$(OpenTelemetryVersion)" />
+    <!-- Rotation implementation behind the optional file-logging provider only. Serilog is not the
+         logging pipeline: it is registered as one ILoggerProvider and is inert unless
+         Endatix:Logging:File:Enabled is set. Referenced by Endatix.Hosting alone. -->
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="10.0.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <!-- Test-only: lets the logging tests assert on exported LogRecords without a collector. -->
     <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="$(OpenTelemetryVersion)" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.12.0" />

--- a/src/Endatix.Hosting/Builders/EndatixLoggingBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixLoggingBuilder.cs
@@ -1,5 +1,6 @@
 using Endatix.Framework.Hosting;
 using Endatix.Hosting.Builders.Logging;
+using Endatix.Hosting.Logging;
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -138,6 +139,10 @@ public class EndatixLoggingBuilder
             // Always registered, unconditionally: this is what `kubectl logs` and `docker logs`
             // read. A host with no OTLP endpoint must still produce output.
             logging.AddConsole();
+
+            // Added after the console and never in place of it, so enabling files cannot take a
+            // deployed host's stdout away. No-op unless Endatix:Logging:File:Enabled is set.
+            logging.AddEndatixFileLogging(Configuration);
         });
 
         _configuredLoggerRegistered = true;

--- a/src/Endatix.Hosting/Endatix.Hosting.csproj
+++ b/src/Endatix.Hosting/Endatix.Hosting.csproj
@@ -19,6 +19,8 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
     <PackageReference Include="AspNetCore.HealthChecks.System" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />

--- a/src/Endatix.Hosting/Logging/EndatixFileLoggerProvider.cs
+++ b/src/Endatix.Hosting/Logging/EndatixFileLoggerProvider.cs
@@ -1,0 +1,41 @@
+using Microsoft.Extensions.Logging;
+using Serilog.Extensions.Logging;
+
+namespace Endatix.Hosting.Logging;
+
+/// <summary>
+/// The file-logging provider, aliased so its levels are configured under
+/// <c>Logging:EndatixFile:LogLevel</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This exists only to control the provider alias. Registering
+/// <see cref="SerilogLoggerProvider"/> directly would make the level key
+/// <c>Logging:Serilog:LogLevel</c>, putting the rotation library's name on the configuration
+/// surface — the one thing this feature is meant to keep private. <see cref="SerilogLoggerProvider"/>
+/// is sealed, so re-aliasing means delegation rather than inheritance.
+/// </para>
+/// </remarks>
+[ProviderAlias("EndatixFile")]
+internal sealed class EndatixFileLoggerProvider : ILoggerProvider, ISupportExternalScope
+{
+    private readonly SerilogLoggerProvider _inner;
+
+    public EndatixFileLoggerProvider(Serilog.ILogger logger, bool dispose)
+    {
+        _inner = new SerilogLoggerProvider(logger, dispose);
+    }
+
+    public ILogger CreateLogger(string categoryName) => _inner.CreateLogger(categoryName);
+
+    /// <summary>
+    /// Forwards the framework's scope provider to the inner provider.
+    /// </summary>
+    /// <remarks>
+    /// Load-bearing: without it the delegation silently drops every scope property from the file,
+    /// and nothing else in the pipeline reports the loss.
+    /// </remarks>
+    public void SetScopeProvider(IExternalScopeProvider scopeProvider) => _inner.SetScopeProvider(scopeProvider);
+
+    public void Dispose() => _inner.Dispose();
+}

--- a/src/Endatix.Hosting/Logging/EndatixFileLoggingExtensions.cs
+++ b/src/Endatix.Hosting/Logging/EndatixFileLoggingExtensions.cs
@@ -1,7 +1,7 @@
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Serilog;
-using Serilog.Extensions.Logging;
 using Serilog.Formatting.Json;
 using SerilogRollingInterval = Serilog.RollingInterval;
 
@@ -29,8 +29,8 @@ public static class EndatixFileLoggingExtensions
     /// <param name="logging">The logging builder.</param>
     /// <param name="configuration">Configuration to bind <see cref="FileLoggingOptions"/> from.</param>
     /// <param name="contentRootPath">
-    /// Base directory for relative paths. Defaults to the current directory, which is the content
-    /// root for both <c>dotnet run</c> and a published host.
+    /// Base directory for relative paths. When omitted, the host's content root is read from
+    /// configuration, falling back to the current directory only if the host did not publish one.
     /// </param>
     /// <returns>The logging builder for chaining.</returns>
     /// <exception cref="InvalidOperationException">
@@ -51,7 +51,7 @@ public static class EndatixFileLoggingExtensions
             return logging;
         }
 
-        var resolvedPath = ResolvePath(options.Path, contentRootPath);
+        var resolvedPath = ResolvePath(options.Path, contentRootPath ?? GetContentRoot(configuration));
         EnsureWritable(resolvedPath);
 
         var loggerConfiguration = new LoggerConfiguration()
@@ -81,10 +81,23 @@ public static class EndatixFileLoggingExtensions
 
         // dispose: true -- this logger is owned by the provider, so the sink is flushed and the file
         // handle released when the host shuts down.
-        logging.AddProvider(new SerilogLoggerProvider(loggerConfiguration.CreateLogger(), dispose: true));
+        logging.AddProvider(new EndatixFileLoggerProvider(loggerConfiguration.CreateLogger(), dispose: true));
 
         return logging;
     }
+
+    /// <summary>
+    /// Reads the host's content root from configuration.
+    /// </summary>
+    /// <remarks>
+    /// The generic host writes its content root into configuration under
+    /// <see cref="HostDefaults.ContentRootKey"/>, so this works without widening
+    /// <c>IAppEnvironment</c>. It matters wherever the content root and the working directory differ
+    /// — most sharply for a Windows service, whose working directory is <c>C:\Windows\System32</c>,
+    /// and which is exactly the self-hosted operator this feature exists for.
+    /// </remarks>
+    internal static string? GetContentRoot(IConfiguration configuration) =>
+        configuration[HostDefaults.ContentRootKey];
 
     internal static FileLoggingOptions BindOptions(IConfiguration configuration)
     {

--- a/src/Endatix.Hosting/Logging/EndatixFileLoggingExtensions.cs
+++ b/src/Endatix.Hosting/Logging/EndatixFileLoggingExtensions.cs
@@ -1,0 +1,168 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Extensions.Logging;
+using Serilog.Formatting.Json;
+using SerilogRollingInterval = Serilog.RollingInterval;
+
+namespace Endatix.Hosting.Logging;
+
+/// <summary>
+/// Registers optional rotating file logging as a single <see cref="ILoggerProvider"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Serilog appears here as the rotation implementation and nowhere else. Rotation is deceptively
+/// hard -- concurrent writers, retention pruning, disk-full and Windows file locking -- and is not
+/// worth owning. It is registered as a plain provider, so source-generated logging, scopes and
+/// OpenTelemetry trace correlation all keep working; it is a sink, not the pipeline.
+/// </para>
+/// <para>
+/// Consumers configure <c>Endatix:Logging:File</c> and never see a <c>Serilog</c> section.
+/// </para>
+/// </remarks>
+public static class EndatixFileLoggingExtensions
+{
+    /// <summary>
+    /// Adds rotating file logging when <c>Endatix:Logging:File:Enabled</c> is true. A no-op otherwise.
+    /// </summary>
+    /// <param name="logging">The logging builder.</param>
+    /// <param name="configuration">Configuration to bind <see cref="FileLoggingOptions"/> from.</param>
+    /// <param name="contentRootPath">
+    /// Base directory for relative paths. Defaults to the current directory, which is the content
+    /// root for both <c>dotnet run</c> and a published host.
+    /// </param>
+    /// <returns>The logging builder for chaining.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// The configured path is not writable. Thrown at startup, by design: a log file that silently
+    /// goes nowhere is worse than a host that refuses to start.
+    /// </exception>
+    public static ILoggingBuilder AddEndatixFileLogging(
+        this ILoggingBuilder logging,
+        IConfiguration configuration,
+        string? contentRootPath = null)
+    {
+        ArgumentNullException.ThrowIfNull(logging);
+        ArgumentNullException.ThrowIfNull(configuration);
+
+        var options = BindOptions(configuration);
+        if (!options.Enabled)
+        {
+            return logging;
+        }
+
+        var resolvedPath = ResolvePath(options.Path, contentRootPath);
+        EnsureWritable(resolvedPath);
+
+        var loggerConfiguration = new LoggerConfiguration()
+            // Level filtering is the logging pipeline's job, through the standard provider-scoped
+            // section. Filtering again here would silently override it and make the two disagree.
+            .MinimumLevel.Verbose();
+
+        if (options.Formatter == FileLogFormatter.Json)
+        {
+            loggerConfiguration.WriteTo.File(
+                formatter: new JsonFormatter(),
+                path: resolvedPath,
+                rollingInterval: ToSerilog(options.RollingInterval),
+                fileSizeLimitBytes: options.FileSizeLimitBytes,
+                rollOnFileSizeLimit: options.RollOnFileSizeLimit,
+                retainedFileCountLimit: options.RetainedFileCountLimit);
+        }
+        else
+        {
+            loggerConfiguration.WriteTo.File(
+                path: resolvedPath,
+                rollingInterval: ToSerilog(options.RollingInterval),
+                fileSizeLimitBytes: options.FileSizeLimitBytes,
+                rollOnFileSizeLimit: options.RollOnFileSizeLimit,
+                retainedFileCountLimit: options.RetainedFileCountLimit);
+        }
+
+        // dispose: true -- this logger is owned by the provider, so the sink is flushed and the file
+        // handle released when the host shuts down.
+        logging.AddProvider(new SerilogLoggerProvider(loggerConfiguration.CreateLogger(), dispose: true));
+
+        return logging;
+    }
+
+    internal static FileLoggingOptions BindOptions(IConfiguration configuration)
+    {
+        var options = new FileLoggingOptions();
+        configuration.GetSection(FileLoggingOptions.SectionName).Bind(options);
+
+        return options;
+    }
+
+    /// <summary>
+    /// Resolves a relative path against the content root.
+    /// </summary>
+    /// <remarks>
+    /// The configuration this replaces wrote to <c>/logs</c> at the filesystem root, which fails on
+    /// every macOS dev machine and any non-root Linux host. Anchoring relative paths to the content
+    /// root is what makes the default usable without elevated permissions.
+    /// </remarks>
+    internal static string ResolvePath(string path, string? contentRootPath)
+    {
+        if (System.IO.Path.IsPathRooted(path))
+        {
+            return path;
+        }
+
+        var root = string.IsNullOrWhiteSpace(contentRootPath)
+            ? Directory.GetCurrentDirectory()
+            : contentRootPath;
+
+        return System.IO.Path.GetFullPath(System.IO.Path.Combine(root, path));
+    }
+
+    /// <summary>
+    /// Fails fast when the target directory cannot be created or written to.
+    /// </summary>
+    /// <remarks>
+    /// The sink being replaced reported this only to Serilog's <c>SelfLog</c>, so a misconfigured
+    /// path produced no log files and no complaint. Probing here converts that into a startup error
+    /// naming the path.
+    /// </remarks>
+    private static void EnsureWritable(string resolvedPath)
+    {
+        var directory = System.IO.Path.GetDirectoryName(resolvedPath);
+        if (string.IsNullOrEmpty(directory))
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(directory);
+
+            // Creating the directory is not proof of write access -- it may already exist and be
+            // read-only, which is exactly the read-only-root-filesystem case.
+            var probe = System.IO.Path.Combine(directory, $".endatix-write-probe-{Guid.NewGuid():N}");
+            using (var stream = new FileStream(probe, FileMode.CreateNew, FileAccess.Write, FileShare.None, 1, FileOptions.DeleteOnClose))
+            {
+                stream.WriteByte(0);
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException or ArgumentException)
+        {
+            throw new InvalidOperationException(
+                $"File logging is enabled but '{directory}' is not writable, so no log files could be "
+                + $"written. Set '{FileLoggingOptions.SectionName}:Path' to a writable location, or set "
+                + $"'{FileLoggingOptions.SectionName}:Enabled' to false. In a container this needs a "
+                + "writable volume mounted at that path.",
+                ex);
+        }
+    }
+
+    private static SerilogRollingInterval ToSerilog(FileRollingInterval interval) => interval switch
+    {
+        FileRollingInterval.Infinite => SerilogRollingInterval.Infinite,
+        FileRollingInterval.Year => SerilogRollingInterval.Year,
+        FileRollingInterval.Month => SerilogRollingInterval.Month,
+        FileRollingInterval.Day => SerilogRollingInterval.Day,
+        FileRollingInterval.Hour => SerilogRollingInterval.Hour,
+        FileRollingInterval.Minute => SerilogRollingInterval.Minute,
+        _ => SerilogRollingInterval.Day
+    };
+}

--- a/src/Endatix.Hosting/Logging/FileLoggingOptions.cs
+++ b/src/Endatix.Hosting/Logging/FileLoggingOptions.cs
@@ -1,0 +1,99 @@
+namespace Endatix.Hosting.Logging;
+
+/// <summary>
+/// How often a new log file is started.
+/// </summary>
+/// <remarks>
+/// Mirrors the underlying sink's intervals but is declared here deliberately: the rotation
+/// implementation is an internal detail, and leaking its enum into this options type would put it in
+/// Endatix's public API and in every consumer's using directives.
+/// </remarks>
+public enum FileRollingInterval
+{
+    /// <summary>One file, never rolled on time.</summary>
+    Infinite,
+
+    /// <summary>A new file each year.</summary>
+    Year,
+
+    /// <summary>A new file each month.</summary>
+    Month,
+
+    /// <summary>A new file each day.</summary>
+    Day,
+
+    /// <summary>A new file each hour.</summary>
+    Hour,
+
+    /// <summary>A new file each minute.</summary>
+    Minute
+}
+
+/// <summary>
+/// Output shape of each line in the log file.
+/// </summary>
+public enum FileLogFormatter
+{
+    /// <summary>One JSON object per record, with its structured properties intact.</summary>
+    Json,
+
+    /// <summary>A rendered, human-readable line.</summary>
+    Text
+}
+
+/// <summary>
+/// Options for optional rotating file logging, bound from <c>Endatix:Logging:File</c>.
+/// </summary>
+/// <remarks>
+/// Disabled by default. File logging exists for self-hosted operators running the API as a service;
+/// containers should rely on console plus OTLP, and the Helm chart's read-only root filesystem makes
+/// a default-on file logger actively harmful.
+/// </remarks>
+public sealed class FileLoggingOptions
+{
+    /// <summary>Configuration section these options bind from.</summary>
+    public const string SectionName = "Endatix:Logging:File";
+
+    /// <summary>
+    /// Whether log files are written. Off by default.
+    /// </summary>
+    public bool Enabled { get; set; }
+
+    /// <summary>
+    /// File path. Relative paths resolve against the content root, not the filesystem root.
+    /// </summary>
+    /// <remarks>
+    /// The rotation suffix is inserted before the extension, so <c>logs/endatix-.log</c> produces
+    /// <c>logs/endatix-20260809.log</c>.
+    /// </remarks>
+    public string Path { get; set; } = "logs/endatix-.log";
+
+    /// <summary>
+    /// Output shape. Defaults to JSON, matching the sink this replaces.
+    /// </summary>
+    public FileLogFormatter Formatter { get; set; } = FileLogFormatter.Json;
+
+    /// <summary>
+    /// How often to start a new file.
+    /// </summary>
+    public FileRollingInterval RollingInterval { get; set; } = FileRollingInterval.Day;
+
+    /// <summary>
+    /// Size at which a new file is started, in bytes. Defaults to 10 MiB.
+    /// </summary>
+    public long FileSizeLimitBytes { get; set; } = 10 * 1024 * 1024;
+
+    /// <summary>
+    /// Whether to roll to a new file on reaching <see cref="FileSizeLimitBytes"/>.
+    /// </summary>
+    /// <remarks>
+    /// With this off, the sink stops writing once the limit is reached rather than rolling, which
+    /// loses records silently.
+    /// </remarks>
+    public bool RollOnFileSizeLimit { get; set; } = true;
+
+    /// <summary>
+    /// How many files to keep, including the current one. Older files are deleted as new ones roll.
+    /// </summary>
+    public int RetainedFileCountLimit { get; set; } = 7;
+}

--- a/src/Endatix.WebHost/appsettings.json
+++ b/src/Endatix.WebHost/appsettings.json
@@ -18,6 +18,17 @@
     }
   },
   "Endatix": {
+    "Logging": {
+      "File": {
+        "Enabled": false,
+        "Path": "logs/endatix-.log",
+        "Formatter": "Json",
+        "RollingInterval": "Day",
+        "FileSizeLimitBytes": 10485760,
+        "RollOnFileSizeLimit": true,
+        "RetainedFileCountLimit": 7
+      }
+    },
     "Hub": {
       "HubBaseUrl": "{{HUB_URL}}"
     },

--- a/tests/Endatix.Hosting.Tests/Logging/EndatixFileLoggingTests.cs
+++ b/tests/Endatix.Hosting.Tests/Logging/EndatixFileLoggingTests.cs
@@ -1,7 +1,9 @@
+using System.Text.Json;
 using Endatix.Hosting.Builders;
 using Endatix.Hosting.Logging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
 
@@ -105,9 +107,118 @@ public sealed class EndatixFileLoggingTests : IDisposable
         factory.Dispose();
 
         // Assert
+        // Parsed rather than substring-matched: "12345" appears in a rendered line too, so a
+        // substring check would pass even if the formatter silently fell back to plain text.
         var contents = File.ReadAllText(Directory.GetFiles(Path.Combine(_root, "logs"))[0]);
-        contents.Should().Contain("\"FormId\"");
-        contents.Should().Contain("12345");
+        var firstLine = contents.Split('\n', StringSplitOptions.RemoveEmptyEntries)[0];
+
+        using var record = JsonDocument.Parse(firstLine);
+        record.RootElement
+            .GetProperty("Properties")
+            .GetProperty("FormId")
+            .GetInt64()
+            .Should().Be(12345L);
+    }
+
+    [Fact]
+    public void AddEndatixFileLogging_WithHostContentRoot_ResolvesRelativePathsAgainstIt()
+    {
+        // Arrange
+        // The content root and the working directory are not always the same. A Windows service
+        // runs with a working directory of C:\Windows\System32 -- which is precisely the
+        // self-hosted operator this feature exists for, so falling back to it would be wrong.
+        var contentRoot = Path.Combine(_root, "content");
+        Directory.CreateDirectory(contentRoot);
+
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Endatix:Logging:File:Enabled"] = "true",
+                ["Endatix:Logging:File:Path"] = "logs/endatix-.log",
+                [HostDefaults.ContentRootKey] = contentRoot
+            })
+            .Build();
+
+        // Act
+        var factory = BuildFactory(configuration);
+        factory.CreateLogger("Endatix.Tests").LogWarning("under the content root");
+        factory.Dispose();
+
+        // Assert
+        var underContentRoot = Path.Combine(contentRoot, "logs");
+        Directory.Exists(underContentRoot).Should().BeTrue();
+        Directory.GetFiles(underContentRoot).Should().NotBeEmpty();
+
+        // And emphatically not under the process working directory.
+        Directory.Exists(Path.Combine(Directory.GetCurrentDirectory(), "logs", "endatix-.log"))
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void FileProvider_LevelsAreConfiguredUnderEndatixFile_NotSerilog()
+    {
+        // Arrange
+        // The provider is aliased so its level key reads Logging:EndatixFile:LogLevel. Registering
+        // SerilogLoggerProvider directly would make it Logging:Serilog:LogLevel and put the rotation
+        // library's name on the configuration surface, which this feature exists to keep private.
+        var path = Path.Combine(_root, "logs", "endatix-.log");
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Endatix:Logging:File:Enabled"] = "true",
+                ["Endatix:Logging:File:Path"] = path,
+                ["Logging:LogLevel:Default"] = "Warning",
+                ["Logging:EndatixFile:LogLevel:Endatix"] = "Information"
+            })
+            .Build();
+
+        var services = new ServiceCollection();
+        services.AddLogging(logging =>
+        {
+            logging.AddConfiguration(configuration.GetSection("Logging"));
+            logging.ClearProviders();
+            logging.AddEndatixFileLogging(configuration);
+        });
+
+        var factory = services.BuildServiceProvider().GetRequiredService<ILoggerFactory>();
+        var logger = factory.CreateLogger("Endatix.Tests");
+
+        // Act
+        logger.LogInformation("INFORMATION-LIFTED-FOR-THE-FILE");
+        logger.LogDebug("DEBUG-BELOW-THE-CONFIGURED-LEVEL");
+        factory.Dispose();
+
+        // Assert
+        var contents = File.ReadAllText(Directory.GetFiles(Path.Combine(_root, "logs"))[0]);
+
+        contents.Should().Contain("INFORMATION-LIFTED-FOR-THE-FILE",
+            "the provider-scoped section should lift Endatix above the global Warning default");
+        contents.Should().NotContain("DEBUG-BELOW-THE-CONFIGURED-LEVEL");
+    }
+
+    [Fact]
+    public void FileProvider_PreservesScopeProperties()
+    {
+        // Arrange
+        // The alias is achieved by delegating to SerilogLoggerProvider, which is sealed. Delegation
+        // drops scopes unless ISupportExternalScope is forwarded, and nothing else in the pipeline
+        // reports that loss -- the properties just stop appearing.
+        var path = Path.Combine(_root, "logs", "endatix-.log");
+        var factory = BuildFactory(EnabledAt(path));
+        var logger = factory.CreateLogger("Endatix.Tests");
+
+        // Act
+        using (logger.BeginScope(new Dictionary<string, object> { ["CorrelationId"] = "abc-123" }))
+        {
+            logger.LogWarning("inside a scope");
+        }
+
+        factory.Dispose();
+
+        // Assert
+        var contents = File.ReadAllText(Directory.GetFiles(Path.Combine(_root, "logs"))[0]);
+        contents.Should().Contain("CorrelationId");
+        contents.Should().Contain("abc-123");
     }
 
     [Fact]
@@ -167,7 +278,7 @@ public sealed class EndatixFileLoggingTests : IDisposable
         var providers = provider.GetServices<ILoggerProvider>().ToList();
 
         providers.Should().Contain(p => p is ConsoleLoggerProvider);
-        providers.Should().Contain(p => p.GetType().Name.Contains("Serilog"));
+        providers.Should().Contain(p => p is EndatixFileLoggerProvider);
     }
 
     [Fact]

--- a/tests/Endatix.Hosting.Tests/Logging/EndatixFileLoggingTests.cs
+++ b/tests/Endatix.Hosting.Tests/Logging/EndatixFileLoggingTests.cs
@@ -1,0 +1,228 @@
+using Endatix.Hosting.Builders;
+using Endatix.Hosting.Logging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
+
+namespace Endatix.Hosting.Tests.Logging;
+
+/// <summary>
+/// Tests for optional rotating file logging: that it stays off unless asked for, actually writes and
+/// rolls when enabled, never displaces the console, and refuses to start rather than writing nowhere.
+/// </summary>
+public sealed class EndatixFileLoggingTests : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(), $"endatix-filelog-{Guid.NewGuid():N}");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+    }
+
+    private static IConfiguration Config(params (string Key, string? Value)[] settings) =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(settings.ToDictionary(s => s.Key, s => s.Value))
+            .Build();
+
+    private static IConfiguration EnabledAt(string path, params (string Key, string? Value)[] extra)
+    {
+        var settings = new List<(string, string?)>
+        {
+            ("Endatix:Logging:File:Enabled", "true"),
+            ("Endatix:Logging:File:Path", path)
+        };
+        settings.AddRange(extra);
+
+        return Config([.. settings]);
+    }
+
+    private static ILoggerFactory BuildFactory(IConfiguration configuration)
+    {
+        var services = new ServiceCollection();
+        services.AddLogging(logging =>
+        {
+            logging.ClearProviders();
+            logging.SetMinimumLevel(LogLevel.Trace);
+            logging.AddEndatixFileLogging(configuration);
+        });
+
+        return services.BuildServiceProvider().GetRequiredService<ILoggerFactory>();
+    }
+
+    [Fact]
+    public void AddEndatixFileLogging_WhenDisabled_RegistersNoProvider()
+    {
+        // Arrange
+        // Off by default matters operationally: the Helm chart runs with a read-only root filesystem,
+        // so a default-on file logger would crash-loop pods.
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddLogging(logging =>
+        {
+            logging.ClearProviders();
+            logging.AddEndatixFileLogging(Config(("Endatix:Logging:File:Path", "logs/x-.log")));
+        });
+
+        // Assert
+        using var provider = services.BuildServiceProvider();
+        provider.GetServices<ILoggerProvider>().Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AddEndatixFileLogging_WhenEnabled_WritesRecordsToTheConfiguredPath()
+    {
+        // Arrange
+        var path = Path.Combine(_root, "logs", "endatix-.log");
+        var factory = BuildFactory(EnabledAt(path));
+
+        // Act
+        factory.CreateLogger("Endatix.Tests").LogWarning("file sink reached");
+        factory.Dispose();
+
+        // Assert
+        var written = Directory.GetFiles(Path.Combine(_root, "logs"));
+        written.Should().NotBeEmpty();
+        File.ReadAllText(written[0]).Should().Contain("file sink reached");
+    }
+
+    [Fact]
+    public void AddEndatixFileLogging_WhenEnabled_DefaultsToJsonWithPropertiesIntact()
+    {
+        // Arrange
+        // Parity with the sink this replaces, which was already configured with a JSON formatter.
+        // Structured output is the point: a rendered line cannot be queried by FormId.
+        var path = Path.Combine(_root, "logs", "endatix-.log");
+        var factory = BuildFactory(EnabledAt(path));
+
+        // Act
+        factory.CreateLogger("Endatix.Tests").LogWarning("Form {FormId} rejected", 12345L);
+        factory.Dispose();
+
+        // Assert
+        var contents = File.ReadAllText(Directory.GetFiles(Path.Combine(_root, "logs"))[0]);
+        contents.Should().Contain("\"FormId\"");
+        contents.Should().Contain("12345");
+    }
+
+    [Fact]
+    public void AddEndatixFileLogging_RollsOnSizeLimit_AndPrunesBeyondRetainedCount()
+    {
+        // Arrange
+        // The whole reason for taking a dependency rather than writing this: rolling and pruning are
+        // what a file logger is for. Asserting only that "a file exists" would pass without either.
+        var path = Path.Combine(_root, "logs", "endatix-.log");
+        var factory = BuildFactory(EnabledAt(
+            path,
+            ("Endatix:Logging:File:RollingInterval", "Infinite"),
+            ("Endatix:Logging:File:FileSizeLimitBytes", "1024"),
+            ("Endatix:Logging:File:RollOnFileSizeLimit", "true"),
+            ("Endatix:Logging:File:RetainedFileCountLimit", "3")));
+
+        var logger = factory.CreateLogger("Endatix.Tests");
+
+        // Act
+        // Comfortably past 3 x 1 KiB, so rolling must happen several times and pruning must engage.
+        for (var i = 0; i < 400; i++)
+        {
+            logger.LogWarning("padding {Index} {Filler}", i, new string('x', 200));
+        }
+
+        factory.Dispose();
+
+        // Assert
+        var files = Directory.GetFiles(Path.Combine(_root, "logs"));
+
+        files.Length.Should().BeGreaterThan(1, "the size limit should have forced a roll");
+        files.Length.Should().BeLessThanOrEqualTo(3, "files beyond RetainedFileCountLimit should be pruned");
+    }
+
+    [Fact]
+    public void AddEndatixFileLogging_WhenEnabled_ConsoleProviderStillRegistered()
+    {
+        // Arrange
+        // Enabling files must not cost a deployed host its stdout -- that is what `kubectl logs`
+        // reads, and losing it would be a silent operational regression.
+        var path = Path.Combine(_root, "logs", "endatix-.log");
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Endatix:Logging:File:Enabled"] = "true",
+                ["Endatix:Logging:File:Path"] = path
+            })
+            .Build();
+
+        var builder = new EndatixLoggingBuilder(new ServiceCollection(), configuration);
+
+        // Act
+        builder.UseDefaults();
+
+        // Assert
+        using var provider = builder.Services.BuildServiceProvider();
+        var providers = provider.GetServices<ILoggerProvider>().ToList();
+
+        providers.Should().Contain(p => p is ConsoleLoggerProvider);
+        providers.Should().Contain(p => p.GetType().Name.Contains("Serilog"));
+    }
+
+    [Fact]
+    public void AddEndatixFileLogging_WithUnusablePath_ThrowsNamingThePath()
+    {
+        // Arrange
+        // The configuration this replaces wrote to /logs at the filesystem root and failed silently
+        // on every non-root host, reporting only to Serilog's SelfLog. Failing loudly is the fix.
+        //
+        // Unusability is created by putting a *file* where a directory has to go, rather than by
+        // clearing write permissions: root ignores permission bits, so a chmod-based test passes or
+        // fails depending on which uid runs it. Tests must not depend on that -- CI containers
+        // commonly run as root while developer machines do not.
+        var blocker = Path.Combine(_root, "blocker");
+        Directory.CreateDirectory(_root);
+        File.WriteAllText(blocker, "not a directory");
+
+        var unusableDirectory = Path.Combine(blocker, "logs");
+        var configuration = EnabledAt(Path.Combine(unusableDirectory, "endatix-.log"));
+
+        // Act
+        var act = () => BuildFactory(configuration);
+
+        // Assert
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage($"*{unusableDirectory}*")
+            .WithMessage("*Enabled*");
+    }
+
+    [Fact]
+    public void ResolvePath_WithRelativePath_AnchorsToContentRootNotFilesystemRoot()
+    {
+        // Arrange
+        // "logs/endatix-.log" must not become "/logs/endatix-.log". That single character was why the
+        // previous configuration silently wrote nothing on macOS and non-root Linux.
+        var contentRoot = Path.Combine(_root, "content");
+
+        // Act
+        var resolved = EndatixFileLoggingExtensions.ResolvePath("logs/endatix-.log", contentRoot);
+
+        // Assert
+        resolved.Should().Be(Path.GetFullPath(Path.Combine(contentRoot, "logs", "endatix-.log")));
+        resolved.Should().NotBe("/logs/endatix-.log");
+    }
+
+    [Fact]
+    public void ResolvePath_WithAbsolutePath_IsLeftAlone()
+    {
+        // Arrange
+        var absolute = Path.Combine(_root, "explicit", "endatix-.log");
+
+        // Act
+        var resolved = EndatixFileLoggingExtensions.ResolvePath(absolute, _root);
+
+        // Assert
+        resolved.Should().Be(absolute);
+    }
+}


### PR DESCRIPTION
## Description

PR-T2 leaves the host with console + OTLP and **no way to write log files**. That's right for containers and wrong for a self-hosted operator running the API as a service, so file logging returns as something you opt into rather than something you inherit.

> [!IMPORTANT]
> **Stacked on [#947](https://github.com/endatix/endatix/pull/947)** (PR-T2) — it depends on that builder. Base retargets to `main` automatically when #947 merges.
>
> **These two must ship in the same release.** #947 alone means a self-hoster upgrades into a version where their log files silently stopped appearing.

## Serilog does not come back as the pipeline

It's the rotation implementation behind **one** `ILoggerProvider`: absent from the default host's behaviour, absent from the config surface, inert for anyone who doesn't opt in. Users configure `Endatix:Logging:File` and never see a `Serilog` section.

Because it registers as a plain provider, `[LoggerMessage]` source generation, scopes and OTel trace correlation all keep working — it's a sink, not the pipeline.

Rotation is deceptively hard: concurrent writers, retention pruning, disk-full, Windows file locking. Not worth owning. Referenced by `Endatix.Hosting` alone — deliberately not `Endatix.Infrastructure`, which sits lower in the stack with more consumers.

**The options type declares its own `FileRollingInterval` and `FileLogFormatter` enums** rather than exposing Serilog's. Otherwise the dependency lands in Endatix's public API and in every consumer's using directives, which is exactly what "Serilog is an implementation detail" has to mean.

## Two failure modes from the old config, fixed rather than reproduced

The Serilog block this replaces had both, and they compounded:

1. **It wrote to `/logs`** — filesystem root. Fails on every macOS dev machine and any non-root Linux host. Relative paths now resolve against the **content root**, so the default works from `dotnet run` without elevated permissions.
2. **It reported that failure only to Serilog's `SelfLog`** — so a misconfigured path produced no files *and no complaint*. An unusable path now **throws at startup**, naming the directory and saying how to fix it, including the container case needing a writable volume.

Together those meant file logging had likely been quietly dead for anyone not running as root. Worth knowing before treating this PR as pure restoration.

## Behaviour

- **Off by default** — the Helm chart runs `readOnlyRootFilesystem: true` with only `/tmp` writable; a default-on file logger would crash-loop pods.
- **Never replaces the console** — console stays registered regardless, both receive every record.
- **JSON by default**, matching the formatter the old sink already used. Parity, not an upgrade.
- **Levels via the standard provider-scoped section**, so file and console can differ.

```json
"Endatix": { "Logging": { "File": {
  "Enabled": false,
  "Path": "logs/endatix-.log",
  "Formatter": "Json",
  "RollingInterval": "Day",
  "FileSizeLimitBytes": 10485760,
  "RollOnFileSizeLimit": true,
  "RetainedFileCountLimit": 7
} } }
```

Shipped in `appsettings.json` at `Enabled: false`, so it's discoverable where operators already look.

## Verification

**3,421 unit tests pass** — Hosting 92, Core 1143, Infrastructure 1134, Api 657, Reporting 395. Full solution builds with 0 errors.

**8 new tests, and the important one is proven on both halves.** `RollsOnSizeLimit_AndPrunesBeyondRetainedCount` asserts the file count after crossing the limit, because asserting "a file exists" would pass without either behaviour:

| Break | Result |
|---|---|
| `rollOnFileSizeLimit: false` | 1 file — *"should have forced a roll"* fails |
| `retainedFileCountLimit: null` | 134 files — *"should be pruned"* fails |

## Note for the reviewer

**The unusable-path test creates a file where a directory must go, rather than clearing permission bits.** My first version used `chmod` and passed locally but not in the container — **root ignores permission bits**, so a chmod-based test passes or fails depending on which uid runs it. CI containers commonly run as root while developer machines don't. The file-collision approach fails identically for every uid, and is a real misconfiguration in its own right.

**Docs are PR-T5's.** Enabling this in a container needs a writable volume via the chart's `extraVolumes`/`extraVolumeMounts` passthrough — the obvious attempt fails against a read-only root filesystem. For now that guidance lives in the startup exception message; it belongs in the observability page when that ships.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Dependency update

Refs #476


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional file logging with text or JSON formatting.
  * Supports rolling logs by time or file size, configurable retention, and file size limits.
  * Relative log paths are resolved from the application content root.
  * Console logging remains available alongside file logging.

* **Bug Fixes**
  * Startup validation now reports unusable log directories with actionable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->