### PR TITLE
feat(e964): Add management GET items endpoint and includeItems flag

### DIFF
--- a/docs/endatix-docs/docs/developers/api/data-lists-translations.mdx
+++ b/docs/endatix-docs/docs/developers/api/data-lists-translations.mdx
@@ -11,7 +11,7 @@ Data list choice labels are stored as a JSON map (`Labels`) with a synthetic `de
 
 ## Management list and items grids
 
-Authenticated Hub grids use the same search/paging contract as other list endpoints (`query` + `page` / `pageSize`). Hub maps its URL `search` param to `query`.
+Parent list search uses the management list query string (`query` + `page` / `pageSize`). Item grids intentionally keep `query` (not `search`) to match the public runtime search contract (`matchMode` / `locale` / `includeLocales`). Hub UI may still expose a `search` box and map it to API `query`.
 
 - `GET /api/data-lists?query=&hasLocale=&page=&pageSize=` — name/description contains search; `hasLocale` keeps lists whose AvailableLocales include that culture.
 - `GET /api/data-lists/{id}?includeItems=false` — catalog metadata and `itemsCount` without loading item rows.

--- a/docs/endatix-docs/docs/developers/api/data-lists-translations.mdx
+++ b/docs/endatix-docs/docs/developers/api/data-lists-translations.mdx
@@ -9,6 +9,16 @@ sidebar_position: 5
 
 Data list choice labels are stored as a JSON map (`Labels`) with a synthetic `default` key plus optional culture codes from the list’s AvailableLocales catalog.
 
+## Management list and items grids
+
+Authenticated Hub grids use the same search/paging contract as other list endpoints (`query` + `page` / `pageSize`). Hub maps its URL `search` param to `query`.
+
+- `GET /api/data-lists?query=&hasLocale=&page=&pageSize=` — name/description contains search; `hasLocale` keeps lists whose AvailableLocales include that culture.
+- `GET /api/data-lists/{id}?includeItems=false` — catalog metadata and `itemsCount` without loading item rows.
+- `GET /api/data-lists/{id}/items?query=&matchMode=&locale=&includeLocales=&page=&pageSize=` — paged item search for authors (inactive lists included). Default `pageSize` is 25.
+
+There is no per-item POST/PATCH/DELETE. Authors replace the file with import/export below.
+
 ## Import / export (management)
 
 Authenticated authors round-trip items with a single import and export surface. Format is negotiated in the JSON body (`format`), same pattern as submissions export.

--- a/docs/endatix-docs/docs/developers/api/index.mdx
+++ b/docs/endatix-docs/docs/developers/api/index.mdx
@@ -33,6 +33,6 @@ A robust, .NET-based backend designed for high-scale data collection. It handles
 - [Integration testing](/docs/developers/integration-testing) — Run and extend Endatix API integration tests (Testcontainers, WebApplicationFactory, traits)
 - [Health Checks](/docs/developers/api/health-checks) — Endpoints, default checks (self, database), and customization
 - [Using feature flags](/docs/developers/api/feature-flags) — `Endatix:FeatureFlags`, FastEndpoints, services, and per-tenant targeting
-- [Data lists — import, export, and includeLocales](/docs/developers/api/data-lists-translations) — `format` negotiation and public `labels` projection
+- [Data lists — import, export, and includeLocales](/docs/developers/api/data-lists-translations) — management list/items grids, `format` negotiation, and public `labels` projection
 - [Explore API Reference](/docs/developers/api/api-reference) — Full OpenAPI spec for all endpoints
 - [Setup from Repository](/docs/getting-started/setup-repository) — Clone and run locally

--- a/src/Endatix.Api/Endpoints/DataLists/GetById.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/GetById.cs
@@ -27,7 +27,7 @@ public sealed class GetById(
         Summary(s =>
         {
             s.Summary = "Get a data list by ID";
-            s.Description = "Gets a data list by its ID, including catalog locales and items.";
+            s.Description = "Gets a data list by its ID, including catalog locales. Pass includeItems=false to omit item rows (use GET .../items for paged search).";
             s.ExampleRequest = new GetDataListRequest { DataListId = 1 };
             s.ResponseExamples[200] = new DataListDetailsModel
             {
@@ -67,7 +67,7 @@ public sealed class GetById(
     /// <inheritdoc />
     public override async Task<Results<Ok<DataListDetailsModel>, ProblemHttpResult>> ExecuteAsync(GetDataListRequest request, CancellationToken ct)
     {
-        GetDataListByIdQuery query = new(request.DataListId);
+        GetDataListByIdQuery query = new(request.DataListId, request.IncludeItems);
         var result = await mediator.Send(query, ct);
 
         return TypedResultsBuilder
@@ -100,4 +100,9 @@ public sealed class GetDataListRequest
     /// The ID of the data list to get.
     /// </summary>
     public long DataListId { get; init; }
+
+    /// <summary>
+    /// When <see langword="false"/>, item rows are omitted. Defaults to <see langword="true"/> for backward compatibility.
+    /// </summary>
+    public bool IncludeItems { get; init; } = true;
 }

--- a/src/Endatix.Api/Endpoints/DataLists/GetById.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/GetById.cs
@@ -28,7 +28,7 @@ public sealed class GetById(
         {
             s.Summary = "Get a data list by ID";
             s.Description = "Gets a data list by its ID, including catalog locales. Pass includeItems=false to omit item rows (use GET .../items for paged search).";
-            s.ExampleRequest = new GetDataListRequest { DataListId = 1 };
+            s.ExampleRequest = new GetDataListRequest { DataListId = 1, IncludeItems = false };
             s.ResponseExamples[200] = new DataListDetailsModel
             {
                 Id = 1,
@@ -39,20 +39,7 @@ public sealed class GetById(
                 ItemsCount = 1,
                 DefaultLocale = "en",
                 AvailableLocales = ["es"],
-                Items =
-                [
-                    new DataListItemModel
-                    {
-                        Id = 10,
-                        Labels = new Dictionary<string, string>(StringComparer.Ordinal)
-                        {
-                            ["default"] = "New York",
-                            ["es"] = "Nueva York"
-                        },
-                        Label = "New York",
-                        Value = "NYC"
-                    }
-                ]
+                Items = []
             };
             s.Responses[200] = "Data list retrieved successfully.";
             s.Responses[400] = "Invalid input data.";

--- a/src/Endatix.Api/Endpoints/DataLists/ListItems.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/ListItems.cs
@@ -57,15 +57,13 @@ public sealed class ListItems(IMediator mediator)
         ListDataListItemsRequest request,
         CancellationToken ct)
     {
-        var page = request.Page ?? 1;
-        var pageSize = request.PageSize ?? DefaultPageSize;
-        var skip = (page - 1) * pageSize;
+        var paging = new PageRequest(request.Page, request.PageSize ?? DefaultPageSize);
 
         SearchDataListItemsQuery query = new(
             request.DataListId,
             request.Query,
-            skip,
-            pageSize,
+            paging.Skip,
+            paging.PageSize,
             request.MatchMode,
             request.Locale,
             request.IncludeLocales,

--- a/src/Endatix.Api/Endpoints/DataLists/ListItems.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/ListItems.cs
@@ -64,10 +64,11 @@ public sealed class ListItems(IMediator mediator)
             request.Query,
             paging.Skip,
             paging.PageSize,
-            request.MatchMode,
-            request.Locale,
-            request.IncludeLocales,
-            requireActive: false);
+            new SearchDataListItemsOptions(
+                request.MatchMode,
+                request.Locale,
+                request.IncludeLocales,
+                RequireActive: false));
         var result = await mediator.Send(query, ct);
         if (!result.IsSuccess)
         {

--- a/src/Endatix.Api/Endpoints/DataLists/ListItems.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/ListItems.cs
@@ -1,0 +1,145 @@
+using Endatix.Api.Common;
+using Endatix.Api.Endpoints.Common;
+using Endatix.Api.Infrastructure;
+using Endatix.Core.Abstractions.Authorization;
+using Endatix.Core.Common.Translations;
+using Endatix.Core.Infrastructure.Paging;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.DataLists.Search;
+using FastEndpoints;
+using FluentValidation;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Endatix.Api.Endpoints.DataLists;
+
+/// <summary>
+/// Endpoint to list/search data list items for Hub management (authenticated).
+/// </summary>
+public sealed class ListItems(IMediator mediator)
+    : Endpoint<ListDataListItemsRequest, Results<Ok<Paged<DataListItemModel>>, ProblemHttpResult>>
+{
+    public const int DefaultPageSize = 25;
+
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Get("data-lists/{dataListId}/items");
+        Permissions(Actions.Forms.View);
+        Summary(s =>
+        {
+            s.Summary = "List data list items";
+            s.Description =
+                "Paged Hub management search of data list items. Matches value and label keys " +
+                "(always including Labels.default, plus locale / includeLocales). Inactive lists are included.";
+            s.ExampleRequest = new ListDataListItemsRequest
+            {
+                DataListId = 1,
+                Query = "york",
+                Page = 1,
+                PageSize = 25,
+                Locale = "es",
+                IncludeLocales = ["es", "fr"]
+            };
+            s.Responses[200] = "Data list items retrieved successfully.";
+            s.Responses[400] = "Invalid input data.";
+            s.Responses[404] = "Data list not found.";
+        });
+        Description(builder => builder
+            .Produces<Paged<DataListItemModel>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
+    }
+
+    /// <inheritdoc />
+    public override async Task<Results<Ok<Paged<DataListItemModel>>, ProblemHttpResult>> ExecuteAsync(
+        ListDataListItemsRequest request,
+        CancellationToken ct)
+    {
+        var page = request.Page ?? 1;
+        var pageSize = request.PageSize ?? DefaultPageSize;
+        var skip = (page - 1) * pageSize;
+
+        SearchDataListItemsQuery query = new(
+            request.DataListId,
+            request.Query,
+            skip,
+            pageSize,
+            request.MatchMode,
+            request.Locale,
+            request.IncludeLocales,
+            requireActive: false);
+        var result = await mediator.Send(query, ct);
+        if (!result.IsSuccess)
+        {
+            return result.ToProblem();
+        }
+
+        var mapped = result.Value.MapToPaged(DataListMapper.Map);
+        return TypedResults.Ok(mapped);
+    }
+}
+
+/// <summary>
+/// Request to list/search data list items.
+/// </summary>
+public sealed class ListDataListItemsRequest : IPagedRequest
+{
+    /// <summary>
+    /// The ID of the data list.
+    /// </summary>
+    public long DataListId { get; init; }
+
+    /// <summary>
+    /// Free-text query against value and searched label keys.
+    /// </summary>
+    public string? Query { get; init; }
+
+    /// <summary>
+    /// Match mode for <see cref="Query"/>. Defaults to Contains.
+    /// </summary>
+    public DataListSearchMatchMode MatchMode { get; init; } = DataListSearchMatchMode.Contains;
+
+    /// <summary>
+    /// Optional locale for which label key to prefer for ordering (and to include in search).
+    /// </summary>
+    public string? Locale { get; init; }
+
+    /// <summary>
+    /// Extra locales to search and return in <c>labels</c>.
+    /// </summary>
+    public IReadOnlyCollection<string> IncludeLocales { get; init; } = [];
+
+    /// <inheritdoc />
+    public int? Page { get; set; }
+
+    /// <inheritdoc />
+    public int? PageSize { get; set; }
+}
+
+/// <summary>
+/// Validator for <see cref="ListDataListItemsRequest"/>.
+/// </summary>
+public sealed class ListDataListItemsValidator : Validator<ListDataListItemsRequest>
+{
+    public ListDataListItemsValidator()
+    {
+        Include(new PageableRequestValidator());
+        RuleFor(x => x.DataListId).GreaterThan(0);
+        RuleFor(x => x.Query)
+            .MaximumLength(PagedRequestLimits.MAX_SEARCH_LENGTH)
+            .When(x => !string.IsNullOrWhiteSpace(x.Query));
+        RuleFor(x => x.MatchMode).IsInEnum();
+        RuleFor(x => x.Locale)
+            .Must(locale => CultureCode.TryParse(locale, out _))
+            .WithMessage("Locale must be a valid culture code (e.g. 'es' or 'en-US') or 'default'.")
+            .When(x => !string.IsNullOrWhiteSpace(x.Locale));
+        RuleFor(x => x.IncludeLocales)
+            .IsIncludeLocales()
+            .When(x => x.IncludeLocales is { Count: > 0 });
+        RuleFor(x => x.PageSize)
+            .LessThanOrEqualTo(SearchDataListItemsQuery.MaxTake)
+            .When(x => x.PageSize.HasValue);
+    }
+}

--- a/src/Endatix.Api/Endpoints/Public/DataLists/Search.cs
+++ b/src/Endatix.Api/Endpoints/Public/DataLists/Search.cs
@@ -72,9 +72,7 @@ public sealed class Search(
             request.Query,
             request.Skip,
             request.Take,
-            request.MatchMode,
-            request.Locale,
-            request.IncludeLocales);
+            new SearchDataListItemsOptions(request.MatchMode, request.Locale, request.IncludeLocales));
         var result = await mediator.Send(query, ct);
         if (!result.IsSuccess)
         {

--- a/src/Endatix.Core/Abstractions/Repositories/DataListSearchCriteria.cs
+++ b/src/Endatix.Core/Abstractions/Repositories/DataListSearchCriteria.cs
@@ -4,7 +4,7 @@ using Endatix.Core.UseCases.DataLists.Search;
 namespace Endatix.Core.Abstractions.Repositories;
 
 /// <summary>
-/// Criteria for a public data list item search.
+/// Criteria for a paged data list item search (public runtime or Hub management).
 /// </summary>
 public sealed record DataListSearchCriteria
 {
@@ -42,4 +42,10 @@ public sealed record DataListSearchCriteria
     /// Additional locales to search and project. Locales outside the culture catalog are ignored.
     /// </summary>
     public IReadOnlyList<CultureCode> IncludeLocales { get; init; } = [];
+
+    /// <summary>
+    /// When <see langword="true"/> (default), inactive lists are treated as missing.
+    /// Management item search sets this to <see langword="false"/>.
+    /// </summary>
+    public bool RequireActive { get; init; } = true;
 }

--- a/src/Endatix.Core/Specifications/DataListsSpecifications.cs
+++ b/src/Endatix.Core/Specifications/DataListsSpecifications.cs
@@ -138,6 +138,31 @@ public static class DataListsSpecifications
     }
 
     /// <summary>
+    /// Projects a data list by ID without loading item rows. <c>ItemsCount</c> is still computed in SQL.
+    /// </summary>
+    public sealed class ByIdWithoutItemsToDtoSpec : SingleResultSpecification<DataList, DataListDto>
+    {
+        public ByIdWithoutItemsToDtoSpec(long dataListId)
+        {
+            Query
+                .Where(x => x.Id == dataListId)
+                .AsNoTracking();
+
+            Query.Select(dataList => new DataListDto(
+                dataList.Id,
+                dataList.Name,
+                dataList.Description,
+                dataList.CreatedAt,
+                dataList.ModifiedAt,
+                dataList.IsActive,
+                dataList.Items.Count,
+                dataList.DefaultLocale,
+                dataList.AvailableLocales,
+                Array.Empty<DataListItemDto>()));
+        }
+    }
+
+    /// <summary>
     /// Specification to get a data list by ID with data list items included by values.
     /// </summary>
     public sealed class ByIdWithItemsByValuesSpec : SingleResultSpecification<DataList>

--- a/src/Endatix.Core/UseCases/DataLists/GetById/GetDataListByIdHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/GetById/GetDataListByIdHandler.cs
@@ -11,6 +11,18 @@ public sealed class GetDataListByIdHandler(IRepository<DataList> repository)
 {
     public async Task<Result<DataListDto>> Handle(GetDataListByIdQuery request, CancellationToken cancellationToken)
     {
+        if (!request.IncludeItems)
+        {
+            var metadataSpec = new DataListsSpecifications.ByIdWithoutItemsToDtoSpec(request.DataListId);
+            DataListDto? metadata = await repository.FirstOrDefaultAsync(metadataSpec, cancellationToken);
+            if (metadata is null)
+            {
+                return Result.NotFound("Data list not found.");
+            }
+
+            return Result.Success(metadata);
+        }
+
         var spec = new DataListsSpecifications.ByIdWithItemsSpec(request.DataListId);
         DataList? dataList = await repository.FirstOrDefaultAsync(spec, cancellationToken);
 

--- a/src/Endatix.Core/UseCases/DataLists/GetById/GetDataListByIdQuery.cs
+++ b/src/Endatix.Core/UseCases/DataLists/GetById/GetDataListByIdQuery.cs
@@ -7,11 +7,13 @@ namespace Endatix.Core.UseCases.DataLists.GetById;
 public sealed record GetDataListByIdQuery : IQuery<Result<DataListDto>>
 {
     public long DataListId { get; init; }
+    public bool IncludeItems { get; init; }
 
-    public GetDataListByIdQuery(long dataListId)
+    public GetDataListByIdQuery(long dataListId, bool includeItems = true)
     {
         Guard.Against.NegativeOrZero(dataListId);
-        
+
         DataListId = dataListId;
+        IncludeItems = includeItems;
     }
 }

--- a/src/Endatix.Core/UseCases/DataLists/Search/SearchDataListItemsHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Search/SearchDataListItemsHandler.cs
@@ -21,7 +21,8 @@ public sealed class SearchDataListItemsHandler(IDataListRepository repository)
             Take = request.Take,
             MatchMode = request.MatchMode,
             Locale = request.Locale,
-            IncludeLocales = request.IncludeLocales
+            IncludeLocales = request.IncludeLocales,
+            RequireActive = request.RequireActive
         };
 
         DataListSearchPageResult? searchPage;

--- a/src/Endatix.Core/UseCases/DataLists/Search/SearchDataListItemsQuery.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Search/SearchDataListItemsQuery.cs
@@ -27,6 +27,11 @@ public sealed record SearchDataListItemsQuery : IQuery<Result<Paged<DataListItem
     /// Extra locales to search and project into the labels map. Malformed codes are dropped.
     /// </summary>
     public IReadOnlyList<CultureCode> IncludeLocales { get; init; }
+
+    /// <summary>
+    /// When <see langword="true"/> (default), inactive lists are treated as missing.
+    /// Management item search sets this to <see langword="false"/>.
+    /// </summary>
     public bool RequireActive { get; init; }
 
     public SearchDataListItemsQuery(

--- a/src/Endatix.Core/UseCases/DataLists/Search/SearchDataListItemsQuery.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Search/SearchDataListItemsQuery.cs
@@ -27,6 +27,7 @@ public sealed record SearchDataListItemsQuery : IQuery<Result<Paged<DataListItem
     /// Extra locales to search and project into the labels map. Malformed codes are dropped.
     /// </summary>
     public IReadOnlyList<CultureCode> IncludeLocales { get; init; }
+    public bool RequireActive { get; init; }
 
     public SearchDataListItemsQuery(
         long dataListId,
@@ -35,7 +36,8 @@ public sealed record SearchDataListItemsQuery : IQuery<Result<Paged<DataListItem
         int take,
         DataListSearchMatchMode matchMode = DataListSearchMatchMode.Contains,
         string? locale = null,
-        IEnumerable<string>? includeLocales = null)
+        IEnumerable<string>? includeLocales = null,
+        bool requireActive = true)
     {
         Guard.Against.NegativeOrZero(dataListId);
         Guard.Against.Negative(skip);
@@ -49,5 +51,6 @@ public sealed record SearchDataListItemsQuery : IQuery<Result<Paged<DataListItem
         MatchMode = matchMode;
         IncludeLocales = TranslationLocaleList.ParseMany(includeLocales);
         Locale = string.IsNullOrWhiteSpace(locale) ? null : CultureCode.Parse(locale);
+        RequireActive = requireActive;
     }
 }

--- a/src/Endatix.Core/UseCases/DataLists/Search/SearchDataListItemsQuery.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Search/SearchDataListItemsQuery.cs
@@ -7,6 +7,15 @@ using Endatix.Core.Infrastructure.Result;
 namespace Endatix.Core.UseCases.DataLists.Search;
 
 /// <summary>
+/// Optional search behavior for <see cref="SearchDataListItemsQuery"/>.
+/// </summary>
+public sealed record SearchDataListItemsOptions(
+    DataListSearchMatchMode MatchMode = DataListSearchMatchMode.Contains,
+    string? Locale = null,
+    IEnumerable<string>? IncludeLocales = null,
+    bool RequireActive = true);
+
+/// <summary>
 /// Query for searching data list items by label (locale key).
 /// </summary>
 public sealed record SearchDataListItemsQuery : IQuery<Result<Paged<DataListItemDto>>>
@@ -39,23 +48,22 @@ public sealed record SearchDataListItemsQuery : IQuery<Result<Paged<DataListItem
         string? query,
         int skip,
         int take,
-        DataListSearchMatchMode matchMode = DataListSearchMatchMode.Contains,
-        string? locale = null,
-        IEnumerable<string>? includeLocales = null,
-        bool requireActive = true)
+        SearchDataListItemsOptions? options = null)
     {
+        options ??= new SearchDataListItemsOptions();
+
         Guard.Against.NegativeOrZero(dataListId);
         Guard.Against.Negative(skip);
         Guard.Against.NegativeOrZero(take);
-        Guard.Against.EnumOutOfRange(matchMode);
+        Guard.Against.EnumOutOfRange(options.MatchMode);
 
         DataListId = dataListId;
         Query = query?.Trim();
         Skip = skip;
         Take = Math.Min(take, MaxTake);
-        MatchMode = matchMode;
-        IncludeLocales = TranslationLocaleList.ParseMany(includeLocales);
-        Locale = string.IsNullOrWhiteSpace(locale) ? null : CultureCode.Parse(locale);
-        RequireActive = requireActive;
+        MatchMode = options.MatchMode;
+        IncludeLocales = TranslationLocaleList.ParseMany(options.IncludeLocales);
+        Locale = string.IsNullOrWhiteSpace(options.Locale) ? null : CultureCode.Parse(options.Locale);
+        RequireActive = options.RequireActive;
     }
 }

--- a/src/Endatix.Infrastructure/Data/Repositories/DataListRepository.cs
+++ b/src/Endatix.Infrastructure/Data/Repositories/DataListRepository.cs
@@ -21,7 +21,9 @@ public sealed class DataListRepository(
     {
         var dataList = await dbContext.DataLists
             .AsNoTracking()
-            .FirstOrDefaultAsync(d => d.Id == criteria.DataListId && d.IsActive, cancellationToken);
+            .FirstOrDefaultAsync(
+                d => d.Id == criteria.DataListId && (!criteria.RequireActive || d.IsActive),
+                cancellationToken);
 
         if (dataList is null)
         {

--- a/src/Endatix.WebHost/appsettings.Development.json
+++ b/src/Endatix.WebHost/appsettings.Development.json
@@ -27,10 +27,7 @@
           "RefreshExpiryInDays": 7,
           "Issuer": "endatix-api",
           "ReBacIssuer": "edx_res_auth",
-          "Audiences": [
-            "endatix-hub",
-            "endatix-client"
-          ]
+          "Audiences": ["endatix-hub", "endatix-client"]
         }
       }
     },
@@ -51,18 +48,21 @@
       "CorsPolicies": [
         {
           "PolicyName": "DevCorsPolicy",
-          "AllowedOrigins": [
-            "*"
-          ],
-          "AllowedMethods": [
-            "*"
-          ],
-          "AllowedHeaders": [
-            "*"
-          ],
+          "AllowedOrigins": ["*"],
+          "AllowedMethods": ["*"],
+          "AllowedHeaders": ["*"],
           "AllowCredentials": false
         }
       ]
+    },
+    "Outbox": {
+      "RunInProcess": true,
+      "PollIntervalSeconds": 5,
+      "BatchSize": 50,
+      "LeaseSeconds": 60,
+      "MaxAttempts": 8,
+      "BackoffBaseSeconds": 5,
+      "BackoffCapSeconds": 300
     },
     "WebHooks": {
       "Tenants": {

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/GetByIdTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/GetByIdTests.cs
@@ -1,0 +1,89 @@
+using Endatix.Api.Endpoints.DataLists;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.DataLists;
+using Endatix.Core.UseCases.DataLists.GetById;
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Endatix.Api.Tests.Endpoints.DataLists;
+
+public class GetByIdTests
+{
+    private readonly IMediator _mediator;
+    private readonly GetById _endpoint;
+
+    public GetByIdTests()
+    {
+        _mediator = Substitute.For<IMediator>();
+        _endpoint = Factory.Create<GetById>(_mediator);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PassesIncludeItemsFalseToQuery()
+    {
+        // Arrange
+        GetDataListRequest request = new() { DataListId = 7, IncludeItems = false };
+        DataListDto dto = new(
+            7,
+            "Cities",
+            "Major cities",
+            DateTime.UtcNow,
+            null,
+            true,
+            2,
+            "en",
+            ["es"],
+            Array.Empty<DataListItemDto>());
+        _mediator.Send(Arg.Any<GetDataListByIdQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(dto));
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        var ok = response.Result.Should().BeOfType<Ok<DataListDetailsModel>>().Subject;
+        ok.Value.Should().NotBeNull();
+        ok.Value.Id.Should().Be(7);
+        ok.Value.ItemsCount.Should().Be(2);
+        ok.Value.Items.Should().BeEmpty();
+
+        await _mediator.Received(1).Send(
+            Arg.Is<GetDataListByIdQuery>(x => x.DataListId == 7 && x.IncludeItems == false),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DefaultsIncludeItemsToTrue()
+    {
+        // Arrange
+        GetDataListRequest request = new() { DataListId = 3 };
+        DataListDto dto = new(
+            3,
+            "Cities",
+            null,
+            DateTime.UtcNow,
+            null,
+            true,
+            1,
+            "en",
+            [],
+            [
+                new DataListItemDto(
+                    10,
+                    new Dictionary<string, string>(StringComparer.Ordinal) { ["default"] = "New York" },
+                    "NYC",
+                    "New York")
+            ]);
+        _mediator.Send(Arg.Any<GetDataListByIdQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(dto));
+
+        // Act
+        await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        await _mediator.Received(1).Send(
+            Arg.Is<GetDataListByIdQuery>(x => x.DataListId == 3 && x.IncludeItems == true),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/ListDataListItemsValidatorTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/ListDataListItemsValidatorTests.cs
@@ -1,0 +1,52 @@
+using Endatix.Api.Endpoints.DataLists;
+using Endatix.Core.UseCases.DataLists.Search;
+using FluentValidation.TestHelper;
+
+namespace Endatix.Api.Tests.Endpoints.DataLists;
+
+public class ListDataListItemsValidatorTests
+{
+    private readonly ListDataListItemsValidator _validator = new();
+
+    [Fact]
+    public void Validate_ValidRequest_PassesValidation()
+    {
+        var result = _validator.TestValidate(new ListDataListItemsRequest
+        {
+            DataListId = 1,
+            Query = "york",
+            Page = 1,
+            PageSize = 25,
+            MatchMode = DataListSearchMatchMode.Contains,
+            Locale = "es",
+            IncludeLocales = ["fr"]
+        });
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Validate_NonPositiveDataListId_ReturnsError(long dataListId)
+    {
+        var result = _validator.TestValidate(new ListDataListItemsRequest
+        {
+            DataListId = dataListId
+        });
+
+        result.ShouldHaveValidationErrorFor(x => x.DataListId);
+    }
+
+    [Fact]
+    public void Validate_PageSizeAboveMaxTake_ReturnsError()
+    {
+        var result = _validator.TestValidate(new ListDataListItemsRequest
+        {
+            DataListId = 1,
+            PageSize = SearchDataListItemsQuery.MaxTake + 1
+        });
+
+        result.ShouldHaveValidationErrorFor(x => x.PageSize);
+    }
+}

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/ListItemsTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/ListItemsTests.cs
@@ -63,6 +63,25 @@ public class ListItemsTests
                 x.Take == 10 &&
                 x.MatchMode == DataListSearchMatchMode.StartsWith &&
                 x.Locale != null &&
+                x.IncludeLocales.Count == 1 &&
+                x.RequireActive == false),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NullPaging_UsesDefaultPageSizeAndZeroSkip()
+    {
+        ListDataListItemsRequest request = new() { DataListId = 5 };
+        _mediator.Send(Arg.Any<SearchDataListItemsQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new Paged<DataListItemDto>(1, ListItems.DefaultPageSize, 0, 0, [])));
+
+        await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        await _mediator.Received(1).Send(
+            Arg.Is<SearchDataListItemsQuery>(x =>
+                x.DataListId == 5 &&
+                x.Skip == 0 &&
+                x.Take == ListItems.DefaultPageSize &&
                 x.RequireActive == false),
             Arg.Any<CancellationToken>());
     }

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/ListItemsTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/ListItemsTests.cs
@@ -1,0 +1,82 @@
+using Endatix.Api.Endpoints.DataLists;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.DataLists;
+using Endatix.Core.UseCases.DataLists.Search;
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Endatix.Api.Tests.Endpoints.DataLists;
+
+public class ListItemsTests
+{
+    private readonly IMediator _mediator;
+    private readonly ListItems _endpoint;
+
+    public ListItemsTests()
+    {
+        _mediator = Substitute.For<IMediator>();
+        _endpoint = Factory.Create<ListItems>(_mediator);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_MapsPagingAndDoesNotRequireActiveList()
+    {
+        ListDataListItemsRequest request = new()
+        {
+            DataListId = 42,
+            Query = "york",
+            Page = 2,
+            PageSize = 10,
+            MatchMode = DataListSearchMatchMode.StartsWith,
+            Locale = "es",
+            IncludeLocales = ["fr"]
+        };
+
+        var result = Result.Success(new Paged<DataListItemDto>(
+            page: 2,
+            pageSize: 10,
+            totalRecords: 11,
+            totalPages: 2,
+            items:
+            [
+                new DataListItemDto(
+                    3,
+                    new Dictionary<string, string>(StringComparer.Ordinal) { ["default"] = "New York" },
+                    "NYC",
+                    "New York")
+            ]));
+        _mediator.Send(Arg.Any<SearchDataListItemsQuery>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        var ok = response.Result.Should().BeOfType<Ok<Paged<DataListItemModel>>>().Subject;
+        ok.Value.Should().NotBeNull();
+        ok.Value.Items.Should().ContainSingle(x => x.Value == "NYC" && x.Id == 3);
+
+        await _mediator.Received(1).Send(
+            Arg.Is<SearchDataListItemsQuery>(x =>
+                x.DataListId == 42 &&
+                x.Query == "york" &&
+                x.Skip == 10 &&
+                x.Take == 10 &&
+                x.MatchMode == DataListSearchMatchMode.StartsWith &&
+                x.Locale != null &&
+                x.RequireActive == false),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NotFound_ReturnsProblem()
+    {
+        _mediator.Send(Arg.Any<SearchDataListItemsQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result<Paged<DataListItemDto>>.NotFound("Data list not found."));
+
+        var response = await _endpoint.ExecuteAsync(
+            new ListDataListItemsRequest { DataListId = 9 },
+            TestContext.Current.CancellationToken);
+
+        response.Result.Should().NotBeOfType<Ok<Paged<DataListItemModel>>>();
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/GetById/GetDataListByIdHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/GetById/GetDataListByIdHandlerTests.cs
@@ -3,6 +3,7 @@ using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;
+using Endatix.Core.UseCases.DataLists;
 using Endatix.Core.UseCases.DataLists.GetById;
 
 namespace Endatix.Core.Tests.UseCases.DataLists.GetById;
@@ -97,6 +98,34 @@ public class GetDataListByIdHandlerTests
         result.Value!.ItemsCount.Should().Be(0);
         result.Value.Items.Should().BeEmpty();
         result.Value.AvailableLocales.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_IncludeItemsFalse_ReturnsMetadataWithoutLoadingItems()
+    {
+        // Arrange
+        DataListDto dto = new(7, "Cities", "Major cities", DateTime.UtcNow, null, true, 2, "en", ["es"], Array.Empty<DataListItemDto>());
+        _repository.FirstOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithoutItemsToDtoSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns(dto);
+
+        // Act
+        var result = await _sut.Handle(new GetDataListByIdQuery(7, includeItems: false), TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value!.Id.Should().Be(7);
+        result.Value.ItemsCount.Should().Be(2);
+        result.Value.Items.Should().BeEmpty();
+        result.Value.AvailableLocales.Should().Equal("es");
+
+        await _repository.Received(1).FirstOrDefaultAsync(
+            Arg.Any<DataListsSpecifications.ByIdWithoutItemsToDtoSpec>(),
+            Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().FirstOrDefaultAsync(
+            Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Theory]

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/Search/SearchDataListItemsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/Search/SearchDataListItemsHandlerTests.cs
@@ -135,7 +135,12 @@ public class SearchDataListItemsHandlerTests
             [Item(1, "apple", "Apple", ("es", "Manzana"))]));
 
         var result = await _sut.Handle(
-            new SearchDataListItemsQuery(1, "Manz", 0, 10, DataListSearchMatchMode.StartsWith, "es"),
+            new SearchDataListItemsQuery(
+                1,
+                "Manz",
+                0,
+                10,
+                new SearchDataListItemsOptions(DataListSearchMatchMode.StartsWith, Locale: "es")),
             TestContext.Current.CancellationToken);
 
         result.Status.Should().Be(ResultStatus.Ok);
@@ -165,7 +170,7 @@ public class SearchDataListItemsHandlerTests
                 null,
                 0,
                 10,
-                includeLocales: ["es", "fr"]),
+                new SearchDataListItemsOptions(IncludeLocales: ["es", "fr"])),
             TestContext.Current.CancellationToken);
 
         result.Status.Should().Be(ResultStatus.Ok);
@@ -259,7 +264,12 @@ public class SearchDataListItemsHandlerTests
     [Fact]
     public void QueryCtor_WithInvalidLocale_ThrowsArgumentException()
     {
-        Action act = () => _ = new SearchDataListItemsQuery(1, "App", 0, 10, locale: "not a culture!");
+        Action act = () => _ = new SearchDataListItemsQuery(
+            1,
+            "App",
+            0,
+            10,
+            new SearchDataListItemsOptions(Locale: "not a culture!"));
 
         act.Should().Throw<ArgumentException>()
             .Which.ParamName.Should().Be("cultureCode");
@@ -270,7 +280,12 @@ public class SearchDataListItemsHandlerTests
     {
         string locale = new('a', IHasTranslations.MAX_CULTURE_CODE_LENGTH + 1);
 
-        Action act = () => _ = new SearchDataListItemsQuery(1, null, 0, 10, locale: locale);
+        Action act = () => _ = new SearchDataListItemsQuery(
+            1,
+            null,
+            0,
+            10,
+            new SearchDataListItemsOptions(Locale: locale));
 
         act.Should().Throw<ArgumentException>()
             .Which.ParamName.Should().Be("cultureCode");

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/Search/SearchDataListItemsQueryTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/Search/SearchDataListItemsQueryTests.cs
@@ -1,0 +1,70 @@
+using Endatix.Core.Common.Translations;
+using Endatix.Core.Infrastructure.Paging;
+using Endatix.Core.UseCases.DataLists.Search;
+
+namespace Endatix.Core.Tests.UseCases.DataLists.Search;
+
+public class SearchDataListItemsQueryTests
+{
+    [Fact]
+    public void Ctor_ValidArgs_AssignsNormalizedProperties()
+    {
+        // Arrange & Act
+        SearchDataListItemsQuery query = new(
+            dataListId: 42,
+            query: "  york  ",
+            skip: 10,
+            take: 25,
+            matchMode: DataListSearchMatchMode.StartsWith,
+            locale: "es",
+            includeLocales: ["fr", "not-a-culture"],
+            requireActive: false);
+
+        // Assert
+        query.DataListId.Should().Be(42);
+        query.Query.Should().Be("york");
+        query.Skip.Should().Be(10);
+        query.Take.Should().Be(25);
+        query.MatchMode.Should().Be(DataListSearchMatchMode.StartsWith);
+        query.Locale.Should().Be(CultureCode.Parse("es"));
+        query.IncludeLocales.Should().ContainSingle(x => x == CultureCode.Parse("fr"));
+        query.RequireActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Ctor_Defaults_RequireActiveTrueAndContainsMatch()
+    {
+        // Arrange & Act
+        SearchDataListItemsQuery query = new(1, null, 0, 10);
+
+        // Assert
+        query.RequireActive.Should().BeTrue();
+        query.MatchMode.Should().Be(DataListSearchMatchMode.Contains);
+        query.Locale.Should().BeNull();
+        query.IncludeLocales.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Ctor_TakeAboveMax_ClampsToMaxTake()
+    {
+        // Arrange & Act
+        SearchDataListItemsQuery query = new(1, null, 0, SearchDataListItemsQuery.MaxTake + 50);
+
+        // Assert
+        query.Take.Should().Be(SearchDataListItemsQuery.MaxTake);
+        query.Take.Should().Be(PagedRequestLimits.MAX_PAGE_SIZE);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Ctor_NonPositiveDataListId_Throws(long dataListId)
+    {
+        // Act
+        Action act = () => _ = new SearchDataListItemsQuery(dataListId, null, 0, 10);
+
+        // Assert
+        act.Should().Throw<ArgumentException>()
+            .Which.ParamName.Should().Be("dataListId");
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/Search/SearchDataListItemsQueryTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/Search/SearchDataListItemsQueryTests.cs
@@ -15,10 +15,11 @@ public class SearchDataListItemsQueryTests
             query: "  york  ",
             skip: 10,
             take: 25,
-            matchMode: DataListSearchMatchMode.StartsWith,
-            locale: "es",
-            includeLocales: ["fr", "not-a-culture"],
-            requireActive: false);
+            new SearchDataListItemsOptions(
+                DataListSearchMatchMode.StartsWith,
+                Locale: "es",
+                IncludeLocales: ["fr", "not-a-culture"],
+                RequireActive: false));
 
         // Assert
         query.DataListId.Should().Be(42);


### PR DESCRIPTION
## Summary
- Add authenticated `GET /data-lists/{id}/items` for paged management item search (`query`/`matchMode`/`locale`/`includeLocales`, default `pageSize` 25); inactive lists included via `RequireActive=false`
- Add `includeItems` on `GET /data-lists/{id}` (default `true`) so Hub can load catalog metadata without item rows
- Keep items `query` (not `ISearchablePagedRequest.Search`) to stay aligned with public runtime search
- Refactor: reduce number of contructor params in `SearchDataListItemsQuery` and reuse that for related Commands
- Docs: clarify parent-list vs item-search params; OpenAPI example for metadata-only get-by-id

## Test plan
- [x] ListItemsTests (paging → skip/take, `RequireActive=false`, defaults)
- [x] ListDataListItemsValidatorTests
- [x] GetByIdTests (`includeItems` false + default true)
- [x] GetDataListByIdHandlerTests (`ByIdWithoutItemsToDtoSpec`)
- [ ] Hub stack (endatix-hub#865) after this lands

## Test plan
- [x] ListItemsTests + GetDataListByIdHandlerTests
- [ ] Hub stack (endatix-hub#865) should merge after this lands