### PR TITLE
feat(e964): allow multi-locale hasLocale list filter

### DIFF
--- a/docs/endatix-docs/docs/developers/api/data-lists-translations.mdx
+++ b/docs/endatix-docs/docs/developers/api/data-lists-translations.mdx
@@ -11,7 +11,7 @@ Data list choice labels are stored as a JSON map (`Labels`) with a synthetic `de
 
 ## Management list and items grids
 
-Parent list search uses the management list query string (`query` + `page` / `pageSize`). Item grids intentionally keep `query` (not `search`) to match the public runtime search contract (`matchMode` / `locale` / `includeLocales`). Hub UI may still expose a `search` box and map it to API `query`.
+Parent list search uses the management list query string (`search` + `page` / `pageSize`). Item grids intentionally keep `query` (not `search`) to match the public runtime search contract (`matchMode` / `locale` / `includeLocales`). Hub UI may still expose a `search` box; the list maps it to API `search`, item grids to API `query`.
 
 - `GET /api/data-lists?search=&hasLocale=&page=&pageSize=` — name/description contains search; `hasLocale` is a culture or comma-separated OR list matching AvailableLocales or DefaultLocale.
 - `GET /api/data-lists/{id}?includeItems=false` — catalog metadata and `itemsCount` without loading item rows.

--- a/docs/endatix-docs/docs/developers/api/data-lists-translations.mdx
+++ b/docs/endatix-docs/docs/developers/api/data-lists-translations.mdx
@@ -1,7 +1,7 @@
 ---
-title: 'Data lists — import, export, and includeLocales'
+title: "Data lists — import, export, and includeLocales"
 description: Authenticated import/export with format negotiation, SurveyJS translations CSV shape, and public labels via includeLocales.
-sidebar_label: 'Data lists translations'
+sidebar_label: "Data lists translations"
 sidebar_position: 5
 ---
 
@@ -13,7 +13,7 @@ Data list choice labels are stored as a JSON map (`Labels`) with a synthetic `de
 
 Parent list search uses the management list query string (`query` + `page` / `pageSize`). Item grids intentionally keep `query` (not `search`) to match the public runtime search contract (`matchMode` / `locale` / `includeLocales`). Hub UI may still expose a `search` box and map it to API `query`.
 
-- `GET /api/data-lists?query=&hasLocale=&page=&pageSize=` — name/description contains search; `hasLocale` keeps lists whose AvailableLocales include that culture.
+- `GET /api/data-lists?search=&hasLocale=&page=&pageSize=` — name/description contains search; `hasLocale` is a culture or comma-separated OR list matching AvailableLocales or DefaultLocale.
 - `GET /api/data-lists/{id}?includeItems=false` — catalog metadata and `itemsCount` without loading item rows.
 - `GET /api/data-lists/{id}/items?query=&matchMode=&locale=&includeLocales=&page=&pageSize=` — paged item search for authors (inactive lists included). Default `pageSize` is 25.
 

--- a/src/Endatix.Api/Endpoints/Common/CultureCodeValidation.cs
+++ b/src/Endatix.Api/Endpoints/Common/CultureCodeValidation.cs
@@ -24,6 +24,41 @@ public static class CultureCodeValidation
             .WithMessage("{PropertyName} must be a valid culture code (e.g. 'es'), not 'default'.");
 
     /// <summary>
+    /// Accepts a single culture or comma-separated list (e.g. <c>es,de</c>).
+    /// Rejects the synthetic <c>default</c> key and caps token count at <see cref="MaxLocales"/>.
+    /// </summary>
+    public static IRuleBuilderOptions<T, string?> IsHasLocaleFilter<T>(
+        this IRuleBuilder<T, string?> ruleBuilder) =>
+        ruleBuilder
+            .Must(BeValidHasLocaleFilter)
+            .WithMessage(
+                "{PropertyName} must be a culture code or comma-separated list (e.g. 'es' or 'es,de'), not 'default'.");
+
+    private static bool BeValidHasLocaleFilter(string? hasLocale)
+    {
+        if (string.IsNullOrWhiteSpace(hasLocale))
+        {
+            return true;
+        }
+
+        List<string> tokens = TranslationLocaleList.Tokenize([hasLocale]).Take(MaxLocales + 1).ToList();
+        if (tokens.Count == 0 || tokens.Count > MaxLocales)
+        {
+            return false;
+        }
+
+        foreach (string token in tokens)
+        {
+            if (!CultureCode.TryParse(token, out CultureCode culture) || culture.IsSyntheticDefault)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
     /// Accepts repeated or comma-separated culture codes, bounded by <see cref="MaxLocales"/>.
     /// Allows the synthetic <c>default</c> key.
     /// Uses rule-level <see cref="CascadeMode.Stop"/> so an oversized list never runs culture parsing

--- a/src/Endatix.Api/Endpoints/Common/CultureCodeValidation.cs
+++ b/src/Endatix.Api/Endpoints/Common/CultureCodeValidation.cs
@@ -23,40 +23,30 @@ public static class CultureCodeValidation
             .Must(locale => CultureCode.TryParse(locale, out var culture) && !culture.IsSyntheticDefault)
             .WithMessage("{PropertyName} must be a valid culture code (e.g. 'es'), not 'default'.");
 
+    private const string HasLocaleInvalidMessage =
+        "{PropertyName} must be a culture code or comma-separated list (e.g. 'es' or 'es,de'), not 'default'.";
+
     /// <summary>
     /// Accepts a single culture or comma-separated list (e.g. <c>es,de</c>).
     /// Rejects the synthetic <c>default</c> key and caps token count at <see cref="MaxLocales"/>.
     /// </summary>
     public static IRuleBuilderOptions<T, string?> IsHasLocaleFilter<T>(
-        this IRuleBuilder<T, string?> ruleBuilder) =>
+        this IRuleBuilderInitial<T, string?> ruleBuilder) =>
         ruleBuilder
-            .Must(BeValidHasLocaleFilter)
-            .WithMessage(
-                "{PropertyName} must be a culture code or comma-separated list (e.g. 'es' or 'es,de'), not 'default'.");
+            .Cascade(CascadeMode.Stop)
+            .Must(HasAtLeastOneToken)
+            .WithMessage(HasLocaleInvalidMessage)
+            .Must(hasLocale => CountTokensAtMost(WrapHasLocale(hasLocale), MaxLocales))
+            .WithMessage($"No more than {MaxLocales} locales can be requested.")
+            .Must(hasLocale => AreTokensValid(WrapHasLocale(hasLocale), allowSyntheticDefault: false))
+            .WithMessage(HasLocaleInvalidMessage);
 
-    private static bool BeValidHasLocaleFilter(string? hasLocale)
-    {
-        if (string.IsNullOrWhiteSpace(hasLocale))
-        {
-            return true;
-        }
+    private static IEnumerable<string>? WrapHasLocale(string? hasLocale) =>
+        string.IsNullOrWhiteSpace(hasLocale) ? null : [hasLocale];
 
-        List<string> tokens = TranslationLocaleList.Tokenize([hasLocale]).Take(MaxLocales + 1).ToList();
-        if (tokens.Count == 0 || tokens.Count > MaxLocales)
-        {
-            return false;
-        }
-
-        foreach (string token in tokens)
-        {
-            if (!CultureCode.TryParse(token, out CultureCode culture) || culture.IsSyntheticDefault)
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
+    private static bool HasAtLeastOneToken(string? hasLocale) =>
+        string.IsNullOrWhiteSpace(hasLocale)
+        || TranslationLocaleList.Tokenize([hasLocale]).Any();
 
     /// <summary>
     /// Accepts repeated or comma-separated culture codes, bounded by <see cref="MaxLocales"/>.

--- a/src/Endatix.Api/Endpoints/Common/CultureCodeValidation.cs
+++ b/src/Endatix.Api/Endpoints/Common/CultureCodeValidation.cs
@@ -37,7 +37,13 @@ public static class CultureCodeValidation
             .Must(HasAtLeastOneToken)
             .WithMessage(HasLocaleInvalidMessage)
             .Must(hasLocale => CountTokensAtMost(WrapHasLocale(hasLocale), MaxLocales))
-            .WithMessage($"No more than {MaxLocales} locales can be requested.")
+            .WithMessage((_, hasLocale) =>
+            {
+                string received = string.Join(
+                    ",",
+                    TranslationLocaleList.Tokenize(WrapHasLocale(hasLocale)).Take(MaxLocales + 1));
+                return $"No more than {MaxLocales} locales can be requested. Received: {received}.";
+            })
             .Must(hasLocale => AreTokensValid(WrapHasLocale(hasLocale), allowSyntheticDefault: false))
             .WithMessage(HasLocaleInvalidMessage);
 

--- a/src/Endatix.Api/Endpoints/DataLists/List.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/List.cs
@@ -35,7 +35,7 @@ public sealed class List(
                 Page = 1,
                 PageSize = 20,
                 Search = "cities",
-                HasLocale = "es"
+                HasLocale = "es,de"
             };
             s.ResponseExamples[200] = new Paged<DataListModel>(
                 page: 1,

--- a/src/Endatix.Api/Endpoints/DataLists/List.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/List.cs
@@ -29,7 +29,7 @@ public sealed class List(
         Summary(s =>
         {
             s.Summary = "List data lists";
-            s.Description = "Lists data lists for the current tenant with paging, optional name/description search, and an optional locale filter.";
+            s.Description = "Lists data lists for the current tenant with paging, optional name/description search, and an optional locale filter (single culture or comma-separated OR list).";
             s.ExampleRequest = new DataListsListRequest
             {
                 Page = 1,
@@ -92,7 +92,7 @@ public sealed class DataListsListValidator : Validator<DataListsListRequest>
     {
         Include(new SearchablePagedRequestValidator());
         RuleFor(x => x.HasLocale)
-            .IsCultureCode()
+            .IsHasLocaleFilter()
             .When(x => !string.IsNullOrWhiteSpace(x.HasLocale));
     }
 }
@@ -112,7 +112,8 @@ public sealed class DataListsListRequest : ISearchablePagedRequest
     public string? Search { get; set; }
 
     /// <summary>
-    /// Optional locale code; returns only lists whose AvailableLocales contain this code.
+    /// Optional culture code or comma-separated list (e.g. <c>es</c> or <c>es,de</c>).
+    /// Returns lists whose AvailableLocales contain any code or whose DefaultLocale equals any code.
     /// </summary>
     public string? HasLocale { get; set; }
 }

--- a/src/Endatix.Core/Specifications/DataListsSpecifications.cs
+++ b/src/Endatix.Core/Specifications/DataListsSpecifications.cs
@@ -61,16 +61,16 @@ public static class DataListsSpecifications
         string? hasLocale,
         string? search)
     {
-        // Comma-separated or single culture codes; OR match on AvailableLocales or DefaultLocale.
-        List<string> locales = TranslationLocaleList.ParseMany([hasLocale])
+        // Closed-over array so EF translates Contains; match catalog rows or DefaultLocale (default is not in AvailableLocales).
+        string[] locales = [.. TranslationLocaleList.ParseMany(hasLocale is null ? null : [hasLocale])
             .Where(code => !code.IsSyntheticDefault)
-            .Select(code => code.Value)
-            .ToList();
+            .Select(code => code.Value)];
 
-        if (locales.Count > 0)
+        if (locales.Length > 0)
         {
-            query.Where(x => locales.Any(locale =>
-                x.AvailableLocales.Contains(locale) || x.DefaultLocale == locale));
+            query.Where(x =>
+                locales.Contains(x.DefaultLocale)
+                || x.AvailableLocales.Any(available => locales.Contains(available)));
         }
 
         if (!string.IsNullOrWhiteSpace(search))

--- a/src/Endatix.Core/Specifications/DataListsSpecifications.cs
+++ b/src/Endatix.Core/Specifications/DataListsSpecifications.cs
@@ -1,4 +1,5 @@
 using Ardalis.Specification;
+using Endatix.Core.Common.Translations;
 using Endatix.Core.Entities;
 using Endatix.Core.Specifications.Common;
 using Endatix.Core.Specifications.Parameters;
@@ -60,10 +61,16 @@ public static class DataListsSpecifications
         string? hasLocale,
         string? search)
     {
-        if (!string.IsNullOrWhiteSpace(hasLocale))
+        // Comma-separated or single culture codes; OR match on AvailableLocales or DefaultLocale.
+        List<string> locales = TranslationLocaleList.ParseMany([hasLocale])
+            .Where(code => !code.IsSyntheticDefault)
+            .Select(code => code.Value)
+            .ToList();
+
+        if (locales.Count > 0)
         {
-            var locale = hasLocale.Trim().ToLowerInvariant();
-            query.Where(x => x.AvailableLocales.Contains(locale));
+            query.Where(x => locales.Any(locale =>
+                x.AvailableLocales.Contains(locale) || x.DefaultLocale == locale));
         }
 
         if (!string.IsNullOrWhiteSpace(search))

--- a/src/Endatix.Core/UseCases/DataLists/List/ListDataListsQuery.cs
+++ b/src/Endatix.Core/UseCases/DataLists/List/ListDataListsQuery.cs
@@ -8,7 +8,7 @@ namespace Endatix.Core.UseCases.DataLists.List;
 /// </summary>
 /// <param name="Page">The page number for pagination.</param>
 /// <param name="PageSize">The number of items per page for pagination.</param>
-/// <param name="HasLocale">Optional locale code; filters parent rows whose AvailableLocales contain this code.</param>
+/// <param name="HasLocale">Optional culture or comma-separated OR list; matches AvailableLocales or DefaultLocale.</param>
 /// <param name="Search">Optional name/description search (case-insensitive contains).</param>
 public sealed record ListDataListsQuery(int? Page, int? PageSize, string? HasLocale = null, string? Search = null)
     : IQuery<Result<Paged<DataListDto>>>;

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/DataListsListValidatorTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/DataListsListValidatorTests.cs
@@ -1,0 +1,46 @@
+using Endatix.Api.Endpoints.Common;
+using Endatix.Api.Endpoints.DataLists;
+using FluentValidation.TestHelper;
+
+namespace Endatix.Api.Tests.Endpoints.DataLists;
+
+public class DataListsListValidatorTests
+{
+    private readonly DataListsListValidator _validator = new();
+
+    [Fact]
+    public void Validate_SingleHasLocale_Passes()
+    {
+        var result = _validator.TestValidate(new DataListsListRequest { HasLocale = "es" });
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_CommaSeparatedHasLocale_Passes()
+    {
+        var result = _validator.TestValidate(new DataListsListRequest { HasLocale = "es,de" });
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_HasLocaleDefault_Fails()
+    {
+        var result = _validator.TestValidate(new DataListsListRequest { HasLocale = "default" });
+
+        result.ShouldHaveValidationErrorFor(x => x.HasLocale);
+    }
+
+    [Fact]
+    public void Validate_HasLocaleTooMany_Fails()
+    {
+        string tooMany = string.Join(
+            ",",
+            Enumerable.Range(0, CultureCodeValidation.MaxLocales + 1).Select(i => $"l{i:00}"));
+
+        var result = _validator.TestValidate(new DataListsListRequest { HasLocale = tooMany });
+
+        result.ShouldHaveValidationErrorFor(x => x.HasLocale);
+    }
+}

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/DataListsListValidatorTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/DataListsListValidatorTests.cs
@@ -29,7 +29,8 @@ public class DataListsListValidatorTests
     {
         var result = _validator.TestValidate(new DataListsListRequest { HasLocale = "default" });
 
-        result.ShouldHaveValidationErrorFor(x => x.HasLocale);
+        result.ShouldHaveValidationErrorFor(x => x.HasLocale)
+            .WithErrorMessage("Has Locale must be a culture code or comma-separated list (e.g. 'es' or 'es,de'), not 'default'.");
     }
 
     [Fact]
@@ -37,9 +38,18 @@ public class DataListsListValidatorTests
     {
         string tooMany = string.Join(
             ",",
-            Enumerable.Range(0, CultureCodeValidation.MaxLocales + 1).Select(i => $"l{i:00}"));
+            Enumerable.Range(0, CultureCodeValidation.MaxLocales + 1).Select(i => $"aa-{i:00}"));
 
         var result = _validator.TestValidate(new DataListsListRequest { HasLocale = tooMany });
+
+        result.ShouldHaveValidationErrorFor(x => x.HasLocale)
+            .WithErrorMessage($"No more than {CultureCodeValidation.MaxLocales} locales can be requested.");
+    }
+
+    [Fact]
+    public void Validate_HasLocaleEmptyTokens_Fails()
+    {
+        var result = _validator.TestValidate(new DataListsListRequest { HasLocale = "," });
 
         result.ShouldHaveValidationErrorFor(x => x.HasLocale);
     }

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/DataListsListValidatorTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/DataListsListValidatorTests.cs
@@ -43,7 +43,8 @@ public class DataListsListValidatorTests
         var result = _validator.TestValidate(new DataListsListRequest { HasLocale = tooMany });
 
         result.ShouldHaveValidationErrorFor(x => x.HasLocale)
-            .WithErrorMessage($"No more than {CultureCodeValidation.MaxLocales} locales can be requested.");
+            .WithErrorMessage(
+                $"No more than {CultureCodeValidation.MaxLocales} locales can be requested. Received: {tooMany}.");
     }
 
     [Fact]

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/List/ListDataListsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/List/ListDataListsHandlerTests.cs
@@ -98,6 +98,48 @@ public class ListDataListsHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WithCommaSeparatedHasLocale_PassesOrFilterToSpecs()
+    {
+        _repository.CountAsync(Arg.Any<DataListsSpecifications.ListSpec>(), Arg.Any<CancellationToken>())
+            .Returns(1);
+        _repository.ListAsync(Arg.Any<DataListsSpecifications.ListWithPagingToDtoSpec>(), Arg.Any<CancellationToken>())
+            .Returns(new List<DataListDto>
+            {
+                new(5, "Cities", null, DateTime.UtcNow, null, true, 1, "en", ["de"], Array.Empty<DataListItemDto>())
+            });
+
+        await _sut.Handle(new ListDataListsQuery(1, 10, "es,de"), TestContext.Current.CancellationToken);
+
+        await _repository.Received(1).CountAsync(
+            Arg.Is<DataListsSpecifications.ListSpec>(spec => SpecFiltersByAnyLocale(spec, "es", "de")),
+            Arg.Any<CancellationToken>());
+        await _repository.Received(1).ListAsync(
+            Arg.Is<DataListsSpecifications.ListWithPagingToDtoSpec>(spec => SpecFiltersByAnyLocale(spec, "es", "de")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_WithHasLocale_MatchesDefaultLocaleWhenNotInCatalog()
+    {
+        _repository.CountAsync(Arg.Any<DataListsSpecifications.ListSpec>(), Arg.Any<CancellationToken>())
+            .Returns(1);
+        _repository.ListAsync(Arg.Any<DataListsSpecifications.ListWithPagingToDtoSpec>(), Arg.Any<CancellationToken>())
+            .Returns(new List<DataListDto>
+            {
+                new(5, "Cities", null, DateTime.UtcNow, null, true, 0, "es", [], Array.Empty<DataListItemDto>())
+            });
+
+        await _sut.Handle(new ListDataListsQuery(1, 10, "es"), TestContext.Current.CancellationToken);
+
+        await _repository.Received(1).CountAsync(
+            Arg.Is<DataListsSpecifications.ListSpec>(spec => SpecFiltersByDefaultLocale(spec, "es")),
+            Arg.Any<CancellationToken>());
+        await _repository.Received(1).ListAsync(
+            Arg.Is<DataListsSpecifications.ListWithPagingToDtoSpec>(spec => SpecFiltersByDefaultLocale(spec, "es")),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task Handle_WithSearch_PassesSearchToSpecs()
     {
         // Arrange

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/List/ListDataListsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/List/ListDataListsHandlerTests.cs
@@ -152,11 +152,28 @@ public class ListDataListsHandlerTests
         DataList withoutLocale = new(SampleData.TENANT_ID, "WithoutLocale");
         withoutLocale.AddCulture(CultureCode.Parse("fr"));
 
-        bool Matches(DataList dataList) =>
-            spec.WhereExpressions.Any()
-            && spec.WhereExpressions.All(expression => expression.FilterFunc(dataList));
+        return Matches(spec, withLocale) && !Matches(spec, withoutLocale);
+    }
 
-        return Matches(withLocale) && !Matches(withoutLocale);
+    private static bool SpecFiltersByAnyLocale(ISpecification<DataList> spec, params string[] locales)
+    {
+        DataList matching = new(SampleData.TENANT_ID, "Matching");
+        matching.AddCulture(CultureCode.Parse(locales[^1]));
+
+        DataList other = new(SampleData.TENANT_ID, "Other");
+        other.AddCulture(CultureCode.Parse("fr"));
+
+        return Matches(spec, matching) && !Matches(spec, other);
+    }
+
+    private static bool SpecFiltersByDefaultLocale(ISpecification<DataList> spec, string defaultLocale)
+    {
+        DataList matchingDefault = new(SampleData.TENANT_ID, "DefaultOnly", defaultLocale: defaultLocale);
+
+        DataList otherDefault = new(SampleData.TENANT_ID, "OtherDefault", defaultLocale: "fr");
+        otherDefault.AddCulture(CultureCode.Parse("de"));
+
+        return Matches(spec, matchingDefault) && !Matches(spec, otherDefault);
     }
 
     private static bool SpecFiltersBySearch(ISpecification<DataList> spec, string search)
@@ -176,4 +193,8 @@ public class ListDataListsHandlerTests
 
         return Matches(matchingDescription) && Matches(matchingName) && !Matches(other);
     }
+
+    private static bool Matches(ISpecification<DataList> spec, DataList dataList) =>
+        spec.WhereExpressions.Any()
+        && spec.WhereExpressions.All(expression => expression.FilterFunc(dataList));
 }


### PR DESCRIPTION
## Summary
`GET /api/data-lists` `hasLocale` accepts a culture or comma-separated OR list (capped, no synthetic `default`). Match is catalog **or** `DefaultLocale` (default is not in `AvailableLocales`).

## Review follow-up
- EF: `locales.Contains(DefaultLocale) || AvailableLocales.Any(l => locales.Contains(l))` so primitive-collection filter translates.
- Validation: cap vs invalid/`default` messages; too-many uses real culture tokens.
- Tests cover comma-OR and DefaultLocale-only lists.
- Docs/`ListDataListsQuery`: `search` + multi `hasLocale`.

## Test plan
- [ ] `hasLocale=es` — catalog hit
- [ ] `hasLocale=es,de` — OR
- [ ] list with `DefaultLocale=es` and empty catalog — included
- [ ] `hasLocale=default` and over-cap — 400, distinct messages

## Related
- relates to #964 

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Data-list searches now support filtering by a single locale or a comma-separated list of locales.
  * Locale filters match available translations or the default locale.
  * Updated API examples and documentation describe the new filtering behavior.

* **Bug Fixes**
  * Invalid filters, including empty entries, unsupported default values, and excessive locale counts, are now rejected with validation feedback.

* **Tests**
  * Added coverage for valid locale filters, validation failures, and default-locale matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->