### PR TITLE
docs(e476): observability and bring-your-own-telemetry pages (PR-T5)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -428,9 +428,46 @@ Rules:
 
 ---
 
+## Observability
+
+Logs, metrics and traces come from **one mechanism**: the OpenTelemetry SDK, exporting OTLP. There is
+no second logging stack and no vendor SDK in the dependency graph.
+
+| Concern | Decision |
+|---|---|
+| Signals | All three from the OTel SDK, sharing one resource so a record and its span agree on `service.name` |
+| Activation | Off until an OTLP endpoint resolves. Nothing configured means no exporter allocated |
+| Precedence | `OTEL_*` environment variables are authoritative; `Endatix:Telemetry` is a fallback, never an override |
+| Registration | `EndatixTelemetryBuilder` owns all three exporters; `EndatixLoggingBuilder` owns the provider list |
+| Failure mode | A malformed endpoint or protocol throws at startup rather than exporting nothing quietly |
+| Vendors | None shipped. Consumers add their own through `Logging.Configure(...)` or `AddOpenTelemetry()` |
+
+**Why the log exporter lives in the telemetry builder, not the logging builder.** All three signals
+have to resolve the same endpoint, protocol and resource. Splitting that across two builders means
+duplicating the resolution and risking a log record whose `service.name` disagrees with its span —
+at which point nothing joins them.
+
+**Ordering between the two builders is load-bearing.** `EndatixLoggingBuilder` calls
+`ClearProviders()`, and `AddLogging` applies its callback immediately rather than at provider-build
+time. The OTel log provider therefore survives only because `Logging.UseDefaults()` runs before
+`Telemetry.Build()`, which `FinalizeConfiguration()` guarantees. A test pins this.
+
+**Serilog's remaining role.** It is not the logging pipeline. It is the rotation implementation
+behind an optional, off-by-default file provider, registered as a single aliased `ILoggerProvider`
+and absent from the configuration surface. .NET ships no file provider, and rotation — concurrent
+writers, retention pruning, disk-full, Windows file locking — is not worth owning.
+
+**No vendor exporters, deliberately.** Endatix ships NuGet packages; which APM a host reports to is
+the host's choice. An Azure SDK in `Endatix.Hosting` would be in the transitive graph of every
+consumer, including those who never deploy to Azure — a permanent dependency to save three
+documented lines.
+
+---
+
 ## Decision log
 
 | Date | Decision |
 |------|----------|
 | 2026-07 | Submission `StartedAt` for reliable completion duration (distinct from `CreatedAt`); export includes `StartedAt` + computed `DurationSeconds`. See [Submission lifecycle timestamps](#submission-lifecycle-timestamps). |
 | 2026-07 | Domain events: evaluate-before-mutate on aggregates; reporting triggers (`FormDefinitionUpdatedEvent`, `SubmissionUpdatedEvent`) live on entities, not handlers. Documented in [Domain and integration events](#domain-and-integration-events). |
+| 2026-08 | Observability: three signals, one mechanism. The OpenTelemetry SDK owns logs, metrics and traces; `OTEL_*` environment variables are authoritative over `appsettings.json`; telemetry is off until an endpoint is configured. Serilog is removed as the logging pipeline and retained only as the rotation implementation behind an optional, off-by-default file provider. **Endatix ships no vendor exporters** — OTLP only. See [Observability](#observability). |

--- a/docs/endatix-docs/docs/configuration/bring-your-own-telemetry.mdx
+++ b/docs/endatix-docs/docs/configuration/bring-your-own-telemetry.mdx
@@ -6,11 +6,8 @@ description: "Export Endatix telemetry to Azure Monitor, an OTLP collector, or a
 
 # Bring Your Own Telemetry
 
-Endatix ships **no vendor exporters**. It exports OTLP and nothing else.
-
-That is a deliberate boundary, not an omission. Endatix is distributed as NuGet packages, and which
-APM a host reports to is the host's decision — baking an Azure SDK into `Endatix.Hosting` would make
-an Azure choice on behalf of every self-hoster, including those who will never deploy to Azure.
+Endatix ships **no vendor exporters**. It exports OTLP and nothing else — Endatix is distributed as
+NuGet packages, and which APM a host reports to is the host's decision.
 
 Adding your own backend takes three lines.
 
@@ -81,9 +78,7 @@ JSON because some envelope fields are not charged. Live Metrics is free.
 
 **Volume is dominated by traces, not logs** — and for a database-heavy API, by *dependency*
 telemetry in particular. Every EF Core query becomes a billable record. That is the line item to
-watch, and it is the one Endatix has never sent before: `Serilog.Sinks.ApplicationInsights` sent log
-records only, so enabling the distro is an **expansion of what is collected**, not a like-for-like
-swap.
+watch, and the reason a cost estimate based on log volume alone will be badly wrong.
 
 Sampling is the control:
 

--- a/docs/endatix-docs/docs/configuration/bring-your-own-telemetry.mdx
+++ b/docs/endatix-docs/docs/configuration/bring-your-own-telemetry.mdx
@@ -1,0 +1,169 @@
+---
+sidebar_position: 8
+title: "Bring Your Own Telemetry"
+description: "Export Endatix telemetry to Azure Monitor, an OTLP collector, or any other backend from your own host — and what each option costs"
+---
+
+# Bring Your Own Telemetry
+
+Endatix ships **no vendor exporters**. It exports OTLP and nothing else.
+
+That is a deliberate boundary, not an omission. Endatix is distributed as NuGet packages, and which
+APM a host reports to is the host's decision — baking an Azure SDK into `Endatix.Hosting` would make
+an Azure choice on behalf of every self-hoster, including those who will never deploy to Azure.
+
+Adding your own backend takes three lines.
+
+## The hook
+
+`endatix.Logging.Configure(...)` takes an `ILoggingBuilder` and runs **after** Endatix has set up its
+own providers. That ordering is the contract.
+
+```csharp title="Program.cs"
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.ConfigureEndatixWithDefaults(endatix =>
+{
+    endatix.Logging.Configure(logging => logging.AddAzureWebAppDiagnostics());
+});
+
+var app = builder.Build();
+app.UseEndatix();
+app.Run();
+```
+
+Repeated calls compose, applying in call order.
+
+:::warning Why not just `builder.Logging.AddX()`?
+Because it will not survive. Endatix registers logging inside `IHostBuilder.ConfigureServices`, which
+runs at `Build()` — and it calls `ClearProviders()` first, since `WebApplication.CreateBuilder` has
+already added Console, Debug, EventSource and EventLog and leaving them produces duplicated output.
+
+Anything you add to `builder.Logging` before `Build()` is therefore discarded. The provider silently
+never runs; nothing errors. `endatix.Logging.Configure(...)` exists to give you a hook on the far
+side of that clear.
+:::
+
+## Azure Monitor / Application Insights
+
+```bash
+dotnet add package Azure.Monitor.OpenTelemetry.AspNetCore
+```
+
+```csharp title="Program.cs"
+builder.Host.ConfigureEndatixWithDefaults(endatix =>
+{
+    endatix.Services.AddOpenTelemetry().UseAzureMonitor();
+});
+```
+
+`UseAzureMonitor()` takes **no argument**. It reads `APPLICATIONINSIGHTS_CONNECTION_STRING` from
+configuration or the environment:
+
+```bash
+APPLICATIONINSIGHTS_CONNECTION_STRING="InstrumentationKey=…;IngestionEndpoint=…"
+```
+
+There is no Endatix key for the connection string, and you should not invent one — the Azure SDK's
+own resolution already covers environment variables, `appsettings.json` and Key Vault.
+
+This composes with Endatix's registration rather than replacing it. Both exporters receive the same
+resource and the same instrumentation; if you also set `OTEL_EXPORTER_OTLP_ENDPOINT`, telemetry goes
+to both destinations.
+
+### What Application Insights costs
+
+This is the page where you decide to switch it on, so the billing model matters more than the wiring.
+
+Workspace-based Application Insights bills **per GB ingested** into its Log Analytics workspace.
+Analytics Logs include 31 days of retention in that price; billed size runs roughly 25% below raw
+JSON because some envelope fields are not charged. Live Metrics is free.
+
+**Volume is dominated by traces, not logs** — and for a database-heavy API, by *dependency*
+telemetry in particular. Every EF Core query becomes a billable record. That is the line item to
+watch, and it is the one Endatix has never sent before: `Serilog.Sinks.ApplicationInsights` sent log
+records only, so enabling the distro is an **expansion of what is collected**, not a like-for-like
+swap.
+
+Sampling is the control:
+
+```csharp
+endatix.Services.AddOpenTelemetry().UseAzureMonitor(o => o.SamplingRatio = 0.1f);
+```
+
+or, equivalently and with higher precedence, the standard environment variables:
+
+```bash
+OTEL_TRACES_SAMPLER=parentbased_traceidratio
+OTEL_TRACES_SAMPLER_ARG=0.1
+```
+
+Environment variables win over code, so a deployment can always dial sampling down without a rebuild.
+
+:::danger Sampling silently drops logs too
+By default, **log records belonging to unsampled traces are dropped**. A naive `SamplingRatio = 0.1`
+therefore discards roughly 90% of your log records as well as 90% of traces — including, quite
+possibly, the error you are trying to diagnose.
+
+If you want full logs with sampled traces, opt logs out of trace-based sampling explicitly. Metrics
+are never sampled and are unaffected.
+:::
+
+Set a **daily cap** on the workspace as a hard ceiling. Sampling controls the average; a cap is what
+stops an incident-driven log storm from producing a surprise invoice.
+
+## An OTLP collector
+
+If your backend speaks OTLP — Grafana Alloy, Datadog's OTLP endpoint, Honeycomb, Grafana Cloud,
+New Relic — no code is needed at all. Endatix already exports OTLP:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.example.com:4317
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+OTEL_SERVICE_NAME=endatix-api
+```
+
+For a backend needing authentication headers:
+
+```bash
+OTEL_EXPORTER_OTLP_HEADERS="api-key=…"
+```
+
+See [Observability](./observability.mdx) for a self-hosted collector configuration.
+
+## A second OTLP destination in code
+
+To export to somewhere in addition to the endpoint Endatix already resolves:
+
+```csharp
+builder.Host.ConfigureEndatixWithDefaults(endatix =>
+{
+    endatix.Services.AddOpenTelemetry()
+        .WithTracing(tracing => tracing.AddOtlpExporter(o =>
+        {
+            o.Endpoint = new Uri("https://second-backend.example.com:4317");
+        }));
+});
+```
+
+`AddOpenTelemetry()` is additive: calling it again returns the same underlying builder, so this adds
+an exporter rather than replacing Endatix's. There is no duplicate registration and no resource
+conflict.
+
+## Choosing
+
+| You want | Do this | Cost shape |
+|---|---|---|
+| Self-hosted, full control | OTLP → your own collector | Infrastructure you already run |
+| Azure App Service logs only | `Logging.Configure(l => l.AddAzureWebAppDiagnostics())` | **No ingestion charge** |
+| Full APM on Azure | `UseAzureMonitor()` | Per GB ingested; dependencies dominate |
+| A SaaS APM vendor | OTLP env vars, no code | Vendor's per-GB or per-span pricing |
+
+If all you need is readable logs on Azure App Service, `AddAzureWebAppDiagnostics()` is the cheap
+answer: Microsoft-shipped, a plain `ILogger` provider, portal-configurable with no redeploy, inert
+outside Azure, and it incurs no Application Insights ingestion cost.
+
+## Related
+
+- [Observability](./observability.mdx) — the OTLP contract, log levels, file logging and the local
+  dashboard

--- a/docs/endatix-docs/docs/configuration/infrastructure-configuration.mdx
+++ b/docs/endatix-docs/docs/configuration/infrastructure-configuration.mdx
@@ -207,50 +207,37 @@ Configure middleware settings in your `appsettings.json`:
 
 ## Logging Configuration
 
-Configure logging for your Endatix application:
+Logging is covered in full by **[Observability](./observability.mdx)**, which documents log levels,
+OTLP export, optional file logging and the local telemetry dashboard.
 
-### Serilog Integration
-
-Endatix uses Serilog for structured logging:
-
-```csharp
-builder.Host.ConfigureEndatix(endatix => {
-    endatix.Infrastructure.ConfigureLogging(logging => {
-        logging.UseConsole = true;
-        logging.UseFile = true;
-        logging.MinimumLevel = LogLevel.Information;
-    });
-});
-```
-
-### Logging Settings in appsettings.json
-
-Configure logging in your `appsettings.json`:
+In brief:
 
 ```json
 {
-  "Serilog": {
-    "MinimumLevel": {
-      "Default": "Information",
-      "Override": {
-        "Microsoft": "Warning",
-        "System": "Warning"
-      }
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "Endatix": "Warning"
     },
-    "WriteTo": [
-      { "Name": "Console" },
-      {
-        "Name": "File",
-        "Args": {
-          "path": "logs/log-.txt",
-          "rollingInterval": "Day"
-        }
-      }
-    ],
-    "Enrich": ["FromLogContext", "WithMachineName", "WithThreadId"]
+    "Console": { "FormatterName": "json" }
   }
 }
 ```
+
+To add a logging provider of your own:
+
+```csharp
+builder.Host.ConfigureEndatixWithDefaults(endatix => {
+    endatix.Logging.Configure(logging => logging.AddAzureWebAppDiagnostics());
+});
+```
+
+:::info Serilog is no longer the logging pipeline
+Earlier versions read a `Serilog` configuration section. Endatix now uses the standard `Logging`
+section, and a leftover `Serilog` section is ignored — the host still starts and logs a warning
+naming it. See the [migration table](./observability.mdx#migrating-from-the-serilog-section).
+:::
 
 ## Best Practices
 

--- a/docs/endatix-docs/docs/configuration/observability.mdx
+++ b/docs/endatix-docs/docs/configuration/observability.mdx
@@ -1,0 +1,276 @@
+---
+sidebar_position: 7
+title: "Observability"
+description: "Configure logs, metrics and traces for Endatix over OpenTelemetry, plus optional file logging and the local telemetry dashboard"
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Observability
+
+Endatix emits **logs, metrics and traces** through a single mechanism: the OpenTelemetry SDK,
+exporting over OTLP. There is no separate logging stack to configure and no vendor SDK in the box.
+
+**Telemetry is off by default.** With no OTLP endpoint configured, nothing is exported, no exporter
+is allocated, and the application starts exactly as before. Setting one environment variable turns
+all three signals on.
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317
+```
+
+Logs also always go to **stdout**, whether or not telemetry is configured — that is what
+`docker logs` and `kubectl logs` read, and Endatix never takes it away.
+
+## What you get
+
+| Signal | Source | Notable series / spans |
+|---|---|---|
+| **Metrics** | ASP.NET Core, HttpClient, .NET runtime | `http.server.request.duration`, `dotnet.gc.collections`, thread pool |
+| **Traces** | Inbound HTTP, outbound HttpClient (including webhook delivery) | one span per request; `/health`, `/alive`, `/ready` excluded |
+| **Logs** | Every `ILogger` record | carries the `TraceId` of the request it happened in |
+
+Because all three come from one SDK with one resource, a log record and the span it belongs to agree
+on `service.name` — which is what lets a backend show them together.
+
+:::note Runtime metric names
+On .NET 9 and later the runtime instrumentation emits `dotnet.*` metrics (`dotnet.gc.collections`,
+`dotnet.thread_pool.thread.count`). The older `process.runtime.dotnet.*` names are **not** emitted;
+they were superseded by built-in .NET metrics. If a dashboard shows nothing, check which names it
+queries.
+:::
+
+## Environment variables
+
+Standard `OTEL_*` variables are **authoritative**. Anything under `Endatix:Telemetry` is a fallback,
+never an override — so a deployment can always change telemetry without a rebuild.
+
+| Variable | Purpose |
+|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector endpoint. **Setting this enables telemetry.** |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc` (default) or `http/protobuf` |
+| `OTEL_EXPORTER_OTLP_{TRACES,METRICS,LOGS}_ENDPOINT` | Per-signal override; any one of them also enables telemetry |
+| `OTEL_EXPORTER_OTLP_{TRACES,METRICS,LOGS}_PROTOCOL` | Per-signal protocol |
+| `OTEL_SERVICE_NAME` | `service.name` on everything exported |
+| `OTEL_SERVICE_VERSION` | `service.version` |
+| `OTEL_TRACES_SAMPLER` / `_ARG` | Sampling strategy, e.g. `parentbased_traceidratio` with `0.1` |
+
+Signal-specific variables take precedence over the global one, per the OpenTelemetry specification.
+Endatix defers to the SDK for that resolution rather than reimplementing it.
+
+:::warning A malformed endpoint fails startup
+An unparseable endpoint or an unknown protocol throws at startup, naming the offending value. This
+is deliberate: the alternative is a host that starts happily and silently exports nothing, which is
+indistinguishable from a working system until you go looking for data that was never sent.
+:::
+
+### Configuration fallback
+
+Every variable above has an `appsettings.json` equivalent, for hosts that prefer configuration files.
+Environment variables win where both are present.
+
+```json
+{
+  "Endatix": {
+    "Telemetry": {
+      "Otlp": { "Endpoint": "http://collector:4317", "Protocol": "grpc" },
+      "ServiceName": "endatix-api",
+      "ResourceAttributes": { "deployment.environment": "staging" }
+    }
+  }
+}
+```
+
+## Log levels
+
+Endatix uses the standard `Logging` section. Levels default to `Warning`, so **exporting without
+raising the Endatix level ships almost nothing** — the pipeline looks broken when it is merely quiet.
+
+The recommended production shape lifts Endatix records for OTLP only, leaving the console terse:
+
+```json
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Warning",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information",
+      "System": "Warning",
+      "Endatix": "Warning"
+    },
+    "OpenTelemetry": { "LogLevel": { "Endatix": "Information" } },
+    "Console": { "FormatterName": "json" }
+  }
+}
+```
+
+`Logging:OpenTelemetry:LogLevel:*` is a **provider-scoped** section: it changes what the OTLP
+exporter receives without touching the console. Each provider can be tuned independently:
+
+| Section | Affects |
+|---|---|
+| `Logging:LogLevel` | every provider |
+| `Logging:Console:LogLevel` | stdout only |
+| `Logging:OpenTelemetry:LogLevel` | OTLP export only |
+| `Logging:EndatixFile:LogLevel` | the log file only (see below) |
+
+## File logging
+
+.NET ships no file logging provider, so Endatix includes an optional one. It is **disabled by
+default** and writes nothing until you turn it on.
+
+```json
+{
+  "Endatix": {
+    "Logging": {
+      "File": {
+        "Enabled": false,
+        "Path": "logs/endatix-.log",
+        "Formatter": "Json",
+        "RollingInterval": "Day",
+        "FileSizeLimitBytes": 10485760,
+        "RollOnFileSizeLimit": true,
+        "RetainedFileCountLimit": 7
+      }
+    }
+  }
+}
+```
+
+| Key | Default | Notes |
+|---|---|---|
+| `Enabled` | `false` | Off by design — see the container note below |
+| `Path` | `logs/endatix-.log` | **Relative paths resolve against the content root**, not the working directory. The rotation suffix is inserted before the extension. |
+| `Formatter` | `Json` | `Json` or `Text`. JSON keeps structured properties queryable. |
+| `RollingInterval` | `Day` | `Infinite`, `Year`, `Month`, `Day`, `Hour`, `Minute` |
+| `FileSizeLimitBytes` | `10485760` | 10 MiB |
+| `RollOnFileSizeLimit` | `true` | With this off the sink **stops writing** at the limit rather than rolling |
+| `RetainedFileCountLimit` | `7` | Older files are deleted as new ones roll |
+
+**Enabling file logging never silences the console.** Both receive every record.
+
+:::danger Enabling this in a container needs a writable volume
+The Helm chart runs with `readOnlyRootFilesystem: true` and only `/tmp` writable. Enabling file
+logging without mounting a writable volume at the configured path will **fail startup** with a
+message naming the directory. Use the chart's `extraVolumes` / `extraVolumeMounts` passthrough.
+
+Failing loudly is intentional. The previous implementation reported write failures only to an
+internal diagnostic channel, so a misconfigured path produced no files and no complaint.
+:::
+
+## Self-hosted collector
+
+A minimal OpenTelemetry Collector that accepts OTLP and forwards metrics to Prometheus, logs to Loki
+and traces to Tempo:
+
+```yaml title="otel-collector-config.yaml"
+receivers:
+  otlp:
+    protocols:
+      grpc: { endpoint: 0.0.0.0:4317 }
+      http: { endpoint: 0.0.0.0:4318 }
+
+processors:
+  batch: {}
+
+exporters:
+  prometheus:
+    endpoint: 0.0.0.0:8889
+  otlphttp/loki:
+    endpoint: http://loki:3100/otlp
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls: { insecure: true }
+
+service:
+  pipelines:
+    metrics: { receivers: [otlp], processors: [batch], exporters: [prometheus] }
+    logs:    { receivers: [otlp], processors: [batch], exporters: [otlphttp/loki] }
+    traces:  { receivers: [otlp], processors: [batch], exporters: [otlp/tempo] }
+```
+
+Point Endatix at it with `OTEL_EXPORTER_OTLP_ENDPOINT=http://collector:4317`.
+
+## Local development
+
+`docker compose up` starts an **Aspire Dashboard** alongside the API and Hub, with both already
+exporting to it. No configuration needed.
+
+- **Dashboard UI** — http://localhost:18888
+- **OTLP/gRPC ingest** — `localhost:18889`
+
+Both ports bind to `127.0.0.1` deliberately: the dashboard is unauthenticated and renders every
+request, log line and form payload the platform handles. Never pair it with a `0.0.0.0` publish, and
+never set `DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS` in a deployed manifest.
+
+To export to it from an app running **outside** Docker:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:18889 \
+OTEL_EXPORTER_OTLP_PROTOCOL=grpc \
+OTEL_SERVICE_NAME=endatix-api \
+dotnet run
+```
+
+## Migrating from the `Serilog` section
+
+Endatix no longer reads a `Serilog` configuration section. A host that still has one **starts
+normally and logs a warning** naming the section — the section is simply ignored, which means the
+levels in it no longer apply.
+
+### Levels
+
+| Before | After |
+|---|---|
+| `Serilog:MinimumLevel:Default` | `Logging:LogLevel:Default` |
+| `Serilog:MinimumLevel:Override:Microsoft` | `Logging:LogLevel:Microsoft` |
+| `Serilog:MinimumLevel:Override:Endatix` | `Logging:LogLevel:Endatix` |
+
+Serilog level names map to .NET names: `Verbose` → `Trace`, `Debug` → `Debug`, `Information` →
+`Information`, `Warning` → `Warning`, `Error` → `Error`, `Fatal` → `Critical`.
+
+### Sinks
+
+| Before | After |
+|---|---|
+| `Serilog:WriteTo` → `Console` | Always on. Shape with `Logging:Console:FormatterName` (`json` or `simple`) |
+| `Serilog:WriteTo` → `File` | `Endatix:Logging:File:Enabled: true` — one key to flip, no package to install |
+| `Serilog:WriteTo` → `ApplicationInsights` | See [Bring your own telemetry](./bring-your-own-telemetry.mdx) |
+
+`Serilog:WriteTo:File:Args` maps key-for-key onto `Endatix:Logging:File`: `path` → `Path`,
+`rollingInterval` → `RollingInterval`, `fileSizeLimitBytes` → `FileSizeLimitBytes`,
+`rollOnFileSizeLimit` → `RollOnFileSizeLimit`, `retainedFileCountLimit` → `RetainedFileCountLimit`.
+
+:::caution Check your file path while migrating
+If your old configuration used an absolute path such as `/logs/log-.txt`, confirm the process can
+actually write there. Relative paths now resolve against the **content root**, which is usually what
+you wanted; absolute paths are left exactly as given.
+:::
+
+### Code
+
+| Before | After |
+|---|---|
+| `endatix.Logging.ConfigureSerilog(cfg => …)` | `endatix.Logging.Configure(logging => …)` |
+| `endatix.Logging.ConfigureBootstrapLogger(…)` | Removed — startup logging is configured from `Logging` |
+
+The replacement takes an `ILoggingBuilder`, so it works with any provider rather than only Serilog:
+
+```csharp
+builder.Host.ConfigureEndatixWithDefaults(endatix =>
+{
+    endatix.Logging.Configure(logging => logging.AddAzureWebAppDiagnostics());
+});
+```
+
+:::warning `builder.Logging.AddX()` in `Program.cs` does not survive
+Endatix registers logging inside `IHostBuilder.ConfigureServices`, which runs at `Build()` and calls
+`ClearProviders()` first — so anything added directly to `builder.Logging` beforehand is discarded.
+`endatix.Logging.Configure(...)` exists precisely because it runs **after** that point.
+:::
+
+## Related
+
+- [Bring your own telemetry](./bring-your-own-telemetry.mdx) — exporting to Azure Monitor or another
+  backend from your own host, and what it costs

--- a/docs/endatix-docs/docs/configuration/observability.mdx
+++ b/docs/endatix-docs/docs/configuration/observability.mdx
@@ -154,9 +154,6 @@ default** and writes nothing until you turn it on.
 The Helm chart runs with `readOnlyRootFilesystem: true` and only `/tmp` writable. Enabling file
 logging without mounting a writable volume at the configured path will **fail startup** with a
 message naming the directory. Use the chart's `extraVolumes` / `extraVolumeMounts` passthrough.
-
-Failing loudly is intentional. The previous implementation reported write failures only to an
-internal diagnostic channel, so a misconfigured path produced no files and no complaint.
 :::
 
 ## Self-hosted collector

--- a/src/Endatix.Hosting/Builders/EndatixLoggingBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixLoggingBuilder.cs
@@ -19,9 +19,7 @@ public class EndatixLoggingBuilder
 {
     internal const string LegacySerilogSection = "Serilog";
     internal const string LoggingSection = "Logging";
-    // The configuration index, not a logging-specific page: no such page exists yet, and a warning
-    // that points at a 404 is worse than one that points at the right section.
-    private const string MigrationDocsUrl = "https://docs.endatix.com/docs/configuration";
+    private const string MigrationDocsUrl = "https://docs.endatix.com/docs/configuration/observability";
 
     private readonly EndatixBuilder? _parentBuilder;
     private readonly IAppEnvironment? _appEnvironment;

--- a/src/Endatix.Hosting/Builders/EndatixLoggingBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixLoggingBuilder.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Endatix.Framework.Hosting;
 using Endatix.Hosting.Builders.Logging;
 using Microsoft.ApplicationInsights.AspNetCore.Extensions;
@@ -19,6 +20,10 @@ public class EndatixLoggingBuilder
 {
     internal const string LegacySerilogSection = "Serilog";
     internal const string LoggingSection = "Logging";
+    [SuppressMessage("csharpsquid", "S1075:URIs should not be hardcoded",
+        Justification = "A documentation link shown in a warning message. It does not vary by "
+                      + "environment, and making it configurable would let an operator break the "
+                      + "help text without noticing.")]
     private const string MigrationDocsUrl = "https://docs.endatix.com/docs/configuration/observability";
 
     private readonly EndatixBuilder? _parentBuilder;


### PR DESCRIPTION
## Description

The documentation half of #476. Two new pages under **Configuration**, plus an architecture decision record.

Written on the assumption that **[#948](https://github.com/endatix/endatix/pull/948) (PR-T6, file logging) merges first** — see the ordering note below.

### `observability.mdx` — the operational page

The OTLP contract and everything around it: the env-var table including signal-specific variants, why a malformed endpoint fails startup rather than exporting nothing quietly, the provider-scoped level sections, file logging, the local Aspire dashboard, a self-hosted collector config, and a key-by-key **Serilog → Logging migration table** covering levels, sinks and the two removed code hooks.

Two things in there are traps rather than reference material, and are called out as such:

- **Levels default to `Warning`.** Exporting without lifting `Endatix` ships almost nothing, and the pipeline looks broken when it is merely quiet.
- **Relative file paths resolve against the content root.** The configuration this replaces used `/logs` at the filesystem root, so anyone copying their old absolute path forward should check it.

### `bring-your-own-telemetry.mdx` — what replaces shipping an exporter

Endatix ships no vendor exporters, so this page has to carry the weight that an `Azure.Monitor` dependency otherwise would. Worked examples for Azure Monitor and plain OTLP, `UseAzureMonitor()` **with no argument** (it resolves `APPLICATIONINSIGHTS_CONNECTION_STRING` itself — the page explicitly says not to invent an Endatix key), and why `builder.Logging.AddX()` in `Program.cs` silently does not survive.

It also carries the **cost material**, because this is the page where someone decides to switch App Insights on:

- Billing is **per GB ingested**; **dependency telemetry dominates** for a DB-heavy API, and every EF Core query becomes a billable record
- Enabling the distro is an **expansion** of what is collected, not a like-for-like swap — the old Serilog sink sent log records only
- **Log records belonging to unsampled traces are dropped by default**, so a naive `SamplingRatio = 0.1` discards ~90% of logs as well as traces — quite possibly including the error being diagnosed

## A pre-existing bug found while working

`infrastructure-configuration.mdx` documented Serilog **and an API that does not exist**:

```csharp
endatix.Infrastructure.ConfigureLogging(logging => {
    logging.UseConsole = true;  // no such thing
});
```

`ConfigureLogging` appears **nowhere in the codebase** — `grep` across `src/` returns nothing. That example never compiled, independently of anything in #476. Replaced with a short summary and a link to the new page.

## Also

- **`ARCHITECTURE.md`** — an Observability section (three signals one mechanism, env-vars authoritative, why the log exporter lives in the telemetry builder, why the builder ordering is load-bearing, Serilog's remaining role, no vendor exporters) and a decision-log entry.
- **`MigrationDocsUrl`** now points at the observability page. It was aimed at the configuration index as a deliberate placeholder because the page did not exist; it does now.

## Verification

**The Docusaurus site builds clean** — `onBrokenLinks: "throw"`, so the cross-page links and the `#migrating-from-the-serilog-section` anchor are verified by the build rather than by eye. No warnings.

84 tests still pass on the one-line code change.

> [!IMPORTANT]
> **Merge after [#948](https://github.com/endatix/endatix/pull/948).** These pages document `Endatix:Logging:File` and `Logging:EndatixFile:LogLevel`, which ship in that PR. Merging this first would publish documentation for a feature not in the release. No file conflicts either way — this PR touches docs plus one constant.

> [!NOTE]
> **Release notes are not in this PR.** The plan lists a CHANGELOG entry, but this repo has no CHANGELOG file — stable releases use a human-edited draft release. **Whoever publishes the release that carries #947 must call out the breaking change explicitly:** the `Serilog` configuration section is no longer read, and `ConfigureSerilog` / `ConfigureBootstrapLogger` are removed. It should not be left to the diff.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

Refs #476
