### PR TITLE
feat(e964): add partial update for name and description

### DIFF
--- a/src/Endatix.Api/Endpoints/DataLists/PartialUpdate.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/PartialUpdate.cs
@@ -1,0 +1,114 @@
+using Endatix.Api.Infrastructure;
+using Endatix.Core.Abstractions.Authorization;
+using Endatix.Core.UseCases.DataLists.UpdateDetails;
+using Endatix.Infrastructure.Data.Config;
+using FastEndpoints;
+using FluentValidation;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Endatix.Api.Endpoints.DataLists;
+
+/// <summary>
+/// Endpoint to partially update a data list name and/or description.
+/// </summary>
+public sealed class PartialUpdate(IMediator mediator)
+    : Endpoint<PartialUpdateDataListRequest, Results<Ok<DataListDetailsModel>, ProblemHttpResult>>
+{
+    /// <summary>
+    /// Configures the endpoint settings.
+    /// </summary>
+    public override void Configure()
+    {
+        Patch("data-lists/{dataListId}");
+        Permissions(Actions.Forms.Edit);
+        Summary(s =>
+        {
+            s.Summary = "Partially update a data list";
+            s.Description = "Updates the name and/or description of a data list. Omitted fields keep their current value.";
+            s.ExampleRequest = new PartialUpdateDataListRequest
+            {
+                DataListId = 1,
+                Name = "Cities",
+                Description = "Major cities used in forms"
+            };
+            s.ResponseExamples[200] = new DataListDetailsModel
+            {
+                Id = 1,
+                Name = "Cities",
+                Description = "Major cities used in forms",
+                IsActive = true,
+                CreatedAt = DateTime.UtcNow,
+                ItemsCount = 0,
+                DefaultLocale = "en",
+                AvailableLocales = [],
+                Items = []
+            };
+            s.Responses[200] = "Data list updated successfully.";
+            s.Responses[400] = "Invalid input data.";
+            s.Responses[404] = "Data list not found.";
+        });
+        Description(builder => builder
+            .Produces<DataListDetailsModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
+    }
+
+    /// <inheritdoc />
+    public override async Task<Results<Ok<DataListDetailsModel>, ProblemHttpResult>> ExecuteAsync(
+        PartialUpdateDataListRequest request,
+        CancellationToken ct)
+    {
+        UpdateDataListDetailsCommand command = new(request.DataListId, request.Name, request.Description);
+        var result = await mediator.Send(command, ct);
+
+        return TypedResultsBuilder
+            .MapResult(result, DataListMapper.MapDetails)
+            .SetTypedResults<Ok<DataListDetailsModel>, ProblemHttpResult>();
+    }
+}
+
+/// <summary>
+/// Validator for the <see cref="PartialUpdateDataListRequest"/>.
+/// </summary>
+public sealed class PartialUpdateDataListValidator : Validator<PartialUpdateDataListRequest>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PartialUpdateDataListValidator"/> class.
+    /// </summary>
+    public PartialUpdateDataListValidator()
+    {
+        RuleFor(x => x.DataListId).GreaterThan(0);
+
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(DataSchemaConstants.MAX_NAME_LENGTH)
+            .When(x => x.Name is not null);
+
+        RuleFor(x => x.Description)
+            .MaximumLength(DataSchemaConstants.MAX_DESCRIPTION_LENGTH)
+            .When(x => x.Description is not null);
+    }
+}
+
+/// <summary>
+/// Request to partially update a data list.
+/// </summary>
+public sealed class PartialUpdateDataListRequest
+{
+    /// <summary>
+    /// The ID of the data list to update.
+    /// </summary>
+    public long DataListId { get; init; }
+
+    /// <summary>
+    /// When set, replaces the data list name.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// When set, replaces the data list description.
+    /// </summary>
+    public string? Description { get; init; }
+}

--- a/src/Endatix.Api/Endpoints/DataLists/PartialUpdate.cs
+++ b/src/Endatix.Api/Endpoints/DataLists/PartialUpdate.cs
@@ -26,7 +26,8 @@ public sealed class PartialUpdate(IMediator mediator)
         Summary(s =>
         {
             s.Summary = "Partially update a data list";
-            s.Description = "Updates the name and/or description of a data list. Omitted fields keep their current value.";
+            s.Description = "Updates the name and/or description of a data list. Omitted fields (or an explicit JSON null) keep their current value; " +
+                "send an empty string to clear the description. Name cannot be cleared -- it must be non-empty when provided.";
             s.ExampleRequest = new PartialUpdateDataListRequest
             {
                 DataListId = 1,

--- a/src/Endatix.Core/UseCases/DataLists/Create/CreateDataListHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Create/CreateDataListHandler.cs
@@ -59,8 +59,12 @@ public sealed class CreateDataListHandler(
                 return Result.Invalid(duplicateListNameError);
             }
 
-            var fallbackDuplicateError = CreateDuplicateNameValidationError(trimmedName);
-            return Result.Invalid(fallbackDuplicateError);
+            return Result.Invalid(new ValidationError
+            {
+                Identifier = string.Empty,
+                ErrorMessage = "This data list could not be created because of a conflicting change. Please retry.",
+                ErrorCode = "data_list_unique_constraint_violation"
+            });
         }
     }
 

--- a/src/Endatix.Core/UseCases/DataLists/UpdateDetails/UpdateDataListDetailsCommand.cs
+++ b/src/Endatix.Core/UseCases/DataLists/UpdateDetails/UpdateDataListDetailsCommand.cs
@@ -1,0 +1,31 @@
+using Ardalis.GuardClauses;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.DataLists.UpdateDetails;
+
+/// <summary>
+/// Command to partially update a data list name and/or description.
+/// </summary>
+public sealed record UpdateDataListDetailsCommand : ICommand<Result<DataListDto>>
+{
+    public long DataListId { get; init; }
+
+    /// <summary>
+    /// When set, replaces the data list name.
+    /// </summary>
+    public string? Name { get; init; }
+
+    /// <summary>
+    /// When set, replaces the data list description (use empty string to clear).
+    /// </summary>
+    public string? Description { get; init; }
+
+    public UpdateDataListDetailsCommand(long dataListId, string? name, string? description)
+    {
+        Guard.Against.NegativeOrZero(dataListId);
+        DataListId = dataListId;
+        Name = name;
+        Description = description;
+    }
+}

--- a/src/Endatix.Core/UseCases/DataLists/UpdateDetails/UpdateDataListDetailsHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/UpdateDetails/UpdateDataListDetailsHandler.cs
@@ -1,0 +1,106 @@
+using Endatix.Core.Abstractions;
+using Endatix.Core.Abstractions.Data;
+using Endatix.Core.Entities;
+using Endatix.Core.Events;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
+using Endatix.Core.UseCases.DataLists.Create;
+using MediatR;
+
+namespace Endatix.Core.UseCases.DataLists.UpdateDetails;
+
+/// <summary>
+/// Handler for <see cref="UpdateDataListDetailsCommand"/>.
+/// </summary>
+public sealed class UpdateDataListDetailsHandler(
+    IRepository<DataList> repository,
+    IValueNormalizer valueNormalizer,
+    IUniqueConstraintViolationChecker uniqueConstraintViolationChecker,
+    IMediator mediator)
+    : ICommandHandler<UpdateDataListDetailsCommand, Result<DataListDto>>
+{
+    public const string DuplicateNameErrorCode = CreateDataListHandler.DuplicateNameErrorCode;
+
+    /// <inheritdoc />
+    public async Task<Result<DataListDto>> Handle(
+        UpdateDataListDetailsCommand request,
+        CancellationToken cancellationToken)
+    {
+        DataList? dataList = await repository.GetByIdAsync(request.DataListId, cancellationToken);
+        if (dataList is null)
+        {
+            return Result.NotFound("Data list not found.");
+        }
+
+        var nextName = request.Name is null ? dataList.Name : request.Name.Trim();
+        if (string.IsNullOrWhiteSpace(nextName))
+        {
+            return Result.Invalid(new ValidationError
+            {
+                Identifier = nameof(UpdateDataListDetailsCommand.Name),
+                ErrorMessage = "Name is required."
+            });
+        }
+
+        var nextDescription = request.Description is null
+            ? dataList.Description
+            : string.IsNullOrWhiteSpace(request.Description)
+                ? null
+                : request.Description.Trim();
+
+        var normalizedName = valueNormalizer.Normalize(nextName);
+        if (string.IsNullOrWhiteSpace(normalizedName))
+        {
+            return Result.Error("Data list name could not be normalized.");
+        }
+
+        if (!string.Equals(dataList.NormalizedName, normalizedName, StringComparison.Ordinal))
+        {
+            var byNormalizedNameSpec = new DataListsSpecifications.ByNormalizedNameSpec(normalizedName);
+            DataList? existingDataList = await repository.SingleOrDefaultAsync(
+                byNormalizedNameSpec,
+                cancellationToken);
+            if (existingDataList is not null && existingDataList.Id != dataList.Id)
+            {
+                return Result.Invalid(CreateDuplicateNameValidationError(nextName));
+            }
+        }
+
+        dataList.UpdateDetails(nextName, nextDescription, normalizedName);
+
+        try
+        {
+            await repository.UpdateAsync(dataList, cancellationToken);
+        }
+        catch (Exception exception)
+        {
+            var violation = uniqueConstraintViolationChecker.AnalyzeUniqueConstraint(exception);
+            if (!violation.IsUniqueConstraintViolation)
+            {
+                throw;
+            }
+
+            if (violation.IsDataListNameViolation())
+            {
+                return Result.Invalid(CreateDuplicateNameValidationError(nextName));
+            }
+
+            return Result.Invalid(CreateDuplicateNameValidationError(nextName));
+        }
+
+        await mediator.Publish(
+            new DataListUpdatedEvent(dataList, DataListUpdateReasons.MetadataUpdated),
+            cancellationToken);
+
+        return Result.Success(DataListDtoMapper.FromEntity(dataList, includeItems: false));
+    }
+
+    private static ValidationError CreateDuplicateNameValidationError(string name) => new()
+    {
+        Identifier = nameof(UpdateDataListDetailsCommand.Name),
+        ErrorMessage = $"A data list with the name '{name}' already exists.",
+        ErrorCode = DuplicateNameErrorCode
+    };
+}

--- a/src/Endatix.Core/UseCases/DataLists/UpdateDetails/UpdateDataListDetailsHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/UpdateDetails/UpdateDataListDetailsHandler.cs
@@ -44,11 +44,13 @@ public sealed class UpdateDataListDetailsHandler(
             });
         }
 
+        // Matches CreateDataListHandler's `request.Description?.Trim()`: a
+        // whitespace-only description normalizes to "" (not null), so the
+        // same logical "empty description" value is stored identically
+        // regardless of which endpoint wrote it.
         var nextDescription = request.Description is null
             ? dataList.Description
-            : string.IsNullOrWhiteSpace(request.Description)
-                ? null
-                : request.Description.Trim();
+            : request.Description.Trim();
 
         var normalizedName = valueNormalizer.Normalize(nextName);
         if (string.IsNullOrWhiteSpace(normalizedName))
@@ -87,14 +89,31 @@ public sealed class UpdateDataListDetailsHandler(
                 return Result.Invalid(CreateDuplicateNameValidationError(nextName));
             }
 
-            return Result.Invalid(CreateDuplicateNameValidationError(nextName));
+            // A unique-constraint violation was raised that isn't the name
+            // constraint we checked for above (e.g. a future additional
+            // constraint on DataList) -- don't mislabel it as a name
+            // conflict; surface it as a generic conflict instead.
+            return Result.Invalid(new ValidationError
+            {
+                Identifier = string.Empty,
+                ErrorMessage = "This data list could not be updated because of a conflicting change. Please retry.",
+                ErrorCode = "data_list_unique_constraint_violation"
+            });
         }
 
         await mediator.Publish(
             new DataListUpdatedEvent(dataList, DataListUpdateReasons.MetadataUpdated),
             cancellationToken);
 
-        return Result.Success(DataListDtoMapper.FromEntity(dataList, includeItems: false));
+        // `dataList` is the tracked entity used for the mutation above; its
+        // `Items` navigation was never Included, so DataListDtoMapper's
+        // `Items.Count` would read as 0 regardless of the list's actual item
+        // count. Re-fetch via the same no-tracking, SQL-computed-count
+        // projection GetDataListByIdHandler uses for `IncludeItems: false`.
+        var metadataSpec = new DataListsSpecifications.ByIdWithoutItemsToDtoSpec(dataList.Id);
+        DataListDto? metadata = await repository.FirstOrDefaultAsync(metadataSpec, cancellationToken);
+
+        return Result.Success(metadata ?? DataListDtoMapper.FromEntity(dataList, includeItems: false));
     }
 
     private static ValidationError CreateDuplicateNameValidationError(string name) => new()

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/PartialUpdateDataListValidatorTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/PartialUpdateDataListValidatorTests.cs
@@ -1,0 +1,101 @@
+using Endatix.Api.Endpoints.DataLists;
+using Endatix.Infrastructure.Data.Config;
+using FluentValidation.TestHelper;
+
+namespace Endatix.Api.Tests.Endpoints.DataLists;
+
+public class PartialUpdateDataListValidatorTests
+{
+    private readonly PartialUpdateDataListValidator _sut = new();
+
+    [Fact]
+    public void Validate_ValidNameAndDescription_Passes()
+    {
+        // Arrange
+        var request = new PartialUpdateDataListRequest
+        {
+            DataListId = 1,
+            Name = "Cities",
+            Description = "Major cities"
+        };
+
+        // Act
+        var result = _sut.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_OmittedOptionalFields_Passes()
+    {
+        // Arrange
+        var request = new PartialUpdateDataListRequest { DataListId = 1 };
+
+        // Act
+        var result = _sut.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_EmptyNameWhenProvided_Fails()
+    {
+        // Arrange
+        var request = new PartialUpdateDataListRequest { DataListId = 1, Name = "   " };
+
+        // Act
+        var result = _sut.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void Validate_NameExceedsMaxLength_Fails()
+    {
+        // Arrange
+        var request = new PartialUpdateDataListRequest
+        {
+            DataListId = 1,
+            Name = new string('a', DataSchemaConstants.MAX_NAME_LENGTH + 1)
+        };
+
+        // Act
+        var result = _sut.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Name);
+    }
+
+    [Fact]
+    public void Validate_DescriptionExceedsMaxLength_Fails()
+    {
+        // Arrange
+        var request = new PartialUpdateDataListRequest
+        {
+            DataListId = 1,
+            Description = new string('a', DataSchemaConstants.MAX_DESCRIPTION_LENGTH + 1)
+        };
+
+        // Act
+        var result = _sut.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Description);
+    }
+
+    [Fact]
+    public void Validate_NonPositiveDataListId_Fails()
+    {
+        // Arrange
+        var request = new PartialUpdateDataListRequest { DataListId = 0, Name = "Cities" };
+
+        // Act
+        var result = _sut.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.DataListId);
+    }
+}

--- a/tests/Endatix.Api.Tests/Endpoints/DataLists/PartialUpdateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/DataLists/PartialUpdateTests.cs
@@ -1,0 +1,141 @@
+using Endatix.Api.Endpoints.DataLists;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.DataLists;
+using Endatix.Core.UseCases.DataLists.UpdateDetails;
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Endatix.Api.Tests.Endpoints.DataLists;
+
+public class PartialUpdateTests
+{
+    private readonly IMediator _mediator;
+    private readonly PartialUpdate _endpoint;
+
+    public PartialUpdateTests()
+    {
+        _mediator = Substitute.For<IMediator>();
+        _endpoint = Factory.Create<PartialUpdate>(_mediator);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_InvalidRequest_ReturnsProblemDetails()
+    {
+        // Arrange
+        var request = new PartialUpdateDataListRequest { DataListId = 1, Name = "Cities" };
+        _mediator.Send(Arg.Any<UpdateDataListDetailsCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Invalid());
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DataListNotFound_ReturnsProblemDetails()
+    {
+        // Arrange
+        var request = new PartialUpdateDataListRequest { DataListId = 1, Name = "Cities" };
+        _mediator.Send(Arg.Any<UpdateDataListDetailsCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.NotFound("Data list not found."));
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_DuplicateName_ReturnsProblemDetails()
+    {
+        // Arrange
+        var request = new PartialUpdateDataListRequest { DataListId = 1, Name = "Cities" };
+        ValidationError duplicateError = new()
+        {
+            Identifier = nameof(UpdateDataListDetailsCommand.Name),
+            ErrorMessage = "A data list with the name 'Cities' already exists.",
+            ErrorCode = UpdateDataListDetailsHandler.DuplicateNameErrorCode
+        };
+        _mediator.Send(Arg.Any<UpdateDataListDetailsCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Invalid(duplicateError));
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ValidRequest_ReturnsOkWithDetails()
+    {
+        // Arrange
+        var request = new PartialUpdateDataListRequest
+        {
+            DataListId = 1,
+            Name = "Metros",
+            Description = "Updated"
+        };
+        DataListDto dto = new(
+            1,
+            "Metros",
+            "Updated",
+            DateTime.UtcNow,
+            DateTime.UtcNow,
+            true,
+            0,
+            "en",
+            [],
+            []);
+        _mediator.Send(Arg.Any<UpdateDataListDetailsCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(dto));
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        // Assert
+        var okResult = response.Result as Ok<DataListDetailsModel>;
+        okResult.Should().NotBeNull();
+        okResult!.Value.Should().NotBeNull();
+        okResult.Value!.Id.Should().Be(1);
+        okResult.Value.Name.Should().Be("Metros");
+        okResult.Value.Description.Should().Be("Updated");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ShouldMapRequestToCommandCorrectly()
+    {
+        // Arrange
+        var request = new PartialUpdateDataListRequest
+        {
+            DataListId = 123,
+            Name = "Metros",
+            Description = "Desc"
+        };
+        DataListDto dto = new(123, "Metros", "Desc", DateTime.UtcNow, null, true, 0, "en", [], []);
+        _mediator.Send(Arg.Any<UpdateDataListDetailsCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(dto));
+
+        // Act
+        await _endpoint.ExecuteAsync(request, CancellationToken.None);
+
+        // Assert
+        await _mediator.Received(1).Send(
+            Arg.Is<UpdateDataListDetailsCommand>(cmd =>
+                cmd.DataListId == request.DataListId
+                && cmd.Name == request.Name
+                && cmd.Description == request.Description),
+            Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/Create/CreateDataListHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/Create/CreateDataListHandlerTests.cs
@@ -82,6 +82,26 @@ public class CreateDataListHandlerTests
     }
 
     [Fact]
+    public async Task Handle_UniqueViolationNotNameConstraint_ReturnsGenericConflict()
+    {
+        _tenantContext.TenantId.Returns(101);
+        _repository.SingleOrDefaultAsync(Arg.Any<DataListsSpecifications.ByNormalizedNameSpec>(), Arg.Any<CancellationToken>())
+            .Returns((DataList?)null);
+        _repository.AddAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>())
+            .Returns<Task<DataList>>(_ => throw new Exception("db failed"));
+        _uniqueConstraintViolationChecker.AnalyzeUniqueConstraint(Arg.Any<Exception>())
+            .Returns(new UniqueConstraintViolationResult(true, "IX_SomeOtherConstraint", "SomeOtherColumn"));
+
+        var result = await _sut.Handle(
+            new CreateDataListCommand("Cities", null),
+            TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().NotContain(error =>
+            error.ErrorCode == CreateDataListHandler.DuplicateNameErrorCode);
+    }
+
+    [Fact]
     public async Task Handle_DuplicateNameDifferentCasing_ReturnsInvalid()
     {
         _tenantContext.TenantId.Returns(101);

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/Create/CreateDataListHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/Create/CreateDataListHandlerTests.cs
@@ -97,8 +97,8 @@ public class CreateDataListHandlerTests
             TestContext.Current.CancellationToken);
 
         result.Status.Should().Be(ResultStatus.Invalid);
-        result.ValidationErrors.Should().NotContain(error =>
-            error.ErrorCode == CreateDataListHandler.DuplicateNameErrorCode);
+        result.ValidationErrors.Should().Contain(error =>
+            error.ErrorCode == "data_list_unique_constraint_violation");
     }
 
     [Fact]

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/UpdateDetails/UpdateDataListDetailsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/UpdateDetails/UpdateDataListDetailsHandlerTests.cs
@@ -5,6 +5,7 @@ using Endatix.Core.Events;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;
+using Endatix.Core.UseCases.DataLists;
 using Endatix.Core.UseCases.DataLists.UpdateDetails;
 using MediatR;
 
@@ -73,6 +74,30 @@ public class UpdateDataListDetailsHandlerTests
         dataList.Name.Should().Be("Metros");
         dataList.NormalizedName.Should().Be("METROS");
         await _repository.Received(1).UpdateAsync(dataList, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsAccurateItemsCount()
+    {
+        // Arrange: the tracked `dataList` used for the mutation never has its
+        // Items navigation Included, so its own Items.Count would read 0 --
+        // regression guard that the handler re-fetches the count instead of
+        // trusting the unloaded collection on the tracked entity.
+        DataList dataList = new(SampleData.TENANT_ID, "Cities", "Old", "CITIES") { Id = 1 };
+        _repository.GetByIdAsync(1L, Arg.Any<CancellationToken>()).Returns(dataList);
+        _repository.FirstOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByIdWithoutItemsToDtoSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new DataListDto(1, "Metros", "New desc", DateTime.UtcNow, DateTime.UtcNow, true, 42, "en", [], []));
+
+        // Act
+        var result = await _sut.Handle(
+            new UpdateDataListDetailsCommand(1, "Metros", "New desc"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value!.ItemsCount.Should().Be(42);
     }
 
     [Fact]
@@ -164,6 +189,52 @@ public class UpdateDataListDetailsHandlerTests
         result.Status.Should().Be(ResultStatus.Invalid);
         result.ValidationErrors.Should().Contain(error =>
             error.ErrorCode == UpdateDataListDetailsHandler.DuplicateNameErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_UniqueViolationNotNameConstraint_ReturnsGenericConflict()
+    {
+        // Arrange: a unique-constraint violation whose constraint/column
+        // doesn't match the name constraint should not be mislabeled as a
+        // duplicate-name error.
+        DataList dataList = new(SampleData.TENANT_ID, "Cities", null, "CITIES") { Id = 1 };
+        _repository.GetByIdAsync(1L, Arg.Any<CancellationToken>()).Returns(dataList);
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByNormalizedNameSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns((DataList?)null);
+        _repository.UpdateAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new Exception("db failed"));
+        _uniqueConstraintViolationChecker.AnalyzeUniqueConstraint(Arg.Any<Exception>())
+            .Returns(new UniqueConstraintViolationResult(true, "IX_SomeOtherConstraint", "SomeOtherColumn"));
+
+        // Act
+        var result = await _sut.Handle(
+            new UpdateDataListDetailsCommand(1, "Metros", null),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().NotContain(error =>
+            error.ErrorCode == UpdateDataListDetailsHandler.DuplicateNameErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_WhitespaceOnlyDescription_NormalizesToEmptyString()
+    {
+        // Arrange: matches CreateDataListHandler's `Description?.Trim()`
+        // behavior -- whitespace-only input becomes "", not null.
+        DataList dataList = new(SampleData.TENANT_ID, "Cities", "Old", "CITIES") { Id = 1 };
+        _repository.GetByIdAsync(1L, Arg.Any<CancellationToken>()).Returns(dataList);
+
+        // Act
+        var result = await _sut.Handle(
+            new UpdateDataListDetailsCommand(1, null, "   "),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        dataList.Description.Should().Be(string.Empty);
     }
 
     [Fact]

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/UpdateDetails/UpdateDataListDetailsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/UpdateDetails/UpdateDataListDetailsHandlerTests.cs
@@ -1,0 +1,196 @@
+using Endatix.Core.Abstractions;
+using Endatix.Core.Abstractions.Data;
+using Endatix.Core.Entities;
+using Endatix.Core.Events;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
+using Endatix.Core.UseCases.DataLists.UpdateDetails;
+using MediatR;
+
+namespace Endatix.Core.Tests.UseCases.DataLists.UpdateDetails;
+
+public class UpdateDataListDetailsHandlerTests
+{
+    private readonly IRepository<DataList> _repository;
+    private readonly IValueNormalizer _valueNormalizer;
+    private readonly IUniqueConstraintViolationChecker _uniqueConstraintViolationChecker;
+    private readonly IMediator _mediator;
+    private readonly UpdateDataListDetailsHandler _sut;
+
+    public UpdateDataListDetailsHandlerTests()
+    {
+        _repository = Substitute.For<IRepository<DataList>>();
+        _valueNormalizer = Substitute.For<IValueNormalizer>();
+        _uniqueConstraintViolationChecker = Substitute.For<IUniqueConstraintViolationChecker>();
+        _mediator = Substitute.For<IMediator>();
+        _valueNormalizer.Normalize(Arg.Any<string>()).Returns(ci => ci.Arg<string>().Trim().ToUpperInvariant());
+        _sut = new UpdateDataListDetailsHandler(
+            _repository,
+            _valueNormalizer,
+            _uniqueConstraintViolationChecker,
+            _mediator);
+    }
+
+    [Fact]
+    public async Task Handle_DataListNotFound_ReturnsNotFound()
+    {
+        // Arrange
+        _repository.GetByIdAsync(1L, Arg.Any<CancellationToken>())
+            .Returns((DataList?)null);
+
+        // Act
+        var result = await _sut.Handle(
+            new UpdateDataListDetailsCommand(1, "Cities", null),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.NotFound);
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_UpdatesNameAndDescription()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities", "Old", "CITIES") { Id = 1 };
+        _repository.GetByIdAsync(1L, Arg.Any<CancellationToken>()).Returns(dataList);
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByNormalizedNameSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns((DataList?)null);
+
+        // Act
+        var result = await _sut.Handle(
+            new UpdateDataListDetailsCommand(1, "Metros", "New desc"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Should().NotBeNull();
+        result.Value!.Name.Should().Be("Metros");
+        result.Value.Description.Should().Be("New desc");
+        dataList.Name.Should().Be("Metros");
+        dataList.NormalizedName.Should().Be("METROS");
+        await _repository.Received(1).UpdateAsync(dataList, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_PublishesMetadataUpdatedEvent()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities", null, "CITIES") { Id = 1 };
+        _repository.GetByIdAsync(1L, Arg.Any<CancellationToken>()).Returns(dataList);
+
+        // Act
+        await _sut.Handle(
+            new UpdateDataListDetailsCommand(1, null, "Updated"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        await _mediator.Received(1).Publish(
+            Arg.Is<DataListUpdatedEvent>(e =>
+                e.DataList.Id == 1
+                && e.Reason == DataListUpdateReasons.MetadataUpdated),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateNameExists_ReturnsInvalid()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities", null, "CITIES") { Id = 1 };
+        DataList other = new(SampleData.TENANT_ID, "Metros", null, "METROS") { Id = 2 };
+        _repository.GetByIdAsync(1L, Arg.Any<CancellationToken>()).Returns(dataList);
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByNormalizedNameSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns(other);
+
+        // Act
+        var result = await _sut.Handle(
+            new UpdateDataListDetailsCommand(1, "Metros", null),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().Contain(error =>
+            error.Identifier == nameof(UpdateDataListDetailsCommand.Name)
+            && error.ErrorCode == UpdateDataListDetailsHandler.DuplicateNameErrorCode);
+        await _repository.DidNotReceive().UpdateAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_SameNormalizedName_SkipsUniquenessCheck()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities", "Old", "CITIES") { Id = 1 };
+        _repository.GetByIdAsync(1L, Arg.Any<CancellationToken>()).Returns(dataList);
+
+        // Act
+        var result = await _sut.Handle(
+            new UpdateDataListDetailsCommand(1, "cities", "New"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value!.Name.Should().Be("cities");
+        await _repository.DidNotReceive()
+            .SingleOrDefaultAsync(Arg.Any<DataListsSpecifications.ByNormalizedNameSpec>(), Arg.Any<CancellationToken>());
+        await _repository.Received(1).UpdateAsync(dataList, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_RaceConditionUniqueViolation_ReturnsInvalid()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities", null, "CITIES") { Id = 1 };
+        _repository.GetByIdAsync(1L, Arg.Any<CancellationToken>()).Returns(dataList);
+        _repository.SingleOrDefaultAsync(
+                Arg.Any<DataListsSpecifications.ByNormalizedNameSpec>(),
+                Arg.Any<CancellationToken>())
+            .Returns((DataList?)null);
+        _repository.UpdateAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>())
+            .Returns<Task>(_ => throw new Exception("db failed"));
+        _uniqueConstraintViolationChecker.AnalyzeUniqueConstraint(Arg.Any<Exception>())
+            .Returns(new UniqueConstraintViolationResult(true, DataList.UniqueConstraints.NamePerTenant, null));
+
+        // Act
+        var result = await _sut.Handle(
+            new UpdateDataListDetailsCommand(1, "Metros", null),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().Contain(error =>
+            error.ErrorCode == UpdateDataListDetailsHandler.DuplicateNameErrorCode);
+    }
+
+    [Fact]
+    public async Task Handle_DescriptionOnly_KeepsName()
+    {
+        // Arrange
+        DataList dataList = new(SampleData.TENANT_ID, "Cities", "Old", "CITIES") { Id = 1 };
+        _repository.GetByIdAsync(1L, Arg.Any<CancellationToken>()).Returns(dataList);
+
+        // Act
+        var result = await _sut.Handle(
+            new UpdateDataListDetailsCommand(1, null, "Only desc"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value!.Name.Should().Be("Cities");
+        result.Value.Description.Should().Be("Only desc");
+    }
+
+    [Fact]
+    public void Constructor_NonPositiveDataListId_ThrowsArgumentException()
+    {
+        // Act
+        Action act = () => _ = new UpdateDataListDetailsCommand(0, "Cities", null);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+}


### PR DESCRIPTION
## Summary
- Add `PATCH /data-lists/{dataListId}` for name and/or description (`UpdateDetails`)
- Duplicate-name validation aligned with create
- Publishes `DataListUpdatedEvent` with `MetadataUpdated`
- Fixed a real data-correctness bug: the partial-update response always reported `ItemsCount: 0` regardless of how many items the list actually had. Fixed a dead code branch that mislabeled any unique-constraint violation as a name conflict, aligned whitespace-description normalization with the create endpoint, and documented the null-vs-empty-string description-clearing contract. Added regression tests for all three behavior fixes.

### 
Last PR from the stack
- closes #964 

## Test plan
- [ ] PATCH name updates friendly name
- [ ] PATCH description (including empty clear)
- [ ] Duplicate name returns 400
- [ ] Missing id returns 404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for partially updating a data list’s name and/or description.
  * Updates validate input, preserve omitted fields, trim text, and return refreshed data-list details.
* **Bug Fixes**
  * Improved handling of uniqueness conflicts so unrelated database conflicts no longer appear as duplicate-name errors.
  * Added clearer retry-oriented validation feedback for these conflicts.
* **Tests**
  * Added coverage for validation, successful updates, missing lists, duplicate names, partial updates, normalization, and conflict handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->