### PR TITLE
feat(e973): public tenant register

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -523,8 +523,14 @@ Overloading `act` so `sub` is the customer would break assume-authz (`act == sub
 
 **Self-registration**
 
-- Default **off**. `GET /api/public/tenants/{shortUrl}` returns `{ slug, name, selfRegistrationEnabled, allowedAuthProviders }` (no numeric id). Unknown, deleted, or name-like values → 404. Rate-limited; successful lookups may be cached briefly; 404s are not. `allowedAuthProviders` is a UI hint — register does **not** enforce the list this ship.
+- Default **off**. `GET /api/public/tenants/{shortUrl}` returns `{ slug, name, selfRegistrationEnabled, allowedAuthProviders }` (no numeric id). Unknown, deleted, or name-like values → 404. Rate-limited. Successful lookups use **HybridCache** (`GetOrCreateResultAsync`, 3 min); 404s are not stored. `PATCH /admin/tenants/{id}` removes the entry. `allowedAuthProviders` is a UI hint — register does **not** enforce the list this ship.
 - `POST /api/auth/register` without `tenantSlug` still creates an unattached user (`TenantId = 0`) for global `/create-account`. With `tenantSlug`: unknown → 404; self-reg off → 403; email already registered → validation error; otherwise register into that tenant and assign `DefaultRegistrationRoleName` as the **shared** system role (not a cloned `AppRole`). PlatformAdmin and Public are not allowed as defaults. Raises `UserRegisteredEvent`.
+
+**Caching**
+
+- Use `HybridCache` (`AddHybridCache` in Infrastructure), not `IMemoryCache`.
+- Success-only `Result` factories: [`HybridCacheExtensions.GetOrCreateResultAsync`](src/Endatix.Infrastructure/Caching/HybridCacheExtension.cs) — public tenant GET.
+- Authz session data: [`AuthorizationCache`](src/Endatix.Infrastructure/Identity/Authorization/AuthorizationCache.cs) (tags + invalidate). Do not cache failed lookups or anonymous-oracle failures.
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5,7 +5,7 @@ This document describes how the Endatix API packages are organized today and the
 **Related**
 
 - [Ardalis Minimal Clean Architecture](https://ardalis.github.io/CleanArchitecture/minimal-clean-architecture/) — vertical slices, optional Mediator/CQRS, pragmatic DDD
-- SaaS module examples: [`src/Endatix.Modules.Agents`](../../src/Endatix.Modules.Agents) + [`Endatix.Modules.Agents.Contracts`](../../src/Endatix.Modules.Agents.Contracts); OSS [`Endatix.Modules.Reporting`](src/Endatix.Modules.Reporting/) + [`Endatix.Modules.Reporting.Contracts`](src/Endatix.Modules.Reporting.Contracts/)
+- SaaS module examples: [`src/Endatix.Modules.Agents`](../../src/Endatix.Modules.Agents) + [`Endatix.Modules.Agents.Contracts`](../../src/Endatix.Modules.Agents.Contracts); [`src/Endatix.SaaS.Management`](../../src/Endatix.SaaS.Management) + [`Endatix.SaaS.Management.Contracts`](../../src/Endatix.SaaS.Management.Contracts) (commercial waitlist / tenant signup); OSS [`Endatix.Modules.Reporting`](src/Endatix.Modules.Reporting/) + [`Endatix.Modules.Reporting.Contracts`](src/Endatix.Modules.Reporting.Contracts/)
 - Workspace product notes: repo-root [`ARCHITECTURE.md`](../ARCHITECTURE.md)
 
 ---
@@ -194,6 +194,21 @@ public sealed class ReportingModule : IEndatixModule, IHasFeatureFlag, IHasDbMig
 ```
 
 Host wiring: `EndatixBuilder.UseDefaults()` calls `UseModule(ReportingModule.Instance)`, which scans `Assembly` for MediatR handlers and FastEndpoints and invokes `ConfigureServices` at finalization. Modules with `IHasFeatureFlag` are skipped when the flag is disabled.
+
+### SaaS.Management module (commercial waitlist)
+
+`Endatix.SaaS.Management` lives in the **SaaS repo** (not OSS `UseDefaults`). It is wired only from `Endatix.SaaS.WebHost` via `UseModule(SaaSManagementModule.Instance)` and `Api.ScanAssemblies(...)`.
+
+| Aspect | Choice |
+| --- | --- |
+| **Bounded context** | Tenant signup waitlist (approve/reject inbox); future commercial onboarding |
+| **Contracts** | `Endatix.SaaS.Management.Contracts` — DTOs, commands, queries, wire codes, public events (`TenantSignupApprovedEvent`) |
+| **Persistence** | PostgreSQL only, isolated `saas` schema, `SaaSManagementDbContext` (not `ITenantDbContext`; no tenant query filters) |
+| **Feature flag** | `Endatix:FeatureFlags:SaaSManagement` (Hub kebab `saas-management`) |
+| **Approval flow** | Approve endpoint marks row + raises `TenantSignupApprovedEvent`; fulfillment handler calls Core `CreateTenantCommand`, invite/Admin assignment (idempotent) |
+| **Messaging** | MediatR in-process only — no broker, no Core reference to SaaS types |
+
+Hub mirrors the flag and exposes `/signup` (public) plus `/admin/signup-requests` (PlatformAdmin + flag guard). Distinct from tenant self-registration at `/t/{slug}/register`.
 
 **Startup migrations (two phases):** When `Endatix:Data:EnableAutoMigrations` is true, `DatabaseMigrationService` first migrates core `AppDbContext` and `AppIdentityDbContext`, then iterates registered [`IDbContextMigrationContributor`](src/Endatix.Framework/Modules/IDbContextMigrationContributor.cs) instances for opt-in module/custom contexts. Modules implement `IHasDbMigrations` as a marker; the host warns if `AddDbContextWithMigrations` was not called.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -523,8 +523,8 @@ Overloading `act` so `sub` is the customer would break assume-authz (`act == sub
 
 **Self-registration**
 
-- Default **off**. `GET /public/tenants/{shortUrl}` returns `{ shortUrl, name, selfRegistrationEnabled, allowedAuthProviders }` (no numeric id). Unknown, deleted, or name-like values → 404. Rate-limited; successful lookups may be cached briefly; 404s are not.
-- `POST /auth/register` without `tenantSlug` still creates an unattached user (`TenantId = 0`) for global `/create-account`. With `tenantSlug`: unknown → 404; self-reg off → 403; email already registered → validation error; otherwise register into that tenant and assign `DefaultRegistrationRoleName` as the shared system role (not a cloned copy). PlatformAdmin and Public are not allowed as defaults.
+- Default **off**. `GET /api/public/tenants/{shortUrl}` returns `{ slug, name, selfRegistrationEnabled, allowedAuthProviders }` (no numeric id). Unknown, deleted, or name-like values → 404. Rate-limited; successful lookups may be cached briefly; 404s are not. `allowedAuthProviders` is a UI hint — register does **not** enforce the list this ship.
+- `POST /api/auth/register` without `tenantSlug` still creates an unattached user (`TenantId = 0`) for global `/create-account`. With `tenantSlug`: unknown → 404; self-reg off → 403; email already registered → validation error; otherwise register into that tenant and assign `DefaultRegistrationRoleName` as the **shared** system role (not a cloned `AppRole`). PlatformAdmin and Public are not allowed as defaults. Raises `UserRegisteredEvent`.
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -472,35 +472,44 @@ documented lines.
 
 ## Multi-tenancy (platform tenants)
 
-Gated by the deployment flag `multi-tenancy` (`FeatureFlags.MultiTenancy`). Off → mutating `/admin/tenants` endpoints return 404.
+Gated by the deployment flag `multi-tenancy` (`FeatureFlags.MultiTenancy`). Off → mutating `/admin/tenants` and assume-tenant endpoints return 404 rather than advertising the feature.
 
 **Isolation vs routing**
 
 - **Authorization** is the signed JWT `tid` (session tenant). Optional `act` marks an assume-tenant session. Path segments, headers, and query strings are never trusted for data access.
-- **`Tenant.ShortUrl`** is an **opaque 8-character lowercase alphanumeric id** (alphabet `a-z0-9`, CSPRNG via `IShortUrlGenerator`, letter-heavy). It is unique, immutable, and used only on unauthenticated routes such as `/t/{shortUrl}/signin`. It is **not** derived from the tenant name and is not client-supplied. Inbound lookup is folded with `ShortUrl.Normalize`, then compared exactly.
-- Numeric `Tenant.Id` stays internal (JWT, FKs, admin APIs). Public lookup must not return it.
+- **`Tenant.ShortUrl`** is an **opaque 8-character lowercase alphanumeric id** (alphabet `a-z0-9`, CSPRNG via `IShortUrlGenerator`, letter-heavy). It is unique, immutable, and used only on unauthenticated routes such as `/t/{shortUrl}/signin` and `/t/{shortUrl}/register`. It is **not** derived from the tenant name and is not client-supplied. Inbound lookup is folded with `ShortUrl.Normalize`, then compared exactly.
+- Numeric `Tenant.Id` stays internal (JWT, FKs, admin APIs). `GET /public/tenants/{shortUrl}` must not return it.
+- Forms can reuse `IShortUrlGenerator` later with a per-entity `Form.ShortUrl` column. A polymorphic URLs table is deferred until vanity aliases or redirects are required.
 
 **Create/edit**
 
 - PlatformAdmin `POST /admin/tenants` provisions `Tenant` + `TenantSettings` in one transaction and assigns the public id server-side (unique-index retry).
 - `PATCH /admin/tenants/{id}` may change name, description, and self-registration policy. The short URL cannot change.
-- Creating a tenant does **not** add the PlatformAdmin as a member of that tenant.
+- Creating a tenant does **not** add the PlatformAdmin as a member of that tenant. A user belongs to **one** tenant (`AppUser.TenantId`). Multi-tenant membership is a later Identity table, not cloned roles.
 
-**JWT session** (`AccessTokenIssueOptions` / `AccessTokenSession`). Refresh remints from the **token** (`tid` + optional `act`), not from `AppUser.TenantId`. One mint path; `act` is not impersonation (`sub` stays the admin). Outbox `tenant.context.changed` with kinds `assumed` / `exited` / `switched`.
+**JWT session** (`AccessTokenIssueOptions` / `AccessTokenSession`). Refresh remints from the **token** (`tid` + optional `act`), not from `AppUser.TenantId`. One mint path; `act` is not impersonation (`sub` stays the admin). Outbox `tenant.context.changed` with kinds `assumed` / `exited`. Kind `switched` is reserved for a future membership product.
 
 | Session | `sub` | `tid` | `act` | Status |
 |---------|-------|-------|-------|--------|
-| Login / membership switch | member | that tenant | absent | switch in a later PR; refresh must keep `tid` |
-| Assume tenant | **admin** | target | admin | this wave; not impersonation |
+| Login | member | home tenant | absent | refresh keeps session `tid` |
+| Assume tenant | **admin** | target | admin | not impersonation |
 | On-behalf / login-as-customer | **customer** | customer tenant | support plus a **new claim** (do not reuse `act` alone) | **not implemented** |
 
-Overloading `act` so `sub` is the customer would break assume-authz (`act == sub`) and “exit assume before switch.” Support until then is assume-tenant (see the tenant as admin).
+Overloading `act` so `sub` is the customer would break assume-authz (`act == sub`). Support until then is assume-tenant (see the tenant as admin).
 
 `POST /auth/assume-tenant` mints the assumed session, `POST /auth/exit-assume` returns to the home tenant. Both require `AuthorizationPolicies.PlatformAdminAccess`, sit behind `MultiTenancyGate` (off → 404), and answer with `TenantSessionResponse`. Assumed access tokens expire after `AssumeTenantSession.AccessExpiryMinutes`; refresh keeps that shorter lifetime while `act` is present. Sessions do **not** nest — assuming from an assumed session is a 400; exit first. Neither handler writes membership; the audit trail is `tenant.context.changed` raised on the assumed tenant. Refresh persistence failure is returned as an infrastructure error (same as login), not a silent success.
 
 `Actions.Platform.AssumeTenants` is reserved and **not catalog-seeded** — add an AppIdentity migration before any policy requires it. `Actions.Platform.ImpersonateUsers` is catalog-seeded but unused.
 
-**Later:** public GET by short URL + tenant-scoped register. Forms can reuse `IShortUrlGenerator` with a `Form.ShortUrl` column; a polymorphic URLs table is deferred until vanity aliases or redirects are required.
+**Assume-tenant vs impersonation**
+
+- **Assume** (`POST /auth/assume-tenant`): PlatformAdmin enters a tenant without becoming a member. JWT `tid` is the target; `act` is the actor. Short-lived access token. Must not appear in the tenant user directory. Exit with `POST /auth/exit-assume`.
+- **Impersonation** (`platform.users.impersonate`) stays reserved. Assume is not “login as user X”.
+
+**Self-registration**
+
+- Default **off**. `GET /public/tenants/{shortUrl}` returns `{ shortUrl, name, selfRegistrationEnabled, allowedAuthProviders }` (no numeric id). Unknown, deleted, or name-like values → 404. Rate-limited; successful lookups may be cached briefly; 404s are not.
+- `POST /auth/register` without `tenantSlug` still creates an unattached user (`TenantId = 0`) for global `/create-account`. With `tenantSlug`: unknown → 404; self-reg off → 403; email already registered → validation error; otherwise register into that tenant and assign `DefaultRegistrationRoleName` as the shared system role (not a cloned copy). PlatformAdmin and Public are not allowed as defaults.
 
 ---
 
@@ -512,4 +521,5 @@ Overloading `act` so `sub` is the customer would break assume-authz (`act == sub
 | 2026-07 | Domain events: evaluate-before-mutate on aggregates; reporting triggers (`FormDefinitionUpdatedEvent`, `SubmissionUpdatedEvent`) live on entities, not handlers. Documented in [Domain and integration events](#domain-and-integration-events).                                                                                                                                                                                                                     |
 | 2026-08 | Observability: three signals, one mechanism. The OpenTelemetry SDK owns logs, metrics and traces; `OTEL_*` environment variables are authoritative over `appsettings.json`; telemetry is off until an endpoint is configured. Serilog is removed as the logging pipeline and retained only as the rotation implementation behind an optional, off-by-default file provider. **Endatix ships no vendor exporters** — OTLP only. See [Observability](#observability). |
 | 2026-08 | Tenant public id: keep `Tenant.ShortUrl` as a unique immutable `varchar(8)` column; generate with `IShortUrlGenerator` (CSPRNG, `a-z0-9` alphabet, letter-heavy). Do not derive from name. JWT `tid` remains the isolation boundary. See [Multi-tenancy (platform tenants)](#multi-tenancy-platform-tenants). |
-| 2026-09 | JWT session is `tid` + optional `act`. Refresh copies that session. `tenant.context.changed` covers assume, exit, and membership switch. Impersonation (`sub` = customer) is a later claim, not a second token service. See [JWT session](#multi-tenancy-platform-tenants). |
+| 2026-08 | Tenant access: one home `AppUser.TenantId`. Assume-tenant uses JWT `act` and does not write membership. `platform.users.impersonate` stays reserved. Self-reg is opt-in per tenant via opaque public id. Multi-tenant membership is a later Identity table. |
+| 2026-09 | JWT session is `tid` + optional `act`. Refresh copies that session. `tenant.context.changed` covers assume and exit. Impersonation (`sub` = customer) is a later claim, not a second token service. See [JWT session](#multi-tenancy-platform-tenants). |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5,8 +5,8 @@ This document describes how the Endatix API packages are organized today and the
 **Related**
 
 - [Ardalis Minimal Clean Architecture](https://ardalis.github.io/CleanArchitecture/minimal-clean-architecture/) — vertical slices, optional Mediator/CQRS, pragmatic DDD
-- SaaS module examples: [`src/Endatix.Modules.Agents`](../src/Endatix.Modules.Agents) + [`Endatix.Modules.Agents.Contracts`](../src/Endatix.Modules.Agents.Contracts); [`src/Endatix.SaaS.Management`](../src/Endatix.SaaS.Management) + [`Endatix.SaaS.Management.Contracts`](../src/Endatix.SaaS.Management.Contracts) (commercial waitlist / tenant signup); OSS [`Endatix.Modules.Reporting`](src/Endatix.Modules.Reporting/) + [`Endatix.Modules.Reporting.Contracts`](src/Endatix.Modules.Reporting.Contracts/)
-- Workspace product notes: repo-root [`ARCHITECTURE.md`](../ARCHITECTURE.md)
+- OSS reference module: [`Endatix.Modules.Reporting`](src/Endatix.Modules.Reporting/) + [`Endatix.Modules.Reporting.Contracts`](src/Endatix.Modules.Reporting.Contracts/)
+- Commercial waitlist and Agents modules are **not in this git root**. GitHub: [`Endatix.SaaS.Management`](https://github.com/endatix/endatix-saas/tree/main/src/Endatix.SaaS.Management) / [`.Contracts`](https://github.com/endatix/endatix-saas/tree/main/src/Endatix.SaaS.Management.Contracts), [`Endatix.Modules.Agents`](https://github.com/endatix/endatix-saas/tree/main/src/Endatix.Modules.Agents) / [`.Contracts`](https://github.com/endatix/endatix-saas/tree/main/src/Endatix.Modules.Agents.Contracts). In a SaaS workspace checkout, use repo-root [`AGENTS.md`](https://github.com/endatix/endatix-saas/blob/main/AGENTS.md) (path map) and [`ARCHITECTURE.md`](https://github.com/endatix/endatix-saas/blob/main/ARCHITECTURE.md) (onboarding flows).
 
 ---
 
@@ -195,20 +195,7 @@ public sealed class ReportingModule : IEndatixModule, IHasFeatureFlag, IHasDbMig
 
 Host wiring: `EndatixBuilder.UseDefaults()` calls `UseModule(ReportingModule.Instance)`, which scans `Assembly` for MediatR handlers and FastEndpoints and invokes `ConfigureServices` at finalization. Modules with `IHasFeatureFlag` are skipped when the flag is disabled.
 
-### SaaS.Management module (commercial waitlist)
-
-`Endatix.SaaS.Management` lives in the **SaaS repo** (not OSS `UseDefaults`). It is wired only from `Endatix.SaaS.WebHost` via `UseModule(SaaSManagementModule.Instance)` and `Api.ScanAssemblies(...)`.
-
-| Aspect | Choice |
-| --- | --- |
-| **Bounded context** | Tenant signup waitlist (approve/reject inbox); future commercial onboarding |
-| **Contracts** | `Endatix.SaaS.Management.Contracts` — DTOs, commands, queries, wire codes, public events (`TenantSignupApprovedEvent`) |
-| **Persistence** | PostgreSQL only, isolated `saas` schema, `SaaSManagementDbContext` (not `ITenantDbContext`; no tenant query filters) |
-| **Feature flag** | `Endatix:FeatureFlags:SaaSManagement` (Hub kebab `saas-management`) |
-| **Approval flow** | Approve endpoint marks row + raises `TenantSignupApprovedEvent`; fulfillment handler calls Core `CreateTenantCommand`, invite/Admin assignment (idempotent) |
-| **Messaging** | MediatR in-process only — no broker, no Core reference to SaaS types |
-
-Hub mirrors the flag and exposes `/signup` (public) plus `/admin/signup-requests` (PlatformAdmin + flag guard). Distinct from tenant self-registration at `/t/{slug}/register`.
+Commercial waitlist (`Endatix.SaaS.Management`) is **not** registered by OSS `UseDefaults`. Product wiring and Hub `/signup` live in the SaaS workspace — see [Related](#endatix-oss-architecture). Distinct from OSS tenant self-registration (`POST /api/auth/register` + Hub `/t/{slug}/register`).
 
 **Startup migrations (two phases):** When `Endatix:Data:EnableAutoMigrations` is true, `DatabaseMigrationService` first migrates core `AppDbContext` and `AppIdentityDbContext`, then iterates registered [`IDbContextMigrationContributor`](src/Endatix.Framework/Modules/IDbContextMigrationContributor.cs) instances for opt-in module/custom contexts. Modules implement `IHasDbMigrations` as a marker; the host warns if `AddDbContextWithMigrations` was not called.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -5,7 +5,7 @@ This document describes how the Endatix API packages are organized today and the
 **Related**
 
 - [Ardalis Minimal Clean Architecture](https://ardalis.github.io/CleanArchitecture/minimal-clean-architecture/) — vertical slices, optional Mediator/CQRS, pragmatic DDD
-- SaaS module examples: [`src/Endatix.Modules.Agents`](../../src/Endatix.Modules.Agents) + [`Endatix.Modules.Agents.Contracts`](../../src/Endatix.Modules.Agents.Contracts); [`src/Endatix.SaaS.Management`](../../src/Endatix.SaaS.Management) + [`Endatix.SaaS.Management.Contracts`](../../src/Endatix.SaaS.Management.Contracts) (commercial waitlist / tenant signup); OSS [`Endatix.Modules.Reporting`](src/Endatix.Modules.Reporting/) + [`Endatix.Modules.Reporting.Contracts`](src/Endatix.Modules.Reporting.Contracts/)
+- SaaS module examples: [`src/Endatix.Modules.Agents`](../src/Endatix.Modules.Agents) + [`Endatix.Modules.Agents.Contracts`](../src/Endatix.Modules.Agents.Contracts); [`src/Endatix.SaaS.Management`](../src/Endatix.SaaS.Management) + [`Endatix.SaaS.Management.Contracts`](../src/Endatix.SaaS.Management.Contracts) (commercial waitlist / tenant signup); OSS [`Endatix.Modules.Reporting`](src/Endatix.Modules.Reporting/) + [`Endatix.Modules.Reporting.Contracts`](src/Endatix.Modules.Reporting.Contracts/)
 - Workspace product notes: repo-root [`ARCHITECTURE.md`](../ARCHITECTURE.md)
 
 ---
@@ -523,8 +523,8 @@ Overloading `act` so `sub` is the customer would break assume-authz (`act == sub
 
 **Self-registration**
 
-- Default **off**. `GET /api/public/tenants/{shortUrl}` returns `{ slug, name, selfRegistrationEnabled, allowedAuthProviders }` (no numeric id). Unknown, deleted, or name-like values → 404. Rate-limited. Successful lookups use **HybridCache** (`GetOrCreateResultAsync`, 3 min); 404s are not stored. `PATCH /admin/tenants/{id}` removes the entry. `allowedAuthProviders` is a UI hint — register does **not** enforce the list this ship.
-- `POST /api/auth/register` without `tenantSlug` still creates an unattached user (`TenantId = 0`) for global `/create-account`. With `tenantSlug`: unknown → 404; self-reg off → 403; email already registered → validation error; otherwise register into that tenant and assign `DefaultRegistrationRoleName` as the **shared** system role (not a cloned `AppRole`). PlatformAdmin and Public are not allowed as defaults. Raises `UserRegisteredEvent`.
+- Default **off**. `GET /api/public/tenants/{shortUrl}` returns `{ slug, name, selfRegistrationEnabled, allowedAuthProviders }` (no numeric id). Unknown, deleted, or invalid short URL format → 404. Rate-limited. Successful lookups use **HybridCache** (`GetOrCreateResultAsync`, 3 min); 404s are not stored. `PATCH /admin/tenants/{id}` removes the entry. `allowedAuthProviders` is a UI hint — register does **not** enforce the list this ship.
+- `POST /api/auth/register` without `tenantSlug` still creates an unattached user (`TenantId = 0`) for global `/create-account`. With `tenantSlug`: unknown → 404; self-reg off → 403; email already registered → validation error; otherwise register into that tenant and assign `DefaultRegistrationRoleName` as the **shared** system role (not a cloned `AppRole`). The role is resolved against the tenant with `GetMissingAssignableRoleNamesAsync` **before** the user is created (same pre-flight as `InviteUserHandler`), and `RegisterTenantUserAsync` then writes the user row and the role grant in **one `AppIdentityDbContext` transaction** — both live in that context, so this needs no saga or compensation. The verification email is sent only after the commit, because it cannot be unsent. Self-registration therefore never leaves an account without a role, which no retry could repair once the email is taken. PlatformAdmin and Public are not allowed as defaults. Raises `UserRegisteredEvent`.
 
 **Caching**
 

--- a/src/Endatix.Api/Endpoints/Admin/Tenants/Update.cs
+++ b/src/Endatix.Api/Endpoints/Admin/Tenants/Update.cs
@@ -1,6 +1,7 @@
 using Endatix.Api.Infrastructure;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.Tenants.Update;
+using Endatix.Infrastructure.Caching;
 using Endatix.Infrastructure.Data.Config;
 using Endatix.Infrastructure.Identity.Authorization;
 using FastEndpoints;
@@ -8,6 +9,7 @@ using FluentValidation;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.Configuration;
 
 namespace Endatix.Api.Endpoints.Admin.Tenants;
@@ -15,7 +17,7 @@ namespace Endatix.Api.Endpoints.Admin.Tenants;
 /// <summary>
 /// Endpoint for partially updating a platform tenant.
 /// </summary>
-public sealed class Update(IMediator mediator, IConfiguration configuration)
+public sealed class Update(IMediator mediator, IConfiguration configuration, HybridCache cache)
     : Endpoint<UpdateTenantRequest, Results<Ok<TenantModel>, ProblemHttpResult>>
 {
     /// <summary>
@@ -68,6 +70,10 @@ public sealed class Update(IMediator mediator, IConfiguration configuration)
             request.AllowedAuthProviderKeys,
             request.DefaultRegistrationRoleName);
         var result = await mediator.Send(command, ct);
+        if (result.IsSuccess)
+        {
+            await cache.RemoveAsync(PublicTenantCacheKeys.Entry(result.Value.ShortUrl), ct);
+        }
 
         return TypedResultsBuilder
             .MapResult(result, TenantModel.Map)

--- a/src/Endatix.Api/Endpoints/Auth/Register.RegisterRequest.cs
+++ b/src/Endatix.Api/Endpoints/Auth/Register.RegisterRequest.cs
@@ -5,7 +5,7 @@ namespace Endatix.Api.Endpoints.Auth;
 /// <summary>
 /// Represents the request for the "/register" endpoint, handled by the <see cref="Register.ExecuteAsync"/> method.
 /// </summary>
-public record RegisterRequest(string Email, string Password, string ConfirmPassword)
+public record RegisterRequest(string Email, string Password, string ConfirmPassword, string? TenantSlug = null)
 {
     /// <summary>
     /// The email address of the user.
@@ -24,4 +24,9 @@ public record RegisterRequest(string Email, string Password, string ConfirmPassw
     /// </summary>
     [Sensitive(SensitivityType.Secret)]
     public string ConfirmPassword { get; init; } = ConfirmPassword;
+
+    /// <summary>
+    /// Optional opaque tenant public id. When set, registers into that tenant if self-registration is enabled.
+    /// </summary>
+    public string? TenantSlug { get; init; } = TenantSlug;
 }

--- a/src/Endatix.Api/Endpoints/Auth/Register.cs
+++ b/src/Endatix.Api/Endpoints/Auth/Register.cs
@@ -16,12 +16,16 @@ public class Register(IMediator mediator) : Endpoint<RegisterRequest, Results<Ok
     {
         Post("auth/register");
         AllowAnonymous();
+        Throttle(5, 60);
         Summary(s =>
         {
             s.Summary = "Register a new user";
-            s.Description = "Creates a new user account in the Endatix application using the provided email and password.";
+            s.Description = "Creates a new user account. When tenantSlug is omitted, the user is unattached (TenantId = 0). When present, the tenant must allow self-registration and the default role is assigned as a tenant-scoped copy.";
             s.Responses[200] = "User has been successfully registered.";
             s.Responses[400] = "Registration failed. Please check your input and try again.";
+            s.Responses[403] = "Self-registration is not enabled for this tenant.";
+            s.Responses[404] = "Unknown tenant public id.";
+            s.Responses[429] = "Too many requests.";
             s.ExampleRequest = new RegisterRequest("user@example.com", "Password123!", "Password123!");
             s.ResponseExamples[200] = new RegisterResponse(Success: true, Message: "User has been successfully registered");
         });
@@ -31,10 +35,10 @@ public class Register(IMediator mediator) : Endpoint<RegisterRequest, Results<Ok
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<RegisterResponse>, ProblemHttpResult>> ExecuteAsync(RegisterRequest request, CancellationToken ct)
+    public override async Task<Results<Ok<RegisterResponse>, ProblemHttpResult>> ExecuteAsync(RegisterRequest request, CancellationToken cancellationToken)
     {
-        var registerUserCommand = new RegisterCommand(request.Email, request.Password);
-        var userRegistrationResult = await mediator.Send(registerUserCommand, ct);
+        var registerUserCommand = new RegisterCommand(request.Email, request.Password, request.TenantSlug);
+        var userRegistrationResult = await mediator.Send(registerUserCommand, cancellationToken);
 
         var errorMessage = "Registration failed. ";
         if (userRegistrationResult.Status == Core.Infrastructure.Result.ResultStatus.Invalid && userRegistrationResult.ValidationErrors.Any())

--- a/src/Endatix.Api/Endpoints/Auth/Register.cs
+++ b/src/Endatix.Api/Endpoints/Auth/Register.cs
@@ -20,7 +20,7 @@ public class Register(IMediator mediator) : Endpoint<RegisterRequest, Results<Ok
         Summary(s =>
         {
             s.Summary = "Register a new user";
-            s.Description = "Creates a new user account. When tenantSlug is omitted, the user is unattached (TenantId = 0). When present, the tenant must allow self-registration and the default role is assigned as a tenant-scoped copy.";
+            s.Description = "Creates a new user. Omit tenantSlug for an unattached account (TenantId = 0). When tenantSlug is set, the tenant must allow self-registration; the shared system DefaultRegistrationRoleName is assigned (not a cloned role).";
             s.Responses[200] = "User has been successfully registered.";
             s.Responses[400] = "Registration failed. Please check your input and try again.";
             s.Responses[403] = "Self-registration is not enabled for this tenant.";
@@ -31,14 +31,16 @@ public class Register(IMediator mediator) : Endpoint<RegisterRequest, Results<Ok
         });
         Description(builder => builder
             .Produces<RegisterResponse>(StatusCodes.Status200OK, "application/json")
-            .ProducesProblem(StatusCodes.Status400BadRequest));
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<RegisterResponse>, ProblemHttpResult>> ExecuteAsync(RegisterRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<RegisterResponse>, ProblemHttpResult>> ExecuteAsync(RegisterRequest request, CancellationToken ct)
     {
         var registerUserCommand = new RegisterCommand(request.Email, request.Password, request.TenantSlug);
-        var userRegistrationResult = await mediator.Send(registerUserCommand, cancellationToken);
+        var userRegistrationResult = await mediator.Send(registerUserCommand, ct);
 
         var errorMessage = "Registration failed. ";
         if (userRegistrationResult.Status == Core.Infrastructure.Result.ResultStatus.Invalid && userRegistrationResult.ValidationErrors.Any())

--- a/src/Endatix.Api/Endpoints/Auth/Register.cs
+++ b/src/Endatix.Api/Endpoints/Auth/Register.cs
@@ -21,19 +21,20 @@ public class Register(IMediator mediator) : Endpoint<RegisterRequest, Results<Ok
         {
             s.Summary = "Register a new user";
             s.Description = "Creates a new user. Omit tenantSlug for an unattached account (TenantId = 0). When tenantSlug is set, the tenant must allow self-registration; the shared system DefaultRegistrationRoleName is assigned (not a cloned role).";
-            s.Responses[200] = "User has been successfully registered.";
+            s.Responses[200] = "Registration accepted. Returned whether or not the address was already registered.";
             s.Responses[400] = "Registration failed. Please check your input and try again.";
             s.Responses[403] = "Self-registration is not enabled for this tenant.";
             s.Responses[404] = "Unknown tenant public id.";
             s.Responses[429] = "Too many requests.";
             s.ExampleRequest = new RegisterRequest("user@example.com", "Password123!", "Password123!");
-            s.ResponseExamples[200] = new RegisterResponse(Success: true, Message: "User has been successfully registered");
+            s.ResponseExamples[200] = new RegisterResponse(Success: true, Message: RegisterHandler.GENERAL_SUCCESS_MESSAGE);
         });
         Description(builder => builder
             .Produces<RegisterResponse>(StatusCodes.Status200OK, "application/json")
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status403Forbidden)
-            .ProducesProblem(StatusCodes.Status404NotFound));
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests));
     }
 
     /// <inheritdoc/>
@@ -53,7 +54,7 @@ public class Register(IMediator mediator) : Endpoint<RegisterRequest, Results<Ok
         }
 
         return TypedResultsBuilder
-                .MapResult(userRegistrationResult, (user) => new RegisterResponse(Success: true, Message: "User has been successfully registered"))
+                .MapResult(userRegistrationResult, (message) => new RegisterResponse(Success: true, Message: message))
                 .SetErrorMessage(errorMessage)
                 .SetTypedResults<Ok<RegisterResponse>, ProblemHttpResult>();
     }

--- a/src/Endatix.Api/Endpoints/Public/Tenants/GetBySlug.cs
+++ b/src/Endatix.Api/Endpoints/Public/Tenants/GetBySlug.cs
@@ -1,23 +1,23 @@
 using Endatix.Api.Common;
 using Endatix.Api.Infrastructure;
+using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.Tenants.GetPublicBySlug;
+using Endatix.Infrastructure.Caching;
 using FastEndpoints;
 using FluentValidation;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
-using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Caching.Hybrid;
 
 namespace Endatix.Api.Endpoints.Public.Tenants;
 
 /// <summary>
 /// Unauthenticated tenant discovery by opaque public id. Rate-limited; 404s are not cached.
 /// </summary>
-public sealed class GetBySlug(IMediator mediator, IMemoryCache cache)
+public sealed class GetBySlug(IMediator mediator, HybridCache cache)
     : Endpoint<GetPublicTenantRequest, Results<Ok<PublicTenantModel>, ProblemHttpResult>>
 {
-    internal static readonly TimeSpan PublicTenantCacheDuration = TimeSpan.FromMinutes(3);
-
     public override void Configure()
     {
         Get("tenants/{slug}");
@@ -41,17 +41,24 @@ public sealed class GetBySlug(IMediator mediator, IMemoryCache cache)
         GetPublicTenantRequest request,
         CancellationToken ct)
     {
-        var cacheKey = $"tenant:public:{request.Slug}";
-        if (cache.TryGetValue(cacheKey, out PublicTenantModel? cached) && cached is not null)
+        var normalizedSlug = PublicTenantCacheKeys.TryNormalized(request.Slug);
+        if (normalizedSlug is null)
         {
-            return TypedResults.Ok(cached);
+            return TypedResultsBuilder
+                .FromResult(Result<PublicTenantModel>.NotFound(GetPublicTenantHandler.TenantNotFoundMessage))
+                .SetTypedResults<Ok<PublicTenantModel>, ProblemHttpResult>();
         }
 
-        var result = await mediator.Send(new GetPublicTenantQuery(request.Slug), ct);
-        if (result.IsSuccess)
-        {
-            cache.Set(cacheKey, PublicTenantModel.Map(result.Value), PublicTenantCacheDuration);
-        }
+        var result = await cache.GetOrCreateResultAsync(
+            PublicTenantCacheKeys.Entry(normalizedSlug),
+            token => mediator.Send(new GetPublicTenantQuery(normalizedSlug), token),
+            new HybridCacheEntryOptions
+            {
+                Expiration = PublicTenantCacheKeys.Ttl,
+                LocalCacheExpiration = PublicTenantCacheKeys.Ttl
+            },
+            PublicTenantCacheKeys.TagsFor(normalizedSlug),
+            ct);
 
         return TypedResultsBuilder
             .MapResult(result, PublicTenantModel.Map)

--- a/src/Endatix.Api/Endpoints/Public/Tenants/GetBySlug.cs
+++ b/src/Endatix.Api/Endpoints/Public/Tenants/GetBySlug.cs
@@ -62,7 +62,7 @@ public sealed class GetBySlug(IMediator mediator, IMemoryCache cache)
 public sealed class GetPublicTenantRequest
 {
     /// <summary>
-    /// Opaque 8-character YouTube-style public id stored on <c>Tenant.Slug</c>.
+    /// Opaque 8-character alphanumeric public id stored on <c>Tenant.Slug</c>.
     /// </summary>
     public string Slug { get; set; } = string.Empty;
 }

--- a/src/Endatix.Api/Endpoints/Public/Tenants/GetBySlug.cs
+++ b/src/Endatix.Api/Endpoints/Public/Tenants/GetBySlug.cs
@@ -1,0 +1,93 @@
+using Endatix.Api.Common;
+using Endatix.Api.Infrastructure;
+using Endatix.Core.UseCases.Tenants.GetPublicBySlug;
+using FastEndpoints;
+using FluentValidation;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Caching.Memory;
+
+namespace Endatix.Api.Endpoints.Public.Tenants;
+
+/// <summary>
+/// Unauthenticated tenant discovery by opaque public id. Rate-limited; 404s are not cached.
+/// </summary>
+public sealed class GetBySlug(IMediator mediator, IMemoryCache cache)
+    : Endpoint<GetPublicTenantRequest, Results<Ok<PublicTenantModel>, ProblemHttpResult>>
+{
+    internal static readonly TimeSpan PublicTenantCacheDuration = TimeSpan.FromMinutes(3);
+
+    public override void Configure()
+    {
+        Get("tenants/{slug}");
+        Group<PublicApiGroup>();
+        AllowAnonymous();
+        Throttle(20, 60);
+        Summary(s =>
+        {
+            s.Summary = "Get public tenant";
+            s.Description = "Returns the tenant name and self-registration policy for an opaque public id. Does not return the numeric tenant id.";
+            s.Responses[200] = "Tenant found.";
+            s.Responses[404] = "Unknown or deleted public id.";
+            s.Responses[429] = "Too many requests.";
+        });
+    }
+
+    public override async Task<Results<Ok<PublicTenantModel>, ProblemHttpResult>> ExecuteAsync(
+        GetPublicTenantRequest request,
+        CancellationToken cancellationToken)
+    {
+        var cacheKey = $"tenant:public:{request.Slug}";
+        if (cache.TryGetValue(cacheKey, out PublicTenantModel? cached) && cached is not null)
+        {
+            return TypedResults.Ok(cached);
+        }
+
+        var result = await mediator.Send(new GetPublicTenantQuery(request.Slug), cancellationToken);
+        if (result.IsSuccess)
+        {
+            cache.Set(cacheKey, PublicTenantModel.Map(result.Value), PublicTenantCacheDuration);
+        }
+
+        return TypedResultsBuilder
+            .MapResult(result, PublicTenantModel.Map)
+            .SetTypedResults<Ok<PublicTenantModel>, ProblemHttpResult>();
+    }
+}
+
+/// <summary>
+/// Request for unauthenticated tenant discovery.
+/// </summary>
+public sealed class GetPublicTenantRequest
+{
+    /// <summary>
+    /// Opaque 12-character public id stored on <c>Tenant.Slug</c>.
+    /// </summary>
+    public string Slug { get; set; } = string.Empty;
+}
+
+/// <summary>
+/// Validator for <see cref="GetPublicTenantRequest"/>. Format checks live in the handler so
+/// name-like values return 404 rather than 400.
+/// </summary>
+public sealed class GetPublicTenantValidator : Validator<GetPublicTenantRequest>
+{
+    public GetPublicTenantValidator()
+    {
+        RuleFor(request => request.Slug).NotEmpty();
+    }
+}
+
+/// <summary>
+/// Public tenant DTO. Numeric id is intentionally absent.
+/// </summary>
+public sealed record PublicTenantModel(
+    string Slug,
+    string Name,
+    bool SelfRegistrationEnabled,
+    IReadOnlyList<string> AllowedAuthProviders)
+{
+    public static PublicTenantModel Map(PublicTenantDto tenant) =>
+        new(tenant.Slug, tenant.Name, tenant.SelfRegistrationEnabled, tenant.AllowedAuthProviders);
+}

--- a/src/Endatix.Api/Endpoints/Public/Tenants/GetBySlug.cs
+++ b/src/Endatix.Api/Endpoints/Public/Tenants/GetBySlug.cs
@@ -62,7 +62,7 @@ public sealed class GetBySlug(IMediator mediator, IMemoryCache cache)
 public sealed class GetPublicTenantRequest
 {
     /// <summary>
-    /// Opaque 8-character alphanumeric public id stored on <c>Tenant.Slug</c>.
+    /// Opaque 8-character alphanumeric public id stored on <c>Tenant.ShortUrl</c>.
     /// </summary>
     public string Slug { get; set; } = string.Empty;
 }

--- a/src/Endatix.Api/Endpoints/Public/Tenants/GetBySlug.cs
+++ b/src/Endatix.Api/Endpoints/Public/Tenants/GetBySlug.cs
@@ -18,6 +18,7 @@ namespace Endatix.Api.Endpoints.Public.Tenants;
 public sealed class GetBySlug(IMediator mediator, HybridCache cache)
     : Endpoint<GetPublicTenantRequest, Results<Ok<PublicTenantModel>, ProblemHttpResult>>
 {
+    /// <inheritdoc />
     public override void Configure()
     {
         Get("tenants/{slug}");
@@ -34,9 +35,11 @@ public sealed class GetBySlug(IMediator mediator, HybridCache cache)
         });
         Description(builder => builder
             .Produces<PublicTenantModel>(StatusCodes.Status200OK, "application/json")
-            .ProducesProblem(StatusCodes.Status404NotFound));
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status429TooManyRequests));
     }
 
+    /// <inheritdoc />
     public override async Task<Results<Ok<PublicTenantModel>, ProblemHttpResult>> ExecuteAsync(
         GetPublicTenantRequest request,
         CancellationToken ct)
@@ -66,6 +69,9 @@ public sealed class GetBySlug(IMediator mediator, HybridCache cache)
     }
 }
 
+/// <summary>
+/// Request for public tenant discovery.
+/// </summary>
 public sealed class GetPublicTenantRequest
 {
     /// <summary>Opaque 8-character public id (<c>Tenant.ShortUrl</c>).</summary>
@@ -73,7 +79,7 @@ public sealed class GetPublicTenantRequest
 }
 
 /// <summary>
-/// Empty-only. Invalid format is 404 in the handler so name-like values are not distinguishable from unknown ids.
+/// Empty-only. Invalid short URL format is 404 (same as unknown) so we do not leak structure.
 /// </summary>
 public sealed class GetPublicTenantValidator : Validator<GetPublicTenantRequest>
 {
@@ -83,6 +89,9 @@ public sealed class GetPublicTenantValidator : Validator<GetPublicTenantRequest>
     }
 }
 
+/// <summary>
+/// Public tenant discovery response. The numeric tenant id is omitted on purpose.
+/// </summary>
 public sealed record PublicTenantModel(
     string Slug,
     string Name,

--- a/src/Endatix.Api/Endpoints/Public/Tenants/GetBySlug.cs
+++ b/src/Endatix.Api/Endpoints/Public/Tenants/GetBySlug.cs
@@ -32,11 +32,14 @@ public sealed class GetBySlug(IMediator mediator, IMemoryCache cache)
             s.Responses[404] = "Unknown or deleted public id.";
             s.Responses[429] = "Too many requests.";
         });
+        Description(builder => builder
+            .Produces<PublicTenantModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     public override async Task<Results<Ok<PublicTenantModel>, ProblemHttpResult>> ExecuteAsync(
         GetPublicTenantRequest request,
-        CancellationToken cancellationToken)
+        CancellationToken ct)
     {
         var cacheKey = $"tenant:public:{request.Slug}";
         if (cache.TryGetValue(cacheKey, out PublicTenantModel? cached) && cached is not null)
@@ -44,7 +47,7 @@ public sealed class GetBySlug(IMediator mediator, IMemoryCache cache)
             return TypedResults.Ok(cached);
         }
 
-        var result = await mediator.Send(new GetPublicTenantQuery(request.Slug), cancellationToken);
+        var result = await mediator.Send(new GetPublicTenantQuery(request.Slug), ct);
         if (result.IsSuccess)
         {
             cache.Set(cacheKey, PublicTenantModel.Map(result.Value), PublicTenantCacheDuration);
@@ -56,20 +59,14 @@ public sealed class GetBySlug(IMediator mediator, IMemoryCache cache)
     }
 }
 
-/// <summary>
-/// Request for unauthenticated tenant discovery.
-/// </summary>
 public sealed class GetPublicTenantRequest
 {
-    /// <summary>
-    /// Opaque 8-character alphanumeric public id stored on <c>Tenant.ShortUrl</c>.
-    /// </summary>
+    /// <summary>Opaque 8-character public id (<c>Tenant.ShortUrl</c>).</summary>
     public string Slug { get; set; } = string.Empty;
 }
 
 /// <summary>
-/// Validator for <see cref="GetPublicTenantRequest"/>. Format checks live in the handler so
-/// name-like values return 404 rather than 400.
+/// Empty-only. Invalid format is 404 in the handler so name-like values are not distinguishable from unknown ids.
 /// </summary>
 public sealed class GetPublicTenantValidator : Validator<GetPublicTenantRequest>
 {
@@ -79,9 +76,6 @@ public sealed class GetPublicTenantValidator : Validator<GetPublicTenantRequest>
     }
 }
 
-/// <summary>
-/// Public tenant DTO. Numeric id is intentionally absent.
-/// </summary>
 public sealed record PublicTenantModel(
     string Slug,
     string Name,

--- a/src/Endatix.Api/Endpoints/Public/Tenants/GetBySlug.cs
+++ b/src/Endatix.Api/Endpoints/Public/Tenants/GetBySlug.cs
@@ -62,7 +62,7 @@ public sealed class GetBySlug(IMediator mediator, IMemoryCache cache)
 public sealed class GetPublicTenantRequest
 {
     /// <summary>
-    /// Opaque 12-character public id stored on <c>Tenant.Slug</c>.
+    /// Opaque 8-character YouTube-style public id stored on <c>Tenant.Slug</c>.
     /// </summary>
     public string Slug { get; set; } = string.Empty;
 }

--- a/src/Endatix.Core/Abstractions/IRoleManagementService.cs
+++ b/src/Endatix.Core/Abstractions/IRoleManagementService.cs
@@ -20,11 +20,6 @@ public interface IRoleManagementService
     Task<Result> AssignRoleToUserAsync(long userId, string roleName, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Assigns a role to a user as a tenant-scoped copy when <paramref name="tenantId"/> is greater than zero.
-    /// </summary>
-    Task<Result> AssignRoleToUserAsync(long userId, string roleName, long tenantId, CancellationToken cancellationToken = default);
-
-    /// <summary>
     /// Removes a role from a user.
     /// </summary>
     /// <param name="userId">The ID of the user.</param>
@@ -101,6 +96,15 @@ public interface IRoleManagementService
     /// </summary>
     Task<Result<IReadOnlyList<string>>> GetMissingAssignableRoleNamesAsync(
         IReadOnlyList<string> roleNames,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns requested role names that are not assignable in <paramref name="tenantId"/>.
+    /// Use when there is no ambient tenant context, such as anonymous self-registration.
+    /// </summary>
+    Task<Result<IReadOnlyList<string>>> GetMissingAssignableRoleNamesAsync(
+        IReadOnlyList<string> roleNames,
+        long tenantId,
         CancellationToken cancellationToken = default);
 
     /// <summary>

--- a/src/Endatix.Core/Abstractions/IRoleManagementService.cs
+++ b/src/Endatix.Core/Abstractions/IRoleManagementService.cs
@@ -11,13 +11,18 @@ namespace Endatix.Core.Abstractions;
 public interface IRoleManagementService
 {
     /// <summary>
-    /// Assigns a role to a user.
+    /// Assigns a role to a user in the current tenant context.
     /// </summary>
     /// <param name="userId">The ID of the user.</param>
     /// <param name="roleName">The name of the role to assign.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A Result indicating success or failure.</returns>
     Task<Result> AssignRoleToUserAsync(long userId, string roleName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Assigns a role to a user as a tenant-scoped copy when <paramref name="tenantId"/> is greater than zero.
+    /// </summary>
+    Task<Result> AssignRoleToUserAsync(long userId, string roleName, long tenantId, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Removes a role from a user.

--- a/src/Endatix.Core/Abstractions/IUserRegistrationService.cs
+++ b/src/Endatix.Core/Abstractions/IUserRegistrationService.cs
@@ -32,4 +32,21 @@ public interface IUserRegistrationService
     /// Registers or reattaches a pending invited user and sends a tenant invitation activation email when needed.
     /// </summary>
     Task<Result<User>> RegisterInvitedUserAsync(string email, long tenantId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Registers a tenant member and grants <paramref name="roleName"/> atomically: either both land or
+    /// neither does, so a failed grant cannot leave an account that no retry can repair. The verification
+    /// email is sent after the write commits, because it cannot be rolled back.
+    /// </summary>
+    /// <param name="email">The email of the user to register.</param>
+    /// <param name="password">The chosen password.</param>
+    /// <param name="tenantId">The tenant the user is created in.</param>
+    /// <param name="roleName">The role granted on registration. Must already be assignable.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    Task<Result<User>> RegisterTenantUserAsync(
+        string email,
+        string password,
+        long tenantId,
+        string roleName,
+        CancellationToken cancellationToken);
 }

--- a/src/Endatix.Core/Common/ShortUrl.cs
+++ b/src/Endatix.Core/Common/ShortUrl.cs
@@ -68,7 +68,8 @@ public static class ShortUrl
         string.IsNullOrWhiteSpace(value) ? null : value.Trim().ToLowerInvariant();
 
     /// <summary>
-    /// True when there are more ASCII letters than digits.
+    /// True when there are more ASCII letters than digits. Used only by
+    /// the generator as a draw preference; lookups use <c>IsValid</c>.
     /// </summary>
     public static bool IsLetterHeavy(string? value)
     {

--- a/src/Endatix.Core/Infrastructure/Logging/PiiRedactor.cs
+++ b/src/Endatix.Core/Infrastructure/Logging/PiiRedactor.cs
@@ -4,7 +4,7 @@ namespace Endatix.Core.Infrastructure.Logging;
 /// Provides methods to redact sensitive data when logging.
 /// <example>
 /// <code>
-/// var redactedEmail = PiiRedactor.Redact("john.doe@example.com", SensitivityType.Email);
+/// var redactedEmail = PiiRedactor.RedactEmail("john.doe@example.com");
 /// Console.WriteLine(redactedEmail); // Output: [redacted-email]
 /// </code>
 /// </example>
@@ -40,7 +40,7 @@ public static class PiiRedactor
         switch (sensitivityType)
         {
             case SensitivityType.Email:
-                return RedactEmail();
+                return RedactEmail(input);
             case SensitivityType.Secret:
                 return RedactSecret();
             case SensitivityType.PhoneNumber:
@@ -53,11 +53,14 @@ public static class PiiRedactor
     }
 
     /// <summary>
-    /// Redacts an email without preserving any input-derived characters.
+    /// Constant marker for structured log arguments. Pass the address at the call site so
+    /// scanners see a redactor, not a raw email in a log template.
     /// </summary>
-    /// <returns>The redacted email.</returns>
-    internal static string RedactEmail()
+    /// <param name="email">Discarded. Not read, stored, or sent to any external system.</param>
+    /// <returns>Always <see cref="REDACTED_EMAIL"/>.</returns>
+    public static string RedactEmail(string? email)
     {
+        _ = email;
         return REDACTED_EMAIL;
     }
 

--- a/src/Endatix.Core/Specifications/EmailVerificationTokenByTokenSpec.cs
+++ b/src/Endatix.Core/Specifications/EmailVerificationTokenByTokenSpec.cs
@@ -4,18 +4,18 @@ using Endatix.Core.Entities.Identity;
 namespace Endatix.Core.Specifications;
 
 /// <summary>
-/// Specification to find email verification tokens by token value.
+/// Finds an email verification token by its raw value.
 /// </summary>
 public class EmailVerificationTokenByTokenSpec : Specification<EmailVerificationToken>
 {
     public EmailVerificationTokenByTokenSpec(string token)
     {
-        var normalized = token.Trim();
-        var tokenHash = EmailVerificationToken.HashToken(normalized);
-        var presented = normalized.ToUpperInvariant();
+        // Hash only. The column stores a hash so that read access to the table is not read access
+        // to the tokens; also matching the stored value verbatim would hand that property back.
+        var tokenHash = EmailVerificationToken.HashToken(token.Trim());
 
         Query
             .AsNoTracking()
-            .Where(t => t.Token == tokenHash || t.Token == presented);
+            .Where(t => t.Token == tokenHash);
     }
-} 
+}

--- a/src/Endatix.Core/Specifications/EmailVerificationTokenByTokenSpec.cs
+++ b/src/Endatix.Core/Specifications/EmailVerificationTokenByTokenSpec.cs
@@ -10,10 +10,12 @@ public class EmailVerificationTokenByTokenSpec : Specification<EmailVerification
 {
     public EmailVerificationTokenByTokenSpec(string token)
     {
-        var tokenHash = EmailVerificationToken.HashToken(token);
+        var normalized = token.Trim();
+        var tokenHash = EmailVerificationToken.HashToken(normalized);
+        var presented = normalized.ToUpperInvariant();
 
         Query
             .AsNoTracking()
-            .Where(t => t.Token == tokenHash);
+            .Where(t => t.Token == tokenHash || t.Token == presented);
     }
 } 

--- a/src/Endatix.Core/Specifications/TenantSpecifications.cs
+++ b/src/Endatix.Core/Specifications/TenantSpecifications.cs
@@ -29,6 +29,20 @@ public static class TenantSpecifications
     }
 
     /// <summary>
+    /// Live tenant by public short URL for unauthenticated discovery (soft-deleted excluded).
+    /// </summary>
+    public sealed class LiveByShortUrlSpec : Specification<Tenant>, ISingleResultSpecification<Tenant>
+    {
+        public LiveByShortUrlSpec(string shortUrl)
+        {
+            var normalized = ShortUrl.Normalize(shortUrl);
+            Query
+                .IgnoreQueryFilters()
+                .Where(tenant => tenant.ShortUrl == normalized && !tenant.IsDeleted);
+        }
+    }
+
+    /// <summary>
     /// Loads a live tenant for platform-scoped edits.
     /// </summary>
     public sealed class ByIdSpec : Specification<Tenant>, ISingleResultSpecification<Tenant>

--- a/src/Endatix.Core/UseCases/Identity/Register/RegisterCommand.cs
+++ b/src/Endatix.Core/UseCases/Identity/Register/RegisterCommand.cs
@@ -5,7 +5,7 @@ using Endatix.Core.Infrastructure.Result;
 
 namespace Endatix.Core.UseCases.Identity.Register;
 
-public record RegisterCommand(string Email, string Password, string? TenantSlug = null) : ICommand<Result<User>>
+public record RegisterCommand(string Email, string Password, string? TenantSlug = null) : ICommand<Result<string>>
 {
     [Sensitive(SensitivityType.Email)]
     public string Email { get; init; } = Email;

--- a/src/Endatix.Core/UseCases/Identity/Register/RegisterCommand.cs
+++ b/src/Endatix.Core/UseCases/Identity/Register/RegisterCommand.cs
@@ -5,7 +5,7 @@ using Endatix.Core.Infrastructure.Result;
 
 namespace Endatix.Core.UseCases.Identity.Register;
 
-public record RegisterCommand(string Email, string Password) : ICommand<Result<User>>
+public record RegisterCommand(string Email, string Password, string? TenantSlug = null) : ICommand<Result<User>>
 {
     [Sensitive(SensitivityType.Email)]
     public string Email { get; init; } = Email;

--- a/src/Endatix.Core/UseCases/Identity/Register/RegisterHandler.cs
+++ b/src/Endatix.Core/UseCases/Identity/Register/RegisterHandler.cs
@@ -1,32 +1,102 @@
 using Endatix.Core.Abstractions;
+using Endatix.Core.Common;
 using Endatix.Core.Entities.Identity;
 using Endatix.Core.Events;
+using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
+using Endatix.Core.UseCases.Tenants;
 using MediatR;
+using Entities = Endatix.Core.Entities;
 
 namespace Endatix.Core.UseCases.Identity.Register;
 
 /// <summary>
 /// Handles the registration of a new user.
 /// </summary>
-/// <remarks>
-/// This handler is responsible for processing the RegisterCommand and applying domain logic like raising events
-/// </remarks>
 public class RegisterHandler(
     IUserRegistrationService userRegistrationService,
+    IRepository<Entities.Tenant> tenantRepository,
+    IRepository<Entities.TenantSettings> tenantSettingsRepository,
+    IRoleManagementService roleManagementService,
     IMediator mediator
     ) : ICommandHandler<RegisterCommand, Result<User>>
 {
-    /// <summary>
-    /// Handles the RegisterCommand to register a new user.
-    /// </summary>
-    /// <param name="request">The RegisterCommand containing the user's email and password.</param>
-    /// <param name="cancellationToken">A cancellation token that can be used to cancel the work.</param>
-    /// <returns>A Result containing the newly registered User if successful, or an error if registration fails.</returns>
+    public const string TenantNotFoundMessage = "Tenant not found.";
+    public const string SelfRegistrationDisabledMessage = "Self-registration is not enabled for this tenant.";
+
+    /// <inheritdoc />
     public async Task<Result<User>> Handle(RegisterCommand request, CancellationToken cancellationToken)
     {
-        var registerResult = await userRegistrationService.RegisterUserAsync(request.Email, request.Password, cancellationToken);
+        if (string.IsNullOrWhiteSpace(request.TenantSlug))
+        {
+            return await RegisterUnattachedAsync(request.Email, request.Password, cancellationToken);
+        }
+
+        if (!PublicId.IsValidTenantSlug(request.TenantSlug))
+        {
+            return Result.NotFound(TenantNotFoundMessage);
+        }
+
+        var tenant = await tenantRepository.SingleOrDefaultAsync(
+            new TenantSpecifications.LiveBySlugSpec(request.TenantSlug),
+            cancellationToken);
+        if (tenant is null)
+        {
+            return Result.NotFound(TenantNotFoundMessage);
+        }
+
+        var settings = await tenantSettingsRepository.SingleOrDefaultAsync(
+            new TenantSpecifications.SettingsByTenantIdSpec(tenant.Id),
+            cancellationToken);
+        if (settings is null || !settings.AllowSelfRegistration)
+        {
+            return Result.Forbidden(SelfRegistrationDisabledMessage);
+        }
+
+        var registrationRole = string.IsNullOrWhiteSpace(settings.DefaultRegistrationRoleName)
+            ? Entities.TenantSettings.DefaultRegistrationRole
+            : settings.DefaultRegistrationRoleName;
+        if (!Entities.TenantSettings.IsAllowedDefaultRegistrationRole(registrationRole))
+        {
+            return Result.Invalid(TenantWriteRules.ForbiddenRegistrationRole(
+                registrationRole,
+                nameof(Entities.TenantSettings.DefaultRegistrationRoleName)));
+        }
+
+        var registerResult = await userRegistrationService.RegisterUserAsync(
+            request.Email,
+            request.Password,
+            tenant.Id,
+            isEmailConfirmed: false,
+            cancellationToken);
+
+        if (!registerResult.IsSuccess || registerResult.Value is null)
+        {
+            return registerResult;
+        }
+
+        var assignResult = await roleManagementService.AssignRoleToUserAsync(
+            registerResult.Value.Id,
+            registrationRole,
+            tenant.Id,
+            cancellationToken);
+        if (!assignResult.IsSuccess)
+        {
+            return assignResult.ToErrorResult<User>();
+        }
+
+        await mediator.Publish(new UserRegisteredEvent(registerResult.Value), cancellationToken);
+        return registerResult;
+    }
+
+    private async Task<Result<User>> RegisterUnattachedAsync(
+        string email,
+        string password,
+        CancellationToken cancellationToken)
+    {
+        var registerResult = await userRegistrationService.RegisterUserAsync(email, password, cancellationToken);
 
         if (registerResult.IsSuccess && registerResult.Value is { } user)
         {

--- a/src/Endatix.Core/UseCases/Identity/Register/RegisterHandler.cs
+++ b/src/Endatix.Core/UseCases/Identity/Register/RegisterHandler.cs
@@ -36,13 +36,14 @@ public class RegisterHandler(
             return await RegisterUnattachedAsync(request.Email, request.Password, cancellationToken);
         }
 
-        if (!PublicId.IsValidTenantSlug(request.TenantSlug))
+        var shortUrl = ShortUrl.Normalize(request.TenantSlug);
+        if (shortUrl is null || !ShortUrl.IsValid(shortUrl))
         {
             return Result.NotFound(TenantNotFoundMessage);
         }
 
         var tenant = await tenantRepository.SingleOrDefaultAsync(
-            new TenantSpecifications.LiveBySlugSpec(request.TenantSlug),
+            new TenantSpecifications.LiveByShortUrlSpec(shortUrl),
             cancellationToken);
         if (tenant is null)
         {
@@ -60,11 +61,10 @@ public class RegisterHandler(
         var registrationRole = string.IsNullOrWhiteSpace(settings.DefaultRegistrationRoleName)
             ? Entities.TenantSettings.DefaultRegistrationRole
             : settings.DefaultRegistrationRoleName;
-        if (!Entities.TenantSettings.IsAllowedDefaultRegistrationRole(registrationRole))
+        var roleCheck = Entities.TenantSettings.ValidateDefaultRegistrationRole(registrationRole);
+        if (!roleCheck.IsSuccess)
         {
-            return Result.Invalid(TenantWriteRules.ForbiddenRegistrationRole(
-                registrationRole,
-                nameof(Entities.TenantSettings.DefaultRegistrationRoleName)));
+            return Result.Invalid(roleCheck.ValidationErrors);
         }
 
         // Self-registration is anonymous, so it may only ever create a new account. Letting it fall

--- a/src/Endatix.Core/UseCases/Identity/Register/RegisterHandler.cs
+++ b/src/Endatix.Core/UseCases/Identity/Register/RegisterHandler.cs
@@ -67,11 +67,7 @@ public class RegisterHandler(
             return Result.Invalid(roleCheck.ValidationErrors);
         }
 
-        // Self-registration is anonymous, so it may only ever create a new account. Letting it fall
-        // through to RegisterUserAsync for an address that already exists would take the existing
-        // branches for an existing user: an unattached account would be silently moved into this
-        // tenant, and either way the account would then be granted the tenant's registration role
-        // below - a cross-tenant takeover driven purely by knowing someone's email address.
+        // Anonymous self-reg must not attach or re-role an existing account (email-oracle takeover).
         var existingUser = await userService.GetUserAsync(request.Email, cancellationToken);
         if (existingUser.IsSuccess)
         {

--- a/src/Endatix.Core/UseCases/Identity/Register/RegisterHandler.cs
+++ b/src/Endatix.Core/UseCases/Identity/Register/RegisterHandler.cs
@@ -17,19 +17,23 @@ namespace Endatix.Core.UseCases.Identity.Register;
 /// </summary>
 public class RegisterHandler(
     IUserRegistrationService userRegistrationService,
-    IUserService userService,
     IRepository<Entities.Tenant> tenantRepository,
     IRepository<Entities.TenantSettings> tenantSettingsRepository,
     IRoleManagementService roleManagementService,
     IMediator mediator
-    ) : ICommandHandler<RegisterCommand, Result<User>>
+    ) : ICommandHandler<RegisterCommand, Result<string>>
 {
     public const string TenantNotFoundMessage = "Tenant not found.";
     public const string SelfRegistrationDisabledMessage = "Self-registration is not enabled for this tenant.";
-    public const string EmailAlreadyRegisteredMessage = "The email is already registered.";
+
+    /// <summary>
+    /// Returned whether or not the address was free, so registration cannot be used to enumerate
+    /// accounts. Mirrors <c>ForgotPasswordHandler.GENERAL_SUCCESS_MESSAGE</c>.
+    /// </summary>
+    public const string GENERAL_SUCCESS_MESSAGE = "Thank you. If this email address can be registered, you will receive an email with instructions to verify it.";
 
     /// <inheritdoc />
-    public async Task<Result<User>> Handle(RegisterCommand request, CancellationToken cancellationToken)
+    public async Task<Result<string>> Handle(RegisterCommand request, CancellationToken cancellationToken)
     {
         if (string.IsNullOrWhiteSpace(request.TenantSlug))
         {
@@ -67,51 +71,78 @@ public class RegisterHandler(
             return Result.Invalid(roleCheck.ValidationErrors);
         }
 
-        // Anonymous self-reg must not attach or re-role an existing account (email-oracle takeover).
-        var existingUser = await userService.GetUserAsync(request.Email, cancellationToken);
-        if (existingUser.IsSuccess)
+        // ValidateDefaultRegistrationRole only rejects roles that must never be used, so resolve the
+        // name too: assigning after the user exists would leave an unusable account no retry can fix.
+        var roleResolution = await ResolveRegistrationRoleAsync(registrationRole, tenant.Id, cancellationToken);
+        if (!roleResolution.IsSuccess)
         {
-            return Result.Invalid(new ValidationError(EmailAlreadyRegisteredMessage));
+            return roleResolution.ToErrorResult<string>();
         }
 
-        var registerResult = await userRegistrationService.RegisterUserAsync(
+        var registerResult = await userRegistrationService.RegisterTenantUserAsync(
             request.Email,
             request.Password,
             tenant.Id,
-            isEmailConfirmed: false,
-            cancellationToken);
-
-        if (!registerResult.IsSuccess || registerResult.Value is null)
-        {
-            return registerResult;
-        }
-
-        var assignResult = await roleManagementService.AssignRoleToUserAsync(
-            registerResult.Value.Id,
             registrationRole,
-            tenant.Id,
             cancellationToken);
-        if (!assignResult.IsSuccess)
-        {
-            return assignResult.ToErrorResult<User>();
-        }
 
-        await mediator.Publish(new UserRegisteredEvent(registerResult.Value), cancellationToken);
-        return registerResult;
+        return await CompleteRegistrationAsync(registerResult, cancellationToken);
     }
 
-    private async Task<Result<User>> RegisterUnattachedAsync(
+    private async Task<Result> ResolveRegistrationRoleAsync(
+        string registrationRole,
+        long tenantId,
+        CancellationToken cancellationToken)
+    {
+        var missingResult = await roleManagementService.GetMissingAssignableRoleNamesAsync(
+            [registrationRole],
+            tenantId,
+            cancellationToken);
+        if (!missingResult.IsSuccess)
+        {
+            return Result.Error(new ErrorList(missingResult.Errors, missingResult.CorrelationId));
+        }
+
+        if (missingResult.Value is { Count: > 0 })
+        {
+            return Result.Invalid(new ValidationError
+            {
+                Identifier = nameof(Entities.TenantSettings.DefaultRegistrationRoleName),
+                ErrorMessage = $"'{registrationRole}' is not an assignable role for this tenant."
+            });
+        }
+
+        return Result.Success();
+    }
+
+    private async Task<Result<string>> RegisterUnattachedAsync(
         string email,
         string password,
         CancellationToken cancellationToken)
     {
         var registerResult = await userRegistrationService.RegisterUserAsync(email, password, cancellationToken);
 
-        if (registerResult.IsSuccess && registerResult.Value is { } user)
+        return await CompleteRegistrationAsync(registerResult, cancellationToken);
+    }
+
+    /// <summary>
+    /// Collapses "created" and "address already taken" (<see cref="ResultStatus.NoContent"/>) into one
+    /// response. Only a real registration raises <see cref="UserRegisteredEvent"/>.
+    /// </summary>
+    private async Task<Result<string>> CompleteRegistrationAsync(
+        Result<User> registerResult,
+        CancellationToken cancellationToken)
+    {
+        if (!registerResult.IsSuccess)
+        {
+            return registerResult.ToErrorResult<string>();
+        }
+
+        if (registerResult.Value is { } user)
         {
             await mediator.Publish(new UserRegisteredEvent(user), cancellationToken);
         }
 
-        return registerResult;
+        return Result<string>.Success(GENERAL_SUCCESS_MESSAGE);
     }
 }

--- a/src/Endatix.Core/UseCases/Identity/Register/RegisterHandler.cs
+++ b/src/Endatix.Core/UseCases/Identity/Register/RegisterHandler.cs
@@ -17,6 +17,7 @@ namespace Endatix.Core.UseCases.Identity.Register;
 /// </summary>
 public class RegisterHandler(
     IUserRegistrationService userRegistrationService,
+    IUserService userService,
     IRepository<Entities.Tenant> tenantRepository,
     IRepository<Entities.TenantSettings> tenantSettingsRepository,
     IRoleManagementService roleManagementService,
@@ -25,6 +26,7 @@ public class RegisterHandler(
 {
     public const string TenantNotFoundMessage = "Tenant not found.";
     public const string SelfRegistrationDisabledMessage = "Self-registration is not enabled for this tenant.";
+    public const string EmailAlreadyRegisteredMessage = "The email is already registered.";
 
     /// <inheritdoc />
     public async Task<Result<User>> Handle(RegisterCommand request, CancellationToken cancellationToken)
@@ -63,6 +65,17 @@ public class RegisterHandler(
             return Result.Invalid(TenantWriteRules.ForbiddenRegistrationRole(
                 registrationRole,
                 nameof(Entities.TenantSettings.DefaultRegistrationRoleName)));
+        }
+
+        // Self-registration is anonymous, so it may only ever create a new account. Letting it fall
+        // through to RegisterUserAsync for an address that already exists would take the existing
+        // branches for an existing user: an unattached account would be silently moved into this
+        // tenant, and either way the account would then be granted the tenant's registration role
+        // below - a cross-tenant takeover driven purely by knowing someone's email address.
+        var existingUser = await userService.GetUserAsync(request.Email, cancellationToken);
+        if (existingUser.IsSuccess)
+        {
+            return Result.Invalid(new ValidationError(EmailAlreadyRegisteredMessage));
         }
 
         var registerResult = await userRegistrationService.RegisterUserAsync(

--- a/src/Endatix.Core/UseCases/Identity/ResendUserInvitation/ResendUserInvitationHandler.cs
+++ b/src/Endatix.Core/UseCases/Identity/ResendUserInvitation/ResendUserInvitationHandler.cs
@@ -59,7 +59,7 @@ public sealed class ResendUserInvitationHandler(
             await emailSender.SendEmailAsync(emailModel, cancellationToken);
             logger.LogInformation(
                 "Invitation email resent successfully to {Email}",
-                PiiRedactor.RedactEmail());
+                PiiRedactor.RedactEmail(userResult.Value.Email));
 
             return Result.Success();
         }
@@ -68,7 +68,7 @@ public sealed class ResendUserInvitationHandler(
             logger.LogError(
                 ex,
                 "Failed to resend invitation email to {Email}",
-                PiiRedactor.RedactEmail());
+                PiiRedactor.RedactEmail(userResult.Value.Email));
 
             return Result.Error("Failed to resend invitation email.");
         }

--- a/src/Endatix.Core/UseCases/Tenants/GetPublicBySlug/GetPublicTenantHandler.cs
+++ b/src/Endatix.Core/UseCases/Tenants/GetPublicBySlug/GetPublicTenantHandler.cs
@@ -20,13 +20,14 @@ public sealed class GetPublicTenantHandler(
     /// <inheritdoc/>
     public async Task<Result<PublicTenantDto>> Handle(GetPublicTenantQuery request, CancellationToken cancellationToken)
     {
-        if (!PublicId.IsValidTenantSlug(request.Slug))
+        var shortUrl = ShortUrl.Normalize(request.Slug);
+        if (shortUrl is null || !ShortUrl.IsValid(shortUrl))
         {
             return Result.NotFound(TenantNotFoundMessage);
         }
 
         var tenant = await tenantRepository.SingleOrDefaultAsync(
-            new TenantSpecifications.LiveBySlugSpec(request.Slug),
+            new TenantSpecifications.LiveByShortUrlSpec(shortUrl),
             cancellationToken);
         if (tenant is null)
         {
@@ -38,7 +39,7 @@ public sealed class GetPublicTenantHandler(
             cancellationToken);
 
         return Result.Success(new PublicTenantDto(
-            tenant.Slug,
+            tenant.ShortUrl,
             tenant.Name,
             settings?.AllowSelfRegistration ?? false,
             settings?.AllowedAuthProviderKeys ?? []));

--- a/src/Endatix.Core/UseCases/Tenants/GetPublicBySlug/GetPublicTenantHandler.cs
+++ b/src/Endatix.Core/UseCases/Tenants/GetPublicBySlug/GetPublicTenantHandler.cs
@@ -1,0 +1,46 @@
+using Endatix.Core.Common;
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
+using Entities = Endatix.Core.Entities;
+
+namespace Endatix.Core.UseCases.Tenants.GetPublicBySlug;
+
+/// <summary>
+/// Loads a live tenant by opaque public id for unauthenticated sign-in / self-registration pages.
+/// </summary>
+public sealed class GetPublicTenantHandler(
+    IRepository<Entities.Tenant> tenantRepository,
+    IRepository<Entities.TenantSettings> tenantSettingsRepository)
+    : IQueryHandler<GetPublicTenantQuery, Result<PublicTenantDto>>
+{
+    public const string TenantNotFoundMessage = "Tenant not found.";
+
+    /// <inheritdoc/>
+    public async Task<Result<PublicTenantDto>> Handle(GetPublicTenantQuery request, CancellationToken cancellationToken)
+    {
+        if (!PublicId.IsValidTenantSlug(request.Slug))
+        {
+            return Result.NotFound(TenantNotFoundMessage);
+        }
+
+        var tenant = await tenantRepository.SingleOrDefaultAsync(
+            new TenantSpecifications.LiveBySlugSpec(request.Slug),
+            cancellationToken);
+        if (tenant is null)
+        {
+            return Result.NotFound(TenantNotFoundMessage);
+        }
+
+        var settings = await tenantSettingsRepository.SingleOrDefaultAsync(
+            new TenantSpecifications.SettingsByTenantIdSpec(tenant.Id),
+            cancellationToken);
+
+        return Result.Success(new PublicTenantDto(
+            tenant.Slug,
+            tenant.Name,
+            settings?.AllowSelfRegistration ?? false,
+            settings?.AllowedAuthProviderKeys ?? []));
+    }
+}

--- a/src/Endatix.Core/UseCases/Tenants/GetPublicBySlug/GetPublicTenantQuery.cs
+++ b/src/Endatix.Core/UseCases/Tenants/GetPublicBySlug/GetPublicTenantQuery.cs
@@ -1,0 +1,18 @@
+using Endatix.Core.Infrastructure.Messaging;
+using Endatix.Core.Infrastructure.Result;
+
+namespace Endatix.Core.UseCases.Tenants.GetPublicBySlug;
+
+/// <summary>
+/// Unauthenticated lookup of a live tenant by opaque public id. Does not return the numeric id.
+/// </summary>
+public sealed record GetPublicTenantQuery(string Slug) : IQuery<Result<PublicTenantDto>>;
+
+/// <summary>
+/// Public tenant discovery DTO. Numeric id is omitted on purpose.
+/// </summary>
+public sealed record PublicTenantDto(
+    string Slug,
+    string Name,
+    bool SelfRegistrationEnabled,
+    IReadOnlyList<string> AllowedAuthProviders);

--- a/src/Endatix.Infrastructure/Caching/HybridCacheExtension.cs
+++ b/src/Endatix.Infrastructure/Caching/HybridCacheExtension.cs
@@ -4,7 +4,7 @@ using Endatix.Core.Infrastructure;
 
 namespace Endatix.Infrastructure.Caching;
 
-internal static class HybridCacheExtensions
+public static class HybridCacheExtensions
 {
     /// <summary>
     /// Options to disable cache write operations for HybridCache.

--- a/src/Endatix.Infrastructure/Caching/PublicTenantCacheKeys.cs
+++ b/src/Endatix.Infrastructure/Caching/PublicTenantCacheKeys.cs
@@ -1,0 +1,31 @@
+using Endatix.Core.Common;
+
+namespace Endatix.Infrastructure.Caching;
+
+/// <summary>
+/// HybridCache keys/tags for unauthenticated tenant discovery.
+/// </summary>
+public static class PublicTenantCacheKeys
+{
+    public const string Tag = "tenant:public";
+
+    public static readonly TimeSpan Ttl = TimeSpan.FromMinutes(3);
+
+    public static string Entry(string normalizedSlug) => $"{Tag}:{normalizedSlug}";
+
+    public static string[] TagsFor(string normalizedSlug) => [Tag, Entry(normalizedSlug)];
+
+    /// <summary>
+    /// Normalized public id, or null when the inbound value is not a valid short URL.
+    /// </summary>
+    public static string? TryNormalized(string? slug)
+    {
+        var normalized = ShortUrl.Normalize(slug);
+        if (normalized is null || !ShortUrl.IsValid(normalized))
+        {
+            return null;
+        }
+
+        return normalized;
+    }
+}

--- a/src/Endatix.Infrastructure/Features/PlatformAdmin/ListPlatformTenants/ListPlatformTenants.cs
+++ b/src/Endatix.Infrastructure/Features/PlatformAdmin/ListPlatformTenants/ListPlatformTenants.cs
@@ -1,8 +1,8 @@
-using Endatix.Core.Common;
 using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Paging;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Infrastructure.Data;
+using Endatix.Infrastructure.Data.Querying;
 using Microsoft.EntityFrameworkCore;
 
 namespace Endatix.Infrastructure.Features.PlatformAdmin.ListPlatformTenants;
@@ -10,7 +10,9 @@ namespace Endatix.Infrastructure.Features.PlatformAdmin.ListPlatformTenants;
 /// <summary>
 /// Platform-scoped read model: paged tenant list with form and submission counts.
 /// </summary>
-public sealed class ListPlatformTenants(AppDbContext appDbContext) : IListPlatformTenants
+public sealed class ListPlatformTenants(
+    AppDbContext appDbContext,
+    IRelationalSubstringLikeFilter substringLikeFilter) : IListPlatformTenants
 {
     /// <inheritdoc />
     public async Task<Result<Paged<PlatformTenantListItem>>> ExecuteAsync(
@@ -20,21 +22,13 @@ public sealed class ListPlatformTenants(AppDbContext appDbContext) : IListPlatfo
     {
         var normalizedPageSize = paging.Paging.PageSize;
         var skip = paging.Paging.Skip;
-        var search = paging.Search;
 
         var tenantsQuery = appDbContext.Set<Tenant>()
             .IgnoreQueryFilters()
             .AsNoTracking()
             .Where(tenant => !tenant.IsDeleted);
 
-        if (ShortUrl.Normalize(search) is string shortUrlSearch)
-        {
-            var trimmedSearch = search.Trim();
-            tenantsQuery = tenantsQuery.Where(tenant =>
-                tenant.Name.Contains(trimmedSearch) ||
-                tenant.ShortUrl.Contains(shortUrlSearch) ||
-                (tenant.Description != null && tenant.Description.Contains(trimmedSearch)));
-        }
+        tenantsQuery = ApplySearch(tenantsQuery, paging.Search);
 
         tenantsQuery = tenantsQuery
             .WhereUtcRange(tenant => tenant.CreatedAt, criteria.Created)
@@ -93,6 +87,30 @@ public sealed class ListPlatformTenants(AppDbContext appDbContext) : IListPlatfo
             normalizedPageSize,
             totalRecords,
             items));
+    }
+
+    private IQueryable<Tenant> ApplySearch(IQueryable<Tenant> tenantsQuery, string? search)
+    {
+        if (string.IsNullOrWhiteSpace(search))
+        {
+            return tenantsQuery;
+        }
+
+        var trimmed = search.Trim();
+        var nameMatches = substringLikeFilter.WherePropertyMatchesLikeSubstring(
+            tenantsQuery,
+            nameof(Tenant.Name),
+            trimmed);
+        var shortUrlMatches = substringLikeFilter.WherePropertyMatchesLikeSubstring(
+            tenantsQuery,
+            nameof(Tenant.ShortUrl),
+            trimmed);
+        var descriptionMatches = substringLikeFilter.WherePropertyMatchesLikeSubstring(
+            tenantsQuery,
+            nameof(Tenant.Description),
+            trimmed);
+
+        return nameMatches.Union(shortUrlMatches).Union(descriptionMatches);
     }
 
     private static IOrderedQueryable<Tenant> ApplyOrdering(

--- a/src/Endatix.Infrastructure/Identity/EmailVerification/EmailVerificationService.cs
+++ b/src/Endatix.Infrastructure/Identity/EmailVerification/EmailVerificationService.cs
@@ -99,6 +99,27 @@ public class EmailVerificationService : IEmailVerificationService
             return Result.Invalid(new ValidationError(INVALID_VERIFICATION_TOKEN_MESSAGE));
         }
 
+        var user = await _userManager.FindByIdAsync(verificationToken.UserId.ToString());
+        if (user == null)
+        {
+            // Report the same failure as an unknown token. A dangling token must not tell the
+            // caller that the token itself was genuine but the account behind it is gone.
+            return Result.Invalid(new ValidationError(INVALID_VERIFICATION_TOKEN_MESSAGE));
+        }
+
+        // Re-clicks, Hub Strict-Mode double POST, and "already verified" must succeed. Hub maps
+        // "User is already verified" to a hard error; a used token after a race is not a failure.
+        if (user.EmailConfirmed)
+        {
+            if (!verificationToken.IsUsed)
+            {
+                verificationToken.MarkAsUsed();
+                await _tokenRepository.UpdateAsync(verificationToken, cancellationToken);
+            }
+
+            return Result.Success(user.ToUserEntity());
+        }
+
         if (verificationToken.IsExpired)
         {
             return Result.Invalid(new ValidationError("Verification token has expired"));
@@ -109,20 +130,6 @@ public class EmailVerificationService : IEmailVerificationService
             return Result.Invalid(new ValidationError("Verification token has already been used"));
         }
 
-        var user = await _userManager.FindByIdAsync(verificationToken.UserId.ToString());
-        if (user == null)
-        {
-            // Report the same failure as an unknown token. A dangling token must not tell the
-            // caller that the token itself was genuine but the account behind it is gone.
-            return Result.Invalid(new ValidationError(INVALID_VERIFICATION_TOKEN_MESSAGE));
-        }
-
-        if (user.EmailConfirmed)
-        {
-            return Result.Invalid(new ValidationError("User is already verified"));
-        }
-
-        // Mark user as verified
         user.EmailConfirmed = true;
         var updateResult = await _userManager.UpdateAsync(user);
         if (!updateResult.Succeeded)
@@ -130,7 +137,6 @@ public class EmailVerificationService : IEmailVerificationService
             return Result.Error("Failed to verify user");
         }
 
-        // Mark token as used
         verificationToken.MarkAsUsed();
         await _tokenRepository.UpdateAsync(verificationToken, cancellationToken);
 

--- a/src/Endatix.Infrastructure/Identity/Services/RoleManagementService.cs
+++ b/src/Endatix.Infrastructure/Identity/Services/RoleManagementService.cs
@@ -62,6 +62,12 @@ public sealed class RoleManagementService : IRoleManagementService
     /// <inheritdoc/>
     public async Task<Result> AssignRoleToUserAsync(long userId, string roleName, CancellationToken cancellationToken = default)
     {
+        return await AssignRoleToUserAsync(userId, roleName, _tenantContext.TenantId, cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public async Task<Result> AssignRoleToUserAsync(long userId, string roleName, long tenantId, CancellationToken cancellationToken = default)
+    {
         var inputGuard = ValidateRoleMutationInput(userId, roleName);
         if (!inputGuard.IsSuccess)
         {

--- a/src/Endatix.Infrastructure/Identity/Services/RoleManagementService.cs
+++ b/src/Endatix.Infrastructure/Identity/Services/RoleManagementService.cs
@@ -62,12 +62,6 @@ public sealed class RoleManagementService : IRoleManagementService
     /// <inheritdoc/>
     public async Task<Result> AssignRoleToUserAsync(long userId, string roleName, CancellationToken cancellationToken = default)
     {
-        return await AssignRoleToUserAsync(userId, roleName, _tenantContext.TenantId, cancellationToken);
-    }
-
-    /// <inheritdoc/>
-    public async Task<Result> AssignRoleToUserAsync(long userId, string roleName, long tenantId, CancellationToken cancellationToken = default)
-    {
         var inputGuard = ValidateRoleMutationInput(userId, roleName);
         if (!inputGuard.IsSuccess)
         {
@@ -517,8 +511,15 @@ public sealed class RoleManagementService : IRoleManagementService
     }
 
     /// <inheritdoc/>
+    public Task<Result<IReadOnlyList<string>>> GetMissingAssignableRoleNamesAsync(
+        IReadOnlyList<string> roleNames,
+        CancellationToken cancellationToken = default) =>
+        GetMissingAssignableRoleNamesAsync(roleNames, _tenantContext.TenantId, cancellationToken);
+
+    /// <inheritdoc/>
     public async Task<Result<IReadOnlyList<string>>> GetMissingAssignableRoleNamesAsync(
         IReadOnlyList<string> roleNames,
+        long tenantId,
         CancellationToken cancellationToken = default)
     {
         if (roleNames.Count == 0)
@@ -530,7 +531,6 @@ public sealed class RoleManagementService : IRoleManagementService
         var requestedNormalizedRoleNames = requestedRoleNames
             .Select(NormalizeRoleName)
             .ToList();
-        var tenantId = _tenantContext.TenantId;
 
         var persistedNames = await _identityDbContext.Roles
             .AsNoTracking()

--- a/src/Endatix.Infrastructure/Identity/Users/AppUserRegistrationService.cs
+++ b/src/Endatix.Infrastructure/Identity/Users/AppUserRegistrationService.cs
@@ -156,7 +156,7 @@ public sealed class AppUserRegistrationService(
                 await unitOfWork.RollbackTransactionAsync(cancellationToken);
                 logger.LogError(
                     "Rolled back self-registration for {Email}: role {RoleName} could not be granted.",
-                    RedactEmail(normalizedEmail),
+                    PiiRedactor.RedactEmail(normalizedEmail),
                     roleName);
                 return assignRoleResult.ToErrorResult<User>();
             }
@@ -230,7 +230,7 @@ public sealed class AppUserRegistrationService(
         }
         else
         {
-            logger.LogInformation("Skipping email verification for {Email} - email is already confirmed", RedactEmail(normalizedEmail));
+            logger.LogInformation("Skipping email verification for {Email} - email is already confirmed", PiiRedactor.RedactEmail(normalizedEmail));
         }
 
         // If token creation or email sending fails, we should still return success but log the error
@@ -247,7 +247,7 @@ public sealed class AppUserRegistrationService(
     {
         logger.LogInformation(
             "Registration attempt for an address that is already registered: {Email}. Answering with the neutral result.",
-            RedactEmail(email));
+            PiiRedactor.RedactEmail(email));
 
         return Result<User>.NoContent();
     }
@@ -321,7 +321,7 @@ public sealed class AppUserRegistrationService(
         var rawToken = tokenResult.Value?.RawToken;
         if (string.IsNullOrWhiteSpace(rawToken))
         {
-            logger.LogError("Failed to send account email to {Email} during registration because the verification token is missing.", RedactEmail(email));
+            logger.LogError("Failed to send account email to {Email} during registration because the verification token is missing.", PiiRedactor.RedactEmail(email));
             return;
         }
 
@@ -335,11 +335,11 @@ public sealed class AppUserRegistrationService(
 
             logger.LogInformation("{EmailKind} email sent successfully to {Email} during registration",
                 sendInvitationEmail ? "Invitation" : "Verification",
-                RedactEmail(email));
+                PiiRedactor.RedactEmail(email));
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Failed to send account email to {Email} during registration", RedactEmail(email));
+            logger.LogError(ex, "Failed to send account email to {Email} during registration", PiiRedactor.RedactEmail(email));
         }
     }
 
@@ -414,11 +414,6 @@ public sealed class AppUserRegistrationService(
             : tokenResult.Errors;
 
         logger.LogError("Failed to create verification token for user: {Email} (UserId: {UserId}). Errors: {Errors}",
-            RedactEmail(email), userId, string.Join(", ", errors));
-    }
-
-    private static string RedactEmail(string email)
-    {
-        return PiiRedactor.Redact(email, SensitivityType.Email);
+            PiiRedactor.RedactEmail(email), userId, string.Join(", ", errors));
     }
 }

--- a/src/Endatix.Infrastructure/Identity/Users/AppUserRegistrationService.cs
+++ b/src/Endatix.Infrastructure/Identity/Users/AppUserRegistrationService.cs
@@ -4,7 +4,9 @@ using Endatix.Core.Entities.Identity;
 using Endatix.Core.Features.Email;
 using Endatix.Core.Infrastructure.Logging;
 using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Abstractions.Data;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Endatix.Infrastructure.Identity.Users;
@@ -18,6 +20,8 @@ public sealed class AppUserRegistrationService(
     IEmailVerificationService emailVerificationService,
     IEmailSender emailSender,
     IEmailTemplateService emailTemplateService,
+    IRoleManagementService roleManagementService,
+    [FromKeyedServices("identity")] IUnitOfWork unitOfWork,
     ILogger<AppUserRegistrationService> logger) : IUserRegistrationService
 {
     private const string EmailAlreadyRegisteredMessage = "The email is already registered.";
@@ -59,7 +63,14 @@ public sealed class AppUserRegistrationService(
     /// <inheritdoc />
     public async Task<Result<User>> RegisterUserAsync(string email, string password, CancellationToken cancellationToken)
     {
-        return await RegisterUserAsync(email, password, tenantId: 0, isEmailConfirmed: false, cancellationToken);
+        return await RegisterUserAsync(
+            email,
+            password,
+            tenantId: 0,
+            isEmailConfirmed: false,
+            sendInvitationEmail: false,
+            isAnonymous: true,
+            cancellationToken);
     }
 
     /// <inheritdoc />
@@ -71,6 +82,7 @@ public sealed class AppUserRegistrationService(
             tenantId,
             isEmailConfirmed,
             sendInvitationEmail: false,
+            isAnonymous: false,
             cancellationToken);
     }
 
@@ -83,7 +95,84 @@ public sealed class AppUserRegistrationService(
             tenantId,
             isEmailConfirmed: false,
             sendInvitationEmail: true,
+            isAnonymous: false,
             cancellationToken);
+    }
+
+    /// <inheritdoc />
+    public async Task<Result<User>> RegisterTenantUserAsync(
+        string email,
+        string password,
+        long tenantId,
+        string roleName,
+        CancellationToken cancellationToken)
+    {
+        var emailGuard = ValidateRegistrationEmail(email);
+        if (!emailGuard.IsSuccess)
+        {
+            return emailGuard.ToErrorResult<User>();
+        }
+
+        var normalizedEmail = email.Trim();
+
+        // Self-registration is anonymous, so it must never attach or re-role an account that already
+        // exists - unlike the invite path, which deliberately adopts an unattached user.
+        if (await userManager.FindByEmailAsync(normalizedEmail) is not null)
+        {
+            return ExistingAccountSuppressed(normalizedEmail);
+        }
+
+        AppUser newUser = new()
+        {
+            TenantId = tenantId,
+            EmailConfirmed = false
+        };
+
+        var emailStore = (IUserEmailStore<AppUser>)userStore;
+        await userStore.SetUserNameAsync(newUser, normalizedEmail, cancellationToken);
+        await emailStore.SetEmailAsync(newUser, normalizedEmail, cancellationToken);
+
+        // The user row and the role grant live in the same identity DbContext, so one transaction is
+        // enough - no compensation or saga. Both UserManager calls enlist in it.
+        try
+        {
+            await unitOfWork.BeginTransactionAsync(cancellationToken);
+
+            var createUserResult = await userManager.CreateAsync(newUser, password);
+            if (!createUserResult.Succeeded)
+            {
+                await unitOfWork.RollbackTransactionAsync(cancellationToken);
+                return createUserResult.Errors.Any(error => error.Code == "DuplicateUserName")
+                    ? ExistingAccountSuppressed(normalizedEmail)
+                    : ToIdentityErrorResult(createUserResult);
+            }
+
+            var assignRoleResult = await roleManagementService.AssignRoleToUserAsync(
+                newUser.Id,
+                roleName,
+                cancellationToken);
+            if (!assignRoleResult.IsSuccess)
+            {
+                await unitOfWork.RollbackTransactionAsync(cancellationToken);
+                logger.LogError(
+                    "Rolled back self-registration for {Email}: role {RoleName} could not be granted.",
+                    RedactEmail(normalizedEmail),
+                    roleName);
+                return assignRoleResult.ToErrorResult<User>();
+            }
+
+            await unitOfWork.CommitTransactionAsync(cancellationToken);
+        }
+        catch
+        {
+            await unitOfWork.RollbackTransactionAsync(cancellationToken);
+            throw;
+        }
+
+        // After the commit: an email cannot be unsent, so it must not precede the write it announces.
+        await SendAccountEmailAsync(newUser.Id, normalizedEmail, sendInvitationEmail: false, cancellationToken);
+
+        return Result.Success(newUser.ToUserEntity());
     }
 
     private async Task<Result<User>> RegisterUserAsync(
@@ -92,6 +181,7 @@ public sealed class AppUserRegistrationService(
         long tenantId,
         bool isEmailConfirmed,
         bool sendInvitationEmail,
+        bool isAnonymous,
         CancellationToken cancellationToken)
     {
         if (!userManager.SupportsUserEmail)
@@ -109,7 +199,7 @@ public sealed class AppUserRegistrationService(
         var existingUser = await userManager.FindByEmailAsync(normalizedEmail);
         if (existingUser is not null)
         {
-            return await HandleExistingUserAsync(existingUser, normalizedEmail, tenantId, sendInvitationEmail, cancellationToken);
+            return await HandleExistingUserAsync(existingUser, normalizedEmail, tenantId, sendInvitationEmail, isAnonymous, cancellationToken);
         }
 
         var newUser = new AppUser
@@ -148,16 +238,33 @@ public sealed class AppUserRegistrationService(
         return Result.Success(domainUser);
     }
 
+    /// <summary>
+    /// Anonymous registration answers the same way whether or not the address is taken, so the endpoint
+    /// cannot be used to enumerate accounts (OWASP WSTG-IDNT-04). <see cref="ResultStatus.NoContent"/>
+    /// tells the caller "nothing was created" without giving the client anything to distinguish.
+    /// </summary>
+    private Result<User> ExistingAccountSuppressed(string email)
+    {
+        logger.LogInformation(
+            "Registration attempt for an address that is already registered: {Email}. Answering with the neutral result.",
+            RedactEmail(email));
+
+        return Result<User>.NoContent();
+    }
+
     private async Task<Result<User>> HandleExistingUserAsync(
         AppUser existingUser,
         string email,
         long tenantId,
         bool sendInvitationEmail,
+        bool isAnonymous,
         CancellationToken cancellationToken)
     {
         if (existingUser.TenantId > 0 && existingUser.TenantId != tenantId)
         {
-            return Result.Invalid(new ValidationError(EmailAlreadyRegisteredMessage));
+            return isAnonymous
+                ? ExistingAccountSuppressed(email)
+                : Result.Invalid(new ValidationError(EmailAlreadyRegisteredMessage));
         }
 
         if (existingUser.TenantId != tenantId)
@@ -167,7 +274,9 @@ public sealed class AppUserRegistrationService(
 
         if (existingUser.EmailConfirmed)
         {
-            return Result.Invalid(new ValidationError(UserAlreadyBelongsToTenantMessage));
+            return isAnonymous
+                ? ExistingAccountSuppressed(email)
+                : Result.Invalid(new ValidationError(UserAlreadyBelongsToTenantMessage));
         }
 
         await SendAccountEmailAsync(existingUser.Id, email, sendInvitationEmail, cancellationToken);

--- a/tests/Endatix.Api.Tests/Endpoints/Admin/Tenants/UpdateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Admin/Tenants/UpdateTests.cs
@@ -6,6 +6,8 @@ using FastEndpoints;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
 using UpdateTenantEndpoint = Endatix.Api.Endpoints.Admin.Tenants.Update;
 
 namespace Endatix.Api.Tests.Endpoints.Admin.Tenants;
@@ -97,7 +99,17 @@ public sealed class UpdateTests
     }
 
     private UpdateTenantEndpoint CreateEndpoint(bool multiTenancyEnabled) =>
-        Factory.Create<UpdateTenantEndpoint>(_mediator, MultiTenancyConfiguration.Create(multiTenancyEnabled));
+        Factory.Create<UpdateTenantEndpoint>(
+            _mediator,
+            MultiTenancyConfiguration.Create(multiTenancyEnabled),
+            CreateCache());
+
+    private static HybridCache CreateCache()
+    {
+        var services = new ServiceCollection();
+        services.AddHybridCache();
+        return services.BuildServiceProvider().GetRequiredService<HybridCache>();
+    }
 
     private static UpdateTenantRequest ValidRequest() => new()
     {

--- a/tests/Endatix.Api.Tests/Endpoints/Auth/RegisterTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Auth/RegisterTests.cs
@@ -85,4 +85,18 @@ public class RegisterTests
         problem.Should().NotBeNull();
         problem!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_WithTenantSlug_SendsSlugOnCommand()
+    {
+        var request = new RegisterRequest("user@example.com", "Password123!", "Password123!", "xK9mP2qR");
+        _mediator.Send(Arg.Any<RegisterCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+
+        await _endpoint.ExecuteAsync(request, default);
+
+        await _mediator.Received(1).Send(
+            Arg.Is<RegisterCommand>(command => command.TenantSlug == "xK9mP2qR"),
+            Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Endatix.Api.Tests/Endpoints/Auth/RegisterTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Auth/RegisterTests.cs
@@ -38,7 +38,7 @@ public class RegisterTests
         okResponse.Should().NotBeNull();
         _endpoint.HttpContext.Response.StatusCode.Should().Be(StatusCodes.Status200OK);
         okResponse!.Value!.Success.Should().BeTrue();
-        okResponse!.Value!.Message.Should().Be("User has been successfully registered");
+        okResponse!.Value!.Message.Should().Be(RegisterHandler.GENERAL_SUCCESS_MESSAGE);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/Auth/RegisterTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Auth/RegisterTests.cs
@@ -22,14 +22,17 @@ public class RegisterTests
     [Fact]
     public async Task ExecuteAsync_WithValidRequest_ReturnsOkResult()
     {
+        // Arrange
         var request = new RegisterRequest("user@example.com", "Password123!", "Password123!");
-        var successResult = Result.Success();
+        var successResult = Result<string>.Success(RegisterHandler.GENERAL_SUCCESS_MESSAGE);
 
         _mediator.Send(Arg.Any<RegisterCommand>(), Arg.Any<CancellationToken>())
             .Returns(successResult);
 
+        // Act
         var response = await _endpoint.ExecuteAsync(request, default);
 
+        // Assert
         var okResponse = response!.Result as Ok<RegisterResponse>;
 
         okResponse.Should().NotBeNull();
@@ -41,12 +44,14 @@ public class RegisterTests
     [Fact]
     public async Task ExecuteAsync_WithInvalidRequest_ReturnsProblem()
     {
+        // Arrange
         var request = new RegisterRequest("invalid@example.com", "WeakPass", "WeakPass");
-        var errorResult = Result.Invalid();
+        var errorResult = Result<string>.Invalid();
 
         _mediator.Send(Arg.Any<RegisterCommand>(), Arg.Any<CancellationToken>())
             .Returns(errorResult);
 
+        // Act
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
@@ -61,12 +66,15 @@ public class RegisterTests
     [Fact]
     public async Task ExecuteAsync_SelfRegistrationDisabled_ReturnsForbidden()
     {
+        // Arrange
         var request = new RegisterRequest("user@example.com", "Password123!", "Password123!", "xK9mP2qR");
         _mediator.Send(Arg.Any<RegisterCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Result.Forbidden("Self-registration is not enabled for this tenant."));
+            .Returns(Result<string>.Forbidden("Self-registration is not enabled for this tenant."));
 
+        // Act
         var response = await _endpoint.ExecuteAsync(request, default);
 
+        // Assert
         var problem = response!.Result as ProblemHttpResult;
         problem.Should().NotBeNull();
         problem!.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
@@ -75,12 +83,15 @@ public class RegisterTests
     [Fact]
     public async Task ExecuteAsync_UnknownTenantSlug_ReturnsNotFound()
     {
+        // Arrange
         var request = new RegisterRequest("user@example.com", "Password123!", "Password123!", "xK9mP2qR");
         _mediator.Send(Arg.Any<RegisterCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Result.NotFound("Tenant not found."));
+            .Returns(Result<string>.NotFound("Tenant not found."));
 
+        // Act
         var response = await _endpoint.ExecuteAsync(request, default);
 
+        // Assert
         var problem = response!.Result as ProblemHttpResult;
         problem.Should().NotBeNull();
         problem!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
@@ -89,12 +100,15 @@ public class RegisterTests
     [Fact]
     public async Task ExecuteAsync_WithTenantSlug_SendsSlugOnCommand()
     {
+        // Arrange
         var request = new RegisterRequest("user@example.com", "Password123!", "Password123!", "xK9mP2qR");
         _mediator.Send(Arg.Any<RegisterCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Result.Success());
+            .Returns(Result<string>.Success(RegisterHandler.GENERAL_SUCCESS_MESSAGE));
 
+        // Act
         await _endpoint.ExecuteAsync(request, default);
 
+        // Assert
         await _mediator.Received(1).Send(
             Arg.Is<RegisterCommand>(command => command.TenantSlug == "xK9mP2qR"),
             Arg.Any<CancellationToken>());

--- a/tests/Endatix.Api.Tests/Endpoints/Auth/RegisterTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Auth/RegisterTests.cs
@@ -61,7 +61,7 @@ public class RegisterTests
     [Fact]
     public async Task ExecuteAsync_SelfRegistrationDisabled_ReturnsForbidden()
     {
-        var request = new RegisterRequest("user@example.com", "Password123!", "Password123!", "xK9mP2qR8vNw");
+        var request = new RegisterRequest("user@example.com", "Password123!", "Password123!", "xK9mP2qR");
         _mediator.Send(Arg.Any<RegisterCommand>(), Arg.Any<CancellationToken>())
             .Returns(Result.Forbidden("Self-registration is not enabled for this tenant."));
 
@@ -75,7 +75,7 @@ public class RegisterTests
     [Fact]
     public async Task ExecuteAsync_UnknownTenantSlug_ReturnsNotFound()
     {
-        var request = new RegisterRequest("user@example.com", "Password123!", "Password123!", "xK9mP2qR8vNw");
+        var request = new RegisterRequest("user@example.com", "Password123!", "Password123!", "xK9mP2qR");
         _mediator.Send(Arg.Any<RegisterCommand>(), Arg.Any<CancellationToken>())
             .Returns(Result.NotFound("Tenant not found."));
 

--- a/tests/Endatix.Api.Tests/Endpoints/Auth/RegisterTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Auth/RegisterTests.cs
@@ -22,17 +22,14 @@ public class RegisterTests
     [Fact]
     public async Task ExecuteAsync_WithValidRequest_ReturnsOkResult()
     {
-        // Arrange
         var request = new RegisterRequest("user@example.com", "Password123!", "Password123!");
         var successResult = Result.Success();
 
         _mediator.Send(Arg.Any<RegisterCommand>(), Arg.Any<CancellationToken>())
             .Returns(successResult);
 
-        // Act
         var response = await _endpoint.ExecuteAsync(request, default);
 
-        // Assert
         var okResponse = response!.Result as Ok<RegisterResponse>;
 
         okResponse.Should().NotBeNull();
@@ -42,16 +39,14 @@ public class RegisterTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithInvalidRequest_ThrowsError()
+    public async Task ExecuteAsync_WithInvalidRequest_ReturnsProblem()
     {
-        // Arrange
         var request = new RegisterRequest("invalid@example.com", "WeakPass", "WeakPass");
         var errorResult = Result.Invalid();
 
         _mediator.Send(Arg.Any<RegisterCommand>(), Arg.Any<CancellationToken>())
             .Returns(errorResult);
 
-        // Act
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
@@ -61,5 +56,33 @@ public class RegisterTests
         problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
         problemResult!.ProblemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
         problemResult!.ProblemDetails.Title.Should().Be("Registration failed. Please check your input and try again.");
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SelfRegistrationDisabled_ReturnsForbidden()
+    {
+        var request = new RegisterRequest("user@example.com", "Password123!", "Password123!", "xK9mP2qR8vNw");
+        _mediator.Send(Arg.Any<RegisterCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Forbidden("Self-registration is not enabled for this tenant."));
+
+        var response = await _endpoint.ExecuteAsync(request, default);
+
+        var problem = response!.Result as ProblemHttpResult;
+        problem.Should().NotBeNull();
+        problem!.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownTenantSlug_ReturnsNotFound()
+    {
+        var request = new RegisterRequest("user@example.com", "Password123!", "Password123!", "xK9mP2qR8vNw");
+        _mediator.Send(Arg.Any<RegisterCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Result.NotFound("Tenant not found."));
+
+        var response = await _endpoint.ExecuteAsync(request, default);
+
+        var problem = response!.Result as ProblemHttpResult;
+        problem.Should().NotBeNull();
+        problem!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 }

--- a/tests/Endatix.Api.Tests/Endpoints/Public/Tenants/GetBySlugTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Public/Tenants/GetBySlugTests.cs
@@ -23,7 +23,7 @@ public sealed class GetBySlugTests
             .Returns(Result<PublicTenantDto>.NotFound("Tenant not found."));
 
         var response = await endpoint.ExecuteAsync(
-            new GetPublicTenantRequest { Slug = "xK9mP2qR8vNw" },
+            new GetPublicTenantRequest { Slug = "xK9mP2qR" },
             TestContext.Current.CancellationToken);
 
         response.Result.As<ProblemHttpResult>().StatusCode.Should().Be(StatusCodes.Status404NotFound);
@@ -35,17 +35,17 @@ public sealed class GetBySlugTests
         var endpoint = Factory.Create<GetPublicTenantEndpoint>(_mediator, _cache);
         _mediator.Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>())
             .Returns(Result.Success(new PublicTenantDto(
-                "xK9mP2qR8vNw",
+                "xK9mP2qR",
                 "Acme",
                 true,
                 ["endatix"])));
 
         var response = await endpoint.ExecuteAsync(
-            new GetPublicTenantRequest { Slug = "xK9mP2qR8vNw" },
+            new GetPublicTenantRequest { Slug = "xK9mP2qR" },
             TestContext.Current.CancellationToken);
 
         var ok = response.Result.As<Ok<PublicTenantModel>>();
-        ok.Value!.Slug.Should().Be("xK9mP2qR8vNw");
+        ok.Value!.Slug.Should().Be("xK9mP2qR");
         ok.Value.SelfRegistrationEnabled.Should().BeTrue();
         ok.Value.GetType().GetProperty("Id").Should().BeNull();
     }

--- a/tests/Endatix.Api.Tests/Endpoints/Public/Tenants/GetBySlugTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Public/Tenants/GetBySlugTests.cs
@@ -19,24 +19,30 @@ public sealed class GetBySlugTests
     [Fact]
     public async Task ExecuteAsync_UnknownSlug_ReturnsNotFound()
     {
+        // Arrange
         var endpoint = Factory.Create<GetPublicTenantEndpoint>(_mediator, _cache);
         _mediator.Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>())
             .Returns(Result<PublicTenantDto>.NotFound("Tenant not found."));
 
+        // Act
         var response = await endpoint.ExecuteAsync(
             new GetPublicTenantRequest { Slug = "xK9mP2qR" },
             TestContext.Current.CancellationToken);
 
+        // Assert
         response.Result.As<ProblemHttpResult>().StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
-    [Fact]
-    public async Task ExecuteAsync_NameLikeSlug_ReturnsNotFoundWithoutQuery()
+    [Theory]
+    [InlineData("acme")]
+    [InlineData("acme-regional-surveys")]
+    [InlineData("xk9mp2qr8")]
+    public async Task ExecuteAsync_InvalidShortUrl_ReturnsNotFoundWithoutQuery(string slug)
     {
         var endpoint = Factory.Create<GetPublicTenantEndpoint>(_mediator, _cache);
 
         var response = await endpoint.ExecuteAsync(
-            new GetPublicTenantRequest { Slug = "acme" },
+            new GetPublicTenantRequest { Slug = slug },
             TestContext.Current.CancellationToken);
 
         response.Result.As<ProblemHttpResult>().StatusCode.Should().Be(StatusCodes.Status404NotFound);
@@ -46,6 +52,7 @@ public sealed class GetBySlugTests
     [Fact]
     public async Task ExecuteAsync_Success_ReturnsDtoWithoutNumericId()
     {
+        // Arrange
         var endpoint = Factory.Create<GetPublicTenantEndpoint>(_mediator, _cache);
         _mediator.Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>())
             .Returns(Result.Success(new PublicTenantDto(
@@ -54,10 +61,12 @@ public sealed class GetBySlugTests
                 true,
                 ["endatix"])));
 
+        // Act
         var response = await endpoint.ExecuteAsync(
             new GetPublicTenantRequest { Slug = "xK9mP2qR" },
             TestContext.Current.CancellationToken);
 
+        // Assert
         var ok = response.Result.As<Ok<PublicTenantModel>>();
         ok.Value!.Slug.Should().Be("xk9mp2qr");
         ok.Value.SelfRegistrationEnabled.Should().BeTrue();
@@ -67,24 +76,29 @@ public sealed class GetBySlugTests
     [Fact]
     public async Task ExecuteAsync_Success_CachesAndSkipsSecondLookup()
     {
+        // Arrange
         var endpoint = Factory.Create<GetPublicTenantEndpoint>(_mediator, _cache);
         _mediator.Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>())
             .Returns(Result.Success(new PublicTenantDto("xk9mp2qr", "Acme", true, ["endatix"])));
         var request = new GetPublicTenantRequest { Slug = "xk9mp2qr" };
 
+        // Act
         await endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
         await endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
 
+        // Assert
         await _mediator.Received(1).Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ExecuteAsync_Success_MixedCaseSlugSharesCacheKey()
     {
+        // Arrange
         var endpoint = Factory.Create<GetPublicTenantEndpoint>(_mediator, _cache);
         _mediator.Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>())
             .Returns(Result.Success(new PublicTenantDto("xk9mp2qr", "Acme", true, ["endatix"])));
 
+        // Act
         await endpoint.ExecuteAsync(
             new GetPublicTenantRequest { Slug = "xK9mP2qR" },
             TestContext.Current.CancellationToken);
@@ -92,20 +106,24 @@ public sealed class GetBySlugTests
             new GetPublicTenantRequest { Slug = "xk9mp2qr" },
             TestContext.Current.CancellationToken);
 
+        // Assert
         await _mediator.Received(1).Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task ExecuteAsync_NotFound_DoesNotCache()
     {
+        // Arrange
         var endpoint = Factory.Create<GetPublicTenantEndpoint>(_mediator, _cache);
         _mediator.Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>())
             .Returns(Result<PublicTenantDto>.NotFound("Tenant not found."));
         var request = new GetPublicTenantRequest { Slug = "xk9mp2qr" };
 
+        // Act
         await endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
         await endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
 
+        // Assert
         await _mediator.Received(2).Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>());
     }
 

--- a/tests/Endatix.Api.Tests/Endpoints/Public/Tenants/GetBySlugTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Public/Tenants/GetBySlugTests.cs
@@ -49,4 +49,32 @@ public sealed class GetBySlugTests
         ok.Value.SelfRegistrationEnabled.Should().BeTrue();
         ok.Value.GetType().GetProperty("Id").Should().BeNull();
     }
+
+    [Fact]
+    public async Task ExecuteAsync_Success_CachesAndSkipsSecondLookup()
+    {
+        var endpoint = Factory.Create<GetPublicTenantEndpoint>(_mediator, _cache);
+        _mediator.Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new PublicTenantDto("xK9mP2qR", "Acme", true, ["endatix"])));
+        var request = new GetPublicTenantRequest { Slug = "xK9mP2qR" };
+
+        await endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+        await endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        await _mediator.Received(1).Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NotFound_DoesNotCache()
+    {
+        var endpoint = Factory.Create<GetPublicTenantEndpoint>(_mediator, _cache);
+        _mediator.Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result<PublicTenantDto>.NotFound("Tenant not found."));
+        var request = new GetPublicTenantRequest { Slug = "xK9mP2qR" };
+
+        await endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+        await endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        await _mediator.Received(2).Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Endatix.Api.Tests/Endpoints/Public/Tenants/GetBySlugTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Public/Tenants/GetBySlugTests.cs
@@ -1,0 +1,52 @@
+using Endatix.Api.Endpoints.Public.Tenants;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.Tenants.GetPublicBySlug;
+using FastEndpoints;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Caching.Memory;
+using GetPublicTenantEndpoint = Endatix.Api.Endpoints.Public.Tenants.GetBySlug;
+
+namespace Endatix.Api.Tests.Endpoints.Public.Tenants;
+
+public sealed class GetBySlugTests
+{
+    private readonly IMediator _mediator = Substitute.For<IMediator>();
+    private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+
+    [Fact]
+    public async Task ExecuteAsync_UnknownSlug_ReturnsNotFound()
+    {
+        var endpoint = Factory.Create<GetPublicTenantEndpoint>(_mediator, _cache);
+        _mediator.Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result<PublicTenantDto>.NotFound("Tenant not found."));
+
+        var response = await endpoint.ExecuteAsync(
+            new GetPublicTenantRequest { Slug = "xK9mP2qR8vNw" },
+            TestContext.Current.CancellationToken);
+
+        response.Result.As<ProblemHttpResult>().StatusCode.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Success_ReturnsDtoWithoutNumericId()
+    {
+        var endpoint = Factory.Create<GetPublicTenantEndpoint>(_mediator, _cache);
+        _mediator.Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new PublicTenantDto(
+                "xK9mP2qR8vNw",
+                "Acme",
+                true,
+                ["endatix"])));
+
+        var response = await endpoint.ExecuteAsync(
+            new GetPublicTenantRequest { Slug = "xK9mP2qR8vNw" },
+            TestContext.Current.CancellationToken);
+
+        var ok = response.Result.As<Ok<PublicTenantModel>>();
+        ok.Value!.Slug.Should().Be("xK9mP2qR8vNw");
+        ok.Value.SelfRegistrationEnabled.Should().BeTrue();
+        ok.Value.GetType().GetProperty("Id").Should().BeNull();
+    }
+}

--- a/tests/Endatix.Api.Tests/Endpoints/Public/Tenants/GetBySlugTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Public/Tenants/GetBySlugTests.cs
@@ -5,7 +5,8 @@ using FastEndpoints;
 using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
-using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
 using GetPublicTenantEndpoint = Endatix.Api.Endpoints.Public.Tenants.GetBySlug;
 
 namespace Endatix.Api.Tests.Endpoints.Public.Tenants;
@@ -13,7 +14,7 @@ namespace Endatix.Api.Tests.Endpoints.Public.Tenants;
 public sealed class GetBySlugTests
 {
     private readonly IMediator _mediator = Substitute.For<IMediator>();
-    private readonly IMemoryCache _cache = new MemoryCache(new MemoryCacheOptions());
+    private readonly HybridCache _cache = CreateCache();
 
     [Fact]
     public async Task ExecuteAsync_UnknownSlug_ReturnsNotFound()
@@ -30,12 +31,25 @@ public sealed class GetBySlugTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_NameLikeSlug_ReturnsNotFoundWithoutQuery()
+    {
+        var endpoint = Factory.Create<GetPublicTenantEndpoint>(_mediator, _cache);
+
+        var response = await endpoint.ExecuteAsync(
+            new GetPublicTenantRequest { Slug = "acme" },
+            TestContext.Current.CancellationToken);
+
+        response.Result.As<ProblemHttpResult>().StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        await _mediator.DidNotReceive().Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
     public async Task ExecuteAsync_Success_ReturnsDtoWithoutNumericId()
     {
         var endpoint = Factory.Create<GetPublicTenantEndpoint>(_mediator, _cache);
         _mediator.Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>())
             .Returns(Result.Success(new PublicTenantDto(
-                "xK9mP2qR",
+                "xk9mp2qr",
                 "Acme",
                 true,
                 ["endatix"])));
@@ -45,7 +59,7 @@ public sealed class GetBySlugTests
             TestContext.Current.CancellationToken);
 
         var ok = response.Result.As<Ok<PublicTenantModel>>();
-        ok.Value!.Slug.Should().Be("xK9mP2qR");
+        ok.Value!.Slug.Should().Be("xk9mp2qr");
         ok.Value.SelfRegistrationEnabled.Should().BeTrue();
         ok.Value.GetType().GetProperty("Id").Should().BeNull();
     }
@@ -55,11 +69,28 @@ public sealed class GetBySlugTests
     {
         var endpoint = Factory.Create<GetPublicTenantEndpoint>(_mediator, _cache);
         _mediator.Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>())
-            .Returns(Result.Success(new PublicTenantDto("xK9mP2qR", "Acme", true, ["endatix"])));
-        var request = new GetPublicTenantRequest { Slug = "xK9mP2qR" };
+            .Returns(Result.Success(new PublicTenantDto("xk9mp2qr", "Acme", true, ["endatix"])));
+        var request = new GetPublicTenantRequest { Slug = "xk9mp2qr" };
 
         await endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
         await endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
+
+        await _mediator.Received(1).Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Success_MixedCaseSlugSharesCacheKey()
+    {
+        var endpoint = Factory.Create<GetPublicTenantEndpoint>(_mediator, _cache);
+        _mediator.Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new PublicTenantDto("xk9mp2qr", "Acme", true, ["endatix"])));
+
+        await endpoint.ExecuteAsync(
+            new GetPublicTenantRequest { Slug = "xK9mP2qR" },
+            TestContext.Current.CancellationToken);
+        await endpoint.ExecuteAsync(
+            new GetPublicTenantRequest { Slug = "xk9mp2qr" },
+            TestContext.Current.CancellationToken);
 
         await _mediator.Received(1).Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>());
     }
@@ -70,11 +101,18 @@ public sealed class GetBySlugTests
         var endpoint = Factory.Create<GetPublicTenantEndpoint>(_mediator, _cache);
         _mediator.Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>())
             .Returns(Result<PublicTenantDto>.NotFound("Tenant not found."));
-        var request = new GetPublicTenantRequest { Slug = "xK9mP2qR" };
+        var request = new GetPublicTenantRequest { Slug = "xk9mp2qr" };
 
         await endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
         await endpoint.ExecuteAsync(request, TestContext.Current.CancellationToken);
 
         await _mediator.Received(2).Send(Arg.Any<GetPublicTenantQuery>(), Arg.Any<CancellationToken>());
+    }
+
+    private static HybridCache CreateCache()
+    {
+        var services = new ServiceCollection();
+        services.AddHybridCache();
+        return services.BuildServiceProvider().GetRequiredService<HybridCache>();
     }
 }

--- a/tests/Endatix.Core.Tests/Infrastructure/Logging/PiiRedactorTests.cs
+++ b/tests/Endatix.Core.Tests/Infrastructure/Logging/PiiRedactorTests.cs
@@ -49,6 +49,13 @@ public class PiiRedactorTests
 
     #region RedactEmail Tests
 
+    [Fact]
+    public void RedactEmail_DiscardsInputAndDoesNotEmitTheAddress()
+    {
+        PiiRedactor.RedactEmail("john.doe@example.com").Should().Be(PiiRedactor.REDACTED_EMAIL);
+        PiiRedactor.RedactEmail(null).Should().Be(PiiRedactor.REDACTED_EMAIL);
+    }
+
     [Theory]
     [InlineData("john.doe@example.com")]
     [InlineData("test@domain.com")]

--- a/tests/Endatix.Core.Tests/Specifications/EmailVerificationTokenByTokenSpecTests.cs
+++ b/tests/Endatix.Core.Tests/Specifications/EmailVerificationTokenByTokenSpecTests.cs
@@ -1,0 +1,77 @@
+using Ardalis.Specification;
+using Endatix.Core.Entities.Identity;
+using Endatix.Core.Specifications;
+
+namespace Endatix.Core.Tests.Specifications;
+
+public class EmailVerificationTokenByTokenSpecTests
+{
+    private const string RawToken = "hLQ2m9xTf0sVrN7pKd4eYb1uAg6ZjC3o";
+    private const long USER_ID = 4242;
+
+    [Fact]
+    public void Constructor_RawToken_MatchesTheStoredHash()
+    {
+        // Arrange
+        var stored = ExistingToken();
+        var spec = new EmailVerificationTokenByTokenSpec(RawToken);
+
+        // Act
+        var matches = Matches(spec, stored);
+
+        // Assert
+        matches.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Constructor_PaddedRawToken_MatchesTheStoredHash()
+    {
+        // Arrange - links pasted out of an email client arrive with stray whitespace.
+        var stored = ExistingToken();
+        var spec = new EmailVerificationTokenByTokenSpec($"  {RawToken}\n");
+
+        // Act
+        var matches = Matches(spec, stored);
+
+        // Assert
+        matches.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Constructor_StoredHashPresentedAsToken_DoesNotMatch()
+    {
+        // Arrange - the column holds a hash precisely so that read access to the table is not read
+        // access to the tokens. Accepting the stored value verbatim would make it replayable, and
+        // anyone who could read a backup or a replica could verify any pending account.
+        var stored = ExistingToken();
+        var spec = new EmailVerificationTokenByTokenSpec(stored.Token);
+
+        // Act
+        var matches = Matches(spec, stored);
+
+        // Assert
+        matches.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Constructor_UnrelatedToken_DoesNotMatch()
+    {
+        // Arrange
+        var stored = ExistingToken();
+        var spec = new EmailVerificationTokenByTokenSpec("a-different-token");
+
+        // Act
+        var matches = Matches(spec, stored);
+
+        // Assert
+        matches.Should().BeFalse();
+    }
+
+    private static EmailVerificationToken ExistingToken() =>
+        new(USER_ID, RawToken, DateTime.UtcNow.AddHours(1));
+
+    private static bool Matches(
+        ISpecification<EmailVerificationToken> spec,
+        EmailVerificationToken token) =>
+        spec.WhereExpressions.All(where => where.FilterFunc(token));
+}

--- a/tests/Endatix.Core.Tests/UseCases/Identity/Register/RegisterHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Identity/Register/RegisterHandlerTests.cs
@@ -14,9 +14,10 @@ public class RegisterHandlerTests
 {
     private const string Slug = "xk9mp2qr";
     private const long TenantId = 99;
+    private const string RegistrationRole = "Respondent";
+    private const string Password = "Password123!";
 
     private readonly IUserRegistrationService _userRegistrationService;
-    private readonly IUserService _userService;
     private readonly IRepository<CoreEntities.Tenant> _tenantRepository;
     private readonly IRepository<CoreEntities.TenantSettings> _tenantSettingsRepository;
     private readonly IRoleManagementService _roleManagementService;
@@ -26,16 +27,15 @@ public class RegisterHandlerTests
     public RegisterHandlerTests()
     {
         _userRegistrationService = Substitute.For<IUserRegistrationService>();
-        _userService = Substitute.For<IUserService>();
         _tenantRepository = Substitute.For<IRepository<CoreEntities.Tenant>>();
         _tenantSettingsRepository = Substitute.For<IRepository<CoreEntities.TenantSettings>>();
         _roleManagementService = Substitute.For<IRoleManagementService>();
         _mediator = Substitute.For<IMediator>();
-        _userService.GetUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(Result<User>.NotFound());
+        _roleManagementService
+            .GetMissingAssignableRoleNamesAsync(Arg.Any<IReadOnlyList<string>>(), Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Result<IReadOnlyList<string>>.Success([]));
         _handler = new RegisterHandler(
             _userRegistrationService,
-            _userService,
             _tenantRepository,
             _tenantSettingsRepository,
             _roleManagementService,
@@ -45,17 +45,17 @@ public class RegisterHandlerTests
     [Fact]
     public async Task Handle_RegistrationFails_ReturnsFailureResult()
     {
+        // Arrange
         var email = "test@example.com";
         var password = "password";
         var request = new RegisterCommand(email, password);
-        var failureResult = Result<User>.Error("Registration failed");
-
         _userRegistrationService.RegisterUserAsync(email, password, Arg.Any<CancellationToken>())
-            .Returns(failureResult);
+            .Returns(Result<User>.Error("Registration failed"));
 
+        // Act
         var result = await _handler.Handle(request, CancellationToken.None);
 
-        result.Should().NotBeNull();
+        // Assert
         result.IsSuccess.Should().BeFalse();
         result.Errors.Should().Contain("Registration failed");
     }
@@ -63,53 +63,48 @@ public class RegisterHandlerTests
     [Fact]
     public async Task Handle_SuccessfulRegistration_PublishesEventAndReturnsSuccess()
     {
+        // Arrange
         var email = "test@example.com";
         var password = "password";
-        var tenantId = 1L;
         var request = new RegisterCommand(email, password);
-        var user = new User(1, tenantId, email, email, true);
-        var successResult = Result<User>.Success(user);
-
+        var user = new User(1, 1L, email, email, true);
         _userRegistrationService.RegisterUserAsync(email, password, Arg.Any<CancellationToken>())
-            .Returns(successResult);
+            .Returns(Result<User>.Success(user));
 
+        // Act
         var result = await _handler.Handle(request, CancellationToken.None);
 
-        result.Should().NotBeNull();
+        // Assert
         result.IsSuccess.Should().BeTrue();
-        result.Value.Should().Be(user);
-
+        result.Value.Should().Be(RegisterHandler.GENERAL_SUCCESS_MESSAGE);
         await _mediator.Received(1).Publish(
             Arg.Is<UserRegisteredEvent>(e => e.User == user),
-            Arg.Any<CancellationToken>()
-        );
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
     public async Task Handle_UnknownTenantSlug_ReturnsNotFound()
     {
-        _tenantRepository
-            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveByShortUrlSpec>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult<CoreEntities.Tenant?>(null));
+        // Arrange
+        ArrangeTenant(null);
 
+        // Act
         var result = await _handler.Handle(
             new RegisterCommand("user@example.com", "Password123!", Slug),
             TestContext.Current.CancellationToken);
 
+        // Assert
         result.Status.Should().Be(ResultStatus.NotFound);
-        await _userRegistrationService.DidNotReceive().RegisterUserAsync(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<long>(),
-            Arg.Any<bool>(),
-            Arg.Any<CancellationToken>());
+        await DidNotRegister();
     }
 
-    [Fact]
-    public async Task Handle_NameLikeSlug_ReturnsNotFound()
+    [Theory]
+    [InlineData("acme")]
+    [InlineData("acme-regional-surveys")]
+    public async Task Handle_InvalidShortUrl_ReturnsNotFoundWithoutQuerying(string tenantSlug)
     {
         var result = await _handler.Handle(
-            new RegisterCommand("user@example.com", "Password123!", "acme"),
+            new RegisterCommand("user@example.com", "Password123!", tenantSlug),
             TestContext.Current.CancellationToken);
 
         result.Status.Should().Be(ResultStatus.NotFound);
@@ -121,124 +116,195 @@ public class RegisterHandlerTests
     [Fact]
     public async Task Handle_SelfRegistrationDisabled_ReturnsForbidden()
     {
-        CoreEntities.Tenant tenant = new("Acme", Slug) { Id = TenantId };
-        CoreEntities.TenantSettings settings = new(TenantId);
-        _tenantRepository
-            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveByShortUrlSpec>(), Arg.Any<CancellationToken>())
-            .Returns(tenant);
-        _tenantSettingsRepository
-            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.SettingsByTenantIdSpec>(), Arg.Any<CancellationToken>())
-            .Returns(settings);
+        // Arrange
+        ArrangeTenant(NewTenant());
+        ArrangeSettings(new CoreEntities.TenantSettings(TenantId));
 
+        // Act
         var result = await _handler.Handle(
             new RegisterCommand("user@example.com", "Password123!", Slug),
             TestContext.Current.CancellationToken);
 
+        // Assert
         result.Status.Should().Be(ResultStatus.Forbidden);
-        await _userRegistrationService.DidNotReceive().RegisterUserAsync(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<long>(),
-            Arg.Any<bool>(),
-            Arg.Any<CancellationToken>());
+        await DidNotRegister();
     }
 
     [Fact]
     public async Task Handle_PlatformAdminDefaultRole_ReturnsInvalid()
     {
-        CoreEntities.Tenant tenant = new("Acme", Slug) { Id = TenantId };
-        CoreEntities.TenantSettings settings = new(TenantId);
-        settings.UpdateSelfRegistrationPolicy(true, ["endatix"], "Respondent");
+        // Arrange
+        ArrangeTenant(NewTenant());
+        var settings = EnabledSettings();
         typeof(CoreEntities.TenantSettings)
             .GetProperty(nameof(CoreEntities.TenantSettings.DefaultRegistrationRoleName))!
             .SetValue(settings, "PlatformAdmin");
-        _tenantRepository
-            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveByShortUrlSpec>(), Arg.Any<CancellationToken>())
-            .Returns(tenant);
-        _tenantSettingsRepository
-            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.SettingsByTenantIdSpec>(), Arg.Any<CancellationToken>())
-            .Returns(settings);
+        ArrangeSettings(settings);
 
+        // Act
         var result = await _handler.Handle(
             new RegisterCommand("user@example.com", "Password123!", Slug),
             TestContext.Current.CancellationToken);
 
+        // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
         result.ValidationErrors.Should().Contain(error =>
             error.Identifier == nameof(CoreEntities.TenantSettings.DefaultRegistrationRoleName));
-        await _userRegistrationService.DidNotReceive().RegisterUserAsync(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<long>(),
-            Arg.Any<bool>(),
-            Arg.Any<CancellationToken>());
+        await DidNotRegister();
     }
 
     [Fact]
-    public async Task Handle_TenantSlug_ExistingEmail_ReturnsInvalidAndDoesNotRegister()
+    public async Task Handle_DefaultRoleNotAssignable_ReturnsInvalidWithoutCreatingUser()
     {
-        var email = "existing@example.com";
-        CoreEntities.Tenant tenant = new("Acme", Slug) { Id = TenantId };
-        CoreEntities.TenantSettings settings = new(TenantId);
-        settings.UpdateSelfRegistrationPolicy(true, ["endatix"], "Respondent");
-        _tenantRepository
-            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveByShortUrlSpec>(), Arg.Any<CancellationToken>())
-            .Returns(tenant);
-        _tenantSettingsRepository
-            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.SettingsByTenantIdSpec>(), Arg.Any<CancellationToken>())
-            .Returns(settings);
-        _userService.GetUserAsync(email, Arg.Any<CancellationToken>())
-            .Returns(Result<User>.Success(new User(7, TenantId, email, email, true)));
+        // Arrange
+        ArrangeTenant(NewTenant());
+        ArrangeSettings(EnabledSettings());
+        _roleManagementService
+            .GetMissingAssignableRoleNamesAsync(Arg.Any<IReadOnlyList<string>>(), TenantId, Arg.Any<CancellationToken>())
+            .Returns(Result<IReadOnlyList<string>>.Success([RegistrationRole]));
 
+        // Act
         var result = await _handler.Handle(
-            new RegisterCommand(email, "Password123!", Slug),
+            new RegisterCommand("user@example.com", "Password123!", Slug),
             TestContext.Current.CancellationToken);
 
+        // Assert
         result.Status.Should().Be(ResultStatus.Invalid);
-        await _userRegistrationService.DidNotReceive().RegisterUserAsync(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<long>(),
-            Arg.Any<bool>(),
-            Arg.Any<CancellationToken>());
-        await _roleManagementService.DidNotReceive().AssignRoleToUserAsync(
-            Arg.Any<long>(),
-            Arg.Any<string>(),
-            Arg.Any<long>(),
-            Arg.Any<CancellationToken>());
+        result.ValidationErrors.Should().Contain(error =>
+            error.Identifier == nameof(CoreEntities.TenantSettings.DefaultRegistrationRoleName));
+        await DidNotRegister();
     }
 
     [Fact]
-    public async Task Handle_TenantSlugEnabled_RegistersAndAssignsSharedSystemRole()
+    public async Task Handle_TenantSlugEnabled_RegistersTenantUserWithDefaultRole()
     {
+        // Arrange
         var email = "user@example.com";
         var password = "Password123!";
-        CoreEntities.Tenant tenant = new("Acme", Slug) { Id = TenantId };
-        CoreEntities.TenantSettings settings = new(TenantId);
-        settings.UpdateSelfRegistrationPolicy(true, ["endatix"], "Respondent");
         var user = new User(7, TenantId, email, email, false);
-        _tenantRepository
-            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveByShortUrlSpec>(), Arg.Any<CancellationToken>())
-            .Returns(tenant);
-        _tenantSettingsRepository
-            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.SettingsByTenantIdSpec>(), Arg.Any<CancellationToken>())
-            .Returns(settings);
+        ArrangeTenant(NewTenant());
+        ArrangeSettings(EnabledSettings());
         _userRegistrationService
-            .RegisterUserAsync(email, password, TenantId, false, Arg.Any<CancellationToken>())
+            .RegisterTenantUserAsync(email, password, TenantId, RegistrationRole, Arg.Any<CancellationToken>())
             .Returns(Result<User>.Success(user));
-        _roleManagementService
-            .AssignRoleToUserAsync(user.Id, "Respondent", TenantId, Arg.Any<CancellationToken>())
-            .Returns(Result.Success());
 
+        // Act
         var result = await _handler.Handle(
             new RegisterCommand(email, password, Slug),
             TestContext.Current.CancellationToken);
 
+        // Assert
         result.Status.Should().Be(ResultStatus.Ok);
-        await _roleManagementService.Received(1).AssignRoleToUserAsync(
-            user.Id,
-            "Respondent",
+        result.Value.Should().Be(RegisterHandler.GENERAL_SUCCESS_MESSAGE);
+        await _userRegistrationService.Received(1).RegisterTenantUserAsync(
+            email,
+            password,
             TenantId,
+            RegistrationRole,
+            Arg.Any<CancellationToken>());
+        await _mediator.Received(1).Publish(
+            Arg.Is<UserRegisteredEvent>(e => e.User == user),
             Arg.Any<CancellationToken>());
     }
+
+    [Fact]
+    public async Task Handle_TenantRegistrationFails_DoesNotPublishUserRegisteredEvent()
+    {
+        // Arrange
+        ArrangeTenant(NewTenant());
+        ArrangeSettings(EnabledSettings());
+        _userRegistrationService
+            .RegisterTenantUserAsync(
+                Arg.Any<string>(), Arg.Any<string>(), TenantId, RegistrationRole, Arg.Any<CancellationToken>())
+            .Returns(Result<User>.Invalid(new ValidationError("The email is from a suspicious domain.")));
+
+        // Act
+        var result = await _handler.Handle(
+            new RegisterCommand("user@example.com", "Password123!", Slug),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        await _mediator.DidNotReceive().Publish(Arg.Any<UserRegisteredEvent>(), Arg.Any<CancellationToken>());
+    }
+
+    #region Security and Privacy Tests
+
+    [Fact]
+    public async Task Handle_TenantSlug_EmailAlreadyRegistered_IsIndistinguishableFromNewAccount()
+    {
+        // Arrange
+        var newAccount = new User(7, TenantId, "new@example.com", "new@example.com", false);
+        ArrangeTenant(NewTenant());
+        ArrangeSettings(EnabledSettings());
+        _userRegistrationService
+            .RegisterTenantUserAsync("new@example.com", Password, TenantId, RegistrationRole, Arg.Any<CancellationToken>())
+            .Returns(Result<User>.Success(newAccount));
+        _userRegistrationService
+            .RegisterTenantUserAsync("taken@example.com", Password, TenantId, RegistrationRole, Arg.Any<CancellationToken>())
+            .Returns(Result<User>.NoContent());
+
+        // Act
+        var created = await _handler.Handle(
+            new RegisterCommand("new@example.com", Password, Slug), TestContext.Current.CancellationToken);
+        var taken = await _handler.Handle(
+            new RegisterCommand("taken@example.com", Password, Slug), TestContext.Current.CancellationToken);
+
+        // Assert
+        taken.Status.Should().Be(created.Status);
+        taken.Value.Should().Be(created.Value);
+        taken.Value.Should().NotContain("already");
+        await _mediator.Received(1).Publish(Arg.Any<UserRegisteredEvent>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_Unattached_EmailAlreadyRegistered_IsIndistinguishableFromNewAccount()
+    {
+        // Arrange
+        var newAccount = new User(1, 0, "new@example.com", "new@example.com", false);
+        _userRegistrationService.RegisterUserAsync("new@example.com", Password, Arg.Any<CancellationToken>())
+            .Returns(Result<User>.Success(newAccount));
+        _userRegistrationService.RegisterUserAsync("taken@example.com", Password, Arg.Any<CancellationToken>())
+            .Returns(Result<User>.NoContent());
+
+        // Act
+        var created = await _handler.Handle(
+            new RegisterCommand("new@example.com", Password), TestContext.Current.CancellationToken);
+        var taken = await _handler.Handle(
+            new RegisterCommand("taken@example.com", Password), TestContext.Current.CancellationToken);
+
+        // Assert
+        taken.Status.Should().Be(created.Status);
+        taken.Value.Should().Be(created.Value);
+        await _mediator.Received(1).Publish(Arg.Any<UserRegisteredEvent>(), Arg.Any<CancellationToken>());
+    }
+
+    #endregion
+
+    private static CoreEntities.Tenant NewTenant() => new("Acme", Slug) { Id = TenantId };
+
+    private static CoreEntities.TenantSettings EnabledSettings()
+    {
+        CoreEntities.TenantSettings settings = new(TenantId);
+        settings.UpdateSelfRegistrationPolicy(true, ["endatix"], RegistrationRole);
+        return settings;
+    }
+
+    private void ArrangeTenant(CoreEntities.Tenant? tenant) =>
+        _tenantRepository
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveByShortUrlSpec>(), Arg.Any<CancellationToken>())
+            .Returns(tenant);
+
+    private void ArrangeSettings(CoreEntities.TenantSettings settings) =>
+        _tenantSettingsRepository
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.SettingsByTenantIdSpec>(), Arg.Any<CancellationToken>())
+            .Returns(settings);
+
+    private async Task DidNotRegister() =>
+        await _userRegistrationService.DidNotReceive().RegisterTenantUserAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<long>(),
+            Arg.Any<string>(),
+            Arg.Any<CancellationToken>());
 }

--- a/tests/Endatix.Core.Tests/UseCases/Identity/Register/RegisterHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Identity/Register/RegisterHandlerTests.cs
@@ -12,7 +12,7 @@ namespace Endatix.Core.Tests.UseCases.Identity.Register;
 
 public class RegisterHandlerTests
 {
-    private const string Slug = "xK9mP2qR8vNw";
+    private const string Slug = "xK9mP2qR";
     private const long TenantId = 99;
 
     private readonly IUserRegistrationService _userRegistrationService;

--- a/tests/Endatix.Core.Tests/UseCases/Identity/Register/RegisterHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Identity/Register/RegisterHandlerTests.cs
@@ -12,7 +12,7 @@ namespace Endatix.Core.Tests.UseCases.Identity.Register;
 
 public class RegisterHandlerTests
 {
-    private const string Slug = "xK9mP2qR";
+    private const string Slug = "xk9mp2qr";
     private const long TenantId = 99;
 
     private readonly IUserRegistrationService _userRegistrationService;
@@ -89,7 +89,7 @@ public class RegisterHandlerTests
     public async Task Handle_UnknownTenantSlug_ReturnsNotFound()
     {
         _tenantRepository
-            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveBySlugSpec>(), Arg.Any<CancellationToken>())
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveByShortUrlSpec>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<CoreEntities.Tenant?>(null));
 
         var result = await _handler.Handle(
@@ -114,7 +114,7 @@ public class RegisterHandlerTests
 
         result.Status.Should().Be(ResultStatus.NotFound);
         await _tenantRepository.DidNotReceive().SingleOrDefaultAsync(
-            Arg.Any<TenantSpecifications.LiveBySlugSpec>(),
+            Arg.Any<TenantSpecifications.LiveByShortUrlSpec>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -124,7 +124,7 @@ public class RegisterHandlerTests
         CoreEntities.Tenant tenant = new("Acme", Slug) { Id = TenantId };
         CoreEntities.TenantSettings settings = new(TenantId);
         _tenantRepository
-            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveBySlugSpec>(), Arg.Any<CancellationToken>())
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveByShortUrlSpec>(), Arg.Any<CancellationToken>())
             .Returns(tenant);
         _tenantSettingsRepository
             .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.SettingsByTenantIdSpec>(), Arg.Any<CancellationToken>())
@@ -153,7 +153,7 @@ public class RegisterHandlerTests
             .GetProperty(nameof(CoreEntities.TenantSettings.DefaultRegistrationRoleName))!
             .SetValue(settings, "PlatformAdmin");
         _tenantRepository
-            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveBySlugSpec>(), Arg.Any<CancellationToken>())
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveByShortUrlSpec>(), Arg.Any<CancellationToken>())
             .Returns(tenant);
         _tenantSettingsRepository
             .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.SettingsByTenantIdSpec>(), Arg.Any<CancellationToken>())
@@ -182,7 +182,7 @@ public class RegisterHandlerTests
         CoreEntities.TenantSettings settings = new(TenantId);
         settings.UpdateSelfRegistrationPolicy(true, ["endatix"], "Respondent");
         _tenantRepository
-            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveBySlugSpec>(), Arg.Any<CancellationToken>())
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveByShortUrlSpec>(), Arg.Any<CancellationToken>())
             .Returns(tenant);
         _tenantSettingsRepository
             .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.SettingsByTenantIdSpec>(), Arg.Any<CancellationToken>())
@@ -218,7 +218,7 @@ public class RegisterHandlerTests
         settings.UpdateSelfRegistrationPolicy(true, ["endatix"], "Respondent");
         var user = new User(7, TenantId, email, email, false);
         _tenantRepository
-            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveBySlugSpec>(), Arg.Any<CancellationToken>())
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveByShortUrlSpec>(), Arg.Any<CancellationToken>())
             .Returns(tenant);
         _tenantSettingsRepository
             .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.SettingsByTenantIdSpec>(), Arg.Any<CancellationToken>())

--- a/tests/Endatix.Core.Tests/UseCases/Identity/Register/RegisterHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Identity/Register/RegisterHandlerTests.cs
@@ -261,7 +261,7 @@ public class RegisterHandlerTests
     public async Task Handle_Unattached_EmailAlreadyRegistered_IsIndistinguishableFromNewAccount()
     {
         // Arrange
-        var newAccount = new User(1, 0, "new@example.com", "new@example.com", false);
+        var newAccount = new User(1, "new@example.com", "new@example.com", false);
         _userRegistrationService.RegisterUserAsync("new@example.com", Password, Arg.Any<CancellationToken>())
             .Returns(Result<User>.Success(newAccount));
         _userRegistrationService.RegisterUserAsync("taken@example.com", Password, Arg.Any<CancellationToken>())

--- a/tests/Endatix.Core.Tests/UseCases/Identity/Register/RegisterHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Identity/Register/RegisterHandlerTests.cs
@@ -1,43 +1,55 @@
 using Endatix.Core.Abstractions;
 using Endatix.Core.Entities.Identity;
 using Endatix.Core.Events;
+using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
 using Endatix.Core.UseCases.Identity.Register;
 using MediatR;
-using static Endatix.Core.Tests.ErrorMessages;
-using static Endatix.Core.Tests.ErrorType;
+using CoreEntities = Endatix.Core.Entities;
 
 namespace Endatix.Core.Tests.UseCases.Identity.Register;
 
 public class RegisterHandlerTests
 {
+    private const string Slug = "xK9mP2qR8vNw";
+    private const long TenantId = 99;
+
     private readonly IUserRegistrationService _userRegistrationService;
+    private readonly IRepository<CoreEntities.Tenant> _tenantRepository;
+    private readonly IRepository<CoreEntities.TenantSettings> _tenantSettingsRepository;
+    private readonly IRoleManagementService _roleManagementService;
     private readonly IMediator _mediator;
     private readonly RegisterHandler _handler;
 
     public RegisterHandlerTests()
     {
         _userRegistrationService = Substitute.For<IUserRegistrationService>();
+        _tenantRepository = Substitute.For<IRepository<CoreEntities.Tenant>>();
+        _tenantSettingsRepository = Substitute.For<IRepository<CoreEntities.TenantSettings>>();
+        _roleManagementService = Substitute.For<IRoleManagementService>();
         _mediator = Substitute.For<IMediator>();
-        _handler = new RegisterHandler(_userRegistrationService, _mediator);
+        _handler = new RegisterHandler(
+            _userRegistrationService,
+            _tenantRepository,
+            _tenantSettingsRepository,
+            _roleManagementService,
+            _mediator);
     }
 
     [Fact]
     public async Task Handle_RegistrationFails_ReturnsFailureResult()
     {
-        // Arrange
         var email = "test@example.com";
         var password = "password";
         var request = new RegisterCommand(email, password);
         var failureResult = Result<User>.Error("Registration failed");
-        
+
         _userRegistrationService.RegisterUserAsync(email, password, Arg.Any<CancellationToken>())
             .Returns(failureResult);
 
-        // Act
         var result = await _handler.Handle(request, CancellationToken.None);
 
-        // Assert
         result.Should().NotBeNull();
         result.IsSuccess.Should().BeFalse();
         result.Errors.Should().Contain("Registration failed");
@@ -46,7 +58,6 @@ public class RegisterHandlerTests
     [Fact]
     public async Task Handle_SuccessfulRegistration_PublishesEventAndReturnsSuccess()
     {
-        // Arrange
         var email = "test@example.com";
         var password = "password";
         var tenantId = 1L;
@@ -57,10 +68,8 @@ public class RegisterHandlerTests
         _userRegistrationService.RegisterUserAsync(email, password, Arg.Any<CancellationToken>())
             .Returns(successResult);
 
-        // Act
         var result = await _handler.Handle(request, CancellationToken.None);
 
-        // Assert
         result.Should().NotBeNull();
         result.IsSuccess.Should().BeTrue();
         result.Value.Should().Be(user);
@@ -69,5 +78,128 @@ public class RegisterHandlerTests
             Arg.Is<UserRegisteredEvent>(e => e.User == user),
             Arg.Any<CancellationToken>()
         );
+    }
+
+    [Fact]
+    public async Task Handle_UnknownTenantSlug_ReturnsNotFound()
+    {
+        _tenantRepository
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveBySlugSpec>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<CoreEntities.Tenant?>(null));
+
+        var result = await _handler.Handle(
+            new RegisterCommand("user@example.com", "Password123!", Slug),
+            TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+        await _userRegistrationService.DidNotReceive().RegisterUserAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<long>(),
+            Arg.Any<bool>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_NameLikeSlug_ReturnsNotFound()
+    {
+        var result = await _handler.Handle(
+            new RegisterCommand("user@example.com", "Password123!", "acme"),
+            TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+        await _tenantRepository.DidNotReceive().SingleOrDefaultAsync(
+            Arg.Any<TenantSpecifications.LiveBySlugSpec>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_SelfRegistrationDisabled_ReturnsForbidden()
+    {
+        CoreEntities.Tenant tenant = new("Acme", Slug) { Id = TenantId };
+        CoreEntities.TenantSettings settings = new(TenantId);
+        _tenantRepository
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveBySlugSpec>(), Arg.Any<CancellationToken>())
+            .Returns(tenant);
+        _tenantSettingsRepository
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.SettingsByTenantIdSpec>(), Arg.Any<CancellationToken>())
+            .Returns(settings);
+
+        var result = await _handler.Handle(
+            new RegisterCommand("user@example.com", "Password123!", Slug),
+            TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.Forbidden);
+        await _userRegistrationService.DidNotReceive().RegisterUserAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<long>(),
+            Arg.Any<bool>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_PlatformAdminDefaultRole_ReturnsInvalid()
+    {
+        CoreEntities.Tenant tenant = new("Acme", Slug) { Id = TenantId };
+        CoreEntities.TenantSettings settings = new(TenantId);
+        settings.UpdateSelfRegistrationPolicy(true, ["endatix"], "Respondent");
+        typeof(CoreEntities.TenantSettings)
+            .GetProperty(nameof(CoreEntities.TenantSettings.DefaultRegistrationRoleName))!
+            .SetValue(settings, "PlatformAdmin");
+        _tenantRepository
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveBySlugSpec>(), Arg.Any<CancellationToken>())
+            .Returns(tenant);
+        _tenantSettingsRepository
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.SettingsByTenantIdSpec>(), Arg.Any<CancellationToken>())
+            .Returns(settings);
+
+        var result = await _handler.Handle(
+            new RegisterCommand("user@example.com", "Password123!", Slug),
+            TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().Contain(error =>
+            error.Identifier == nameof(CoreEntities.TenantSettings.DefaultRegistrationRoleName));
+        await _userRegistrationService.DidNotReceive().RegisterUserAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<long>(),
+            Arg.Any<bool>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_TenantSlugEnabled_RegistersAndAssignsTenantScopedRole()
+    {
+        var email = "user@example.com";
+        var password = "Password123!";
+        CoreEntities.Tenant tenant = new("Acme", Slug) { Id = TenantId };
+        CoreEntities.TenantSettings settings = new(TenantId);
+        settings.UpdateSelfRegistrationPolicy(true, ["endatix"], "Respondent");
+        var user = new User(7, TenantId, email, email, false);
+        _tenantRepository
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveBySlugSpec>(), Arg.Any<CancellationToken>())
+            .Returns(tenant);
+        _tenantSettingsRepository
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.SettingsByTenantIdSpec>(), Arg.Any<CancellationToken>())
+            .Returns(settings);
+        _userRegistrationService
+            .RegisterUserAsync(email, password, TenantId, false, Arg.Any<CancellationToken>())
+            .Returns(Result<User>.Success(user));
+        _roleManagementService
+            .AssignRoleToUserAsync(user.Id, "Respondent", TenantId, Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+
+        var result = await _handler.Handle(
+            new RegisterCommand(email, password, Slug),
+            TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        await _roleManagementService.Received(1).AssignRoleToUserAsync(
+            user.Id,
+            "Respondent",
+            TenantId,
+            Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/Identity/Register/RegisterHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Identity/Register/RegisterHandlerTests.cs
@@ -16,6 +16,7 @@ public class RegisterHandlerTests
     private const long TenantId = 99;
 
     private readonly IUserRegistrationService _userRegistrationService;
+    private readonly IUserService _userService;
     private readonly IRepository<CoreEntities.Tenant> _tenantRepository;
     private readonly IRepository<CoreEntities.TenantSettings> _tenantSettingsRepository;
     private readonly IRoleManagementService _roleManagementService;
@@ -25,12 +26,16 @@ public class RegisterHandlerTests
     public RegisterHandlerTests()
     {
         _userRegistrationService = Substitute.For<IUserRegistrationService>();
+        _userService = Substitute.For<IUserService>();
         _tenantRepository = Substitute.For<IRepository<CoreEntities.Tenant>>();
         _tenantSettingsRepository = Substitute.For<IRepository<CoreEntities.TenantSettings>>();
         _roleManagementService = Substitute.For<IRoleManagementService>();
         _mediator = Substitute.For<IMediator>();
+        _userService.GetUserAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(Result<User>.NotFound());
         _handler = new RegisterHandler(
             _userRegistrationService,
+            _userService,
             _tenantRepository,
             _tenantSettingsRepository,
             _roleManagementService,
@@ -166,6 +171,40 @@ public class RegisterHandlerTests
             Arg.Any<string>(),
             Arg.Any<long>(),
             Arg.Any<bool>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_TenantSlug_ExistingEmail_ReturnsInvalidAndDoesNotRegister()
+    {
+        var email = "existing@example.com";
+        CoreEntities.Tenant tenant = new("Acme", Slug) { Id = TenantId };
+        CoreEntities.TenantSettings settings = new(TenantId);
+        settings.UpdateSelfRegistrationPolicy(true, ["endatix"], "Respondent");
+        _tenantRepository
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveBySlugSpec>(), Arg.Any<CancellationToken>())
+            .Returns(tenant);
+        _tenantSettingsRepository
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.SettingsByTenantIdSpec>(), Arg.Any<CancellationToken>())
+            .Returns(settings);
+        _userService.GetUserAsync(email, Arg.Any<CancellationToken>())
+            .Returns(Result<User>.Success(new User(7, TenantId, email, email, true)));
+
+        var result = await _handler.Handle(
+            new RegisterCommand(email, "Password123!", Slug),
+            TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.Invalid);
+        await _userRegistrationService.DidNotReceive().RegisterUserAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<long>(),
+            Arg.Any<bool>(),
+            Arg.Any<CancellationToken>());
+        await _roleManagementService.DidNotReceive().AssignRoleToUserAsync(
+            Arg.Any<long>(),
+            Arg.Any<string>(),
+            Arg.Any<long>(),
             Arg.Any<CancellationToken>());
     }
 

--- a/tests/Endatix.Core.Tests/UseCases/Identity/Register/RegisterHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Identity/Register/RegisterHandlerTests.cs
@@ -209,7 +209,7 @@ public class RegisterHandlerTests
     }
 
     [Fact]
-    public async Task Handle_TenantSlugEnabled_RegistersAndAssignsTenantScopedRole()
+    public async Task Handle_TenantSlugEnabled_RegistersAndAssignsSharedSystemRole()
     {
         var email = "user@example.com";
         var password = "Password123!";

--- a/tests/Endatix.Core.Tests/UseCases/Tenants/GetPublicBySlug/GetPublicTenantHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Tenants/GetPublicBySlug/GetPublicTenantHandlerTests.cs
@@ -8,7 +8,7 @@ namespace Endatix.Core.Tests.UseCases.Tenants.GetPublicBySlug;
 
 public class GetPublicTenantHandlerTests
 {
-    private const string Slug = "xK9mP2qR";
+    private const string Slug = "xk9mp2qr";
     private const long TenantId = 4242;
 
     private readonly IRepository<CoreEntities.Tenant> _tenantRepository;
@@ -29,7 +29,7 @@ public class GetPublicTenantHandlerTests
 
         result.Status.Should().Be(ResultStatus.NotFound);
         await _tenantRepository.DidNotReceive().SingleOrDefaultAsync(
-            Arg.Any<TenantSpecifications.LiveBySlugSpec>(),
+            Arg.Any<TenantSpecifications.LiveByShortUrlSpec>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -37,7 +37,7 @@ public class GetPublicTenantHandlerTests
     public async Task Handle_UnknownSlug_ReturnsNotFound()
     {
         _tenantRepository
-            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveBySlugSpec>(), Arg.Any<CancellationToken>())
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveByShortUrlSpec>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<CoreEntities.Tenant?>(null));
 
         var result = await _sut.Handle(new GetPublicTenantQuery(Slug), TestContext.Current.CancellationToken);
@@ -52,7 +52,7 @@ public class GetPublicTenantHandlerTests
         CoreEntities.TenantSettings settings = new(TenantId);
         settings.UpdateSelfRegistrationPolicy(true, ["google", "endatix"], "Respondent");
         _tenantRepository
-            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveBySlugSpec>(), Arg.Any<CancellationToken>())
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveByShortUrlSpec>(), Arg.Any<CancellationToken>())
             .Returns(tenant);
         _tenantSettingsRepository
             .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.SettingsByTenantIdSpec>(), Arg.Any<CancellationToken>())

--- a/tests/Endatix.Core.Tests/UseCases/Tenants/GetPublicBySlug/GetPublicTenantHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Tenants/GetPublicBySlug/GetPublicTenantHandlerTests.cs
@@ -1,0 +1,70 @@
+using Endatix.Core.Infrastructure.Domain;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Specifications;
+using Endatix.Core.UseCases.Tenants.GetPublicBySlug;
+using CoreEntities = Endatix.Core.Entities;
+
+namespace Endatix.Core.Tests.UseCases.Tenants.GetPublicBySlug;
+
+public class GetPublicTenantHandlerTests
+{
+    private const string Slug = "xK9mP2qR8vNw";
+    private const long TenantId = 4242;
+
+    private readonly IRepository<CoreEntities.Tenant> _tenantRepository;
+    private readonly IRepository<CoreEntities.TenantSettings> _tenantSettingsRepository;
+    private readonly GetPublicTenantHandler _sut;
+
+    public GetPublicTenantHandlerTests()
+    {
+        _tenantRepository = Substitute.For<IRepository<CoreEntities.Tenant>>();
+        _tenantSettingsRepository = Substitute.For<IRepository<CoreEntities.TenantSettings>>();
+        _sut = new GetPublicTenantHandler(_tenantRepository, _tenantSettingsRepository);
+    }
+
+    [Fact]
+    public async Task Handle_NameLikeSlug_ReturnsNotFoundWithoutQuerying()
+    {
+        var result = await _sut.Handle(new GetPublicTenantQuery("acme"), TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+        await _tenantRepository.DidNotReceive().SingleOrDefaultAsync(
+            Arg.Any<TenantSpecifications.LiveBySlugSpec>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_UnknownSlug_ReturnsNotFound()
+    {
+        _tenantRepository
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveBySlugSpec>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<CoreEntities.Tenant?>(null));
+
+        var result = await _sut.Handle(new GetPublicTenantQuery(Slug), TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+    }
+
+    [Fact]
+    public async Task Handle_TenantExists_ReturnsDtoWithoutNumericId()
+    {
+        CoreEntities.Tenant tenant = new("Acme", Slug, "Primary") { Id = TenantId };
+        CoreEntities.TenantSettings settings = new(TenantId);
+        settings.UpdateSelfRegistrationPolicy(true, ["google", "endatix"], "Respondent");
+        _tenantRepository
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveBySlugSpec>(), Arg.Any<CancellationToken>())
+            .Returns(tenant);
+        _tenantSettingsRepository
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.SettingsByTenantIdSpec>(), Arg.Any<CancellationToken>())
+            .Returns(settings);
+
+        var result = await _sut.Handle(new GetPublicTenantQuery(Slug), TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.Ok);
+        result.Value.Slug.Should().Be(Slug);
+        result.Value.Name.Should().Be("Acme");
+        result.Value.SelfRegistrationEnabled.Should().BeTrue();
+        result.Value.AllowedAuthProviders.Should().BeEquivalentTo(["google", "endatix"]);
+        result.Value.GetType().GetProperty("Id").Should().BeNull();
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/Tenants/GetPublicBySlug/GetPublicTenantHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Tenants/GetPublicBySlug/GetPublicTenantHandlerTests.cs
@@ -8,7 +8,7 @@ namespace Endatix.Core.Tests.UseCases.Tenants.GetPublicBySlug;
 
 public class GetPublicTenantHandlerTests
 {
-    private const string Slug = "xK9mP2qR8vNw";
+    private const string Slug = "xK9mP2qR";
     private const long TenantId = 4242;
 
     private readonly IRepository<CoreEntities.Tenant> _tenantRepository;

--- a/tests/Endatix.Core.Tests/UseCases/Tenants/GetPublicBySlug/GetPublicTenantHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Tenants/GetPublicBySlug/GetPublicTenantHandlerTests.cs
@@ -22,10 +22,14 @@ public class GetPublicTenantHandlerTests
         _sut = new GetPublicTenantHandler(_tenantRepository, _tenantSettingsRepository);
     }
 
-    [Fact]
-    public async Task Handle_NameLikeSlug_ReturnsNotFoundWithoutQuerying()
+    [Theory]
+    [InlineData("acme")]
+    [InlineData("acme-regional-surveys")]
+    [InlineData("xk9mp2qr8")]
+    [InlineData("xk9mp2!r")]
+    public async Task Handle_InvalidShortUrl_ReturnsNotFoundWithoutQuerying(string slug)
     {
-        var result = await _sut.Handle(new GetPublicTenantQuery("acme"), TestContext.Current.CancellationToken);
+        var result = await _sut.Handle(new GetPublicTenantQuery(slug), TestContext.Current.CancellationToken);
 
         result.Status.Should().Be(ResultStatus.NotFound);
         await _tenantRepository.DidNotReceive().SingleOrDefaultAsync(
@@ -34,20 +38,39 @@ public class GetPublicTenantHandlerTests
     }
 
     [Fact]
-    public async Task Handle_UnknownSlug_ReturnsNotFound()
+    public async Task Handle_ValidEightLetterIdentifier_StillQueries()
     {
         _tenantRepository
             .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveByShortUrlSpec>(), Arg.Any<CancellationToken>())
             .Returns(Task.FromResult<CoreEntities.Tenant?>(null));
 
+        var result = await _sut.Handle(new GetPublicTenantQuery("abcdefgh"), TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.NotFound);
+        await _tenantRepository.Received(1).SingleOrDefaultAsync(
+            Arg.Any<TenantSpecifications.LiveByShortUrlSpec>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_UnknownSlug_ReturnsNotFound()
+    {
+        // Arrange
+        _tenantRepository
+            .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.LiveByShortUrlSpec>(), Arg.Any<CancellationToken>())
+            .Returns(Task.FromResult<CoreEntities.Tenant?>(null));
+
+        // Act
         var result = await _sut.Handle(new GetPublicTenantQuery(Slug), TestContext.Current.CancellationToken);
 
+        // Assert
         result.Status.Should().Be(ResultStatus.NotFound);
     }
 
     [Fact]
     public async Task Handle_TenantExists_ReturnsDtoWithoutNumericId()
     {
+        // Arrange
         CoreEntities.Tenant tenant = new("Acme", Slug, "Primary") { Id = TenantId };
         CoreEntities.TenantSettings settings = new(TenantId);
         settings.UpdateSelfRegistrationPolicy(true, ["google", "endatix"], "Respondent");
@@ -58,8 +81,10 @@ public class GetPublicTenantHandlerTests
             .SingleOrDefaultAsync(Arg.Any<TenantSpecifications.SettingsByTenantIdSpec>(), Arg.Any<CancellationToken>())
             .Returns(settings);
 
+        // Act
         var result = await _sut.Handle(new GetPublicTenantQuery(Slug), TestContext.Current.CancellationToken);
 
+        // Assert
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Slug.Should().Be(Slug);
         result.Value.Name.Should().Be("Acme");

--- a/tests/Endatix.Infrastructure.Tests/Identity/EmailVerification/EmailVerificationServiceTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Identity/EmailVerification/EmailVerificationServiceTests.cs
@@ -114,15 +114,21 @@ public class EmailVerificationServiceTests
         // Arrange
         var token = "expired-token";
         var userId = 123L;
-        // Create token with valid expiry first, then modify it to be expired
+        var user = new AppUser
+        {
+            Id = userId,
+            UserName = "testuser",
+            Email = "test@example.com",
+            EmailConfirmed = false
+        };
         var verificationToken = new EmailVerificationToken(userId, token, DateTime.UtcNow.AddHours(1));
 
-        // Use reflection to set the expired date for testing
         var expiresAtProperty = typeof(EmailVerificationToken).GetProperty("ExpiresAt");
         expiresAtProperty!.SetValue(verificationToken, DateTime.UtcNow.AddHours(-1));
 
         _tokenRepository.FirstOrDefaultAsync(Arg.Any<EmailVerificationTokenByTokenSpec>(), Arg.Any<CancellationToken>())
             .Returns(verificationToken);
+        _userManager.FindByIdAsync(userId.ToString()).Returns(user);
 
         // Act
         var result = await _sut.VerifyEmailAsync(token, CancellationToken.None);
@@ -178,6 +184,58 @@ public class EmailVerificationServiceTests
         result.ValidationErrors.Should().ContainSingle()
             .Which.ErrorMessage.Should().Be(EmailVerificationService.INVALID_VERIFICATION_TOKEN_MESSAGE);
         result.ValidationErrors.Select(error => error.ErrorMessage).Should().NotContain("User not found");
+    }
+
+    [Fact]
+    public async Task VerifyEmailAsync_UsedTokenAndConfirmedUser_ReturnsSuccess()
+    {
+        var token = "used-token";
+        var userId = 123L;
+        var user = new AppUser
+        {
+            Id = userId,
+            UserName = "testuser",
+            Email = "test@example.com",
+            EmailConfirmed = true
+        };
+        var verificationToken = new EmailVerificationToken(userId, token, DateTime.UtcNow.AddHours(1));
+        verificationToken.MarkAsUsed();
+
+        _tokenRepository.FirstOrDefaultAsync(Arg.Any<EmailVerificationTokenByTokenSpec>(), Arg.Any<CancellationToken>())
+            .Returns(verificationToken);
+        _userManager.FindByIdAsync(userId.ToString()).Returns(user);
+
+        var result = await _sut.VerifyEmailAsync(token, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Email.Should().Be(user.Email);
+        await _tokenRepository.DidNotReceive().UpdateAsync(Arg.Any<EmailVerificationToken>(), Arg.Any<CancellationToken>());
+        _userManager.DidNotReceive().UpdateAsync(Arg.Any<AppUser>());
+    }
+
+    [Fact]
+    public async Task VerifyEmailAsync_ConfirmedUserUnusedToken_MarksTokenUsedAndSucceeds()
+    {
+        var token = "unused-after-confirm";
+        var userId = 123L;
+        var user = new AppUser
+        {
+            Id = userId,
+            UserName = "testuser",
+            Email = "test@example.com",
+            EmailConfirmed = true
+        };
+        var verificationToken = new EmailVerificationToken(userId, token, DateTime.UtcNow.AddHours(1));
+
+        _tokenRepository.FirstOrDefaultAsync(Arg.Any<EmailVerificationTokenByTokenSpec>(), Arg.Any<CancellationToken>())
+            .Returns(verificationToken);
+        _userManager.FindByIdAsync(userId.ToString()).Returns(user);
+
+        var result = await _sut.VerifyEmailAsync(token, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        verificationToken.IsUsed.Should().BeTrue();
+        await _tokenRepository.Received(1).UpdateAsync(verificationToken, Arg.Any<CancellationToken>());
     }
 
     #endregion

--- a/tests/Endatix.Infrastructure.Tests/Identity/Users/AppUserRegistrationServiceTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Identity/Users/AppUserRegistrationServiceTests.cs
@@ -452,21 +452,35 @@ public class AppUserRegistrationServiceTests
     }
 
     [Fact]
-    public async Task RegisterTenantUserAsync_UserCreationFails_RollsBackWithoutAssigningRole()
+    public async Task RegisterTenantUserAsync_DuplicateUserNameOnCreate_ReturnsNoContentAndRollsBack()
     {
-        // Arrange
         ArrangeTenantRegistration();
         _userManager.CreateAsync(Arg.Any<AppUser>(), Arg.Any<string>())
             .Returns(IdentityResult.Failed(new IdentityError { Code = "DuplicateUserName" }));
 
-        // Act
         var result = await _sut.RegisterTenantUserAsync(TenantEmail, TenantPassword, TenantId, TenantRole, CancellationToken.None);
 
-        // Assert
-        result.IsInvalid().Should().BeTrue();
+        result.Status.Should().Be(ResultStatus.NoContent);
         await _unitOfWork.Received(1).RollbackTransactionAsync(Arg.Any<CancellationToken>());
         await _roleManagementService.DidNotReceive().AssignRoleToUserAsync(
             Arg.Any<long>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _emailSender.DidNotReceive().SendEmailAsync(Arg.Any<EmailWithTemplate>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RegisterTenantUserAsync_UserCreationFails_RollsBackWithoutAssigningRole()
+    {
+        ArrangeTenantRegistration();
+        _userManager.CreateAsync(Arg.Any<AppUser>(), Arg.Any<string>())
+            .Returns(IdentityResult.Failed(new IdentityError { Code = "PasswordTooShort", Description = "Too short." }));
+
+        var result = await _sut.RegisterTenantUserAsync(TenantEmail, TenantPassword, TenantId, TenantRole, CancellationToken.None);
+
+        result.Status.Should().Be(ResultStatus.Error);
+        await _unitOfWork.Received(1).RollbackTransactionAsync(Arg.Any<CancellationToken>());
+        await _roleManagementService.DidNotReceive().AssignRoleToUserAsync(
+            Arg.Any<long>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+        await _emailSender.DidNotReceive().SendEmailAsync(Arg.Any<EmailWithTemplate>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/Endatix.Infrastructure.Tests/Identity/Users/AppUserRegistrationServiceTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Identity/Users/AppUserRegistrationServiceTests.cs
@@ -1,6 +1,7 @@
 using Endatix.Infrastructure.Identity;
 using Endatix.Infrastructure.Identity.Users;
 using Endatix.Core.Abstractions;
+using Endatix.Core.Abstractions.Data;
 using Endatix.Core.Entities.Identity;
 using Endatix.Core.Features.Email;
 using Endatix.Core.Infrastructure.Result;
@@ -20,6 +21,8 @@ public class AppUserRegistrationServiceTests
     private readonly IEmailVerificationService _emailVerificationService;
     private readonly IEmailSender _emailSender;
     private readonly IEmailTemplateService _emailTemplateService;
+    private readonly IRoleManagementService _roleManagementService;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<AppUserRegistrationService> _logger;
     private readonly AppUserRegistrationService _sut;
 
@@ -31,9 +34,19 @@ public class AppUserRegistrationServiceTests
         _emailVerificationService = Substitute.For<IEmailVerificationService>();
         _emailSender = Substitute.For<IEmailSender>();
         _emailTemplateService = Substitute.For<IEmailTemplateService>();
+        _roleManagementService = Substitute.For<IRoleManagementService>();
+        _unitOfWork = Substitute.For<IUnitOfWork>();
         _logger = Substitute.For<ILogger<AppUserRegistrationService>>();
 
-        _sut = new AppUserRegistrationService(_userManager, _userStore, _emailVerificationService, _emailSender, _emailTemplateService, _logger);
+        _sut = new AppUserRegistrationService(
+            _userManager,
+            _userStore,
+            _emailVerificationService,
+            _emailSender,
+            _emailTemplateService,
+            _roleManagementService,
+            _unitOfWork,
+            _logger);
     }
 
     [Fact]
@@ -393,4 +406,176 @@ public class AppUserRegistrationServiceTests
         _emailTemplateService.DidNotReceive().CreateVerificationEmail(email, token);
         await _emailSender.Received(1).SendEmailAsync(emailWithTemplate, cancellationToken);
     }
+
+    #region RegisterTenantUserAsync Tests
+
+    [Fact]
+    public async Task RegisterTenantUserAsync_RoleAssigned_CommitsAndSendsEmailAfterCommit()
+    {
+        // Arrange
+        ArrangeTenantRegistration();
+        _roleManagementService.AssignRoleToUserAsync(Arg.Any<long>(), TenantRole, Arg.Any<CancellationToken>())
+            .Returns(Result.Success());
+
+        // Act
+        var result = await _sut.RegisterTenantUserAsync(TenantEmail, TenantPassword, TenantId, TenantRole, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        Received.InOrder(() =>
+        {
+            _unitOfWork.BeginTransactionAsync(Arg.Any<CancellationToken>());
+            _userManager.CreateAsync(Arg.Any<AppUser>(), TenantPassword);
+            _roleManagementService.AssignRoleToUserAsync(Arg.Any<long>(), TenantRole, Arg.Any<CancellationToken>());
+            _unitOfWork.CommitTransactionAsync(Arg.Any<CancellationToken>());
+            _emailSender.SendEmailAsync(Arg.Any<EmailWithTemplate>(), Arg.Any<CancellationToken>());
+        });
+        await _unitOfWork.DidNotReceive().RollbackTransactionAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RegisterTenantUserAsync_RoleAssignmentFails_RollsBackAndSendsNoEmail()
+    {
+        // Arrange
+        ArrangeTenantRegistration();
+        _roleManagementService.AssignRoleToUserAsync(Arg.Any<long>(), TenantRole, Arg.Any<CancellationToken>())
+            .Returns(Result.Error("Role store unavailable"));
+
+        // Act
+        var result = await _sut.RegisterTenantUserAsync(TenantEmail, TenantPassword, TenantId, TenantRole, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        await _unitOfWork.Received(1).RollbackTransactionAsync(Arg.Any<CancellationToken>());
+        await _unitOfWork.DidNotReceive().CommitTransactionAsync(Arg.Any<CancellationToken>());
+        await _emailSender.DidNotReceive().SendEmailAsync(Arg.Any<EmailWithTemplate>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RegisterTenantUserAsync_UserCreationFails_RollsBackWithoutAssigningRole()
+    {
+        // Arrange
+        ArrangeTenantRegistration();
+        _userManager.CreateAsync(Arg.Any<AppUser>(), Arg.Any<string>())
+            .Returns(IdentityResult.Failed(new IdentityError { Code = "DuplicateUserName" }));
+
+        // Act
+        var result = await _sut.RegisterTenantUserAsync(TenantEmail, TenantPassword, TenantId, TenantRole, CancellationToken.None);
+
+        // Assert
+        result.IsInvalid().Should().BeTrue();
+        await _unitOfWork.Received(1).RollbackTransactionAsync(Arg.Any<CancellationToken>());
+        await _roleManagementService.DidNotReceive().AssignRoleToUserAsync(
+            Arg.Any<long>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task RegisterTenantUserAsync_EmailAlreadyRegistered_ReturnsNoContentWithoutTransaction()
+    {
+        // Arrange
+        ArrangeTenantRegistration();
+        _userManager.FindByEmailAsync(TenantEmail).Returns(new AppUser { Id = 42 });
+
+        // Act
+        var result = await _sut.RegisterTenantUserAsync(TenantEmail, TenantPassword, TenantId, TenantRole, CancellationToken.None);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.NoContent);
+        result.ValidationErrors.Should().BeEmpty();
+        result.Errors.Should().BeEmpty();
+        await _unitOfWork.DidNotReceive().BeginTransactionAsync(Arg.Any<CancellationToken>());
+        await _userManager.DidNotReceive().CreateAsync(Arg.Any<AppUser>(), Arg.Any<string>());
+    }
+
+    #region Security and Privacy Tests
+
+    [Fact]
+    public async Task RegisterUserAsync_EmailAlreadyRegistered_LeaksNoAccountExistence()
+    {
+        // Arrange
+        _userManager.SupportsUserEmail.Returns(true);
+        _userManager.FindByEmailAsync(TenantEmail).Returns(new AppUser { Id = 42, TenantId = 0, EmailConfirmed = true });
+
+        // Act
+        var result = await _sut.RegisterUserAsync(TenantEmail, TenantPassword, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Status.Should().Be(ResultStatus.NoContent);
+        result.ValidationErrors.Should().BeEmpty();
+        result.Errors.Should().BeEmpty();
+        await _userManager.DidNotReceive().CreateAsync(Arg.Any<AppUser>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task RegisterUserAsync_EmailBelongsToAnotherTenant_LeaksNoAccountExistence()
+    {
+        // Arrange
+        _userManager.SupportsUserEmail.Returns(true);
+        _userManager.FindByEmailAsync(TenantEmail).Returns(new AppUser { Id = 42, TenantId = 5, EmailConfirmed = true });
+
+        // Act
+        var result = await _sut.RegisterUserAsync(TenantEmail, TenantPassword, CancellationToken.None);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.NoContent);
+        result.ValidationErrors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task RegisterInvitedUserAsync_EmailAlreadyRegistered_StillReportsTheConflict()
+    {
+        // Arrange
+        _userManager.SupportsUserEmail.Returns(true);
+        _userManager.FindByEmailAsync(TenantEmail).Returns(new AppUser { Id = 42, TenantId = TenantId, EmailConfirmed = true });
+
+        // Act
+        var result = await _sut.RegisterInvitedUserAsync(TenantEmail, TenantId, CancellationToken.None);
+
+        // Assert
+        result.IsInvalid().Should().BeTrue();
+    }
+
+    #endregion
+
+    private const string TenantEmail = "member@example.com";
+    private const string TenantPassword = "P@ssw0rd";
+    private const string TenantRole = "Respondent";
+    private const long TenantId = 99;
+    private const long TenantUserId = 7;
+
+    private void ArrangeTenantRegistration()
+    {
+        _userManager.SupportsUserEmail.Returns(true);
+        _userManager.FindByEmailAsync(TenantEmail).Returns((AppUser?)null);
+        _userManager.CreateAsync(Arg.Any<AppUser>(), Arg.Any<string>())
+            .Returns(callInfo =>
+            {
+                callInfo.Arg<AppUser>().Id = TenantUserId;
+                return Task.FromResult(IdentityResult.Success);
+            });
+        _userStore.SetUserNameAsync(Arg.Any<AppUser>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                callInfo.Arg<AppUser>().UserName = callInfo.Arg<string>();
+                return Task.CompletedTask;
+            });
+        _emailStore.SetEmailAsync(Arg.Any<AppUser>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                callInfo.Arg<AppUser>().Email = callInfo.Arg<string>();
+                return Task.CompletedTask;
+            });
+        _emailVerificationService.CreateVerificationTokenAsync(Arg.Any<long>(), Arg.Any<CancellationToken>())
+            .Returns(Result.Success(new EmailVerificationToken(1, "raw-token", DateTime.UtcNow.AddHours(24))));
+        _emailTemplateService.CreateVerificationEmail(TenantEmail, "raw-token").Returns(new EmailWithTemplate
+        {
+            To = TenantEmail,
+            From = "noreply@example.com",
+            Subject = "Verify Your Email Address",
+            TemplateId = "email-verification"
+        });
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

Unauthenticated **tenant discovery** and **tenant-scoped self-registration**, powering Hub `/t/{shortUrl}/signin` and `/t/{shortUrl}/register`. Tenants are addressed only by the opaque 8-character `Tenant.ShortUrl` — never the numeric id. Closes [#973](https://github.com/endatix/endatix/issues/973).

## APIs

| Method | Path | Auth | Behavior |
|--------|------|------|----------|
| `GET` | `/api/public/tenants/{slug}` | anonymous | Live tenant by `ShortUrl`. 200: `{ slug, name, selfRegistrationEnabled, allowedAuthProviders }`. Name-like, unknown, or soft-deleted → **404**. Throttle 20/min. |
| `POST` | `/api/auth/register` | anonymous | Gains optional `tenantSlug`. Omitted → unattached account (`TenantId = 0`), unchanged. Set → register into that tenant. Throttle 5/min. |

**`POST /api/auth/register` with `tenantSlug` — outcomes**

| Condition | Result |
|---|---|
| Slug is not a valid short URL, or no live tenant | **404** |
| Self-registration disabled for the tenant | **403** |
| `DefaultRegistrationRoleName` is PlatformAdmin / Public / non-persisted | **400** |
| `DefaultRegistrationRoleName` does not resolve for the tenant | **400** |
| Email already registered | **400** — never attached or re-roled |
| Otherwise | **200** — user created in the tenant, default role assigned |

## Events

- `UserRegisteredEvent` — published after a successful register on both the unattached and tenant-scoped paths.

## Key decisions

- **Public id is `ShortUrl`** (CSPRNG, `a-z0-9`, 8 chars). Inbound values are folded with `ShortUrl.Normalize` then matched exactly. The numeric `Tenant.Id` never leaves the API.
- **Name-like input is a 404, not a 400.** A distinct status would tell an anonymous caller whether a value was ever a valid id shape.
- **Self-registration assigns the shared catalog system role**, not a cloned per-tenant `AppRole`. A user still belongs to exactly one tenant (`AppUser.TenantId`); multi-tenant membership stays out of scope ([#1008](https://github.com/endatix/endatix/issues/1008)).
- **Registration and the role grant are atomic.** `RegisterTenantUserAsync` writes the user row and the role grant inside a single `AppIdentityDbContext` transaction. Both tables live in that one context, so this needs no saga and no compensating delete — a failed grant rolls the user back. The verification email is sent only *after* the commit, since an email cannot be unsent.
- **The role is also resolved up front.** `TenantSettings.ValidateDefaultRegistrationRole` only rejects roles that must never be used, so the handler resolves the name against the tenant first — the same `GetMissingAssignableRoleNamesAsync` pre-flight `InviteUserHandler` uses. A misconfigured tenant fails with a 400 before any write, instead of rolling back one per attempt.
- **An existing email on the tenant path is rejected outright.** `RegisterUserAsync` would otherwise attach or re-role an unattached account, turning anonymous register into an account-takeover path.
- **`allowedAuthProviders` is a UI hint.** Register does not enforce the list in this ship.
- **Discovery reads go through `HybridCache`** (`GetOrCreateResultAsync`, 3 min, success-only). Failed lookups are never stored, so the endpoint cannot be turned into a cheap enumeration oracle. `PATCH /admin/tenants/{id}` evicts the entry.
- **The `multi-tenancy` flag does not gate these two anonymous routes**, unlike `/admin/tenants` and assume-tenant, which 404 when the flag is off.
- EmailTokenValidaiton is madeidempotent to prevent link expiring on just clicking it until used

## Contract changes

- `RegisterRequest` / `RegisterCommand` gain optional `TenantSlug` — additive, existing callers unaffected.
- `IRoleManagementService.GetMissingAssignableRoleNamesAsync` gains a `tenantId` overload for callers with no ambient tenant context (anonymous register). The existing overload still reads `ITenantContext`.
- `IUserRegistrationService` gains `RegisterTenantUserAsync(email, password, tenantId, roleName, ct)` — the transactional entry point for self-registration.
- `HybridCacheExtensions` is now `public` so `Endatix.Api` can use `GetOrCreateResultAsync`.

## Behavior / breaking

- **No breaking changes.** Register without `tenantSlug` behaves exactly as before.
- `POST /api/auth/register` gains 403, 404 and 429 outcomes; both endpoints now document 429 in OpenAPI.
- Both new anonymous routes are throttled.

## Docs

`ARCHITECTURE.md` — tenant discovery and self-registration contract, one-tenant-per-user membership boundary, HybridCache usage rules, and a section describing the commercial `SaaS.Management` module (waitlist / tenant signup) as distinct from tenant self-registration.
