### PR TITLE
feat(e991)!: Adding Paged metadata to the GET Themes

### DIFF
--- a/src/Endatix.Api/Endpoints/Themes/List.cs
+++ b/src/Endatix.Api/Endpoints/Themes/List.cs
@@ -4,7 +4,9 @@ using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Api.Common;
 using Endatix.Core.Abstractions.Authorization;
+using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Paging;
+using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.Themes.List;
 
 namespace Endatix.Api.Endpoints.Themes;
@@ -12,7 +14,7 @@ namespace Endatix.Api.Endpoints.Themes;
 /// <summary>
 /// Endpoint for listing themes.
 /// </summary>
-public class List(IMediator mediator) : Endpoint<ListRequest, Results<Ok<IEnumerable<ThemeModel>>, BadRequest>>
+public class List(IMediator mediator) : Endpoint<ListRequest, Results<Ok<Paged<ThemeModel>>, BadRequest>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -25,7 +27,7 @@ public class List(IMediator mediator) : Endpoint<ListRequest, Results<Ok<IEnumer
         {
             s.Summary = "List themes";
             s.Description =
-                "Lists all themes with optional pagination, sort, and created/modified date bounds.";
+                "Lists themes with paging, optional sort, and created/modified date bounds.";
             s.ExampleRequest = new ListRequest
             {
                 Page = 1,
@@ -39,7 +41,7 @@ public class List(IMediator mediator) : Endpoint<ListRequest, Results<Ok<IEnumer
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<IEnumerable<ThemeModel>>, BadRequest>> ExecuteAsync(
+    public override async Task<Results<Ok<Paged<ThemeModel>>, BadRequest>> ExecuteAsync(
         ListRequest request,
         CancellationToken ct)
     {
@@ -54,7 +56,10 @@ public class List(IMediator mediator) : Endpoint<ListRequest, Results<Ok<IEnumer
         var result = await mediator.Send(query, ct);
 
         return TypedResultsBuilder
-            .MapResult(result, ThemeMapper.Map<ThemeModel>)
-            .SetTypedResults<Ok<IEnumerable<ThemeModel>>, BadRequest>();
+            .MapResult(result, Map)
+            .SetTypedResults<Ok<Paged<ThemeModel>>, BadRequest>();
     }
+
+    private static Paged<ThemeModel> Map(Paged<Theme> paged) =>
+        paged.MapToPaged(ThemeMapper.Map<ThemeModel>);
 }

--- a/src/Endatix.Core/Specifications/ThemeSpecifications.cs
+++ b/src/Endatix.Core/Specifications/ThemeSpecifications.cs
@@ -48,6 +48,22 @@ public static class ThemeSpecifications
     }
 
     /// <summary>
+    /// Applies calendar date bounds without pagination (for counts).
+    /// </summary>
+    public sealed class ListFilter : Specification<Theme>
+    {
+        public ListFilter(
+            UtcDateTimeRange created = default,
+            UtcDateTimeRange modified = default)
+        {
+            Query
+                .WhereUtcRange(x => x.CreatedAt, created)
+                .WhereUtcRange(x => x.ModifiedAt, modified)
+                .AsNoTracking();
+        }
+    }
+
+    /// <summary>
     /// Specification to get themes with pagination, sort, and calendar date bounds.
     /// </summary>
     public sealed class Paginated : Specification<Theme>

--- a/src/Endatix.Core/UseCases/Themes/List/ListThemesHandler.cs
+++ b/src/Endatix.Core/UseCases/Themes/List/ListThemesHandler.cs
@@ -8,18 +8,13 @@ using Endatix.Core.Specifications.Parameters;
 namespace Endatix.Core.UseCases.Themes.List;
 
 /// <summary>
-/// Handler for retrieving all themes.
+/// Handler for retrieving themes as a paged envelope.
 /// </summary>
 public class ListThemesHandler(IRepository<Theme> themeRepository)
-    : IQueryHandler<ListThemesQuery, Result<IEnumerable<Theme>>>
+    : IQueryHandler<ListThemesQuery, Result<Paged<Theme>>>
 {
-    /// <summary>
-    /// Handles the retrieval of all themes.
-    /// </summary>
-    /// <param name="request">The query containing optional pagination, sort, and date bounds.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>Result containing the list of themes.</returns>
-    public async Task<Result<IEnumerable<Theme>>> Handle(
+    /// <inheritdoc />
+    public async Task<Result<Paged<Theme>>> Handle(
         ListThemesQuery request,
         CancellationToken cancellationToken)
     {
@@ -27,14 +22,32 @@ public class ListThemesHandler(IRepository<Theme> themeRepository)
             request.Page,
             request.PageSize);
 
-        var spec = new ThemeSpecifications.Paginated(
-            pagingParams,
-            request.SortBy,
-            request.SortDescending,
+        var countSpec = new ThemeSpecifications.ListFilter(
             request.Created,
             request.Modified);
-        IEnumerable<Theme> themes = await themeRepository.ListAsync(spec, cancellationToken);
+        var totalRecords = await themeRepository.CountAsync(countSpec, cancellationToken);
 
-        return Result<IEnumerable<Theme>>.Success(themes);
+        var page = Paged<Theme>.ResolvePage(
+            pagingParams.Page,
+            pagingParams.PageSize,
+            totalRecords);
+
+        IReadOnlyList<Theme> items = [];
+        if (totalRecords > 0)
+        {
+            var spec = new ThemeSpecifications.Paginated(
+                new PagingParameters(page, pagingParams.PageSize),
+                request.SortBy,
+                request.SortDescending,
+                request.Created,
+                request.Modified);
+            items = [.. await themeRepository.ListAsync(spec, cancellationToken)];
+        }
+
+        return Result.Success(Paged<Theme>.FromPage(
+            page,
+            pagingParams.PageSize,
+            totalRecords,
+            items));
     }
 }

--- a/src/Endatix.Core/UseCases/Themes/List/ListThemesQuery.cs
+++ b/src/Endatix.Core/UseCases/Themes/List/ListThemesQuery.cs
@@ -21,4 +21,4 @@ public record ListThemesQuery(
     bool SortDescending = true,
     UtcDateTimeRange Created = default,
     UtcDateTimeRange Modified = default)
-    : IQuery<Result<IEnumerable<Theme>>>;
+    : IQuery<Result<Paged<Theme>>>;

--- a/tests/Endatix.Api.Tests/Endpoints/Themes/ListTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Themes/ListTests.cs
@@ -25,10 +25,10 @@ public class ListTests
     {
         // Arrange
         var request = new ListRequest();
-        var result = Result<IEnumerable<Theme>>.Invalid();
+        var result = Result.Invalid();
 
         _mediator.Send(Arg.Any<ListThemesQuery>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(result));
+            .Returns(result);
 
         // Act
         var response = await _endpoint.ExecuteAsync(request, default);
@@ -39,49 +39,52 @@ public class ListTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_ValidRequest_ReturnsOkWithThemes()
+    public async Task ExecuteAsync_ValidRequest_ReturnsOkWithPagedThemes()
     {
         // Arrange
-        var request = new ListRequest();
+        var request = new ListRequest { Page = 1, PageSize = 10 };
         var themes = new List<Theme>
         {
             new Theme(SampleData.TENANT_ID, "Theme 1") { Id = 1 },
             new Theme(SampleData.TENANT_ID, "Theme 2") { Id = 2 }
         };
-        var result = Result<IEnumerable<Theme>>.Success(themes);
+        var paged = Paged<Theme>.FromPage(1, 10, 2, themes);
+        var result = Result.Success(paged);
 
         _mediator.Send(Arg.Any<ListThemesQuery>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(result));
+            .Returns(result);
 
         // Act
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var okResult = response.Result as Ok<IEnumerable<ThemeModel>>;
+        var okResult = response.Result as Ok<Paged<ThemeModel>>;
         okResult.Should().NotBeNull();
         okResult!.Value.Should().NotBeNull();
-        okResult!.Value.Should().HaveCount(2);
+        okResult.Value!.Items.Should().HaveCount(2);
+        okResult.Value.TotalRecords.Should().Be(2);
+        okResult.Value.Items.First().Name.Should().Be("Theme 1");
     }
 
     [Fact]
-    public async Task ExecuteAsync_EmptyList_ReturnsOkWithEmptyList()
+    public async Task ExecuteAsync_EmptyList_ReturnsOkWithEmptyPage()
     {
         // Arrange
-        var request = new ListRequest();
-        var themes = new List<Theme>();
-        var result = Result<IEnumerable<Theme>>.Success(themes);
+        var request = new ListRequest { Page = 1, PageSize = 10 };
+        var result = Result.Success(Paged<Theme>.Empty(10));
 
         _mediator.Send(Arg.Any<ListThemesQuery>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(result));
+            .Returns(result);
 
         // Act
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var okResult = response.Result as Ok<IEnumerable<ThemeModel>>;
+        var okResult = response.Result as Ok<Paged<ThemeModel>>;
         okResult.Should().NotBeNull();
         okResult!.Value.Should().NotBeNull();
-        okResult!.Value.Should().BeEmpty();
+        okResult.Value!.Items.Should().BeEmpty();
+        okResult.Value.TotalRecords.Should().Be(0);
     }
 
     [Fact]
@@ -99,10 +102,10 @@ public class ListTests
             ModifiedFrom = "2024-02-01",
             ModifiedTo = "2024-02-28",
         };
-        var result = Result<IEnumerable<Theme>>.Success([]);
+        var result = Result.Success(Paged<Theme>.Empty(15));
 
         _mediator.Send(Arg.Any<ListThemesQuery>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(result));
+            .Returns(result);
 
         // Act
         await _endpoint.ExecuteAsync(request, CancellationToken.None);

--- a/tests/Endatix.Core.Tests/UseCases/Themes/List/ListThemesHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Themes/List/ListThemesHandlerTests.cs
@@ -19,12 +19,14 @@ public class ListThemesHandlerTests
     }
 
     [Fact]
-    public async Task Handle_NoThemes_ReturnsEmptyList()
+    public async Task Handle_NoThemes_ReturnsEmptyPage()
     {
         // Arrange
-        var request = new ListThemesQuery();
-        _themesRepository.ListAsync(Arg.Any<ThemeSpecifications.Paginated>(), Arg.Any<CancellationToken>())
-                     .Returns(new List<Theme>());
+        var request = new ListThemesQuery(1, 10);
+        _themesRepository.CountAsync(
+            Arg.Any<ThemeSpecifications.ListFilter>(),
+            Arg.Any<CancellationToken>())
+            .Returns(0);
 
         // Act
         var result = await _handler.Handle(request, CancellationToken.None);
@@ -33,11 +35,16 @@ public class ListThemesHandlerTests
         result.Should().NotBeNull();
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().NotBeNull();
-        result.Value.Should().BeEmpty();
+        result.Value.Items.Should().BeEmpty();
+        result.Value.TotalRecords.Should().Be(0);
+
+        await _themesRepository.DidNotReceive().ListAsync(
+            Arg.Any<ThemeSpecifications.Paginated>(),
+            Arg.Any<CancellationToken>());
     }
 
     [Fact]
-    public async Task Handle_ExistingThemes_ReturnsAllThemes()
+    public async Task Handle_ExistingThemes_ReturnsPagedThemes()
     {
         // Arrange
         var themes = new List<Theme>
@@ -46,9 +53,15 @@ public class ListThemesHandlerTests
             new Theme(SampleData.TENANT_ID, "Theme 2", "Description 2") { Id = 2 },
             new Theme(SampleData.TENANT_ID, "Theme 3", "Description 3") { Id = 3 }
         };
-        var request = new ListThemesQuery();
-        _themesRepository.ListAsync(Arg.Any<ThemeSpecifications.Paginated>(), Arg.Any<CancellationToken>())
-                     .Returns(themes);
+        var request = new ListThemesQuery(1, 10);
+        _themesRepository.CountAsync(
+            Arg.Any<ThemeSpecifications.ListFilter>(),
+            Arg.Any<CancellationToken>())
+            .Returns(3);
+        _themesRepository.ListAsync(
+            Arg.Any<ThemeSpecifications.Paginated>(),
+            Arg.Any<CancellationToken>())
+            .Returns(themes);
 
         // Act
         var result = await _handler.Handle(request, CancellationToken.None);
@@ -57,19 +70,23 @@ public class ListThemesHandlerTests
         result.Should().NotBeNull();
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().NotBeNull();
-        result.Value.Should().HaveCount(3);
-        result.Value.Should().BeEquivalentTo(themes);
+        result.Value.Items.Should().HaveCount(3);
+        result.Value.Items.Should().BeEquivalentTo(themes);
+        result.Value.TotalRecords.Should().Be(3);
+        result.Value.Page.Should().Be(1);
     }
 
     [Fact]
     public async Task Handle_RepositoryException_ThrowsException()
     {
         // Arrange
-        var request = new ListThemesQuery();
-        _themesRepository.ListAsync(Arg.Any<ThemeSpecifications.Paginated>(), Arg.Any<CancellationToken>())
-                     .ThrowsAsync(new Exception("Database error"));
+        var request = new ListThemesQuery(1, 10);
+        _themesRepository.CountAsync(
+            Arg.Any<ThemeSpecifications.ListFilter>(),
+            Arg.Any<CancellationToken>())
+            .ThrowsAsync(new Exception("Database error"));
 
-        // Act 
+        // Act
         var act = () => _handler.Handle(request, CancellationToken.None);
 
         // Assert


### PR DESCRIPTION
# feat(e991)!: Adding Paged<> envelope to the Themes API

## Description
Please include a summary of the changes and the related issue. Also, explain the context and the reason for the proposed changes.

## Related Issues
- closes https://github.com/endatix/endatix/issues/991

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [x] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme listings now support paginated responses.
  * Responses include page details, total matching records, and items for the requested page.
  * Date-range filtering for theme creation and modification dates is supported when listing themes.

* **Bug Fixes**
  * Empty theme results now return a consistent empty page with zero total records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->