### PR TITLE
feat(e964): add list query search for management grids

### DIFF
--- a/src/Endatix.Api/Endpoints/DataLists/List.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/List.cs
@@ -1,9 +1,12 @@
 using Endatix.Api.Common;
+using Endatix.Api.Endpoints.Common;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.Abstractions.Authorization;
+using Endatix.Core.Infrastructure.Paging;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.DataLists.List;
 using FastEndpoints;
+using FluentValidation;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -27,11 +30,12 @@ public sealed class List(
         Summary(s =>
         {
             s.Summary = "List data lists";
-            s.Description = "Lists data lists for the current tenant with paging and an optional locale filter.";
+            s.Description = "Lists data lists for the current tenant with paging, optional name/description search, and an optional locale filter.";
             s.ExampleRequest = new DataListsListRequest
             {
                 Page = 1,
                 PageSize = 20,
+                Query = "cities",
                 HasLocale = "es"
             };
             s.ResponseExamples[200] = new Paged<DataListModel>(
@@ -64,7 +68,7 @@ public sealed class List(
     /// <inheritdoc />
     public override async Task<Results<Ok<Paged<DataListModel>>, ProblemHttpResult>> ExecuteAsync(DataListsListRequest request, CancellationToken ct)
     {
-        var result = await mediator.Send(new ListDataListsQuery(request.Page, request.PageSize, request.HasLocale), ct);
+        var result = await mediator.Send(new ListDataListsQuery(request.Page, request.PageSize, request.HasLocale, request.Query), ct);
 
         if (!result.IsSuccess)
         {
@@ -88,6 +92,12 @@ public sealed class DataListsListValidator : Validator<DataListsListRequest>
     public DataListsListValidator()
     {
         Include(new PageableRequestValidator());
+        RuleFor(x => x.Query)
+            .MaximumLength(PagedRequestLimits.MAX_SEARCH_LENGTH)
+            .When(x => !string.IsNullOrWhiteSpace(x.Query));
+        RuleFor(x => x.HasLocale)
+            .IsCultureCode()
+            .When(x => !string.IsNullOrWhiteSpace(x.HasLocale));
     }
 }
 
@@ -106,4 +116,9 @@ public sealed class DataListsListRequest : IPagedRequest
     /// Optional locale code; returns only lists whose AvailableLocales contain this code.
     /// </summary>
     public string? HasLocale { get; set; }
+
+    /// <summary>
+    /// Optional name/description search (case-insensitive contains).
+    /// </summary>
+    public string? Query { get; set; }
 }

--- a/src/Endatix.Api/Endpoints/DataLists/List.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/List.cs
@@ -2,7 +2,6 @@ using Endatix.Api.Common;
 using Endatix.Api.Endpoints.Common;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.Abstractions.Authorization;
-using Endatix.Core.Infrastructure.Paging;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.DataLists.List;
 using FastEndpoints;
@@ -35,7 +34,7 @@ public sealed class List(
             {
                 Page = 1,
                 PageSize = 20,
-                Query = "cities",
+                Search = "cities",
                 HasLocale = "es"
             };
             s.ResponseExamples[200] = new Paged<DataListModel>(
@@ -68,7 +67,7 @@ public sealed class List(
     /// <inheritdoc />
     public override async Task<Results<Ok<Paged<DataListModel>>, ProblemHttpResult>> ExecuteAsync(DataListsListRequest request, CancellationToken ct)
     {
-        var result = await mediator.Send(new ListDataListsQuery(request.Page, request.PageSize, request.HasLocale, request.Query), ct);
+        var result = await mediator.Send(new ListDataListsQuery(request.Page, request.PageSize, request.HasLocale, request.Search), ct);
 
         if (!result.IsSuccess)
         {
@@ -91,10 +90,7 @@ public sealed class DataListsListValidator : Validator<DataListsListRequest>
     /// </summary>
     public DataListsListValidator()
     {
-        Include(new PageableRequestValidator());
-        RuleFor(x => x.Query)
-            .MaximumLength(PagedRequestLimits.MAX_SEARCH_LENGTH)
-            .When(x => !string.IsNullOrWhiteSpace(x.Query));
+        Include(new SearchablePagedRequestValidator());
         RuleFor(x => x.HasLocale)
             .IsCultureCode()
             .When(x => !string.IsNullOrWhiteSpace(x.HasLocale));
@@ -104,7 +100,7 @@ public sealed class DataListsListValidator : Validator<DataListsListRequest>
 /// <summary>
 /// Request to list data lists.
 /// </summary>
-public sealed class DataListsListRequest : IPagedRequest
+public sealed class DataListsListRequest : ISearchablePagedRequest
 {
     /// <inheritdoc />
     public int? Page { get; set; }
@@ -112,13 +108,11 @@ public sealed class DataListsListRequest : IPagedRequest
     /// <inheritdoc />
     public int? PageSize { get; set; }
 
+    /// <inheritdoc />
+    public string? Search { get; set; }
+
     /// <summary>
     /// Optional locale code; returns only lists whose AvailableLocales contain this code.
     /// </summary>
     public string? HasLocale { get; set; }
-
-    /// <summary>
-    /// Optional name/description search (case-insensitive contains).
-    /// </summary>
-    public string? Query { get; set; }
 }

--- a/src/Endatix.Core/Specifications/DataListsSpecifications.cs
+++ b/src/Endatix.Core/Specifications/DataListsSpecifications.cs
@@ -17,9 +17,9 @@ public static class DataListsSpecifications
     /// </summary>
     public sealed class ListSpec : Specification<DataList>
     {
-        public ListSpec(string? hasLocale = null, string? query = null)
+        public ListSpec(string? hasLocale = null, string? search = null)
         {
-            ApplyListFilters(Query, hasLocale, query);
+            ApplyListFilters(Query, hasLocale, search);
 
             Query
                  .OrderByDescending(x => x.CreatedAt)
@@ -32,9 +32,9 @@ public static class DataListsSpecifications
     /// </summary>
     public sealed class ListWithPagingToDtoSpec : Specification<DataList, DataListDto>
     {
-        public ListWithPagingToDtoSpec(PagingParameters pagingParams, string? hasLocale = null, string? query = null)
+        public ListWithPagingToDtoSpec(PagingParameters pagingParams, string? hasLocale = null, string? search = null)
         {
-            ApplyListFilters(Query, hasLocale, query);
+            ApplyListFilters(Query, hasLocale, search);
 
             Query
                 .OrderByDescending(x => x.CreatedAt)
@@ -136,32 +136,6 @@ public static class DataListsSpecifications
                 .Include(x => x.Items);
         }
     }
-
-    /// <summary>
-    /// Projects a data list by ID without loading item rows. <c>ItemsCount</c> is still computed in SQL.
-    /// </summary>
-    public sealed class ByIdWithoutItemsToDtoSpec : SingleResultSpecification<DataList, DataListDto>
-    {
-        public ByIdWithoutItemsToDtoSpec(long dataListId)
-        {
-            Query
-                .Where(x => x.Id == dataListId)
-                .AsNoTracking();
-
-            Query.Select(dataList => new DataListDto(
-                dataList.Id,
-                dataList.Name,
-                dataList.Description,
-                dataList.CreatedAt,
-                dataList.ModifiedAt,
-                dataList.IsActive,
-                dataList.Items.Count,
-                dataList.DefaultLocale,
-                dataList.AvailableLocales,
-                Array.Empty<DataListItemDto>()));
-        }
-    }
-
 
     /// <summary>
     /// Specification to get a data list by ID with data list items included by values.

--- a/src/Endatix.Core/Specifications/DataListsSpecifications.cs
+++ b/src/Endatix.Core/Specifications/DataListsSpecifications.cs
@@ -17,13 +17,9 @@ public static class DataListsSpecifications
     /// </summary>
     public sealed class ListSpec : Specification<DataList>
     {
-        public ListSpec(string? hasLocale = null)
+        public ListSpec(string? hasLocale = null, string? query = null)
         {
-            if (!string.IsNullOrWhiteSpace(hasLocale))
-            {
-                var locale = hasLocale.Trim().ToLowerInvariant();
-                Query.Where(x => x.AvailableLocales.Contains(locale));
-            }
+            ApplyListFilters(Query, hasLocale, query);
 
             Query
                  .OrderByDescending(x => x.CreatedAt)
@@ -36,13 +32,9 @@ public static class DataListsSpecifications
     /// </summary>
     public sealed class ListWithPagingToDtoSpec : Specification<DataList, DataListDto>
     {
-        public ListWithPagingToDtoSpec(PagingParameters pagingParams, string? hasLocale = null)
+        public ListWithPagingToDtoSpec(PagingParameters pagingParams, string? hasLocale = null, string? query = null)
         {
-            if (!string.IsNullOrWhiteSpace(hasLocale))
-            {
-                var locale = hasLocale.Trim().ToLowerInvariant();
-                Query.Where(x => x.AvailableLocales.Contains(locale));
-            }
+            ApplyListFilters(Query, hasLocale, query);
 
             Query
                 .OrderByDescending(x => x.CreatedAt)
@@ -60,6 +52,26 @@ public static class DataListsSpecifications
                 dataList.DefaultLocale,
                 dataList.AvailableLocales,
                 Array.Empty<DataListItemDto>()));
+        }
+    }
+
+    private static void ApplyListFilters(
+        ISpecificationBuilder<DataList> query,
+        string? hasLocale,
+        string? search)
+    {
+        if (!string.IsNullOrWhiteSpace(hasLocale))
+        {
+            var locale = hasLocale.Trim().ToLowerInvariant();
+            query.Where(x => x.AvailableLocales.Contains(locale));
+        }
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var term = search.Trim().ToLowerInvariant();
+            query.Where(x =>
+                x.Name.ToLower().Contains(term) ||
+                (x.Description != null && x.Description.ToLower().Contains(term)));
         }
     }
 
@@ -122,6 +134,31 @@ public static class DataListsSpecifications
             Query
                 .Where(x => x.Id == dataListId)
                 .Include(x => x.Items);
+        }
+    }
+
+    /// <summary>
+    /// Projects a data list by ID without loading item rows. <c>ItemsCount</c> is still computed in SQL.
+    /// </summary>
+    public sealed class ByIdWithoutItemsToDtoSpec : SingleResultSpecification<DataList, DataListDto>
+    {
+        public ByIdWithoutItemsToDtoSpec(long dataListId)
+        {
+            Query
+                .Where(x => x.Id == dataListId)
+                .AsNoTracking();
+
+            Query.Select(dataList => new DataListDto(
+                dataList.Id,
+                dataList.Name,
+                dataList.Description,
+                dataList.CreatedAt,
+                dataList.ModifiedAt,
+                dataList.IsActive,
+                dataList.Items.Count,
+                dataList.DefaultLocale,
+                dataList.AvailableLocales,
+                Array.Empty<DataListItemDto>()));
         }
     }
 

--- a/src/Endatix.Core/UseCases/DataLists/List/ListDataListsHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/List/ListDataListsHandler.cs
@@ -17,8 +17,8 @@ public sealed class ListDataListsHandler(IRepository<DataList> repository)
     public async Task<Result<Paged<DataListDto>>> Handle(ListDataListsQuery request, CancellationToken cancellationToken)
     {
         PagingParameters pagingParams = new(request.Page, request.PageSize);
-        var pagedSpec = new DataListsSpecifications.ListWithPagingToDtoSpec(pagingParams, request.HasLocale);
-        var listSpec = new DataListsSpecifications.ListSpec(request.HasLocale);
+        var pagedSpec = new DataListsSpecifications.ListWithPagingToDtoSpec(pagingParams, request.HasLocale, request.Query);
+        var listSpec = new DataListsSpecifications.ListSpec(request.HasLocale, request.Query);
         var totalRecords = await repository.CountAsync(listSpec, cancellationToken);
 
         var dataListDtos = totalRecords <= 0

--- a/src/Endatix.Core/UseCases/DataLists/List/ListDataListsHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/List/ListDataListsHandler.cs
@@ -17,8 +17,8 @@ public sealed class ListDataListsHandler(IRepository<DataList> repository)
     public async Task<Result<Paged<DataListDto>>> Handle(ListDataListsQuery request, CancellationToken cancellationToken)
     {
         PagingParameters pagingParams = new(request.Page, request.PageSize);
-        var pagedSpec = new DataListsSpecifications.ListWithPagingToDtoSpec(pagingParams, request.HasLocale, request.Query);
-        var listSpec = new DataListsSpecifications.ListSpec(request.HasLocale, request.Query);
+        var pagedSpec = new DataListsSpecifications.ListWithPagingToDtoSpec(pagingParams, request.HasLocale, request.Search);
+        var listSpec = new DataListsSpecifications.ListSpec(request.HasLocale, request.Search);
         var totalRecords = await repository.CountAsync(listSpec, cancellationToken);
 
         var dataListDtos = totalRecords <= 0

--- a/src/Endatix.Core/UseCases/DataLists/List/ListDataListsQuery.cs
+++ b/src/Endatix.Core/UseCases/DataLists/List/ListDataListsQuery.cs
@@ -9,6 +9,6 @@ namespace Endatix.Core.UseCases.DataLists.List;
 /// <param name="Page">The page number for pagination.</param>
 /// <param name="PageSize">The number of items per page for pagination.</param>
 /// <param name="HasLocale">Optional locale code; filters parent rows whose AvailableLocales contain this code.</param>
-/// <param name="Query">Optional name/description search (case-insensitive contains).</param>
-public sealed record ListDataListsQuery(int? Page, int? PageSize, string? HasLocale = null, string? Query = null)
+/// <param name="Search">Optional name/description search (case-insensitive contains).</param>
+public sealed record ListDataListsQuery(int? Page, int? PageSize, string? HasLocale = null, string? Search = null)
     : IQuery<Result<Paged<DataListDto>>>;

--- a/src/Endatix.Core/UseCases/DataLists/List/ListDataListsQuery.cs
+++ b/src/Endatix.Core/UseCases/DataLists/List/ListDataListsQuery.cs
@@ -9,5 +9,6 @@ namespace Endatix.Core.UseCases.DataLists.List;
 /// <param name="Page">The page number for pagination.</param>
 /// <param name="PageSize">The number of items per page for pagination.</param>
 /// <param name="HasLocale">Optional locale code; filters parent rows whose AvailableLocales contain this code.</param>
-public sealed record ListDataListsQuery(int? Page, int? PageSize, string? HasLocale = null)
+/// <param name="Query">Optional name/description search (case-insensitive contains).</param>
+public sealed record ListDataListsQuery(int? Page, int? PageSize, string? HasLocale = null, string? Query = null)
     : IQuery<Result<Paged<DataListDto>>>;

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/ListTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/ListTests.cs
@@ -60,16 +60,16 @@ public class ListTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_PassesQueryAndHasLocaleToQuery()
+    public async Task ExecuteAsync_PassesSearchAndHasLocaleToQuery()
     {
-        DataListsListRequest request = new() { Query = "cities", HasLocale = "es" };
+        DataListsListRequest request = new() { Search = "cities", HasLocale = "es" };
         _mediator.Send(Arg.Any<ListDataListsQuery>(), Arg.Any<CancellationToken>())
             .Returns(Result.Success(new Paged<DataListDto>(1, 10, 0, 0, Array.Empty<DataListDto>())));
 
         await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
 
         await _mediator.Received(1).Send(
-            Arg.Is<ListDataListsQuery>(x => x.Query == "cities" && x.HasLocale == "es"),
+            Arg.Is<ListDataListsQuery>(x => x.Search == "cities" && x.HasLocale == "es"),
             Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/ListTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/ListTests.cs
@@ -58,4 +58,18 @@ public class ListTests
             Arg.Is<ListDataListsQuery>(x => x.Page == 2 && x.PageSize == 25),
             Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task ExecuteAsync_PassesQueryAndHasLocaleToQuery()
+    {
+        DataListsListRequest request = new() { Query = "cities", HasLocale = "es" };
+        _mediator.Send(Arg.Any<ListDataListsQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new Paged<DataListDto>(1, 10, 0, 0, Array.Empty<DataListDto>())));
+
+        await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        await _mediator.Received(1).Send(
+            Arg.Is<ListDataListsQuery>(x => x.Query == "cities" && x.HasLocale == "es"),
+            Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/List/ListDataListsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/List/ListDataListsHandlerTests.cs
@@ -110,14 +110,14 @@ public class ListDataListsHandlerTests
             });
 
         // Act
-        await _sut.Handle(new ListDataListsQuery(1, 10, Search: "major"), TestContext.Current.CancellationToken);
+        await _sut.Handle(new ListDataListsQuery(1, 10, Search: "MaJoR"), TestContext.Current.CancellationToken);
 
         // Assert
         await _repository.Received(1).CountAsync(
-            Arg.Is<DataListsSpecifications.ListSpec>(spec => SpecFiltersBySearch(spec, "major")),
+            Arg.Is<DataListsSpecifications.ListSpec>(spec => SpecFiltersBySearch(spec, "MaJoR")),
             Arg.Any<CancellationToken>());
         await _repository.Received(1).ListAsync(
-            Arg.Is<DataListsSpecifications.ListWithPagingToDtoSpec>(spec => SpecFiltersBySearch(spec, "major")),
+            Arg.Is<DataListsSpecifications.ListWithPagingToDtoSpec>(spec => SpecFiltersBySearch(spec, "MaJoR")),
             Arg.Any<CancellationToken>());
     }
 
@@ -161,8 +161,13 @@ public class ListDataListsHandlerTests
 
     private static bool SpecFiltersBySearch(ISpecification<DataList> spec, string search)
     {
-        DataList matchingDescription = new(SampleData.TENANT_ID, "Cities", "Major cities");
-        DataList matchingName = new(SampleData.TENANT_ID, "Major metros", "ISO codes");
+        var normalizedTerm = search.Trim().ToLowerInvariant();
+        var displayTerm = normalizedTerm.Length == 0
+            ? normalizedTerm
+            : char.ToUpperInvariant(normalizedTerm[0]) + normalizedTerm[1..];
+
+        DataList matchingDescription = new(SampleData.TENANT_ID, "Cities", $"{displayTerm} cities");
+        DataList matchingName = new(SampleData.TENANT_ID, $"{displayTerm} metros", "ISO codes");
         DataList other = new(SampleData.TENANT_ID, "Countries", "ISO codes");
 
         bool Matches(DataList dataList) =>

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/List/ListDataListsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/List/ListDataListsHandlerTests.cs
@@ -98,6 +98,30 @@ public class ListDataListsHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WithQuery_PassesSearchToSpecs()
+    {
+        // Arrange
+        _repository.CountAsync(Arg.Any<DataListsSpecifications.ListSpec>(), Arg.Any<CancellationToken>())
+            .Returns(1);
+        _repository.ListAsync(Arg.Any<DataListsSpecifications.ListWithPagingToDtoSpec>(), Arg.Any<CancellationToken>())
+            .Returns(new List<DataListDto>
+            {
+                new(5, "Cities", "Major cities", DateTime.UtcNow, null, true, 1, "en", [], Array.Empty<DataListItemDto>())
+            });
+
+        // Act
+        await _sut.Handle(new ListDataListsQuery(1, 10, Query: "major"), TestContext.Current.CancellationToken);
+
+        // Assert
+        await _repository.Received(1).CountAsync(
+            Arg.Is<DataListsSpecifications.ListSpec>(spec => SpecFiltersByQuery(spec, "major")),
+            Arg.Any<CancellationToken>());
+        await _repository.Received(1).ListAsync(
+            Arg.Is<DataListsSpecifications.ListWithPagingToDtoSpec>(spec => SpecFiltersByQuery(spec, "major")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Handle_SecondPage_ComputesSkipFromPaging()
     {
         // Arrange
@@ -133,5 +157,17 @@ public class ListDataListsHandlerTests
             && spec.WhereExpressions.All(expression => expression.FilterFunc(dataList));
 
         return Matches(withLocale) && !Matches(withoutLocale);
+    }
+
+    private static bool SpecFiltersByQuery(ISpecification<DataList> spec, string query)
+    {
+        DataList matching = new(SampleData.TENANT_ID, "Cities", "Major cities");
+        DataList other = new(SampleData.TENANT_ID, "Countries", "ISO codes");
+
+        bool Matches(DataList dataList) =>
+            spec.WhereExpressions.Any()
+            && spec.WhereExpressions.All(expression => expression.FilterFunc(dataList));
+
+        return Matches(matching) && !Matches(other);
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/List/ListDataListsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/List/ListDataListsHandlerTests.cs
@@ -98,7 +98,7 @@ public class ListDataListsHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithQuery_PassesSearchToSpecs()
+    public async Task Handle_WithSearch_PassesSearchToSpecs()
     {
         // Arrange
         _repository.CountAsync(Arg.Any<DataListsSpecifications.ListSpec>(), Arg.Any<CancellationToken>())
@@ -110,14 +110,14 @@ public class ListDataListsHandlerTests
             });
 
         // Act
-        await _sut.Handle(new ListDataListsQuery(1, 10, Query: "major"), TestContext.Current.CancellationToken);
+        await _sut.Handle(new ListDataListsQuery(1, 10, Search: "major"), TestContext.Current.CancellationToken);
 
         // Assert
         await _repository.Received(1).CountAsync(
-            Arg.Is<DataListsSpecifications.ListSpec>(spec => SpecFiltersByQuery(spec, "major")),
+            Arg.Is<DataListsSpecifications.ListSpec>(spec => SpecFiltersBySearch(spec, "major")),
             Arg.Any<CancellationToken>());
         await _repository.Received(1).ListAsync(
-            Arg.Is<DataListsSpecifications.ListWithPagingToDtoSpec>(spec => SpecFiltersByQuery(spec, "major")),
+            Arg.Is<DataListsSpecifications.ListWithPagingToDtoSpec>(spec => SpecFiltersBySearch(spec, "major")),
             Arg.Any<CancellationToken>());
     }
 
@@ -159,15 +159,16 @@ public class ListDataListsHandlerTests
         return Matches(withLocale) && !Matches(withoutLocale);
     }
 
-    private static bool SpecFiltersByQuery(ISpecification<DataList> spec, string query)
+    private static bool SpecFiltersBySearch(ISpecification<DataList> spec, string search)
     {
-        DataList matching = new(SampleData.TENANT_ID, "Cities", "Major cities");
+        DataList matchingDescription = new(SampleData.TENANT_ID, "Cities", "Major cities");
+        DataList matchingName = new(SampleData.TENANT_ID, "Major metros", "ISO codes");
         DataList other = new(SampleData.TENANT_ID, "Countries", "ISO codes");
 
         bool Matches(DataList dataList) =>
             spec.WhereExpressions.Any()
             && spec.WhereExpressions.All(expression => expression.FilterFunc(dataList));
 
-        return Matches(matching) && !Matches(other);
+        return Matches(matchingDescription) && Matches(matchingName) && !Matches(other);
     }
 }


### PR DESCRIPTION
## Summary
- Add optional `search` on `GET /data-lists` (case-insensitive name/description contains) using `ISearchablePagedRequest` + `SearchablePagedRequestValidator`, same contract as other management lists.
- Keep paging, `hasLocale` (valid culture when set), and `Forms.View`.
- Part of stacked delivery for endatix/endatix#964 (API-1).

## Test plan
- [x] `dotnet test` ListTests + ListDataListsHandlerTests
- [ ] OpenAPI: `search` (not `query`) on List
- [ ] Hub: pass `search` on the data-lists grid request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional search support when listing data lists.
  * Search matches data-list names and descriptions, without regard to letter casing.
  * Added locale filtering validation and documented the new search option in the endpoint.
* **Bug Fixes**
  * Improved total-result counts so they reflect active search filters.
* **Tests**
  * Added coverage for search forwarding, matching, and non-matching results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->