### PR TITLE
feat(e971): assume-tenant token claims and authorization scope

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -496,6 +496,8 @@ Gated by the deployment flag `multi-tenancy` (`FeatureFlags.MultiTenancy`). Off 
 
 Overloading `act` so `sub` is the customer would break assume-authz (`act == sub`) and “exit assume before switch.” Support until then is assume-tenant (see the tenant as admin).
 
+`Actions.Platform.AssumeTenants` is reserved and **not catalog-seeded** — add an AppIdentity migration before any policy requires it. `Actions.Platform.ImpersonateUsers` is catalog-seeded but unused.
+
 **Later:** public GET by short URL + tenant-scoped register. Forms can reuse `IShortUrlGenerator` with a `Form.ShortUrl` column; a polymorphic URLs table is deferred until vanity aliases or redirects are required.
 
 ---

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -476,7 +476,7 @@ Gated by the deployment flag `multi-tenancy` (`FeatureFlags.MultiTenancy`). Off 
 
 **Isolation vs routing**
 
-- **Authorization** is the signed JWT `tid` (and later optional `act` for assume-tenant). Path segments, headers, and query strings are never trusted for data access.
+- **Authorization** is the signed JWT `tid` (session tenant). Optional `act` marks an assume-tenant session. Path segments, headers, and query strings are never trusted for data access.
 - **`Tenant.ShortUrl`** is an **opaque 8-character lowercase alphanumeric id** (alphabet `a-z0-9`, CSPRNG via `IShortUrlGenerator`, letter-heavy). It is unique, immutable, and used only on unauthenticated routes such as `/t/{shortUrl}/signin`. It is **not** derived from the tenant name and is not client-supplied. Inbound lookup is folded with `ShortUrl.Normalize`, then compared exactly.
 - Numeric `Tenant.Id` stays internal (JWT, FKs, admin APIs). Public lookup must not return it.
 
@@ -486,7 +486,17 @@ Gated by the deployment flag `multi-tenancy` (`FeatureFlags.MultiTenancy`). Off 
 - `PATCH /admin/tenants/{id}` may change name, description, and self-registration policy. The short URL cannot change.
 - Creating a tenant does **not** add the PlatformAdmin as a member of that tenant.
 
-**Later (not this wave):** assume-tenant (`act` claim, not impersonation), membership-based switch, public GET by short URL + tenant-scoped register. Forms can reuse `IShortUrlGenerator` with a `Form.ShortUrl` column; a polymorphic URLs table is deferred until vanity aliases or redirects are required.
+**JWT session** (`AccessTokenIssueOptions` / `AccessTokenSession`). Refresh remints from the **token** (`tid` + optional `act`), not from `AppUser.TenantId`. One mint path; `act` is not impersonation (`sub` stays the admin). Outbox `tenant.context.changed` with kinds `assumed` / `exited` / `switched`.
+
+| Session | `sub` | `tid` | `act` | Status |
+|---------|-------|-------|-------|--------|
+| Login / membership switch | member | that tenant | absent | switch in a later PR; refresh must keep `tid` |
+| Assume tenant | **admin** | target | admin | this wave; not impersonation |
+| On-behalf / login-as-customer | **customer** | customer tenant | support plus a **new claim** (do not reuse `act` alone) | **not implemented** |
+
+Overloading `act` so `sub` is the customer would break assume-authz (`act == sub`) and “exit assume before switch.” Support until then is assume-tenant (see the tenant as admin).
+
+**Later:** public GET by short URL + tenant-scoped register. Forms can reuse `IShortUrlGenerator` with a `Form.ShortUrl` column; a polymorphic URLs table is deferred until vanity aliases or redirects are required.
 
 ---
 
@@ -498,3 +508,4 @@ Gated by the deployment flag `multi-tenancy` (`FeatureFlags.MultiTenancy`). Off 
 | 2026-07 | Domain events: evaluate-before-mutate on aggregates; reporting triggers (`FormDefinitionUpdatedEvent`, `SubmissionUpdatedEvent`) live on entities, not handlers. Documented in [Domain and integration events](#domain-and-integration-events).                                                                                                                                                                                                                     |
 | 2026-08 | Observability: three signals, one mechanism. The OpenTelemetry SDK owns logs, metrics and traces; `OTEL_*` environment variables are authoritative over `appsettings.json`; telemetry is off until an endpoint is configured. Serilog is removed as the logging pipeline and retained only as the rotation implementation behind an optional, off-by-default file provider. **Endatix ships no vendor exporters** — OTLP only. See [Observability](#observability). |
 | 2026-08 | Tenant public id: keep `Tenant.ShortUrl` as a unique immutable `varchar(8)` column; generate with `IShortUrlGenerator` (CSPRNG, `a-z0-9` alphabet, letter-heavy). Do not derive from name. JWT `tid` remains the isolation boundary. See [Multi-tenancy (platform tenants)](#multi-tenancy-platform-tenants). |
+| 2026-09 | JWT session is `tid` + optional `act`. Refresh copies that session. `tenant.context.changed` covers assume, exit, and membership switch. Impersonation (`sub` = customer) is a later claim, not a second token service. See [JWT session](#multi-tenancy-platform-tenants). |

--- a/src/Endatix.Core/Abstractions/AccessTokenIssueOptions.cs
+++ b/src/Endatix.Core/Abstractions/AccessTokenIssueOptions.cs
@@ -1,8 +1,7 @@
 namespace Endatix.Core.Abstractions;
 
 /// <summary>
-/// Options for minting an access token. Login uses the user's home tenant with no actor claim.
-/// Assume-tenant supplies a target <see cref="TenantId"/> and <see cref="ActorUserId"/>.
+/// Options for minting an access token. Assume-tenant sets target TenantId and ActorUserId.
 /// </summary>
 public sealed record AccessTokenIssueOptions(
     long TenantId,

--- a/src/Endatix.Core/Abstractions/AccessTokenIssueOptions.cs
+++ b/src/Endatix.Core/Abstractions/AccessTokenIssueOptions.cs
@@ -1,0 +1,11 @@
+namespace Endatix.Core.Abstractions;
+
+/// <summary>
+/// Options for minting an access token. Login uses the user's home tenant with no actor claim.
+/// Assume-tenant supplies a target <see cref="TenantId"/> and <see cref="ActorUserId"/>.
+/// </summary>
+public sealed record AccessTokenIssueOptions(
+    long TenantId,
+    long? ActorUserId = null,
+    int? AccessExpiryMinutes = null,
+    string? Audience = null);

--- a/src/Endatix.Core/Abstractions/AccessTokenIssueOptions.cs
+++ b/src/Endatix.Core/Abstractions/AccessTokenIssueOptions.cs
@@ -1,7 +1,8 @@
 namespace Endatix.Core.Abstractions;
 
 /// <summary>
-/// Options for minting an access token. Assume-tenant sets target TenantId and ActorUserId.
+/// Options for minting an access token. See ARCHITECTURE.md (JWT session).
+/// TenantId is always the session tid. ActorUserId set → act claim (assume-tenant).
 /// </summary>
 public sealed record AccessTokenIssueOptions(
     long TenantId,

--- a/src/Endatix.Core/Abstractions/AccessTokenSession.cs
+++ b/src/Endatix.Core/Abstractions/AccessTokenSession.cs
@@ -1,0 +1,6 @@
+namespace Endatix.Core.Abstractions;
+
+/// <summary>
+/// Claims read from a validated Endatix access token.
+/// </summary>
+public sealed record AccessTokenSession(long UserId, long TenantId, long? ActorUserId);

--- a/src/Endatix.Core/Abstractions/Authorization/Actions.cs
+++ b/src/Endatix.Core/Abstractions/Authorization/Actions.cs
@@ -33,6 +33,7 @@ public static class Actions
     public static class Platform
     {
         public const string ManageTenants = "platform.tenants.manage";
+        public const string AssumeTenants = "platform.tenants.assume";
         public const string ManageSettings = "platform.settings.manage";
         public const string ManageIntegrations = "platform.integrations.manage";
         public const string ImpersonateUsers = "platform.users.impersonate";

--- a/src/Endatix.Core/Abstractions/Authorization/Actions.cs
+++ b/src/Endatix.Core/Abstractions/Authorization/Actions.cs
@@ -33,9 +33,19 @@ public static class Actions
     public static class Platform
     {
         public const string ManageTenants = "platform.tenants.manage";
+
+        /// <summary>
+        /// Reserved. Not enforced yet (assume uses PlatformAdmin + <c>act</c>). Seed with an AppIdentity
+        /// migration (permission + RolePermissions); it is not in the original catalog seed.
+        /// </summary>
         public const string AssumeTenants = "platform.tenants.assume";
         public const string ManageSettings = "platform.settings.manage";
         public const string ManageIntegrations = "platform.integrations.manage";
+
+        /// <summary>
+        /// Reserved. Catalog-seeded in RolesAndPermissions; not on a policy yet. Login-as-customer
+        /// needs a later claim — do not treat this as assume-tenant. See ARCHITECTURE.md (JWT session).
+        /// </summary>
         public const string ImpersonateUsers = "platform.users.impersonate";
         public const string ViewMetrics = "platform.metrics.view";
         public const string ViewLogs = "platform.logs.view";

--- a/src/Endatix.Core/Abstractions/IUserContext.cs
+++ b/src/Endatix.Core/Abstractions/IUserContext.cs
@@ -26,4 +26,9 @@ public interface IUserContext
     /// Gets the current user's ID, or null if not authenticated.
     /// </summary>
     string? GetCurrentUserId();
+
+    /// <summary>
+    /// Actor user id when the session was issued via assume-tenant; otherwise null.
+    /// </summary>
+    long? GetActorUserId();
 }

--- a/src/Endatix.Core/Abstractions/IUserTokenService.cs
+++ b/src/Endatix.Core/Abstractions/IUserTokenService.cs
@@ -15,7 +15,7 @@ public interface IUserTokenService
     TokenDto IssueAccessToken(User forUser, string? forAudience = null);
 
     /// <summary>
-    /// Issues an access token with an explicit tenant, optional actor claim, and optional expiry override.
+    /// Issues an access token for a session (tid + optional act). See ARCHITECTURE.md (JWT session).
     /// </summary>
     TokenDto IssueAccessToken(User forUser, AccessTokenIssueOptions options);
 

--- a/src/Endatix.Core/Abstractions/IUserTokenService.cs
+++ b/src/Endatix.Core/Abstractions/IUserTokenService.cs
@@ -12,18 +12,22 @@ public interface IUserTokenService
     /// <summary>
     /// Issues an access token for the specified user, optionally for a specific audience.
     /// </summary>
-    /// <param name="forUser">The user for whom the token is being issued.</param>
-    /// <param name="forAudience">The audience for whom the token is intended, if any.</param>
-    /// <returns>A TokenDto representing the issued access token.</returns>
     TokenDto IssueAccessToken(User forUser, string? forAudience = null);
+
+    /// <summary>
+    /// Issues an access token with an explicit tenant, optional actor claim, and optional expiry override.
+    /// </summary>
+    TokenDto IssueAccessToken(User forUser, AccessTokenIssueOptions options);
 
     /// <summary>
     /// Validates an access token and returns the user ID if the token is valid.
     /// </summary>
-    /// <param name="accessToken">The access token to validate.</param>
-    /// <param name="validateLifetime">Indicates whether the token's lifetime should be validated. Default value is true.</param>
-    /// <returns>A Result containing the user ID if the token is valid.</returns>
     Task<Result<long>> ValidateAccessTokenAsync(string accessToken, bool validateLifetime = true);
+
+    /// <summary>
+    /// Validates an access token and returns user id, tenant id, and optional actor id.
+    /// </summary>
+    Task<Result<AccessTokenSession>> ReadAccessTokenSessionAsync(string accessToken, bool validateLifetime = true);
 
     /// <summary>
     /// Revokes tokens associated with the specified user.

--- a/src/Endatix.Core/Entities/Tenant.cs
+++ b/src/Endatix.Core/Entities/Tenant.cs
@@ -86,7 +86,11 @@ namespace Endatix.Core.Entities
         public void RaiseUpdated(TenantSettings? settings) =>
             RegisterDomainEvent(new TenantUpdatedEvent(this, settings));
 
-        public void RaiseContextChanged(long actorUserId, long fromTenantId, string changeKind, DateTime occurredAt)
+        public void RaiseContextChanged(
+            long actorUserId,
+            long fromTenantId,
+            TenantContextChangedEvent.Kind changeKind,
+            DateTime occurredAt)
             => RegisterDomainEvent(new TenantContextChangedEvent(actorUserId, fromTenantId, Id, changeKind, occurredAt));
     }
 }

--- a/src/Endatix.Core/Entities/Tenant.cs
+++ b/src/Endatix.Core/Entities/Tenant.cs
@@ -85,5 +85,8 @@ namespace Endatix.Core.Entities
 
         public void RaiseUpdated(TenantSettings? settings) =>
             RegisterDomainEvent(new TenantUpdatedEvent(this, settings));
+
+        public void RaiseContextChanged(long actorUserId, long fromTenantId, string changeKind, DateTime occurredAt)
+            => RegisterDomainEvent(new TenantContextChangedEvent(actorUserId, fromTenantId, Id, changeKind, occurredAt));
     }
 }

--- a/src/Endatix.Core/Events/TenantContextChangedEvent.cs
+++ b/src/Endatix.Core/Events/TenantContextChangedEvent.cs
@@ -1,11 +1,7 @@
-using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Domain;
 
 namespace Endatix.Core.Events;
 
-/// <summary>
-/// Outbox event when the active tenant on a session changes (assume, exit, or later switch).
-/// </summary>
 public sealed class TenantContextChangedEvent(
     long actorUserId,
     long fromTenantId,

--- a/src/Endatix.Core/Events/TenantContextChangedEvent.cs
+++ b/src/Endatix.Core/Events/TenantContextChangedEvent.cs
@@ -16,19 +16,22 @@ public sealed class TenantContextChangedEvent : DomainEventBase, IIntegrationEve
         {
         }
 
-        public sealed record Assumed : Kind;
+        public abstract string WireValue { get; }
 
-        public sealed record Exited : Kind;
-
-        public sealed record Switched : Kind;
-
-        public string WireValue => this switch
+        public sealed record Assumed : Kind
         {
-            Assumed => "assumed",
-            Exited => "exited",
-            Switched => "switched",
-            _ => throw new InvalidOperationException()
-        };
+            public override string WireValue => "assumed";
+        }
+
+        public sealed record Exited : Kind
+        {
+            public override string WireValue => "exited";
+        }
+
+        public sealed record Switched : Kind
+        {
+            public override string WireValue => "switched";
+        }
     }
 
     public static Kind Assumed { get; } = new Kind.Assumed();

--- a/src/Endatix.Core/Events/TenantContextChangedEvent.cs
+++ b/src/Endatix.Core/Events/TenantContextChangedEvent.cs
@@ -2,6 +2,9 @@ using Endatix.Core.Infrastructure.Domain;
 
 namespace Endatix.Core.Events;
 
+/// <summary>
+/// Outbox <c>tenant.context.changed</c>. Kinds: assumed, exited, switched. See ARCHITECTURE.md (JWT session).
+/// </summary>
 public sealed class TenantContextChangedEvent(
     long actorUserId,
     long fromTenantId,

--- a/src/Endatix.Core/Events/TenantContextChangedEvent.cs
+++ b/src/Endatix.Core/Events/TenantContextChangedEvent.cs
@@ -3,28 +3,64 @@ using Endatix.Core.Infrastructure.Domain;
 namespace Endatix.Core.Events;
 
 /// <summary>
-/// Outbox <c>tenant.context.changed</c>. Kinds: assumed, exited, switched. See ARCHITECTURE.md (JWT session).
+/// Outbox <c>tenant.context.changed</c>. See ARCHITECTURE.md (JWT session).
 /// </summary>
-public sealed class TenantContextChangedEvent(
-    long actorUserId,
-    long fromTenantId,
-    long toTenantId,
-    string changeKind,
-    DateTime occurredAt) : DomainEventBase, IIntegrationEvent
+public sealed class TenantContextChangedEvent : DomainEventBase, IIntegrationEvent
 {
-    public const string KindAssumed = "assumed";
-    public const string KindExited = "exited";
-    public const string KindSwitched = "switched";
+    /// <summary>
+    /// Closed set of wire kinds. Payload still emits <c>changeKind</c> as assumed | exited | switched.
+    /// </summary>
+    public abstract record Kind
+    {
+        private Kind()
+        {
+        }
 
-    public long ActorUserId { get; } = actorUserId;
+        public sealed record Assumed : Kind;
 
-    public long FromTenantId { get; } = fromTenantId;
+        public sealed record Exited : Kind;
 
-    public long ToTenantId { get; } = toTenantId;
+        public sealed record Switched : Kind;
 
-    public string ChangeKind { get; } = changeKind;
+        public string WireValue => this switch
+        {
+            Assumed => "assumed",
+            Exited => "exited",
+            Switched => "switched",
+            _ => throw new InvalidOperationException()
+        };
+    }
 
-    public DateTime OccurredAt { get; } = occurredAt;
+    public static Kind Assumed { get; } = new Kind.Assumed();
+
+    public static Kind Exited { get; } = new Kind.Exited();
+
+    public static Kind Switched { get; } = new Kind.Switched();
+
+    public TenantContextChangedEvent(
+        long actorUserId,
+        long fromTenantId,
+        long toTenantId,
+        Kind changeKind,
+        DateTime occurredAt)
+    {
+        ActorUserId = actorUserId;
+        FromTenantId = fromTenantId;
+        ToTenantId = toTenantId;
+        ChangeKind = changeKind;
+        OccurredAt = occurredAt;
+        DateOccurred = occurredAt;
+    }
+
+    public long ActorUserId { get; }
+
+    public long FromTenantId { get; }
+
+    public long ToTenantId { get; }
+
+    public Kind ChangeKind { get; }
+
+    public DateTime OccurredAt { get; }
 
     /// <inheritdoc />
     public string EventType => "tenant.context.changed";
@@ -35,7 +71,7 @@ public sealed class TenantContextChangedEvent(
         actorUserId = ActorUserId,
         fromTenantId = FromTenantId,
         toTenantId = ToTenantId,
-        changeKind = ChangeKind,
+        changeKind = ChangeKind.WireValue,
         occurredAt = OccurredAt
     };
 }

--- a/src/Endatix.Core/Events/TenantContextChangedEvent.cs
+++ b/src/Endatix.Core/Events/TenantContextChangedEvent.cs
@@ -1,0 +1,42 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Domain;
+
+namespace Endatix.Core.Events;
+
+/// <summary>
+/// Outbox event when the active tenant on a session changes (assume, exit, or later switch).
+/// </summary>
+public sealed class TenantContextChangedEvent(
+    long actorUserId,
+    long fromTenantId,
+    long toTenantId,
+    string changeKind,
+    DateTime occurredAt) : DomainEventBase, IIntegrationEvent
+{
+    public const string KindAssumed = "assumed";
+    public const string KindExited = "exited";
+    public const string KindSwitched = "switched";
+
+    public long ActorUserId { get; } = actorUserId;
+
+    public long FromTenantId { get; } = fromTenantId;
+
+    public long ToTenantId { get; } = toTenantId;
+
+    public string ChangeKind { get; } = changeKind;
+
+    public DateTime OccurredAt { get; } = occurredAt;
+
+    /// <inheritdoc />
+    public string EventType => "tenant.context.changed";
+
+    /// <inheritdoc />
+    public object GetPayload() => new
+    {
+        actorUserId = ActorUserId,
+        fromTenantId = FromTenantId,
+        toTenantId = ToTenantId,
+        changeKind = ChangeKind,
+        occurredAt = OccurredAt
+    };
+}

--- a/src/Endatix.Core/UseCases/Identity/RefreshToken/RefreshTokenHandler.cs
+++ b/src/Endatix.Core/UseCases/Identity/RefreshToken/RefreshTokenHandler.cs
@@ -5,7 +5,7 @@ using Endatix.Core.Infrastructure.Result;
 namespace Endatix.Core.UseCases.Identity.RefreshToken;
 
 /// <summary>
-/// Handles refresh-token rotation. Assumed sessions keep target tenant and actor claim.
+/// Handles refresh-token rotation. Remints from the access-token session (tid + optional act).
 /// </summary>
 public class RefreshTokenHandler(IAuthService authService, IUserTokenService tokenService) : ICommandHandler<RefreshTokenCommand, Result<AuthTokensDto>>
 {
@@ -37,11 +37,9 @@ public class RefreshTokenHandler(IAuthService authService, IUserTokenService tok
         }
 
         var user = refreshTokenValidationResult.Value;
-        var accessToken = session.ActorUserId is not null
-            ? tokenService.IssueAccessToken(
-                user,
-                new AccessTokenIssueOptions(session.TenantId, session.ActorUserId))
-            : tokenService.IssueAccessToken(user);
+        var accessToken = tokenService.IssueAccessToken(
+            user,
+            new AccessTokenIssueOptions(session.TenantId, session.ActorUserId));
         var refreshToken = tokenService.IssueRefreshToken();
 
         await authService.StoreRefreshToken(user.Id, refreshToken.Token, refreshToken.ExpireAt, cancellationToken);

--- a/src/Endatix.Core/UseCases/Identity/RefreshToken/RefreshTokenHandler.cs
+++ b/src/Endatix.Core/UseCases/Identity/RefreshToken/RefreshTokenHandler.cs
@@ -5,8 +5,7 @@ using Endatix.Core.Infrastructure.Result;
 namespace Endatix.Core.UseCases.Identity.RefreshToken;
 
 /// <summary>
-/// Handles the refresh token logic by validating the refresh token and issuing new access and refresh tokens.
-/// Assumed sessions keep their target tenant and actor claim across refresh.
+/// Handles refresh-token rotation. Assumed sessions keep target tenant and actor claim.
 /// </summary>
 public class RefreshTokenHandler(IAuthService authService, IUserTokenService tokenService) : ICommandHandler<RefreshTokenCommand, Result<AuthTokensDto>>
 {

--- a/src/Endatix.Core/UseCases/Identity/RefreshToken/RefreshTokenHandler.cs
+++ b/src/Endatix.Core/UseCases/Identity/RefreshToken/RefreshTokenHandler.cs
@@ -6,25 +6,26 @@ namespace Endatix.Core.UseCases.Identity.RefreshToken;
 
 /// <summary>
 /// Handles the refresh token logic by validating the refresh token and issuing new access and refresh tokens.
+/// Assumed sessions keep their target tenant and actor claim across refresh.
 /// </summary>
 public class RefreshTokenHandler(IAuthService authService, IUserTokenService tokenService) : ICommandHandler<RefreshTokenCommand, Result<AuthTokensDto>>
 {
     public async Task<Result<AuthTokensDto>> Handle(RefreshTokenCommand request, CancellationToken cancellationToken)
     {
-        var accessTokenValidationResult = await tokenService.ValidateAccessTokenAsync(request.AccessToken, validateLifetime: false);
+        var sessionResult = await tokenService.ReadAccessTokenSessionAsync(request.AccessToken, validateLifetime: false);
 
-        if (accessTokenValidationResult.IsInvalid())
+        if (sessionResult.IsInvalid())
         {
-            return Result.Invalid(accessTokenValidationResult.ValidationErrors);
+            return Result.Invalid(sessionResult.ValidationErrors);
         }
 
-        if (!accessTokenValidationResult.IsSuccess)
+        if (!sessionResult.IsSuccess)
         {
             return Result.Error();
         }
 
-        var userId = accessTokenValidationResult.Value;
-        var refreshTokenValidationResult = await authService.ValidateRefreshToken(userId, request.RefreshToken, cancellationToken);
+        var session = sessionResult.Value;
+        var refreshTokenValidationResult = await authService.ValidateRefreshToken(session.UserId, request.RefreshToken, cancellationToken);
 
         if (refreshTokenValidationResult.IsInvalid())
         {
@@ -37,7 +38,11 @@ public class RefreshTokenHandler(IAuthService authService, IUserTokenService tok
         }
 
         var user = refreshTokenValidationResult.Value;
-        var accessToken = tokenService.IssueAccessToken(user);
+        var accessToken = session.ActorUserId is not null
+            ? tokenService.IssueAccessToken(
+                user,
+                new AccessTokenIssueOptions(session.TenantId, session.ActorUserId))
+            : tokenService.IssueAccessToken(user);
         var refreshToken = tokenService.IssueRefreshToken();
 
         await authService.StoreRefreshToken(user.Id, refreshToken.Token, refreshToken.ExpireAt, cancellationToken);

--- a/src/Endatix.Infrastructure/Identity/Authentication/JwtTokenService.cs
+++ b/src/Endatix.Infrastructure/Identity/Authentication/JwtTokenService.cs
@@ -56,28 +56,44 @@ internal sealed class JwtTokenService : IUserTokenService
 
     /// <inheritdoc />
     public TokenDto IssueAccessToken(User forUser, string? forAudience = null)
+        => IssueAccessToken(forUser, new AccessTokenIssueOptions(forUser.TenantId, Audience: forAudience));
+
+    /// <inheritdoc />
+    public TokenDto IssueAccessToken(User forUser, AccessTokenIssueOptions options)
     {
+        Guard.Against.Null(forUser);
+        Guard.Against.Null(options);
+        Guard.Against.NegativeOrZero(options.TenantId);
+
         var secret = _endatixJwtOptions.SigningKey;
         var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret));
-
-        if (string.IsNullOrEmpty(forAudience))
-        {
-            forAudience = _endatixJwtOptions.Audiences.First();
-        }
+        var forAudience = string.IsNullOrEmpty(options.Audience)
+            ? _endatixJwtOptions.Audiences.First()
+            : options.Audience;
 
         var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);
-        var subject = new ClaimsIdentity(claims: [
-                new Claim(JwtRegisteredClaimNames.Sub, forUser.Id.ToString()),
-                new Claim(JwtRegisteredClaimNames.Jti, Guid.CreateVersion7().ToString()),
-                new Claim(JwtRegisteredClaimNames.Email, forUser.Email.ToString()),
-                new Claim(JwtRegisteredClaimNames.EmailVerified, forUser.IsVerified? "true" : "false"),
-                new Claim(ClaimNames.TenantId, forUser.TenantId.ToString())
-            ]);
+        List<Claim> claims =
+        [
+            new Claim(JwtRegisteredClaimNames.Sub, forUser.Id.ToString()),
+            new Claim(JwtRegisteredClaimNames.Jti, Guid.CreateVersion7().ToString()),
+            new Claim(JwtRegisteredClaimNames.Email, forUser.Email.ToString()),
+            new Claim(JwtRegisteredClaimNames.EmailVerified, forUser.IsVerified ? "true" : "false"),
+            new Claim(ClaimNames.TenantId, options.TenantId.ToString())
+        ];
+
+        if (options.ActorUserId is long actorUserId)
+        {
+            Guard.Against.NegativeOrZero(actorUserId);
+            claims.Add(new Claim(ClaimNames.Actor, actorUserId.ToString()));
+        }
+
+        var expiryMinutes = options.AccessExpiryMinutes ?? _endatixJwtOptions.AccessExpiryInMinutes;
+        Guard.Against.NegativeOrZero(expiryMinutes);
 
         var tokenDescriptor = new SecurityTokenDescriptor
         {
-            Subject = subject,
-            Expires = DateTime.UtcNow.AddMinutes(_endatixJwtOptions.AccessExpiryInMinutes),
+            Subject = new ClaimsIdentity(claims),
+            Expires = DateTime.UtcNow.AddMinutes(expiryMinutes),
             SigningCredentials = credentials,
             Issuer = _endatixJwtOptions.Issuer,
             Audience = forAudience
@@ -90,6 +106,23 @@ internal sealed class JwtTokenService : IUserTokenService
     }
 
     public async Task<Result<long>> ValidateAccessTokenAsync(string accessToken, bool validateLifetime = true)
+    {
+        var sessionResult = await ReadAccessTokenSessionAsync(accessToken, validateLifetime);
+        if (sessionResult.IsInvalid())
+        {
+            return Result.Invalid(sessionResult.ValidationErrors);
+        }
+
+        if (!sessionResult.IsSuccess)
+        {
+            return Result.Error();
+        }
+
+        return Result.Success(sessionResult.Value.UserId);
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<AccessTokenSession>> ReadAccessTokenSessionAsync(string accessToken, bool validateLifetime = true)
     {
         var selectedScheme = _authSchemeSelector.SelectScheme(accessToken);
         if (selectedScheme != AuthSchemes.EndatixJwt)
@@ -130,7 +163,25 @@ internal sealed class JwtTokenService : IUserTokenService
             return Result.Invalid(new ValidationError("Invalid user ID"));
         }
 
-        return Result.Success(userId);
+        var tenantClaim = validatedJwtToken.Claims.FirstOrDefault(claim => claim.Type == ClaimNames.TenantId);
+        if (tenantClaim is null || !long.TryParse(tenantClaim.Value, out var tenantId) || tenantId <= 0)
+        {
+            return Result.Invalid(new ValidationError("Invalid tenant ID"));
+        }
+
+        long? actorUserId = null;
+        var actorClaim = validatedJwtToken.Claims.FirstOrDefault(claim => claim.Type == ClaimNames.Actor);
+        if (actorClaim is not null)
+        {
+            if (!long.TryParse(actorClaim.Value, out var parsedActor) || parsedActor <= 0)
+            {
+                return Result.Invalid(new ValidationError("Invalid actor ID"));
+            }
+
+            actorUserId = parsedActor;
+        }
+
+        return Result.Success(new AccessTokenSession(userId, tenantId, actorUserId));
     }
 
     public TokenDto IssueRefreshToken()

--- a/src/Endatix.Infrastructure/Identity/Authentication/JwtTokenService.cs
+++ b/src/Endatix.Infrastructure/Identity/Authentication/JwtTokenService.cs
@@ -68,7 +68,7 @@ internal sealed class JwtTokenService : IUserTokenService
         var secret = _endatixJwtOptions.SigningKey;
         var securityKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret));
         var forAudience = string.IsNullOrEmpty(options.Audience)
-            ? _endatixJwtOptions.Audiences.First()
+            ? _endatixJwtOptions.Audiences[0]
             : options.Audience;
 
         var credentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256);

--- a/src/Endatix.Infrastructure/Identity/Authorization/Data/DefaultAuthorizationDataProvider.cs
+++ b/src/Endatix.Infrastructure/Identity/Authorization/Data/DefaultAuthorizationDataProvider.cs
@@ -22,7 +22,11 @@ internal sealed class DefaultAuthorizationDataProvider(
     ILogger<DefaultAuthorizationDataProvider> logger) : IAuthorizationDataProvider
 {
     /// <inheritdoc />
-    public async Task<Result<AuthorizationData>> GetAuthorizationDataAsync(long userId, long tenantId, CancellationToken cancellationToken)
+    public async Task<Result<AuthorizationData>> GetAuthorizationDataAsync(
+        long userId,
+        long tenantId,
+        CancellationToken cancellationToken,
+        long? actorUserId = null)
     {
         var utcNow = dateTimeProvider.Now.UtcDateTime;
 
@@ -43,12 +47,19 @@ internal sealed class DefaultAuthorizationDataProvider(
 
             if (!IsUserInAuthorizationTenantScope(user, tenantId))
             {
-                logger.LogWarning(
-                    "Blocked authorization data request for user {UserId} with mismatched tenant scope {TenantId}. User belongs to tenant {UserTenantId}.",
-                    userId,
-                    tenantId,
-                    user.TenantId);
-                return Result.Forbidden("User does not belong to the requested tenant.");
+                var assumed = actorUserId is long actorId
+                    && actorId == user.Id
+                    && tenantId > 0
+                    && await UserHasPlatformAdminRoleAsync(user.Id, cancellationToken);
+                if (!assumed)
+                {
+                    logger.LogWarning(
+                        "Blocked authorization data request for user {UserId} with mismatched tenant scope {TenantId}. User belongs to tenant {UserTenantId}.",
+                        userId,
+                        tenantId,
+                        user.TenantId);
+                    return Result.Forbidden("User does not belong to the requested tenant.");
+                }
             }
 
             var userRoleIds = identityDbContext.UserRoles
@@ -100,6 +111,29 @@ internal sealed class DefaultAuthorizationDataProvider(
     internal static bool IsUserInAuthorizationTenantScope(AppUser user, long tenantId)
     {
         return user.TenantId == tenantId;
+    }
+
+    internal static bool IsAssumeTenantSession(long userId, long? actorUserId, long homeTenantId, long requestedTenantId)
+    {
+        return actorUserId is long actorId
+            && actorId == userId
+            && requestedTenantId > 0
+            && homeTenantId != requestedTenantId;
+    }
+
+    private async Task<bool> UserHasPlatformAdminRoleAsync(long userId, CancellationToken cancellationToken)
+    {
+        var platformAdminRoleName = SystemRole.PlatformAdmin.Name;
+        return await identityDbContext.UserRoles
+            .Where(userRole => userRole.UserId == userId)
+            .Join(
+                identityDbContext.Roles,
+                userRole => userRole.RoleId,
+                role => role.Id,
+                (_, role) => role)
+            .AnyAsync(
+                role => role.IsActive && role.Name == platformAdminRoleName,
+                cancellationToken);
     }
 }
 

--- a/src/Endatix.Infrastructure/Identity/Authorization/Data/DefaultAuthorizationDataProvider.cs
+++ b/src/Endatix.Infrastructure/Identity/Authorization/Data/DefaultAuthorizationDataProvider.cs
@@ -47,9 +47,7 @@ internal sealed class DefaultAuthorizationDataProvider(
 
             if (!IsUserInAuthorizationTenantScope(user, tenantId))
             {
-                var assumed = actorUserId is long actorId
-                    && actorId == user.Id
-                    && tenantId > 0
+                var assumed = IsAssumeTenantSession(user.Id, actorUserId, user.TenantId, tenantId)
                     && await UserHasPlatformAdminRoleAsync(user.Id, cancellationToken);
                 if (!assumed)
                 {
@@ -76,7 +74,6 @@ internal sealed class DefaultAuthorizationDataProvider(
                 .AsSplitQuery()
                 .AsNoTracking()
                 .ToListAsync(cancellationToken);
-
 
             var assignedRoles = userRoles
                 .Select(r => r.Name!)

--- a/src/Endatix.Infrastructure/Identity/Authorization/Data/IAuthorizationDataProvider.cs
+++ b/src/Endatix.Infrastructure/Identity/Authorization/Data/IAuthorizationDataProvider.cs
@@ -14,7 +14,12 @@ public interface IAuthorizationDataProvider
     /// <param name="userId">The ID of the user.</param>
     /// <param name="tenantId">The tenant scope to resolve authorization for.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
+    /// <param name="actorUserId">Assume-tenant actor user id from the <c>act</c> claim; null for membership sessions.</param>
     /// <returns>The authorization data for the user.</returns>
-    Task<Result<AuthorizationData>> GetAuthorizationDataAsync(long userId, long tenantId, CancellationToken cancellationToken);
+    Task<Result<AuthorizationData>> GetAuthorizationDataAsync(
+        long userId,
+        long tenantId,
+        CancellationToken cancellationToken,
+        long? actorUserId = null);
 }
 

--- a/src/Endatix.Infrastructure/Identity/Authorization/Strategies/DefaultAuthorization.cs
+++ b/src/Endatix.Infrastructure/Identity/Authorization/Strategies/DefaultAuthorization.cs
@@ -54,6 +54,10 @@ public sealed class DefaultAuthorization(
             return Result.Error("Tenant ID is required");
         }
 
-        return await authorizationDataProvider.GetAuthorizationDataAsync(endatixUserId, tenantId, cancellationToken);
+        return await authorizationDataProvider.GetAuthorizationDataAsync(
+            endatixUserId,
+            tenantId,
+            cancellationToken,
+            principal.GetActorUserId());
     }
 }

--- a/src/Endatix.Infrastructure/Identity/ClaimNames.cs
+++ b/src/Endatix.Infrastructure/Identity/ClaimNames.cs
@@ -33,6 +33,12 @@ public static class ClaimNames
     public const string TenantId = "tid";
 
     /// <summary>
+    /// Acting PlatformAdmin user id when the token was issued via assume-tenant.
+    /// Absent on normal membership sessions. Not impersonation: the subject stays the actor.
+    /// </summary>
+    public const string Actor = "act";
+
+    /// <summary>
     /// Represents a claim for the user's unique identifier.
     /// Uses standard JWT 'sub' (subject) claim for better interoperability.
     /// </summary>

--- a/src/Endatix.Infrastructure/Identity/ClaimNames.cs
+++ b/src/Endatix.Infrastructure/Identity/ClaimNames.cs
@@ -33,8 +33,7 @@ public static class ClaimNames
     public const string TenantId = "tid";
 
     /// <summary>
-    /// Acting PlatformAdmin user id when the token was issued via assume-tenant.
-    /// Absent on normal membership sessions. Not impersonation: the subject stays the actor.
+    /// Acting PlatformAdmin user id on an assume-tenant session. Absent on membership tokens.
     /// </summary>
     public const string Actor = "act";
 

--- a/src/Endatix.Infrastructure/Identity/ClaimsPrincipalExtensions.cs
+++ b/src/Endatix.Infrastructure/Identity/ClaimsPrincipalExtensions.cs
@@ -99,6 +99,25 @@ public static class ClaimsPrincipalExtensions
         return AuthConstants.DEFAULT_TENANT_ID;
     }
 
+    /// <summary>
+    /// Gets the assume-tenant actor user id, or null when this is a normal membership session.
+    /// </summary>
+    public static long? GetActorUserId(this ClaimsPrincipal principal)
+    {
+        if (principal?.Identity is not ClaimsIdentity identity || !identity.IsAuthenticated)
+        {
+            return null;
+        }
+
+        var actorClaim = identity.FindFirst(ClaimNames.Actor);
+        if (actorClaim is not null && long.TryParse(actorClaim.Value, out var actorUserId) && actorUserId > 0)
+        {
+            return actorUserId;
+        }
+
+        return null;
+    }
+
 
     /// <summary>
     /// Gets the issuer from the claims principal.

--- a/src/Endatix.Infrastructure/Identity/ClaimsPrincipalExtensions.cs
+++ b/src/Endatix.Infrastructure/Identity/ClaimsPrincipalExtensions.cs
@@ -118,7 +118,6 @@ public static class ClaimsPrincipalExtensions
         return null;
     }
 
-
     /// <summary>
     /// Gets the issuer from the claims principal.
     /// </summary>

--- a/src/Endatix.Infrastructure/Identity/UserContext.cs
+++ b/src/Endatix.Infrastructure/Identity/UserContext.cs
@@ -58,6 +58,18 @@ public class UserContext(IHttpContextAccessor httpContextAccessor) : IUserContex
         return principal.GetUserId();
     }
 
+    /// <inheritdoc/>
+    public long? GetActorUserId()
+    {
+        var principal = httpContextAccessor.HttpContext?.User;
+        if (principal is null)
+        {
+            return null;
+        }
+
+        return principal.GetActorUserId();
+    }
+
     private static long? ExtractUserId(ClaimsPrincipal principal)
     {
         var userId = principal.GetUserId();

--- a/tests/Endatix.Api.Tests/Common/FeatureFlags/FeatureGateTargetingTests.cs
+++ b/tests/Endatix.Api.Tests/Common/FeatureFlags/FeatureGateTargetingTests.cs
@@ -118,6 +118,7 @@ public sealed class FeatureGateTargetingTests
     public bool IsAnonymous => false;
     public bool IsAuthenticated => true;
     public string? GetCurrentUserId() => userId;
+    public long? GetActorUserId() => null;
     public User? GetCurrentUser() => new User(1, userId, "test@example.com", true);
   }
 }

--- a/tests/Endatix.Api.Tests/Common/FeatureFlags/FeatureGateTests.cs
+++ b/tests/Endatix.Api.Tests/Common/FeatureFlags/FeatureGateTests.cs
@@ -82,6 +82,7 @@ public sealed class FeatureGateTests
         public bool IsAnonymous => false;
         public bool IsAuthenticated => true;
         public string? GetCurrentUserId() => "test-user";
+        public long? GetActorUserId() => null;
         public User? GetCurrentUser() => new User(1, "test-user", "test@example.com", true);
     }
 }

--- a/tests/Endatix.Core.Tests/Entities/TenantTests.cs
+++ b/tests/Endatix.Core.Tests/Entities/TenantTests.cs
@@ -70,7 +70,7 @@ public class TenantTests
     [Fact]
     public void RaiseContextChanged_RegistersOutboxEvent()
     {
-        var tenant = new Tenant("Acme", ValidSlug);
+        var tenant = new Tenant("Acme", ValidShortUrl);
         var occurredAt = DateTime.UtcNow;
 
         tenant.RaiseContextChanged(7, fromTenantId: 1, TenantContextChangedEvent.KindAssumed, occurredAt);

--- a/tests/Endatix.Core.Tests/Entities/TenantTests.cs
+++ b/tests/Endatix.Core.Tests/Entities/TenantTests.cs
@@ -1,5 +1,7 @@
 using Endatix.Core.Common;
 using Endatix.Core.Entities;
+using Endatix.Core.Events;
+using Endatix.Core.Infrastructure.Domain;
 
 namespace Endatix.Core.Tests.Entities;
 
@@ -63,5 +65,25 @@ public class TenantTests
         tenant.UpdateDescription("Updated");
 
         tenant.Description.Should().Be("Updated");
+    }
+
+    [Fact]
+    public void RaiseContextChanged_RegistersOutboxEvent()
+    {
+        var tenant = new Tenant("Acme", ValidSlug);
+        var occurredAt = DateTime.UtcNow;
+
+        tenant.RaiseContextChanged(7, fromTenantId: 1, TenantContextChangedEvent.KindAssumed, occurredAt);
+
+        var domainEvent = tenant.DomainEvents.Should().ContainSingle().Which.Should().BeOfType<TenantContextChangedEvent>().Subject;
+        domainEvent.Should().BeAssignableTo<IIntegrationEvent>();
+        domainEvent.EventType.Should().Be("tenant.context.changed");
+        domainEvent.ChangeKind.Should().Be(TenantContextChangedEvent.KindAssumed);
+        domainEvent.ActorUserId.Should().Be(7);
+        domainEvent.FromTenantId.Should().Be(1);
+        domainEvent.OccurredAt.Should().Be(occurredAt);
+
+        var payload = domainEvent.GetPayload();
+        payload.Should().NotBeNull();
     }
 }

--- a/tests/Endatix.Core.Tests/Entities/TenantTests.cs
+++ b/tests/Endatix.Core.Tests/Entities/TenantTests.cs
@@ -73,15 +73,17 @@ public class TenantTests
         var tenant = new Tenant("Acme", ValidShortUrl);
         var occurredAt = DateTime.UtcNow;
 
-        tenant.RaiseContextChanged(7, fromTenantId: 1, TenantContextChangedEvent.KindAssumed, occurredAt);
+        tenant.RaiseContextChanged(7, fromTenantId: 1, TenantContextChangedEvent.Assumed, occurredAt);
 
         var domainEvent = tenant.DomainEvents.Should().ContainSingle().Which.Should().BeOfType<TenantContextChangedEvent>().Subject;
         domainEvent.Should().BeAssignableTo<IIntegrationEvent>();
         domainEvent.EventType.Should().Be("tenant.context.changed");
-        domainEvent.ChangeKind.Should().Be(TenantContextChangedEvent.KindAssumed);
+        domainEvent.ChangeKind.Should().Be(TenantContextChangedEvent.Assumed);
+        domainEvent.ChangeKind.WireValue.Should().Be("assumed");
         domainEvent.ActorUserId.Should().Be(7);
         domainEvent.FromTenantId.Should().Be(1);
         domainEvent.OccurredAt.Should().Be(occurredAt);
+        domainEvent.DateOccurred.Should().Be(occurredAt);
 
         var payload = domainEvent.GetPayload();
         payload.Should().NotBeNull();

--- a/tests/Endatix.Core.Tests/UseCases/Identity/RefreshToken/RefreshTokenHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Identity/RefreshToken/RefreshTokenHandlerTests.cs
@@ -1,11 +1,9 @@
 using Endatix.Core.Abstractions;
 using Endatix.Core.Entities.Identity;
+using Endatix.Core.Tests;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.Identity;
 using Endatix.Core.UseCases.Identity.RefreshToken;
-using FluentAssertions;
-using NSubstitute;
-using Xunit;
 
 namespace Endatix.Core.Tests.UseCases.Identity.RefreshToken;
 
@@ -25,16 +23,13 @@ public class RefreshTokenHandlerTests
     [Fact]
     public async Task Handle_InvalidAccessToken_ReturnsInvalidResult()
     {
-        // Arrange
         var command = new RefreshTokenCommand("invalid_access_token", "refresh_token");
         var validationErrors = new List<ValidationError> { new("Invalid access token") };
-        _tokenService.ValidateAccessTokenAsync(command.AccessToken, false)
-            .Returns(Task.FromResult<Result<long>>(Result.Invalid(validationErrors)));
+        _tokenService.ReadAccessTokenSessionAsync(command.AccessToken, false)
+            .Returns(Task.FromResult<Result<AccessTokenSession>>(Result.Invalid(validationErrors)));
 
-        // Act
         var result = await _handler.Handle(command, CancellationToken.None);
 
-        // Assert
         result.IsInvalid().Should().BeTrue();
         result.ValidationErrors.Should().BeEquivalentTo(validationErrors);
     }
@@ -42,16 +37,13 @@ public class RefreshTokenHandlerTests
     [Fact]
     public async Task Handle_ExternalAccessTokenScheme_ReturnsInvalidResult()
     {
-        // Arrange
         var command = new RefreshTokenCommand("external_access_token", "refresh_token");
         var validationErrors = new List<ValidationError> { new("Token validation not supported for scheme: Keycloak.") };
-        _tokenService.ValidateAccessTokenAsync(command.AccessToken, false)
-            .Returns(Task.FromResult<Result<long>>(Result.Invalid(validationErrors)));
+        _tokenService.ReadAccessTokenSessionAsync(command.AccessToken, false)
+            .Returns(Task.FromResult<Result<AccessTokenSession>>(Result.Invalid(validationErrors)));
 
-        // Act
         var result = await _handler.Handle(command, CancellationToken.None);
 
-        // Assert
         result.IsInvalid().Should().BeTrue();
         result.ValidationErrors.Should().BeEquivalentTo(validationErrors);
     }
@@ -59,35 +51,29 @@ public class RefreshTokenHandlerTests
     [Fact]
     public async Task Handle_AccessTokenValidationError_ReturnsErrorResult()
     {
-        // Arrange
         var command = new RefreshTokenCommand("access_token", "refresh_token");
-        _tokenService.ValidateAccessTokenAsync(command.AccessToken, false)
-            .Returns(Task.FromResult<Result<long>>(Result.Error()));
+        _tokenService.ReadAccessTokenSessionAsync(command.AccessToken, false)
+            .Returns(Task.FromResult<Result<AccessTokenSession>>(Result.Error()));
 
-        // Act
         var result = await _handler.Handle(command, CancellationToken.None);
 
-        // Assert
         result.IsError().Should().BeTrue();
     }
 
     [Fact]
     public async Task Handle_InvalidRefreshToken_ReturnsInvalidResult()
     {
-        // Arrange
         var command = new RefreshTokenCommand("access_token", "invalid_refresh_token");
-        var userId = 1;
+        var userId = 1L;
         var validationErrors = new List<ValidationError> { new("Invalid refresh token") };
 
-        _tokenService.ValidateAccessTokenAsync(command.AccessToken, false)
-            .Returns(Task.FromResult(Result.Success((long)userId)));
+        _tokenService.ReadAccessTokenSessionAsync(command.AccessToken, false)
+            .Returns(Task.FromResult(Result.Success(new AccessTokenSession(userId, SampleData.TENANT_ID, null))));
         _authService.ValidateRefreshToken(userId, command.RefreshToken, Arg.Any<CancellationToken>())
             .Returns(Result.Invalid(validationErrors));
 
-        // Act
         var result = await _handler.Handle(command, CancellationToken.None);
 
-        // Assert
         result.IsInvalid().Should().BeTrue();
         result.ValidationErrors.Should().BeEquivalentTo(validationErrors);
     }
@@ -95,48 +81,69 @@ public class RefreshTokenHandlerTests
     [Fact]
     public async Task Handle_RefreshTokenValidationError_ReturnsErrorResult()
     {
-        // Arrange
         var command = new RefreshTokenCommand("access_token", "refresh_token");
-        var userId = 1;
+        var userId = 1L;
 
-        _tokenService.ValidateAccessTokenAsync(command.AccessToken, false)
-            .Returns(Task.FromResult(Result.Success((long)userId)));
+        _tokenService.ReadAccessTokenSessionAsync(command.AccessToken, false)
+            .Returns(Task.FromResult(Result.Success(new AccessTokenSession(userId, SampleData.TENANT_ID, null))));
         _authService.ValidateRefreshToken(userId, command.RefreshToken, Arg.Any<CancellationToken>())
             .Returns(Result.Error());
 
-        // Act
         var result = await _handler.Handle(command, CancellationToken.None);
 
-        // Assert
         result.IsError().Should().BeTrue();
     }
 
     [Fact]
     public async Task Handle_ValidTokens_ReturnsSuccessResultWithNewTokens()
     {
-        // Arrange
         var command = new RefreshTokenCommand("access_token", "refresh_token");
-        var userId = 1;
+        var userId = 1L;
         var user = new User(userId, SampleData.TENANT_ID, "testuser", "test@example.com", true);
         var newAccessToken = new TokenDto("new_access_token", DateTime.UtcNow.AddMinutes(15));
         var newRefreshToken = new TokenDto("new_refresh_token", DateTime.UtcNow.AddDays(7));
 
-        _tokenService.ValidateAccessTokenAsync(command.AccessToken, false)
-            .Returns(Task.FromResult(Result.Success((long)userId)));
+        _tokenService.ReadAccessTokenSessionAsync(command.AccessToken, false)
+            .Returns(Task.FromResult(Result.Success(new AccessTokenSession(userId, SampleData.TENANT_ID, null))));
         _authService.ValidateRefreshToken(userId, command.RefreshToken, Arg.Any<CancellationToken>())
             .Returns(Result<User>.Success(user));
         _tokenService.IssueAccessToken(user).Returns(newAccessToken);
         _tokenService.IssueRefreshToken().Returns(newRefreshToken);
 
-        // Act
         var result = await _handler.Handle(command, CancellationToken.None);
 
-        // Assert
         result.IsSuccess.Should().BeTrue();
         result.Value.Should().NotBeNull();
         result.Value.AccessToken.Should().Be(newAccessToken);
         result.Value.RefreshToken.Should().Be(newRefreshToken);
 
         await _authService.Received(1).StoreRefreshToken(user.Id, newRefreshToken.Token, newRefreshToken.ExpireAt, Arg.Any<CancellationToken>());
+        _tokenService.DidNotReceive().IssueAccessToken(user, Arg.Any<AccessTokenIssueOptions>());
+    }
+
+    [Fact]
+    public async Task Handle_AssumedSession_RemintsWithActorAndTargetTenant()
+    {
+        var command = new RefreshTokenCommand("access_token", "refresh_token");
+        var userId = 7L;
+        const long assumedTenantId = 99;
+        var user = new User(userId, SampleData.TENANT_ID, "admin", "admin@example.com", true);
+        var newAccessToken = new TokenDto("assumed_access_token", DateTime.UtcNow.AddMinutes(15));
+        var newRefreshToken = new TokenDto("new_refresh_token", DateTime.UtcNow.AddDays(7));
+
+        _tokenService.ReadAccessTokenSessionAsync(command.AccessToken, false)
+            .Returns(Task.FromResult(Result.Success(new AccessTokenSession(userId, assumedTenantId, userId))));
+        _authService.ValidateRefreshToken(userId, command.RefreshToken, Arg.Any<CancellationToken>())
+            .Returns(Result<User>.Success(user));
+        _tokenService.IssueAccessToken(user, Arg.Is<AccessTokenIssueOptions>(
+                options => options.TenantId == assumedTenantId && options.ActorUserId == userId))
+            .Returns(newAccessToken);
+        _tokenService.IssueRefreshToken().Returns(newRefreshToken);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.AccessToken.Should().Be(newAccessToken);
+        _tokenService.DidNotReceive().IssueAccessToken(user);
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/Identity/RefreshToken/RefreshTokenHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Identity/RefreshToken/RefreshTokenHandlerTests.cs
@@ -107,7 +107,11 @@ public class RefreshTokenHandlerTests
             .Returns(Task.FromResult(Result.Success(new AccessTokenSession(userId, SampleData.TENANT_ID, null))));
         _authService.ValidateRefreshToken(userId, command.RefreshToken, Arg.Any<CancellationToken>())
             .Returns(Result<User>.Success(user));
-        _tokenService.IssueAccessToken(user).Returns(newAccessToken);
+        _tokenService.IssueAccessToken(
+                user,
+                Arg.Is<AccessTokenIssueOptions>(options =>
+                    options.TenantId == SampleData.TENANT_ID && options.ActorUserId == null))
+            .Returns(newAccessToken);
         _tokenService.IssueRefreshToken().Returns(newRefreshToken);
 
         var result = await _handler.Handle(command, CancellationToken.None);
@@ -118,7 +122,35 @@ public class RefreshTokenHandlerTests
         result.Value.RefreshToken.Should().Be(newRefreshToken);
 
         await _authService.Received(1).StoreRefreshToken(user.Id, newRefreshToken.Token, newRefreshToken.ExpireAt, Arg.Any<CancellationToken>());
-        _tokenService.DidNotReceive().IssueAccessToken(user, Arg.Any<AccessTokenIssueOptions>());
+        _tokenService.DidNotReceive().IssueAccessToken(user);
+    }
+
+    [Fact]
+    public async Task Handle_MembershipSession_RemintsSessionTenantNotUserHomeTenant()
+    {
+        var command = new RefreshTokenCommand("access_token", "refresh_token");
+        var userId = 1L;
+        const long sessionTenantId = 50;
+        var user = new User(userId, SampleData.TENANT_ID, "testuser", "test@example.com", true);
+        var newAccessToken = new TokenDto("switched_access_token", DateTime.UtcNow.AddMinutes(15));
+        var newRefreshToken = new TokenDto("new_refresh_token", DateTime.UtcNow.AddDays(7));
+
+        _tokenService.ReadAccessTokenSessionAsync(command.AccessToken, false)
+            .Returns(Task.FromResult(Result.Success(new AccessTokenSession(userId, sessionTenantId, null))));
+        _authService.ValidateRefreshToken(userId, command.RefreshToken, Arg.Any<CancellationToken>())
+            .Returns(Result<User>.Success(user));
+        _tokenService.IssueAccessToken(
+                user,
+                Arg.Is<AccessTokenIssueOptions>(options =>
+                    options.TenantId == sessionTenantId && options.ActorUserId == null))
+            .Returns(newAccessToken);
+        _tokenService.IssueRefreshToken().Returns(newRefreshToken);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.AccessToken.Should().Be(newAccessToken);
+        _tokenService.DidNotReceive().IssueAccessToken(user);
     }
 
     [Fact]

--- a/tests/Endatix.Infrastructure.Tests/FeatureFlags/FeatureFlagsTargetingContextTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/FeatureFlags/FeatureFlagsTargetingContextTests.cs
@@ -63,6 +63,7 @@ public sealed class FeatureFlagsTargetingContextTests
         public bool IsAnonymous => userId is null;
         public bool IsAuthenticated => userId is not null;
         public string? GetCurrentUserId() => userId;
+        public long? GetActorUserId() => null;
         public User? GetCurrentUser() =>
             userId is null ? null : new User(1, userId, "test@example.com", true);
     }

--- a/tests/Endatix.Infrastructure.Tests/Identity/Authentication/JwtTokenServiceTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Identity/Authentication/JwtTokenServiceTests.cs
@@ -1,4 +1,5 @@
 using System.IdentityModel.Tokens.Jwt;
+using Endatix.Core.Abstractions;
 using Endatix.Core.Entities.Identity;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Tests;
@@ -299,5 +300,63 @@ public class JwtTokenServiceTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IssueAccessToken_WithActorAndTargetTenant_IncludesActClaimAndTid()
+    {
+        var optionsWrapper = Substitute.For<IOptions<EndatixJwtOptions>>();
+        optionsWrapper.Value.Returns(_validJwtOptions);
+        var tokenService = new JwtTokenService(optionsWrapper, _configuration, _logger, _authSchemeSelector);
+        var user = new User(7, SampleData.TENANT_ID, "admin", "admin@example.com", true);
+        const long assumedTenantId = 99;
+
+        var result = tokenService.IssueAccessToken(
+            user,
+            new AccessTokenIssueOptions(assumedTenantId, ActorUserId: 7, AccessExpiryMinutes: 15));
+
+        var jsonToken = new JwtSecurityTokenHandler().ReadToken(result.Token) as JwtSecurityToken;
+        jsonToken.Should().NotBeNull();
+        jsonToken!.Claims.Should().Contain(c => c.Type == ClaimNames.TenantId && c.Value == assumedTenantId.ToString());
+        jsonToken.Claims.Should().Contain(c => c.Type == ClaimNames.Actor && c.Value == "7");
+        jsonToken.Claims.Should().Contain(c => c.Type == JwtRegisteredClaimNames.Sub && c.Value == "7");
+        jsonToken.Claims.Should().NotContain(c => c.Type == ClaimNames.Role);
+        result.ExpireAt.Should().BeBefore(DateTime.UtcNow.AddMinutes(16));
+    }
+
+    [Fact]
+    public async Task ReadAccessTokenSessionAsync_AssumedToken_ReturnsActorAndTenant()
+    {
+        var optionsWrapper = Substitute.For<IOptions<EndatixJwtOptions>>();
+        optionsWrapper.Value.Returns(_validJwtOptions);
+        var tokenService = new JwtTokenService(optionsWrapper, _configuration, _logger, _authSchemeSelector);
+        var user = new User(7, SampleData.TENANT_ID, "admin", "admin@example.com", true);
+        var token = tokenService.IssueAccessToken(user, new AccessTokenIssueOptions(99, ActorUserId: 7));
+        _authSchemeSelector.SelectScheme(token.Token).Returns(AuthSchemes.EndatixJwt);
+
+        var result = await tokenService.ReadAccessTokenSessionAsync(token.Token);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.UserId.Should().Be(7);
+        result.Value.TenantId.Should().Be(99);
+        result.Value.ActorUserId.Should().Be(7);
+    }
+
+    [Fact]
+    public async Task ReadAccessTokenSessionAsync_HomeToken_HasNoActor()
+    {
+        var optionsWrapper = Substitute.For<IOptions<EndatixJwtOptions>>();
+        optionsWrapper.Value.Returns(_validJwtOptions);
+        var tokenService = new JwtTokenService(optionsWrapper, _configuration, _logger, _authSchemeSelector);
+        var user = new User(1, SampleData.TENANT_ID, "testuser", "test@example.com", false);
+        var token = tokenService.IssueAccessToken(user);
+        _authSchemeSelector.SelectScheme(token.Token).Returns(AuthSchemes.EndatixJwt);
+
+        var result = await tokenService.ReadAccessTokenSessionAsync(token.Token);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.UserId.Should().Be(1);
+        result.Value.TenantId.Should().Be(SampleData.TENANT_ID);
+        result.Value.ActorUserId.Should().BeNull();
     }
 }

--- a/tests/Endatix.Infrastructure.Tests/Identity/Authorization/Data/DefaultAuthorizationDataProviderTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Identity/Authorization/Data/DefaultAuthorizationDataProviderTests.cs
@@ -1,0 +1,44 @@
+using Endatix.Infrastructure.Identity;
+using Endatix.Infrastructure.Identity.Authorization.Data;
+
+namespace Endatix.Infrastructure.Tests.Identity.Authorization.Data;
+
+public class DefaultAuthorizationDataProviderTests
+{
+    [Fact]
+    public void IsUserInAuthorizationTenantScope_MatchingTenant_ReturnsTrue()
+    {
+        var user = new AppUser { Id = 7, TenantId = 10 };
+
+        DefaultAuthorizationDataProvider.IsUserInAuthorizationTenantScope(user, 10).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsUserInAuthorizationTenantScope_MismatchedTenant_ReturnsFalse()
+    {
+        var user = new AppUser { Id = 7, TenantId = 10 };
+
+        DefaultAuthorizationDataProvider.IsUserInAuthorizationTenantScope(user, 99).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAssumeTenantSession_ActorMatchesDifferentTenant_ReturnsTrue()
+    {
+        DefaultAuthorizationDataProvider.IsAssumeTenantSession(7, 7, homeTenantId: 1, requestedTenantId: 99)
+            .Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAssumeTenantSession_NoActor_ReturnsFalse()
+    {
+        DefaultAuthorizationDataProvider.IsAssumeTenantSession(7, null, homeTenantId: 1, requestedTenantId: 99)
+            .Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAssumeTenantSession_HomeTenant_ReturnsFalse()
+    {
+        DefaultAuthorizationDataProvider.IsAssumeTenantSession(7, 7, homeTenantId: 10, requestedTenantId: 10)
+            .Should().BeFalse();
+    }
+}

--- a/tests/Endatix.Infrastructure.Tests/Identity/Authorization/DefaultAuthorizationTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Identity/Authorization/DefaultAuthorizationTests.cs
@@ -84,62 +84,70 @@ public sealed class DefaultAuthorizationTests
     [Fact]
     public async Task GetAuthorizationDataAsync_DelegatesToProvider_WhenInputsValid()
     {
-        // Arrange
         var context = CreateTestContext();
         context.RegisterEndatixProvider(TestIssuer, activate: true);
         var principal = CreatePrincipal("123", TestIssuer, tenantId: 10);
         var expected = AuthorizationData.ForAuthenticatedUser("123", 10, ["Role"], ["perm"]);
         context.AuthorizationDataProvider
-            .GetAuthorizationDataAsync(123, 10, Arg.Any<CancellationToken>())
+            .GetAuthorizationDataAsync(123, 10, Arg.Any<CancellationToken>(), Arg.Any<long?>())
             .Returns(Result.Success(expected));
 
-        // Act
         var result = await context.Strategy.GetAuthorizationDataAsync(principal, CancellationToken.None);
 
-        // Assert
-        await context.AuthorizationDataProvider.Received(1).GetAuthorizationDataAsync(123, 10, Arg.Any<CancellationToken>());
+        await context.AuthorizationDataProvider.Received(1).GetAuthorizationDataAsync(123, 10, Arg.Any<CancellationToken>(), null);
         result.IsSuccess.Should().BeTrue();
         result.Value.Should().Be(expected);
     }
 
     [Fact]
+    public async Task GetAuthorizationDataAsync_PassesActorUserId_WhenActClaimPresent()
+    {
+        var context = CreateTestContext();
+        context.RegisterEndatixProvider(TestIssuer, activate: true);
+        var principal = CreatePrincipal("123", TestIssuer, tenantId: 10, actorUserId: 123);
+        var expected = AuthorizationData.ForAuthenticatedUser("123", 10, ["Role"], ["perm"]);
+        context.AuthorizationDataProvider
+            .GetAuthorizationDataAsync(123, 10, Arg.Any<CancellationToken>(), 123)
+            .Returns(Result.Success(expected));
+
+        var result = await context.Strategy.GetAuthorizationDataAsync(principal, CancellationToken.None);
+
+        await context.AuthorizationDataProvider.Received(1).GetAuthorizationDataAsync(123, 10, Arg.Any<CancellationToken>(), 123);
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
     public async Task GetAuthorizationDataAsync_ReturnsError_WhenTenantIdMissing()
     {
-        // Arrange
         var context = CreateTestContext();
         context.RegisterEndatixProvider(TestIssuer, activate: true);
         var principal = CreatePrincipal("123", TestIssuer);
 
-        // Act
         var result = await context.Strategy.GetAuthorizationDataAsync(principal, CancellationToken.None);
 
-        // Assert
         result.IsSuccess.Should().BeFalse();
         result.Errors.Should().Contain("Tenant ID is required");
         await context.AuthorizationDataProvider.DidNotReceive()
-            .GetAuthorizationDataAsync(Arg.Any<long>(), Arg.Any<long>(), Arg.Any<CancellationToken>());
+            .GetAuthorizationDataAsync(Arg.Any<long>(), Arg.Any<long>(), Arg.Any<CancellationToken>(), Arg.Any<long?>());
     }
 
     [Fact]
     public async Task GetAuthorizationDataAsync_ReturnsError_WhenDataProviderFails()
     {
-        // Arrange
         var context = CreateTestContext();
         context.RegisterEndatixProvider(TestIssuer, activate: true);
         var principal = CreatePrincipal("123", TestIssuer, tenantId: 10);
         context.AuthorizationDataProvider
-            .GetAuthorizationDataAsync(123, 10, Arg.Any<CancellationToken>())
+            .GetAuthorizationDataAsync(123, 10, Arg.Any<CancellationToken>(), Arg.Any<long?>())
             .Returns(Result<AuthorizationData>.Error("failed"));
 
-        // Act
         var result = await context.Strategy.GetAuthorizationDataAsync(principal, CancellationToken.None);
 
-        // Assert
         result.IsSuccess.Should().BeFalse();
         result.Errors.Should().Contain("failed");
     }
 
-    private static ClaimsPrincipal CreatePrincipal(string userId, string issuer, long? tenantId = null)
+    private static ClaimsPrincipal CreatePrincipal(string userId, string issuer, long? tenantId = null, long? actorUserId = null)
     {
         var claims = new List<Claim>
         {
@@ -150,6 +158,11 @@ public sealed class DefaultAuthorizationTests
         if (tenantId is not null)
         {
             claims.Add(new Claim(ClaimNames.TenantId, tenantId.Value.ToString()));
+        }
+
+        if (actorUserId is not null)
+        {
+            claims.Add(new Claim(ClaimNames.Actor, actorUserId.Value.ToString()));
         }
 
         var identity = new ClaimsIdentity(claims, "test");


### PR DESCRIPTION
# Assume-tenant token foundation

JWT and authorization plumbing for PlatformAdmin **assume-tenant**. No HTTP endpoints here — those land in #985. Stacks on #983. Part of #970.

## What this PR adds

- **`act` claim** (`ClaimNames.Actor`): acting PlatformAdmin user id. `sub` stays the same user (not impersonation).
- **`tid` on assumed tokens** is the *target* tenant, not the actor’s home tenant.
- **`AccessTokenIssueOptions`** / **`AccessTokenSession`**: mint and read tenant + optional actor + optional expiry.
- **`IUserTokenService.IssueAccessToken(user, options)`** and **`ReadAccessTokenSessionAsync`**.
- **`IUserContext.GetActorUserId()`** from the current principal.
- **Refresh** remints assumed sessions with the same `tid` + `act`.
- **Authorization**: if `tid` ≠ home tenant, allow only when `act == sub` and the user has the PlatformAdmin role; then resolve roles/permissions in the *target* tenant scope (plus system roles).
- Permission name **`platform.tenants.assume`** reserved. Gate in this layer is PlatformAdmin + `act`, not that permission yet.

## Events (outbox)

| Event | When | Payload |
|-------|------|---------|
| `tenant.context.changed` | Raise on the **target** tenant (`RaiseContextChanged`) | `actorUserId`, `fromTenantId`, `toTenantId`, `changeKind` (`assumed` / `exited` / `switched`), `occurredAt` |

Call sites (assume / exit / switch) are the following PRs. Kinds are defined here so those layers share one contract.

## Behavior changes

- Login tokens unchanged (home `tid`, no `act`).
- Callers that mint tokens can pin tenant + actor; refresh preserves that session.
- Cross-tenant authz data is **Forbidden** unless it is a valid assume session.

No public API / route changes.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>