### PR TITLE
feat(e964): add list sort, date bounds, and distinct locales

### DIFF
--- a/src/Endatix.Api/Endpoints/DataLists/List.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/List.cs
@@ -133,6 +133,14 @@ public sealed class List(
             return null;
         }
 
+        // DateOnly.MaxValue (9999-12-31) has no "next day" to represent the
+        // exclusive upper bound; clamp to DateTime.MaxValue instead of letting
+        // AddDays(1) throw ArgumentOutOfRangeException.
+        if (day == DateOnly.MaxValue)
+        {
+            return DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc);
+        }
+
         return DateTime.SpecifyKind(day.AddDays(1).ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc);
     }
 

--- a/src/Endatix.Api/Endpoints/DataLists/List.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/List.cs
@@ -187,11 +187,11 @@ public sealed class DataListsListValidator : Validator<DataListsListRequest>
             .IsHasLocaleFilter()
             .When(x => !string.IsNullOrWhiteSpace(x.HasLocale));
         RuleFor(x => x.SortBy)
-            .Must(value => AllowedSortBy.Contains(value!, StringComparer.OrdinalIgnoreCase))
+            .Must(value => AllowedSortBy.Contains(value, StringComparer.OrdinalIgnoreCase))
             .When(x => !string.IsNullOrWhiteSpace(x.SortBy))
             .WithMessage("SortBy must be one of: name, createdAt, modifiedAt, itemsCount, isActive.");
         RuleFor(x => x.SortDir)
-            .Must(value => AllowedSortDir.Contains(value!, StringComparer.OrdinalIgnoreCase))
+            .Must(value => AllowedSortDir.Contains(value, StringComparer.OrdinalIgnoreCase))
             .When(x => !string.IsNullOrWhiteSpace(x.SortDir))
             .WithMessage("SortDir must be asc or desc.");
         RuleFor(x => x.CreatedFrom)

--- a/src/Endatix.Api/Endpoints/DataLists/List.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/List.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Endatix.Api.Common;
 using Endatix.Api.Endpoints.Common;
 using Endatix.Api.Infrastructure;
@@ -29,13 +30,17 @@ public sealed class List(
         Summary(s =>
         {
             s.Summary = "List data lists";
-            s.Description = "Lists data lists for the current tenant with paging, optional name/description search, and an optional locale filter (single culture or comma-separated OR list).";
+            s.Description =
+                "Lists data lists for the current tenant with paging, optional name/description search, " +
+                "locale filter, sort, and created/modified date bounds.";
             s.ExampleRequest = new DataListsListRequest
             {
                 Page = 1,
                 PageSize = 20,
                 Search = "cities",
-                HasLocale = "es,de"
+                HasLocale = "es,de",
+                SortBy = "name",
+                SortDir = "asc"
             };
             s.ResponseExamples[200] = new Paged<DataListModel>(
                 page: 1,
@@ -67,7 +72,19 @@ public sealed class List(
     /// <inheritdoc />
     public override async Task<Results<Ok<Paged<DataListModel>>, ProblemHttpResult>> ExecuteAsync(DataListsListRequest request, CancellationToken ct)
     {
-        var result = await mediator.Send(new ListDataListsQuery(request.Page, request.PageSize, request.HasLocale, request.Search), ct);
+        var result = await mediator.Send(
+            new ListDataListsQuery(
+                request.Page,
+                request.PageSize,
+                request.HasLocale,
+                request.Search,
+                ParseSortBy(request.SortBy),
+                ParseSortDescending(request.SortDir),
+                ParseInclusiveDayStartUtc(request.CreatedFrom),
+                ParseExclusiveDayEndUtc(request.CreatedTo),
+                ParseInclusiveDayStartUtc(request.ModifiedFrom),
+                ParseExclusiveDayEndUtc(request.ModifiedTo)),
+            ct);
 
         if (!result.IsSuccess)
         {
@@ -78,6 +95,62 @@ public sealed class List(
 
         return TypedResults.Ok(mapped);
     }
+
+    internal static DataListListSortBy ParseSortBy(string? sortBy) =>
+        sortBy?.Trim().ToLowerInvariant() switch
+        {
+            "name" => DataListListSortBy.Name,
+            "modifiedat" => DataListListSortBy.ModifiedAt,
+            "itemscount" => DataListListSortBy.ItemsCount,
+            "isactive" => DataListListSortBy.IsActive,
+            "createdat" => DataListListSortBy.CreatedAt,
+            _ => DataListListSortBy.CreatedAt
+        };
+
+    internal static bool ParseSortDescending(string? sortDir) =>
+        !string.Equals(sortDir?.Trim(), "asc", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Parses a UTC calendar date (<c>YYYY-MM-DD</c>) as the inclusive start of that day.
+    /// </summary>
+    internal static DateTime? ParseInclusiveDayStartUtc(string? value)
+    {
+        if (!TryParseUtcCalendarDate(value, out DateOnly day))
+        {
+            return null;
+        }
+
+        return DateTime.SpecifyKind(day.ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc);
+    }
+
+    /// <summary>
+    /// Parses a UTC calendar date (<c>YYYY-MM-DD</c>) as the exclusive end (start of next day).
+    /// </summary>
+    internal static DateTime? ParseExclusiveDayEndUtc(string? value)
+    {
+        if (!TryParseUtcCalendarDate(value, out DateOnly day))
+        {
+            return null;
+        }
+
+        return DateTime.SpecifyKind(day.AddDays(1).ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc);
+    }
+
+    private static bool TryParseUtcCalendarDate(string? value, out DateOnly day)
+    {
+        day = default;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        return DateOnly.TryParseExact(
+            value.Trim(),
+            "yyyy-MM-dd",
+            CultureInfo.InvariantCulture,
+            DateTimeStyles.None,
+            out day);
+    }
 }
 
 /// <summary>
@@ -85,6 +158,17 @@ public sealed class List(
 /// </summary>
 public sealed class DataListsListValidator : Validator<DataListsListRequest>
 {
+    private static readonly string[] AllowedSortBy =
+    [
+        "name",
+        "createdAt",
+        "modifiedAt",
+        "itemsCount",
+        "isActive"
+    ];
+
+    private static readonly string[] AllowedSortDir = ["asc", "desc"];
+
     /// <summary>
     /// Initializes a new instance of the <see cref="DataListsListValidator"/> class.
     /// </summary>
@@ -94,7 +178,34 @@ public sealed class DataListsListValidator : Validator<DataListsListRequest>
         RuleFor(x => x.HasLocale)
             .IsHasLocaleFilter()
             .When(x => !string.IsNullOrWhiteSpace(x.HasLocale));
+        RuleFor(x => x.SortBy)
+            .Must(value => AllowedSortBy.Contains(value!, StringComparer.OrdinalIgnoreCase))
+            .When(x => !string.IsNullOrWhiteSpace(x.SortBy))
+            .WithMessage("SortBy must be one of: name, createdAt, modifiedAt, itemsCount, isActive.");
+        RuleFor(x => x.SortDir)
+            .Must(value => AllowedSortDir.Contains(value!, StringComparer.OrdinalIgnoreCase))
+            .When(x => !string.IsNullOrWhiteSpace(x.SortDir))
+            .WithMessage("SortDir must be asc or desc.");
+        RuleFor(x => x.CreatedFrom)
+            .Must(BeCalendarDate)
+            .When(x => !string.IsNullOrWhiteSpace(x.CreatedFrom))
+            .WithMessage("CreatedFrom must be a UTC calendar date (YYYY-MM-DD).");
+        RuleFor(x => x.CreatedTo)
+            .Must(BeCalendarDate)
+            .When(x => !string.IsNullOrWhiteSpace(x.CreatedTo))
+            .WithMessage("CreatedTo must be a UTC calendar date (YYYY-MM-DD).");
+        RuleFor(x => x.ModifiedFrom)
+            .Must(BeCalendarDate)
+            .When(x => !string.IsNullOrWhiteSpace(x.ModifiedFrom))
+            .WithMessage("ModifiedFrom must be a UTC calendar date (YYYY-MM-DD).");
+        RuleFor(x => x.ModifiedTo)
+            .Must(BeCalendarDate)
+            .When(x => !string.IsNullOrWhiteSpace(x.ModifiedTo))
+            .WithMessage("ModifiedTo must be a UTC calendar date (YYYY-MM-DD).");
     }
+
+    private static bool BeCalendarDate(string? value) =>
+        List.ParseInclusiveDayStartUtc(value).HasValue;
 }
 
 /// <summary>
@@ -116,4 +227,34 @@ public sealed class DataListsListRequest : ISearchablePagedRequest
     /// Returns lists whose AvailableLocales contain any code or whose DefaultLocale equals any code.
     /// </summary>
     public string? HasLocale { get; set; }
+
+    /// <summary>
+    /// Optional sort field: name, createdAt, modifiedAt, itemsCount, isActive.
+    /// </summary>
+    public string? SortBy { get; set; }
+
+    /// <summary>
+    /// Optional sort direction: asc or desc (default desc).
+    /// </summary>
+    public string? SortDir { get; set; }
+
+    /// <summary>
+    /// Inclusive created-at UTC calendar day (<c>YYYY-MM-DD</c>).
+    /// </summary>
+    public string? CreatedFrom { get; set; }
+
+    /// <summary>
+    /// Inclusive created-at UTC calendar day (<c>YYYY-MM-DD</c>).
+    /// </summary>
+    public string? CreatedTo { get; set; }
+
+    /// <summary>
+    /// Inclusive modified-at UTC calendar day (<c>YYYY-MM-DD</c>).
+    /// </summary>
+    public string? ModifiedFrom { get; set; }
+
+    /// <summary>
+    /// Inclusive modified-at UTC calendar day (<c>YYYY-MM-DD</c>).
+    /// </summary>
+    public string? ModifiedTo { get; set; }
 }

--- a/src/Endatix.Api/Endpoints/DataLists/ListLocales.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/ListLocales.cs
@@ -1,0 +1,47 @@
+using Endatix.Api.Infrastructure;
+using Endatix.Core.Abstractions.Authorization;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.DataLists.List;
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Endatix.Api.Endpoints.DataLists;
+
+/// <summary>
+/// Lists distinct culture codes stored on tenant data lists.
+/// </summary>
+public sealed class ListLocales(IMediator mediator)
+    : EndpointWithoutRequest<Results<Ok<IReadOnlyList<string>>, ProblemHttpResult>>
+{
+    /// <inheritdoc />
+    public override void Configure()
+    {
+        Get("data-lists/locales");
+        Permissions(Actions.Forms.View);
+        Summary(s =>
+        {
+            s.Summary = "List distinct data list locales";
+            s.Description =
+                "Returns distinct culture codes from DefaultLocale and AvailableLocales across all tenant data lists.";
+            s.Responses[200] = "Distinct locales retrieved successfully.";
+        });
+        Description(builder => builder
+            .Produces<IReadOnlyList<string>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
+    }
+
+    /// <inheritdoc />
+    public override async Task<Results<Ok<IReadOnlyList<string>>, ProblemHttpResult>> ExecuteAsync(
+        CancellationToken ct)
+    {
+        var result = await mediator.Send(new ListDistinctDataListLocalesQuery(), ct);
+        if (!result.IsSuccess)
+        {
+            return result.ToProblem();
+        }
+
+        return TypedResults.Ok(result.Value);
+    }
+}

--- a/src/Endatix.Core/Abstractions/Repositories/IDataListRepository.cs
+++ b/src/Endatix.Core/Abstractions/Repositories/IDataListRepository.cs
@@ -17,4 +17,11 @@ public interface IDataListRepository
     Task<DataListSearchPageResult?> SearchItemsAsync(
         DataListSearchCriteria criteria,
         CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns distinct culture codes from tenant data lists
+    /// (<c>DefaultLocale</c> ∪ <c>AvailableLocales</c>), sorted ascending.
+    /// </summary>
+    Task<IReadOnlyList<string>> ListDistinctLocalesAsync(
+        CancellationToken cancellationToken = default);
 }

--- a/src/Endatix.Core/Specifications/DataListsSpecifications.cs
+++ b/src/Endatix.Core/Specifications/DataListsSpecifications.cs
@@ -4,6 +4,7 @@ using Endatix.Core.Entities;
 using Endatix.Core.Specifications.Common;
 using Endatix.Core.Specifications.Parameters;
 using Endatix.Core.UseCases.DataLists;
+using Endatix.Core.UseCases.DataLists.List;
 
 namespace Endatix.Core.Specifications;
 
@@ -14,17 +15,33 @@ namespace Endatix.Core.Specifications;
 public static class DataListsSpecifications
 {
     /// <summary>
+    /// Shared list filters / ordering for management grids.
+    /// </summary>
+    public sealed record ListFilter(
+        string? HasLocale = null,
+        string? Search = null,
+        DataListListSortBy SortBy = DataListListSortBy.CreatedAt,
+        bool SortDescending = true,
+        DateTime? CreatedFrom = null,
+        DateTime? CreatedTo = null,
+        DateTime? ModifiedFrom = null,
+        DateTime? ModifiedTo = null);
+
+    /// <summary>
     /// Base specification to list data lists without pagination.
     /// </summary>
     public sealed class ListSpec : Specification<DataList>
     {
         public ListSpec(string? hasLocale = null, string? search = null)
+            : this(new ListFilter(hasLocale, search))
         {
-            ApplyListFilters(Query, hasLocale, search);
+        }
 
-            Query
-                 .OrderByDescending(x => x.CreatedAt)
-                 .AsNoTracking();
+        public ListSpec(ListFilter filter)
+        {
+            ApplyListFilters(Query, filter);
+            ApplyListOrdering(Query, filter);
+            Query.AsNoTracking();
         }
     }
 
@@ -33,12 +50,19 @@ public static class DataListsSpecifications
     /// </summary>
     public sealed class ListWithPagingToDtoSpec : Specification<DataList, DataListDto>
     {
-        public ListWithPagingToDtoSpec(PagingParameters pagingParams, string? hasLocale = null, string? search = null)
+        public ListWithPagingToDtoSpec(
+            PagingParameters pagingParams,
+            string? hasLocale = null,
+            string? search = null)
+            : this(pagingParams, new ListFilter(hasLocale, search))
         {
-            ApplyListFilters(Query, hasLocale, search);
+        }
 
+        public ListWithPagingToDtoSpec(PagingParameters pagingParams, ListFilter filter)
+        {
+            ApplyListFilters(Query, filter);
+            ApplyListOrdering(Query, filter);
             Query
-                .OrderByDescending(x => x.CreatedAt)
                 .Paginate(pagingParams)
                 .AsNoTracking();
 
@@ -58,11 +82,11 @@ public static class DataListsSpecifications
 
     private static void ApplyListFilters(
         ISpecificationBuilder<DataList> query,
-        string? hasLocale,
-        string? search)
+        ListFilter filter)
     {
-        // Closed-over array so EF translates Contains; match catalog rows or DefaultLocale (default is not in AvailableLocales).
-        string[] locales = [.. TranslationLocaleList.ParseMany(hasLocale is null ? null : [hasLocale])
+        // Closed-over array so EF translates Contains; DefaultLocale is not in AvailableLocales.
+        string[] locales = [.. TranslationLocaleList.ParseMany(
+                filter.HasLocale is null ? null : [filter.HasLocale])
             .Where(code => !code.IsSyntheticDefault)
             .Select(code => code.Value)];
 
@@ -73,15 +97,68 @@ public static class DataListsSpecifications
                 || x.AvailableLocales.Any(available => locales.Contains(available)));
         }
 
-        if (!string.IsNullOrWhiteSpace(search))
+        if (!string.IsNullOrWhiteSpace(filter.Search))
         {
-            var term = search.Trim().ToLowerInvariant();
+            var term = filter.Search.Trim().ToLowerInvariant();
             query.Where(x =>
                 x.Name.ToLower().Contains(term) ||
                 (x.Description != null && x.Description.ToLower().Contains(term)));
         }
+
+        if (filter.CreatedFrom.HasValue)
+        {
+            var from = filter.CreatedFrom.Value;
+            query.Where(x => x.CreatedAt >= from);
+        }
+
+        if (filter.CreatedTo.HasValue)
+        {
+            var toExclusive = filter.CreatedTo.Value;
+            query.Where(x => x.CreatedAt < toExclusive);
+        }
+
+        if (filter.ModifiedFrom.HasValue)
+        {
+            var from = filter.ModifiedFrom.Value;
+            query.Where(x => x.ModifiedAt != null && x.ModifiedAt >= from);
+        }
+
+        if (filter.ModifiedTo.HasValue)
+        {
+            var toExclusive = filter.ModifiedTo.Value;
+            query.Where(x => x.ModifiedAt != null && x.ModifiedAt < toExclusive);
+        }
     }
 
+    private static void ApplyListOrdering(
+        ISpecificationBuilder<DataList> query,
+        ListFilter filter)
+    {
+        switch (filter.SortBy)
+        {
+            case DataListListSortBy.Name:
+                if (filter.SortDescending) { query.OrderByDescending(x => x.Name); }
+                else { query.OrderBy(x => x.Name); }
+                break;
+            case DataListListSortBy.ModifiedAt:
+                if (filter.SortDescending) { query.OrderByDescending(x => x.ModifiedAt); }
+                else { query.OrderBy(x => x.ModifiedAt); }
+                break;
+            case DataListListSortBy.ItemsCount:
+                if (filter.SortDescending) { query.OrderByDescending(x => x.Items.Count); }
+                else { query.OrderBy(x => x.Items.Count); }
+                break;
+            case DataListListSortBy.IsActive:
+                if (filter.SortDescending) { query.OrderByDescending(x => x.IsActive); }
+                else { query.OrderBy(x => x.IsActive); }
+                break;
+            case DataListListSortBy.CreatedAt:
+            default:
+                if (filter.SortDescending) { query.OrderByDescending(x => x.CreatedAt); }
+                else { query.OrderBy(x => x.CreatedAt); }
+                break;
+        }
+    }
 
     /// <summary>
     /// Specification to get a data list by name.

--- a/src/Endatix.Core/Specifications/DataListsSpecifications.cs
+++ b/src/Endatix.Core/Specifications/DataListsSpecifications.cs
@@ -115,7 +115,18 @@ public static class DataListsSpecifications
         if (filter.CreatedTo.HasValue)
         {
             var toExclusive = filter.CreatedTo.Value;
-            query.Where(x => x.CreatedAt < toExclusive);
+            // DateTime.MaxValue has no exclusive "successor" moment (see
+            // List.ParseExclusiveDayEndUtc, which clamps the 9999-12-31 day
+            // bound to it) -- treat it as an inclusive upper bound so a
+            // record timestamped at the sentinel itself isn't dropped.
+            if (toExclusive == DateTime.MaxValue)
+            {
+                query.Where(x => x.CreatedAt <= toExclusive);
+            }
+            else
+            {
+                query.Where(x => x.CreatedAt < toExclusive);
+            }
         }
 
         if (filter.ModifiedFrom.HasValue)
@@ -127,7 +138,14 @@ public static class DataListsSpecifications
         if (filter.ModifiedTo.HasValue)
         {
             var toExclusive = filter.ModifiedTo.Value;
-            query.Where(x => x.ModifiedAt != null && x.ModifiedAt < toExclusive);
+            if (toExclusive == DateTime.MaxValue)
+            {
+                query.Where(x => x.ModifiedAt != null && x.ModifiedAt <= toExclusive);
+            }
+            else
+            {
+                query.Where(x => x.ModifiedAt != null && x.ModifiedAt < toExclusive);
+            }
         }
     }
 

--- a/src/Endatix.Core/Specifications/DataListsSpecifications.cs
+++ b/src/Endatix.Core/Specifications/DataListsSpecifications.cs
@@ -1,3 +1,4 @@
+using System.Linq.Expressions;
 using Ardalis.Specification;
 using Endatix.Core.Common.Translations;
 using Endatix.Core.Entities;
@@ -134,34 +135,40 @@ public static class DataListsSpecifications
         ISpecificationBuilder<DataList> query,
         ListFilter filter)
     {
-        // Every branch chains a `.ThenBy(x => x.Id)` tiebreaker: low-cardinality/
-        // duplicate-prone sort keys (IsActive, ItemsCount, and ties on Name/
-        // ModifiedAt) would otherwise leave pagination unstable across pages for
-        // rows sharing the same primary sort value.
+        // ThenBy Id keeps paging stable when the primary key has ties
+        // (IsActive, ItemsCount, duplicate Name / timestamps).
         switch (filter.SortBy)
         {
             case DataListListSortBy.Name:
-                if (filter.SortDescending) { query.OrderByDescending(x => x.Name).ThenBy(x => x.Id); }
-                else { query.OrderBy(x => x.Name).ThenBy(x => x.Id); }
+                OrderByWithIdTiebreaker(query, x => x.Name, filter.SortDescending);
                 break;
             case DataListListSortBy.ModifiedAt:
-                if (filter.SortDescending) { query.OrderByDescending(x => x.ModifiedAt).ThenBy(x => x.Id); }
-                else { query.OrderBy(x => x.ModifiedAt).ThenBy(x => x.Id); }
+                OrderByWithIdTiebreaker(query, x => x.ModifiedAt, filter.SortDescending);
                 break;
             case DataListListSortBy.ItemsCount:
-                if (filter.SortDescending) { query.OrderByDescending(x => x.Items.Count).ThenBy(x => x.Id); }
-                else { query.OrderBy(x => x.Items.Count).ThenBy(x => x.Id); }
+                OrderByWithIdTiebreaker(query, x => x.Items.Count, filter.SortDescending);
                 break;
             case DataListListSortBy.IsActive:
-                if (filter.SortDescending) { query.OrderByDescending(x => x.IsActive).ThenBy(x => x.Id); }
-                else { query.OrderBy(x => x.IsActive).ThenBy(x => x.Id); }
+                OrderByWithIdTiebreaker(query, x => x.IsActive, filter.SortDescending);
                 break;
-            case DataListListSortBy.CreatedAt:
             default:
-                if (filter.SortDescending) { query.OrderByDescending(x => x.CreatedAt).ThenBy(x => x.Id); }
-                else { query.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id); }
+                OrderByWithIdTiebreaker(query, x => x.CreatedAt, filter.SortDescending);
                 break;
         }
+    }
+
+    private static void OrderByWithIdTiebreaker(
+        ISpecificationBuilder<DataList> query,
+        Expression<Func<DataList, object?>> keySelector,
+        bool descending)
+    {
+        if (descending)
+        {
+            query.OrderByDescending(keySelector).ThenBy(x => x.Id);
+            return;
+        }
+
+        query.OrderBy(keySelector).ThenBy(x => x.Id);
     }
 
     /// <summary>

--- a/src/Endatix.Core/Specifications/DataListsSpecifications.cs
+++ b/src/Endatix.Core/Specifications/DataListsSpecifications.cs
@@ -134,28 +134,32 @@ public static class DataListsSpecifications
         ISpecificationBuilder<DataList> query,
         ListFilter filter)
     {
+        // Every branch chains a `.ThenBy(x => x.Id)` tiebreaker: low-cardinality/
+        // duplicate-prone sort keys (IsActive, ItemsCount, and ties on Name/
+        // ModifiedAt) would otherwise leave pagination unstable across pages for
+        // rows sharing the same primary sort value.
         switch (filter.SortBy)
         {
             case DataListListSortBy.Name:
-                if (filter.SortDescending) { query.OrderByDescending(x => x.Name); }
-                else { query.OrderBy(x => x.Name); }
+                if (filter.SortDescending) { query.OrderByDescending(x => x.Name).ThenBy(x => x.Id); }
+                else { query.OrderBy(x => x.Name).ThenBy(x => x.Id); }
                 break;
             case DataListListSortBy.ModifiedAt:
-                if (filter.SortDescending) { query.OrderByDescending(x => x.ModifiedAt); }
-                else { query.OrderBy(x => x.ModifiedAt); }
+                if (filter.SortDescending) { query.OrderByDescending(x => x.ModifiedAt).ThenBy(x => x.Id); }
+                else { query.OrderBy(x => x.ModifiedAt).ThenBy(x => x.Id); }
                 break;
             case DataListListSortBy.ItemsCount:
-                if (filter.SortDescending) { query.OrderByDescending(x => x.Items.Count); }
-                else { query.OrderBy(x => x.Items.Count); }
+                if (filter.SortDescending) { query.OrderByDescending(x => x.Items.Count).ThenBy(x => x.Id); }
+                else { query.OrderBy(x => x.Items.Count).ThenBy(x => x.Id); }
                 break;
             case DataListListSortBy.IsActive:
-                if (filter.SortDescending) { query.OrderByDescending(x => x.IsActive); }
-                else { query.OrderBy(x => x.IsActive); }
+                if (filter.SortDescending) { query.OrderByDescending(x => x.IsActive).ThenBy(x => x.Id); }
+                else { query.OrderBy(x => x.IsActive).ThenBy(x => x.Id); }
                 break;
             case DataListListSortBy.CreatedAt:
             default:
-                if (filter.SortDescending) { query.OrderByDescending(x => x.CreatedAt); }
-                else { query.OrderBy(x => x.CreatedAt); }
+                if (filter.SortDescending) { query.OrderByDescending(x => x.CreatedAt).ThenBy(x => x.Id); }
+                else { query.OrderBy(x => x.CreatedAt).ThenBy(x => x.Id); }
                 break;
         }
     }

--- a/src/Endatix.Core/UseCases/DataLists/List/DataListListSortBy.cs
+++ b/src/Endatix.Core/UseCases/DataLists/List/DataListListSortBy.cs
@@ -1,0 +1,13 @@
+namespace Endatix.Core.UseCases.DataLists.List;
+
+/// <summary>
+/// Sort fields for management data-list grids.
+/// </summary>
+public enum DataListListSortBy
+{
+    CreatedAt = 0,
+    ModifiedAt = 1,
+    Name = 2,
+    ItemsCount = 3,
+    IsActive = 4,
+}

--- a/src/Endatix.Core/UseCases/DataLists/List/ListDataListsHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/List/ListDataListsHandler.cs
@@ -17,8 +17,17 @@ public sealed class ListDataListsHandler(IRepository<DataList> repository)
     public async Task<Result<Paged<DataListDto>>> Handle(ListDataListsQuery request, CancellationToken cancellationToken)
     {
         PagingParameters pagingParams = new(request.Page, request.PageSize);
-        var pagedSpec = new DataListsSpecifications.ListWithPagingToDtoSpec(pagingParams, request.HasLocale, request.Search);
-        var listSpec = new DataListsSpecifications.ListSpec(request.HasLocale, request.Search);
+        var filter = new DataListsSpecifications.ListFilter(
+            request.HasLocale,
+            request.Search,
+            request.SortBy,
+            request.SortDescending,
+            request.CreatedFrom,
+            request.CreatedTo,
+            request.ModifiedFrom,
+            request.ModifiedTo);
+        var pagedSpec = new DataListsSpecifications.ListWithPagingToDtoSpec(pagingParams, filter);
+        var listSpec = new DataListsSpecifications.ListSpec(filter);
         var totalRecords = await repository.CountAsync(listSpec, cancellationToken);
 
         var dataListDtos = totalRecords <= 0

--- a/src/Endatix.Core/UseCases/DataLists/List/ListDataListsQuery.cs
+++ b/src/Endatix.Core/UseCases/DataLists/List/ListDataListsQuery.cs
@@ -8,7 +8,26 @@ namespace Endatix.Core.UseCases.DataLists.List;
 /// </summary>
 /// <param name="Page">The page number for pagination.</param>
 /// <param name="PageSize">The number of items per page for pagination.</param>
-/// <param name="HasLocale">Optional culture or comma-separated OR list; matches AvailableLocales or DefaultLocale.</param>
+/// <param name="HasLocale">
+/// Optional culture or comma-separated OR list (e.g. <c>es</c> or <c>es,de</c>).
+/// Matches AvailableLocales or DefaultLocale.
+/// </param>
 /// <param name="Search">Optional name/description search (case-insensitive contains).</param>
-public sealed record ListDataListsQuery(int? Page, int? PageSize, string? HasLocale = null, string? Search = null)
+/// <param name="SortBy">Optional sort field. Defaults to <see cref="DataListListSortBy.CreatedAt"/>.</param>
+/// <param name="SortDescending">When true, sort descending (default).</param>
+/// <param name="CreatedFrom">Inclusive UTC start of created-at day filter.</param>
+/// <param name="CreatedTo">Inclusive UTC end of created-at day filter (start of next day exclusive).</param>
+/// <param name="ModifiedFrom">Inclusive UTC start of modified-at day filter.</param>
+/// <param name="ModifiedTo">Inclusive UTC end of modified-at day filter (start of next day exclusive).</param>
+public sealed record ListDataListsQuery(
+    int? Page,
+    int? PageSize,
+    string? HasLocale = null,
+    string? Search = null,
+    DataListListSortBy SortBy = DataListListSortBy.CreatedAt,
+    bool SortDescending = true,
+    DateTime? CreatedFrom = null,
+    DateTime? CreatedTo = null,
+    DateTime? ModifiedFrom = null,
+    DateTime? ModifiedTo = null)
     : IQuery<Result<Paged<DataListDto>>>;

--- a/src/Endatix.Core/UseCases/DataLists/List/ListDistinctDataListLocalesHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/List/ListDistinctDataListLocalesHandler.cs
@@ -1,0 +1,21 @@
+using Endatix.Core.Abstractions.Repositories;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.DataLists.List;
+
+/// <summary>
+/// Handler for <see cref="ListDistinctDataListLocalesQuery"/>.
+/// </summary>
+public sealed class ListDistinctDataListLocalesHandler(IDataListRepository repository)
+    : IQueryHandler<ListDistinctDataListLocalesQuery, Result<IReadOnlyList<string>>>
+{
+    /// <inheritdoc />
+    public async Task<Result<IReadOnlyList<string>>> Handle(
+        ListDistinctDataListLocalesQuery request,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<string> locales = await repository.ListDistinctLocalesAsync(cancellationToken);
+        return Result.Success(locales);
+    }
+}

--- a/src/Endatix.Core/UseCases/DataLists/List/ListDistinctDataListLocalesQuery.cs
+++ b/src/Endatix.Core/UseCases/DataLists/List/ListDistinctDataListLocalesQuery.cs
@@ -1,0 +1,10 @@
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.DataLists.List;
+
+/// <summary>
+/// Returns distinct culture codes stored on tenant data lists (DefaultLocale ∪ AvailableLocales).
+/// </summary>
+public sealed record ListDistinctDataListLocalesQuery()
+    : IQuery<Result<IReadOnlyList<string>>>;

--- a/src/Endatix.Infrastructure/Data/Repositories/DataListRepository.cs
+++ b/src/Endatix.Infrastructure/Data/Repositories/DataListRepository.cs
@@ -98,24 +98,11 @@ public sealed class DataListRepository(
             })
             .ToListAsync(cancellationToken);
 
-        HashSet<string> locales = new(StringComparer.Ordinal);
-        foreach (var row in rows)
-        {
-            if (!string.IsNullOrWhiteSpace(row.DefaultLocale))
-            {
-                locales.Add(row.DefaultLocale);
-            }
-
-            foreach (string locale in row.AvailableLocales)
-            {
-                if (!string.IsNullOrWhiteSpace(locale))
-                {
-                    locales.Add(locale);
-                }
-            }
-        }
-
-        return [.. locales.OrderBy(locale => locale, StringComparer.Ordinal)];
+        return [.. rows
+            .SelectMany(row => row.AvailableLocales.Prepend(row.DefaultLocale))
+            .Where(locale => !string.IsNullOrWhiteSpace(locale))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(locale => locale, StringComparer.Ordinal)];
     }
 
     private static IReadOnlyList<string> BuildDistinctKeys(IEnumerable<string> keys) =>

--- a/src/Endatix.Infrastructure/Data/Repositories/DataListRepository.cs
+++ b/src/Endatix.Infrastructure/Data/Repositories/DataListRepository.cs
@@ -85,6 +85,39 @@ public sealed class DataListRepository(
             ToRelationalMode(criteria.MatchMode));
     }
 
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<string>> ListDistinctLocalesAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var rows = await dbContext.DataLists
+            .AsNoTracking()
+            .Select(dataList => new
+            {
+                dataList.DefaultLocale,
+                dataList.AvailableLocales
+            })
+            .ToListAsync(cancellationToken);
+
+        HashSet<string> locales = new(StringComparer.Ordinal);
+        foreach (var row in rows)
+        {
+            if (!string.IsNullOrWhiteSpace(row.DefaultLocale))
+            {
+                locales.Add(row.DefaultLocale);
+            }
+
+            foreach (string locale in row.AvailableLocales)
+            {
+                if (!string.IsNullOrWhiteSpace(locale))
+                {
+                    locales.Add(locale);
+                }
+            }
+        }
+
+        return [.. locales.OrderBy(locale => locale, StringComparer.Ordinal)];
+    }
+
     private static IReadOnlyList<string> BuildDistinctKeys(IEnumerable<string> keys) =>
         [.. keys.Distinct(StringComparer.Ordinal)];
 

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/DataListsListValidatorTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/DataListsListValidatorTests.cs
@@ -54,4 +54,73 @@ public class DataListsListValidatorTests
 
         result.ShouldHaveValidationErrorFor(x => x.HasLocale);
     }
+
+    [Theory]
+    [InlineData("name")]
+    [InlineData("CreatedAt")]
+    [InlineData("modifiedAt")]
+    [InlineData("itemsCount")]
+    [InlineData("isActive")]
+    public void Validate_AllowedSortBy_Passes(string sortBy)
+    {
+        var result = _validator.TestValidate(new DataListsListRequest { SortBy = sortBy });
+
+        result.ShouldNotHaveValidationErrorFor(x => x.SortBy);
+    }
+
+    [Fact]
+    public void Validate_UnknownSortBy_Fails()
+    {
+        var result = _validator.TestValidate(new DataListsListRequest { SortBy = "unknownField" });
+
+        result.ShouldHaveValidationErrorFor(x => x.SortBy);
+    }
+
+    [Theory]
+    [InlineData("asc")]
+    [InlineData("DESC")]
+    public void Validate_AllowedSortDir_Passes(string sortDir)
+    {
+        var result = _validator.TestValidate(new DataListsListRequest { SortDir = sortDir });
+
+        result.ShouldNotHaveValidationErrorFor(x => x.SortDir);
+    }
+
+    [Fact]
+    public void Validate_UnknownSortDir_Fails()
+    {
+        var result = _validator.TestValidate(new DataListsListRequest { SortDir = "sideways" });
+
+        result.ShouldHaveValidationErrorFor(x => x.SortDir);
+    }
+
+    [Theory]
+    [InlineData(nameof(DataListsListRequest.CreatedFrom))]
+    [InlineData(nameof(DataListsListRequest.CreatedTo))]
+    [InlineData(nameof(DataListsListRequest.ModifiedFrom))]
+    [InlineData(nameof(DataListsListRequest.ModifiedTo))]
+    public void Validate_DateBound_InvalidFormat_Fails(string propertyName)
+    {
+        var request = new DataListsListRequest();
+        typeof(DataListsListRequest).GetProperty(propertyName)!.SetValue(request, "12/31/2024");
+
+        var result = _validator.TestValidate(request);
+
+        result.ShouldHaveValidationErrorFor(propertyName);
+    }
+
+    [Fact]
+    public void Validate_DateBoundAtCalendarMaximum_Passes()
+    {
+        // Regression guard: List.ParseExclusiveDayEndUtc must not overflow on the
+        // last representable calendar date when computing the exclusive upper bound.
+        var result = _validator.TestValidate(new DataListsListRequest
+        {
+            CreatedTo = "9999-12-31",
+            ModifiedTo = "9999-12-31"
+        });
+
+        result.ShouldNotHaveValidationErrorFor(x => x.CreatedTo);
+        result.ShouldNotHaveValidationErrorFor(x => x.ModifiedTo);
+    }
 }

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/ListLocalesTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/ListLocalesTests.cs
@@ -1,0 +1,32 @@
+using Endatix.Api.Endpoints.DataLists;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.DataLists.List;
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Endatix.Api.Tests.Endpoints.DataLists;
+
+public class ListLocalesTests
+{
+    private readonly IMediator _mediator;
+    private readonly ListLocales _endpoint;
+
+    public ListLocalesTests()
+    {
+        _mediator = Substitute.For<IMediator>();
+        _endpoint = Factory.Create<ListLocales>(_mediator);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsOkWithLocales()
+    {
+        IReadOnlyList<string> locales = ["de", "en", "es"];
+        _mediator.Send(Arg.Any<ListDistinctDataListLocalesQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(locales));
+
+        var response = await _endpoint.ExecuteAsync(TestContext.Current.CancellationToken);
+        var ok = response.Result.Should().BeOfType<Ok<IReadOnlyList<string>>>().Subject;
+        ok.Value.Should().BeEquivalentTo(locales);
+    }
+}

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/ListTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/ListTests.cs
@@ -100,4 +100,28 @@ public class ListTests
                 x.ModifiedTo == new DateTime(2024, 2, 29, 0, 0, 0, DateTimeKind.Utc)),
             Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task ExecuteAsync_DateBoundAtCalendarMaximum_DoesNotThrow()
+    {
+        // Regression guard: ParseExclusiveDayEndUtc must clamp instead of
+        // overflowing when CreatedTo/ModifiedTo is the last representable
+        // calendar date (DateOnly.MaxValue has no "next day").
+        DataListsListRequest request = new()
+        {
+            CreatedTo = "9999-12-31",
+            ModifiedTo = "9999-12-31"
+        };
+        _mediator.Send(Arg.Any<ListDataListsQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new Paged<DataListDto>(1, 10, 0, 0, Array.Empty<DataListDto>())));
+
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        response.Result.Should().BeOfType<Ok<Paged<DataListModel>>>();
+        await _mediator.Received(1).Send(
+            Arg.Is<ListDataListsQuery>(x =>
+                x.CreatedTo == DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc) &&
+                x.ModifiedTo == DateTime.SpecifyKind(DateTime.MaxValue, DateTimeKind.Utc)),
+            Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/ListTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/ListTests.cs
@@ -72,4 +72,32 @@ public class ListTests
             Arg.Is<ListDataListsQuery>(x => x.Search == "cities" && x.HasLocale == "es"),
             Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task ExecuteAsync_PassesSortAndDateBoundsToQuery()
+    {
+        DataListsListRequest request = new()
+        {
+            SortBy = "name",
+            SortDir = "asc",
+            CreatedFrom = "2024-01-01",
+            CreatedTo = "2024-01-31",
+            ModifiedFrom = "2024-02-01",
+            ModifiedTo = "2024-02-28"
+        };
+        _mediator.Send(Arg.Any<ListDataListsQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new Paged<DataListDto>(1, 10, 0, 0, Array.Empty<DataListDto>())));
+
+        await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        await _mediator.Received(1).Send(
+            Arg.Is<ListDataListsQuery>(x =>
+                x.SortBy == DataListListSortBy.Name &&
+                x.SortDescending == false &&
+                x.CreatedFrom == new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc) &&
+                x.CreatedTo == new DateTime(2024, 2, 1, 0, 0, 0, DateTimeKind.Utc) &&
+                x.ModifiedFrom == new DateTime(2024, 2, 1, 0, 0, 0, DateTimeKind.Utc) &&
+                x.ModifiedTo == new DateTime(2024, 2, 29, 0, 0, 0, DateTimeKind.Utc)),
+            Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Endatix.Core.Tests/Specifications/DataListsSpecificationsTests.cs
+++ b/tests/Endatix.Core.Tests/Specifications/DataListsSpecificationsTests.cs
@@ -1,0 +1,82 @@
+using Ardalis.Specification;
+using Endatix.Core.Entities;
+using Endatix.Core.Specifications;
+
+namespace Endatix.Core.Tests.Specifications;
+
+public class DataListsSpecificationsTests
+{
+    [Fact]
+    public void ListSpec_CreatedToAtDateTimeMaxValue_IncludesRecordAtSentinel()
+    {
+        // Arrange: DateTime.MaxValue reaches this filter as the clamped
+        // exclusive-day-end for CreatedTo=9999-12-31 (see
+        // List.ParseExclusiveDayEndUtc, which clamps to it since
+        // DateOnly.MaxValue has no "next day"). A record timestamped exactly
+        // at the sentinel must not be dropped by a strict "<" comparison.
+        var filter = new DataListsSpecifications.ListFilter(CreatedTo: DateTime.MaxValue);
+        var spec = new DataListsSpecifications.ListSpec(filter);
+
+        var atSentinel = CreateDataList(createdAt: DateTime.MaxValue);
+        var wellBeforeSentinel = CreateDataList(createdAt: new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        // Act & Assert
+        Matches(spec, atSentinel).Should().BeTrue();
+        Matches(spec, wellBeforeSentinel).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ListSpec_ModifiedToAtDateTimeMaxValue_IncludesRecordAtSentinel()
+    {
+        var filter = new DataListsSpecifications.ListFilter(ModifiedTo: DateTime.MaxValue);
+        var spec = new DataListsSpecifications.ListSpec(filter);
+
+        var atSentinel = CreateDataList(modifiedAt: DateTime.MaxValue);
+
+        Matches(spec, atSentinel).Should().BeTrue();
+    }
+
+    [Fact]
+    public void ListSpec_CreatedToNonSentinelValue_StaysExclusive()
+    {
+        // Arrange: ordinary (non-sentinel) CreatedTo bounds must remain
+        // exclusive -- only the DateTime.MaxValue sentinel gets inclusive
+        // treatment.
+        var bound = new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc);
+        var filter = new DataListsSpecifications.ListFilter(CreatedTo: bound);
+        var spec = new DataListsSpecifications.ListSpec(filter);
+
+        var atBound = CreateDataList(createdAt: bound);
+        var beforeBound = CreateDataList(createdAt: bound.AddSeconds(-1));
+
+        // Act & Assert
+        Matches(spec, atBound).Should().BeFalse();
+        Matches(spec, beforeBound).Should().BeTrue();
+    }
+
+    private static bool Matches(ISpecification<DataList> spec, DataList dataList)
+    {
+        return spec.WhereExpressions.All(where => where.FilterFunc(dataList));
+    }
+
+    private static DataList CreateDataList(DateTime? createdAt = null, DateTime? modifiedAt = null)
+    {
+        var dataList = new DataList(SampleData.TENANT_ID, "Cities", null, "CITIES");
+
+        if (createdAt.HasValue)
+        {
+            typeof(DataList)
+                .GetProperty(nameof(DataList.CreatedAt))!
+                .SetValue(dataList, createdAt.Value);
+        }
+
+        if (modifiedAt.HasValue)
+        {
+            typeof(DataList)
+                .GetProperty(nameof(DataList.ModifiedAt))!
+                .SetValue(dataList, modifiedAt.Value);
+        }
+
+        return dataList;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `GET /data-lists/locales` returning distinct tenant catalog cultures (`DefaultLocale` ∪ `AvailableLocales`)
- Extend list query with `sortBy`/`sortDir` and inclusive UTC calendar day bounds for created/modified
- Specs apply filters/ordering for management grid header chrome
- Fixed a real crash: date-bound filters at the max representable calendar date (9999-12-31) threw an unhandled exception instead of a valid response. Added a stable pagination tiebreaker for the new sort options, plus validator/endpoint regression tests for the new sort and date-bound rules.


## Test plan
- [ ] `GET /data-lists/locales` returns sorted distinct cultures for the tenant
- [ ] List with `sortBy=name&sortDir=asc` orders by friendly name
- [ ] `createdFrom`/`createdTo` and `modifiedFrom`/`modifiedTo` (`YYYY-MM-DD`) filter inclusively by UTC day
- [ ] Existing `query` / `hasLocale` behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added sorting options for data lists, including name, creation date, modification date, item count, and active status.
  - Added filtering by created and modified date ranges.
  - Added an endpoint to retrieve distinct locales available across data lists.
  - Improved data-list listing with stable sorting and combined search, locale, and date filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->