### PR TITLE
docs(e476): add Observability pages to the Configuration sidebar

### DIFF
--- a/docs/endatix-docs/sidebars.ts
+++ b/docs/endatix-docs/sidebars.ts
@@ -96,6 +96,8 @@ const sidebars: SidebarsConfig = {
         "configuration/background-processing",
         "configuration/infrastructure-configuration",
         "configuration/security-configuration",
+        "configuration/observability",
+        "configuration/bring-your-own-telemetry",
         {
           type: "category",
           label: "Settings",


### PR DESCRIPTION
## Description

The Observability and Bring-your-own-telemetry pages shipped in #950 and are live, but neither is reachable by navigation. The Configuration category in `sidebars.ts` uses an explicit `items` list, and they were never added to it.

Verified against production, not just the source:

| Check | Result |
|---|---|
| `/docs/configuration/observability` | 200, `last-modified` 08:23:14 today |
| Sidebar entries under Configuration (live) | 5 — neither page among them |
| Inbound links from `/docs/configuration/`, `/deployment/self-hosting`, `/getting-started/quick-start` | **0** |

The only page that links to them, `infrastructure-configuration.mdx`, carries `draft: true` and 404s in production — so the migration guidance for the Serilog removal was reachable only by typing the URL.

## The DocCardList side effect

`configuration/index.mdx` renders `<DocCardList />`, which lists *sidebar children*. The Configuration landing page was therefore advertising three of its pages. This restores the two missing cards from the same change.

## Verified with a production build

`pnpm build` (drops drafts, `onBrokenLinks: "throw"`) — exit 0. Built output:

```
Configuration sidebar, before → after
  /docs/configuration/                     /docs/configuration/
  /docs/configuration/asset-storage        /docs/configuration/asset-storage
  /docs/configuration/background-processing/docs/configuration/background-processing
  /docs/configuration/settings/          + /docs/configuration/bring-your-own-telemetry
                                         + /docs/configuration/observability
                                           /docs/configuration/settings/
```

The four `draft: true` Configuration pages remain excluded from the build, unchanged.

## Scope

`sidebars.ts` only — two lines. No page content edited, no draft un-drafted, nothing newly published (both pages were already live and in `sitemap.xml`).

## Follow-ups, deliberately not here

- `infrastructure-configuration.mdx` documents APIs that do not exist in `src/` — `endatix.Infrastructure.AddHealthChecks`, `AddHealthUI`, `UseExceptionHandling`, `UseResponseCompression` all have zero occurrences. It needs a rewrite against the real builders before it can be un-drafted.
- The Serilog migration section under-reports silent breaks: file logging was enabled in the shipped `appsettings.json` and is now off by default, the console output format changed, the `Enrich`/`Properties` blocks have no equivalent, `{Date}` is no longer a path token, and the public `SerilogConfigurator` was deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)