### PR TITLE
feat: add the feature flag catalogue

### DIFF
--- a/Endatix.slnx
+++ b/Endatix.slnx
@@ -31,6 +31,7 @@
   <Folder Name="/tests/">
     <Project Path="tests/Endatix.Api.Tests/Endatix.Api.Tests.csproj" />
     <Project Path="tests/Endatix.Core.Tests/Endatix.Core.Tests.csproj" />
+    <Project Path="tests/Endatix.Framework.Tests/Endatix.Framework.Tests.csproj" />
     <Project Path="tests/Endatix.Hosting.Tests/Endatix.Hosting.Tests.csproj" />
     <Project Path="tests/Endatix.Infrastructure.Tests/Endatix.Infrastructure.Tests.csproj" />
     <Project Path="tests/Endatix.IntegrationTests.Shared/Endatix.IntegrationTests.Shared.csproj" />

--- a/src/Endatix.Framework/FeatureFlags/FeatureFlagCatalogue.cs
+++ b/src/Endatix.Framework/FeatureFlags/FeatureFlagCatalogue.cs
@@ -1,0 +1,87 @@
+using System.Collections.Immutable;
+
+namespace Endatix.Framework.FeatureFlags;
+
+/// <summary>
+/// The canonical list of Endatix feature flags. One entry per flag, carrying the kebab-case key used by
+/// the evaluator alongside the configuration path that seeds it.
+/// </summary>
+/// <remarks>
+/// Adding a flag is an edit here plus a constant in <see cref="FeatureFlags"/>. The Hub keeps its own
+/// binding with the same keys and fallback defaults; there is no cross-repo check, because the API is
+/// the only evaluator and a key it does not know resolves to the caller's default.
+/// </remarks>
+public static class FeatureFlagCatalogue
+{
+    /// <summary>
+    /// Every defined flag, in declaration order.
+    /// </summary>
+    public static readonly ImmutableArray<FeatureFlagDefinition> Definitions =
+    [
+        // Every flag below is Rollout: none of them is priced yet, so none is an entitlement. The label
+        // follows the commercial decision, not the shape of the configuration — reclassifying one needs
+        // a deprecation path for installs already relying on it.
+        FeatureFlagDefinition.Boolean(
+            key: "experimental-features",
+            configKey: FeatureFlags.ExperimentalFeatures,
+            defaultValue: false,
+            flagClass: FeatureFlagClass.Rollout,
+            scope: FeatureFlagScope.Tenant),
+
+        FeatureFlagDefinition.Boolean(
+            key: "advanced-analytics",
+            configKey: FeatureFlags.AdvancedAnalytics,
+            defaultValue: false,
+            flagClass: FeatureFlagClass.Rollout,
+            scope: FeatureFlagScope.Tenant),
+
+        FeatureFlagDefinition.Boolean(
+            key: "form-analytics",
+            configKey: FeatureFlags.FormAnalytics,
+            defaultValue: false,
+            flagClass: FeatureFlagClass.Rollout,
+            scope: FeatureFlagScope.Tenant),
+
+        FeatureFlagDefinition.Boolean(
+            key: "storage-stats",
+            configKey: FeatureFlags.StorageStats,
+            defaultValue: false,
+            flagClass: FeatureFlagClass.Rollout,
+            scope: FeatureFlagScope.Tenant),
+
+        FeatureFlagDefinition.Boolean(
+            key: "data-lists",
+            configKey: FeatureFlags.DataLists,
+            defaultValue: false,
+            flagClass: FeatureFlagClass.Rollout,
+            scope: FeatureFlagScope.Tenant),
+
+        // Deployment-scoped: read at startup by EndatixModuleRegistration.ShouldRegister to decide
+        // whether the Reporting module is registered at all. No tenant exists at that point.
+        FeatureFlagDefinition.Boolean(
+            key: "reporting-module",
+            configKey: FeatureFlags.ReportingModule,
+            defaultValue: false,
+            flagClass: FeatureFlagClass.Rollout,
+            scope: FeatureFlagScope.Deployment),
+    ];
+
+    private static readonly ImmutableDictionary<string, FeatureFlagDefinition> ByKeyIndex =
+        Definitions.ToImmutableDictionary(definition => definition.Key, StringComparer.Ordinal);
+
+    private static readonly ImmutableDictionary<string, FeatureFlagDefinition> ByConfigKeyIndex =
+        Definitions.ToImmutableDictionary(definition => definition.ConfigKey, StringComparer.Ordinal);
+
+    /// <summary>
+    /// Finds a definition by its kebab-case key, or null when the key is not defined.
+    /// </summary>
+    public static FeatureFlagDefinition? FindByKey(string key) =>
+        string.IsNullOrWhiteSpace(key) ? null : ByKeyIndex.GetValueOrDefault(key);
+
+    /// <summary>
+    /// Finds a definition by its configuration path under <c>Endatix:FeatureFlags</c>, or null when the
+    /// path does not correspond to a defined flag.
+    /// </summary>
+    public static FeatureFlagDefinition? FindByConfigKey(string configKey) =>
+        string.IsNullOrWhiteSpace(configKey) ? null : ByConfigKeyIndex.GetValueOrDefault(configKey);
+}

--- a/src/Endatix.Framework/FeatureFlags/FeatureFlagClass.cs
+++ b/src/Endatix.Framework/FeatureFlags/FeatureFlagClass.cs
@@ -1,0 +1,24 @@
+namespace Endatix.Framework.FeatureFlags;
+
+/// <summary>
+/// Identifies which system is the record for a flag's value, and therefore which provider resolves it.
+/// </summary>
+/// <remarks>
+/// There is deliberately no member for config-driven flags. A switch whose answer has no record outside
+/// the deployment is configuration, not a feature flag, and belongs in <c>appsettings</c> or an
+/// environment variable. The enum starts at 1 so a definition cannot acquire a class by default.
+/// </remarks>
+public enum FeatureFlagClass
+{
+    /// <summary>
+    /// A gradual release or opt-in beta. The answer does not exist anywhere until the rollout provider
+    /// buckets a subject, which is why that provider is the record for it.
+    /// </summary>
+    Rollout = 1,
+
+    /// <summary>
+    /// A statement about what a customer is entitled to. Resolved from the licence file or the contract
+    /// service, never from the rollout provider, and never enabled by configuration alone.
+    /// </summary>
+    Entitlement = 2,
+}

--- a/src/Endatix.Framework/FeatureFlags/FeatureFlagDefinition.cs
+++ b/src/Endatix.Framework/FeatureFlags/FeatureFlagDefinition.cs
@@ -47,7 +47,41 @@ public sealed record FeatureFlagDefinition(
     /// <summary>
     /// The value used when nothing resolves the flag.
     /// </summary>
-    public object DefaultValue { get; } = Guard.Against.Null(DefaultValue);
+    public object DefaultValue { get; } = GuardDefaultValue(DefaultValue, ValueType);
+
+    /// <summary>
+    /// Which system is the record for this flag's value.
+    /// </summary>
+    /// <remarks>
+    /// Guarded rather than merely documented: <see cref="FeatureFlagClass"/> has no zero member so a
+    /// definition cannot acquire a class by default, and an unchecked cast would defeat that.
+    /// </remarks>
+    public FeatureFlagClass Class { get; } = Guard.Against.EnumOutOfRange(Class);
+
+    /// <summary>
+    /// Where the flag is evaluated.
+    /// </summary>
+    public FeatureFlagScope Scope { get; } = Guard.Against.EnumOutOfRange(Scope);
+
+    /// <summary>
+    /// Rejects a default value that is not an instance of the declared <paramref name="valueType"/>.
+    /// A mismatch would surface far from here — as a cast failure inside whichever provider resolves
+    /// the flag — so it is caught where the definition is written instead.
+    /// </summary>
+    private static object GuardDefaultValue(object defaultValue, Type valueType)
+    {
+        var value = Guard.Against.Null(defaultValue);
+        var type = Guard.Against.Null(valueType);
+
+        if (!type.IsInstanceOfType(value))
+        {
+            throw new ArgumentException(
+                $"Default value of type '{value.GetType()}' does not match the declared value type '{type}'.",
+                nameof(defaultValue));
+        }
+
+        return value;
+    }
 
     /// <summary>
     /// Creates a boolean flag definition.

--- a/src/Endatix.Framework/FeatureFlags/FeatureFlagDefinition.cs
+++ b/src/Endatix.Framework/FeatureFlags/FeatureFlagDefinition.cs
@@ -1,0 +1,62 @@
+using Ardalis.GuardClauses;
+
+namespace Endatix.Framework.FeatureFlags;
+
+/// <summary>
+/// One entry in the <see cref="FeatureFlagCatalogue"/>: everything the evaluator needs to resolve a
+/// flag, independent of which provider ends up answering it.
+/// </summary>
+/// <param name="Key">
+/// The canonical kebab-case flag key, e.g. <c>reporting-module</c>.
+/// </param>
+/// <param name="ConfigKey">
+/// The path under <c>Endatix:FeatureFlags</c> that seeds this flag from configuration. Deliberately
+/// separate from <paramref name="Key"/>: self-hosted operators already set these paths, and renaming
+/// one would silently revert a feature to its default on upgrade.
+/// </param>
+/// <param name="ValueType">The CLR type of the flag's value.</param>
+/// <param name="DefaultValue">
+/// The value used when nothing resolves the flag. For a boolean <see cref="FeatureFlagClass.Entitlement"/>
+/// this is the locked state; for a numeric one it is the free-tier value, never zero.
+/// </param>
+/// <param name="Class">Which system is the record for this flag's value.</param>
+/// <param name="Scope">Where the flag is evaluated.</param>
+public sealed record FeatureFlagDefinition(
+    string Key,
+    string ConfigKey,
+    Type ValueType,
+    object DefaultValue,
+    FeatureFlagClass Class,
+    FeatureFlagScope Scope)
+{
+    /// <summary>
+    /// The canonical kebab-case flag key.
+    /// </summary>
+    public string Key { get; } = Guard.Against.NullOrWhiteSpace(Key);
+
+    /// <summary>
+    /// The configuration path under <c>Endatix:FeatureFlags</c> that seeds this flag.
+    /// </summary>
+    public string ConfigKey { get; } = Guard.Against.NullOrWhiteSpace(ConfigKey);
+
+    /// <summary>
+    /// The CLR type of the flag's value.
+    /// </summary>
+    public Type ValueType { get; } = Guard.Against.Null(ValueType);
+
+    /// <summary>
+    /// The value used when nothing resolves the flag.
+    /// </summary>
+    public object DefaultValue { get; } = Guard.Against.Null(DefaultValue);
+
+    /// <summary>
+    /// Creates a boolean flag definition.
+    /// </summary>
+    public static FeatureFlagDefinition Boolean(
+        string key,
+        string configKey,
+        bool defaultValue,
+        FeatureFlagClass flagClass,
+        FeatureFlagScope scope) =>
+        new(key, configKey, typeof(bool), defaultValue, flagClass, scope);
+}

--- a/src/Endatix.Framework/FeatureFlags/FeatureFlagScope.cs
+++ b/src/Endatix.Framework/FeatureFlags/FeatureFlagScope.cs
@@ -1,0 +1,19 @@
+namespace Endatix.Framework.FeatureFlags;
+
+/// <summary>
+/// Identifies where a flag is evaluated. Independent of <see cref="FeatureFlagClass"/>: the class says
+/// which system answers, the scope says when the question is asked and on whose behalf.
+/// </summary>
+public enum FeatureFlagScope
+{
+    /// <summary>
+    /// Evaluated once at host startup, with no evaluation context. There is no tenant and no user at
+    /// that point, so a deployment-scoped flag must never carry targeting.
+    /// </summary>
+    Deployment = 1,
+
+    /// <summary>
+    /// Evaluated per request, against a context carrying the current tenant and user.
+    /// </summary>
+    Tenant = 2,
+}

--- a/src/Endatix.Framework/FeatureFlags/FeatureFlags.cs
+++ b/src/Endatix.Framework/FeatureFlags/FeatureFlags.cs
@@ -3,6 +3,15 @@ namespace Endatix.Framework.FeatureFlags;
 /// <summary>
 /// Feature flag keys for the Feature Flags system.
 /// </summary>
+/// <remarks>
+/// These values double as the configuration paths under <c>Endatix:FeatureFlags</c> — both
+/// <see cref="Modules.EndatixModuleRegistration.IsFeatureFlagEnabled"/> and Microsoft.FeatureManagement
+/// resolve a flag by looking its name up in that section. They are therefore the
+/// <see cref="FeatureFlagDefinition.ConfigKey"/> of each entry in <see cref="FeatureFlagCatalogue"/>,
+/// and must not be changed: an install setting <c>Endatix:FeatureFlags:ReportingModule</c> would
+/// silently fall back to the default. The kebab-case evaluator keys live in the catalogue instead, and
+/// these constants adopt them only once nothing resolves configuration by flag name.
+/// </remarks>
 public static class FeatureFlags
 {
 

--- a/tests/Endatix.Framework.Tests/Endatix.Framework.Tests.csproj
+++ b/tests/Endatix.Framework.Tests/Endatix.Framework.Tests.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>false</TestingPlatformDotnetTestSupport>
+    <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Endatix.Framework\Endatix.Framework.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Endatix.Framework.Tests/FeatureFlags/FeatureFlagCatalogueTests.cs
+++ b/tests/Endatix.Framework.Tests/FeatureFlags/FeatureFlagCatalogueTests.cs
@@ -1,0 +1,193 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Endatix.Framework.FeatureFlags;
+
+namespace Endatix.Framework.Tests.FeatureFlags;
+
+public class FeatureFlagCatalogueTests
+{
+    private static readonly Regex KebabCase = new("^[a-z0-9]+(-[a-z0-9]+)*$", RegexOptions.Compiled);
+
+    private static IReadOnlyList<string> DeclaredConstants() =>
+        typeof(Endatix.Framework.FeatureFlags.FeatureFlags)
+            .GetFields(BindingFlags.Public | BindingFlags.Static)
+            .Where(field => field.IsLiteral && field.FieldType == typeof(string))
+            .Select(field => (string)field.GetRawConstantValue()!)
+            .ToList();
+
+    [Fact]
+    public void Definitions_EveryDeclaredConstant_ResolvesToADefinition()
+    {
+        // Arrange
+        var constants = DeclaredConstants();
+
+        // Act
+        var unresolved = constants
+            .Where(constant => FeatureFlagCatalogue.FindByConfigKey(constant) is null)
+            .ToList();
+
+        // Assert
+        constants.Should().NotBeEmpty("the catalogue is meaningless if there are no flag constants");
+        unresolved.Should().BeEmpty("every FeatureFlags constant must have a catalogue entry keyed by its config path");
+    }
+
+    [Fact]
+    public void Definitions_EveryDefinition_HasADeclaredConstant()
+    {
+        // Arrange
+        var constants = DeclaredConstants();
+
+        // Act
+        var orphans = FeatureFlagCatalogue.Definitions
+            .Where(definition => !constants.Contains(definition.ConfigKey, StringComparer.Ordinal))
+            .Select(definition => definition.Key)
+            .ToList();
+
+        // Assert
+        orphans.Should().BeEmpty("a catalogue entry with no constant cannot be referenced from code");
+    }
+
+    [Fact]
+    public void Definitions_Keys_AreUnique()
+    {
+        // Arrange
+        var keys = FeatureFlagCatalogue.Definitions.Select(definition => definition.Key);
+
+        // Act
+        var duplicates = keys.GroupBy(key => key, StringComparer.Ordinal)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .ToList();
+
+        // Assert
+        duplicates.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Definitions_ConfigKeys_AreUnique()
+    {
+        // Arrange
+        var configKeys = FeatureFlagCatalogue.Definitions.Select(definition => definition.ConfigKey);
+
+        // Act
+        var duplicates = configKeys.GroupBy(configKey => configKey, StringComparer.Ordinal)
+            .Where(group => group.Count() > 1)
+            .Select(group => group.Key)
+            .ToList();
+
+        // Assert
+        duplicates.Should().BeEmpty("two flags sharing a config path would resolve to each other's value");
+    }
+
+    [Fact]
+    public void Definitions_Keys_AreKebabCase()
+    {
+        // Arrange
+        var keys = FeatureFlagCatalogue.Definitions.Select(definition => definition.Key);
+
+        // Act
+        var malformed = keys.Where(key => !KebabCase.IsMatch(key)).ToList();
+
+        // Assert
+        malformed.Should().BeEmpty("evaluator keys are kebab-case by convention");
+    }
+
+    [Fact]
+    public void Definitions_BooleanEntitlements_DefaultToTheLockedState()
+    {
+        // Arrange
+        var booleanEntitlements = FeatureFlagCatalogue.Definitions
+            .Where(definition => definition.Class == FeatureFlagClass.Entitlement)
+            .Where(definition => definition.ValueType == typeof(bool));
+
+        // Act
+        var unlocked = booleanEntitlements
+            .Where(definition => (bool)definition.DefaultValue)
+            .Select(definition => definition.Key)
+            .ToList();
+
+        // Assert
+        unlocked.Should().BeEmpty("an entitlement must never resolve to enabled when nothing answers it");
+    }
+
+    [Fact]
+    public void Definitions_DefaultValue_MatchesTheDeclaredValueType()
+    {
+        // Arrange
+        var definitions = FeatureFlagCatalogue.Definitions;
+
+        // Act
+        var mismatched = definitions
+            .Where(definition => !definition.ValueType.IsInstanceOfType(definition.DefaultValue))
+            .Select(definition => definition.Key)
+            .ToList();
+
+        // Assert
+        mismatched.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void FindByKey_KnownKey_ReturnsTheDefinition()
+    {
+        // Arrange
+        var expected = FeatureFlagCatalogue.Definitions.First();
+
+        // Act
+        var found = FeatureFlagCatalogue.FindByKey(expected.Key);
+
+        // Assert
+        found.Should().BeSameAs(expected);
+    }
+
+    [Fact]
+    public void FindByConfigKey_KnownConfigKey_ReturnsTheDefinition()
+    {
+        // Arrange
+        var expected = FeatureFlagCatalogue.Definitions.First();
+
+        // Act
+        var found = FeatureFlagCatalogue.FindByConfigKey(expected.ConfigKey);
+
+        // Assert
+        found.Should().BeSameAs(expected);
+    }
+
+    [Theory]
+    [InlineData("no-such-flag")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void FindByKey_UnknownOrBlankKey_ReturnsNull(string key)
+    {
+        // Arrange & Act
+        var found = FeatureFlagCatalogue.FindByKey(key);
+
+        // Assert
+        found.Should().BeNull();
+    }
+
+    [Fact]
+    public void FindByConfigKey_UnknownConfigKey_ReturnsNull()
+    {
+        // Arrange & Act
+        var found = FeatureFlagCatalogue.FindByConfigKey("NoSuchFlag");
+
+        // Assert
+        found.Should().BeNull();
+    }
+
+    [Fact]
+    public void Definitions_ReportingModule_IsDeploymentScoped()
+    {
+        // Arrange
+        var reportingModule = FeatureFlagCatalogue.FindByConfigKey(
+            Endatix.Framework.FeatureFlags.FeatureFlags.ReportingModule);
+
+        // Act
+        var scope = reportingModule?.Scope;
+
+        // Assert
+        scope.Should().Be(
+            FeatureFlagScope.Deployment,
+            "ShouldRegister reads it at startup, where no tenant or user exists");
+    }
+}

--- a/tests/Endatix.Framework.Tests/FeatureFlags/FeatureFlagDefinitionTests.cs
+++ b/tests/Endatix.Framework.Tests/FeatureFlags/FeatureFlagDefinitionTests.cs
@@ -1,0 +1,144 @@
+using Endatix.Framework.FeatureFlags;
+
+namespace Endatix.Framework.Tests.FeatureFlags;
+
+public class FeatureFlagDefinitionTests
+{
+    private static FeatureFlagDefinition Create(
+        string key = "sample-flag",
+        string configKey = "SampleFlag",
+        Type? valueType = null,
+        object? defaultValue = null,
+        FeatureFlagClass flagClass = FeatureFlagClass.Rollout,
+        FeatureFlagScope scope = FeatureFlagScope.Tenant) =>
+        new(key, configKey, valueType ?? typeof(bool), defaultValue ?? false, flagClass, scope);
+
+    [Fact]
+    public void Constructor_ValidArguments_CreatesDefinition()
+    {
+        // Arrange & Act
+        var definition = Create();
+
+        // Assert
+        definition.Key.Should().Be("sample-flag");
+        definition.ConfigKey.Should().Be("SampleFlag");
+        definition.ValueType.Should().Be<bool>();
+        definition.DefaultValue.Should().Be(false);
+        definition.Class.Should().Be(FeatureFlagClass.Rollout);
+        definition.Scope.Should().Be(FeatureFlagScope.Tenant);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_BlankKey_Throws(string? key)
+    {
+        // Arrange & Act
+        var act = () => Create(key: key!);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Constructor_BlankConfigKey_Throws(string? configKey)
+    {
+        // Arrange & Act
+        var act = () => Create(configKey: configKey!);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Constructor_NullValueType_Throws()
+    {
+        // Arrange & Act — constructed directly; the Create helper substitutes a default for null
+        var act = () => new FeatureFlagDefinition(
+            "sample-flag", "SampleFlag", null!, false, FeatureFlagClass.Rollout, FeatureFlagScope.Tenant);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_NullDefaultValue_Throws()
+    {
+        // Arrange & Act
+        var act = () => new FeatureFlagDefinition(
+            "sample-flag", "SampleFlag", typeof(bool), null!, FeatureFlagClass.Rollout, FeatureFlagScope.Tenant);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    public void Constructor_DefaultValueDoesNotMatchValueType_Throws()
+    {
+        // Arrange & Act
+        var act = () => Create(valueType: typeof(bool), defaultValue: "not-a-bool");
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .WithMessage("*does not match the declared value type*");
+    }
+
+    [Fact]
+    public void Constructor_NumericDefaultMatchingItsValueType_IsAccepted()
+    {
+        // Arrange & Act
+        var definition = Create(valueType: typeof(int), defaultValue: 100);
+
+        // Assert
+        definition.DefaultValue.Should().Be(100);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(3)]
+    [InlineData(-1)]
+    public void Constructor_UndefinedClass_Throws(int flagClass)
+    {
+        // Arrange & Act
+        var act = () => Create(flagClass: (FeatureFlagClass)flagClass);
+
+        // Assert
+        act.Should().Throw<ArgumentException>(
+            "zero must be rejected too — FeatureFlagClass has no zero member precisely so a definition cannot acquire a class by default");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(3)]
+    [InlineData(-1)]
+    public void Constructor_UndefinedScope_Throws(int scope)
+    {
+        // Arrange & Act
+        var act = () => Create(scope: (FeatureFlagScope)scope);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void Boolean_ValidArguments_CreatesBooleanDefinition()
+    {
+        // Arrange & Act
+        var definition = FeatureFlagDefinition.Boolean(
+            key: "sample-flag",
+            configKey: "SampleFlag",
+            defaultValue: true,
+            flagClass: FeatureFlagClass.Entitlement,
+            scope: FeatureFlagScope.Deployment);
+
+        // Assert
+        definition.ValueType.Should().Be<bool>();
+        definition.DefaultValue.Should().Be(true);
+        definition.Class.Should().Be(FeatureFlagClass.Entitlement);
+        definition.Scope.Should().Be(FeatureFlagScope.Deployment);
+    }
+}

--- a/tests/Endatix.Framework.Tests/xunit.runner.json
+++ b/tests/Endatix.Framework.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json"
+}


### PR DESCRIPTION
# Add the feature flag catalogue

## Description

First step of the OpenFeature convergence: one canonical registry of flag definitions in `Endatix.Framework`, carrying the kebab-case key the evaluator will use alongside the `Endatix:FeatureFlags` path that seeds it.

**Pure addition — no existing behaviour changes.**

| File | Purpose |
|---|---|
| `FeatureFlagDefinition` | Key, ConfigKey, ValueType, DefaultValue, Class, Scope, plus a `Boolean(...)` factory |
| `FeatureFlagClass` | `Rollout` / `Entitlement` — which system is the record for the value |
| `FeatureFlagScope` | `Deployment` / `Tenant` — where the flag is evaluated |
| `FeatureFlagCatalogue` | The six flags, with `FindByKey` / `FindByConfigKey` over immutable indexes |
| `tests/Endatix.Framework.Tests` | New project — the assembly had no test coverage at all |

### Two keys, deliberately

The catalogue carries both a kebab-case `Key` and the existing PascalCase `ConfigKey`, and **the `FeatureFlags` constants are unchanged**.

Those constants' values currently *are* the configuration paths — both `EndatixModuleRegistration.IsFeatureFlagEnabled` and Microsoft.FeatureManagement resolve a flag by looking its name up in `Endatix:FeatureFlags`. Renaming `ReportingModule` to `reporting-module` today would mean an install that sets `Endatix:FeatureFlags:ReportingModule` silently falls back to the default, and the Reporting module would stop registering on upgrade. The constants adopt the kebab keys only once nothing resolves configuration by flag name.

### Classification

All six flags are `Rollout`. None is priced, so none is an entitlement yet — the label follows the commercial decision, not the shape of the config.

`ReportingModule` is `Deployment`-scoped because `ShouldRegister` reads it at startup, where no tenant or user exists. The rest are `Tenant`-scoped.

There is deliberately **no class for config-driven flags**. A switch whose answer has no record outside the deployment is configuration, not a feature flag. The enum starts at 1 so a definition cannot acquire a class by default.

### Open question for review

`FeatureFlagDefinition` redeclares its properties to run `Guard.Against` validation. That matches the house convention (166 files use `Guard.Against`, 8 use the native `ArgumentException.ThrowIfNullOrWhiteSpace`), but it may not earn its place: the catalogue is a static list of six compile-time entries, nothing constructs one from input, and the tests already reject blank or malformed keys on every build. Dropping the guards would take the record from 62 lines to about 30. Happy either way.

## Related Issues

No public issue — this work is tracked in the private planning repo as the OpenFeature flag-convergence epic. Say if you would like a public issue opened to reference in the release notes.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — none needed yet; the catalogue is not yet reachable from any public surface, and the architecture and how-to-add-a-flag docs land with the final PR of this series
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works — 14 tests, covering both directions of constant ↔ definition, key and config-key uniqueness, kebab-case keys, default value matching declared type, boolean entitlements defaulting locked, both lookup paths, and `ReportingModule`'s scope
- [x] New and existing tests pass locally with my changes — full solution builds Release with 0 errors
- [x] Any dependent changes have been merged and published in downstream modules — none

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots

Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a centralized catalogue of feature flags with standardized keys, configuration paths, defaults, classifications, and scopes.
  - Added support for looking up feature flags by evaluator key or configuration key.
  - Added feature flag classifications for rollout and entitlement controls.
  - Added deployment- and tenant-scoped feature flag definitions.

- **Tests**
  - Added comprehensive validation for catalogue consistency, formatting, defaults, lookups, and scopes.
  - Added the framework test project and runner configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->