### PR TITLE
feat(e993)!: apply Paged metadata envelope to GET FormDefinitions

### DIFF
--- a/docs/endatix-docs/docs/guides/api-permissions-reference.mdx
+++ b/docs/endatix-docs/docs/guides/api-permissions-reference.mdx
@@ -165,7 +165,7 @@ Deleting a form will delete all associated form definitions and submissions.
 | Method | Route | Permission | Description |
 |--------|-------|------------|-------------|
 | POST | `/forms/{formId}/definitions` | `forms.edit` | Create new form definition |
-| GET | `/forms/{formId}/definitions` | `forms.view` | List all form definitions for a form |
+| GET | `/forms/{formId}/definitions` | `forms.view` | List form definitions for a form. Empty form is 404. |
 | GET | `/forms/{formId}/definition` | **Public** | Get active form definition (for rendering) |
 | GET | `/forms/{formId}/definitions/{definitionId}` | `forms.view` | Get specific form definition by ID |
 | PUT | `/forms/{formId}/definitions/{definitionId}` | `forms.edit` | Update form definition |

--- a/docs/endatix-docs/swagger.json
+++ b/docs/endatix-docs/swagger.json
@@ -2570,7 +2570,7 @@
           "Forms"
         ],
         "summary": "List form definitions",
-        "description": "Lists all form definitions for a given form with optional pagination.",
+        "description": "Lists form definitions for a given form as a paged envelope (items, page, pageSize, totalRecords, totalPages). Optional sort and created/modified date bounds. Empty form returns 404.",
         "operationId": "EndatixApiEndpointsFormDefinitionsList",
         "parameters": [
           {
@@ -2586,7 +2586,7 @@
           {
             "name": "page",
             "in": "query",
-            "description": "The number of the page",
+            "description": "The page number (1-based).",
             "schema": {
               "type": "integer",
               "format": "int32",
@@ -2596,10 +2596,64 @@
           {
             "name": "pageSize",
             "in": "query",
-            "description": "The number of items to take.",
+            "description": "The number of items per page.",
             "schema": {
               "type": "integer",
               "format": "int32",
+              "nullable": true
+            }
+          },
+          {
+            "name": "sortBy",
+            "in": "query",
+            "description": "Sort field (createdAt, modifiedAt).",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "sortDir",
+            "in": "query",
+            "description": "Sort direction (asc, desc).",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "createdFrom",
+            "in": "query",
+            "description": "Inclusive UTC calendar day (YYYY-MM-DD) for createdAt.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "createdTo",
+            "in": "query",
+            "description": "Inclusive UTC calendar day (YYYY-MM-DD) for createdAt.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "modifiedFrom",
+            "in": "query",
+            "description": "Inclusive UTC calendar day (YYYY-MM-DD) for modifiedAt.",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "modifiedTo",
+            "in": "query",
+            "description": "Inclusive UTC calendar day (YYYY-MM-DD) for modifiedAt.",
+            "schema": {
+              "type": "string",
               "nullable": true
             }
           }
@@ -2610,10 +2664,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/FormDefinitionModel"
-                  }
+                  "$ref": "#/components/schemas/PagedOfFormDefinitionModel"
                 }
               }
             }
@@ -4284,6 +4335,34 @@
             }
           }
         ]
+      },
+      "PagedOfFormDefinitionModel": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalRecords": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalPages": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FormDefinitionModel"
+            }
+          }
+        }
       },
       "FormDefinitionModel": {
         "type": "object",

--- a/src/Endatix.Api/Endpoints/FormDefinitions/List.cs
+++ b/src/Endatix.Api/Endpoints/FormDefinitions/List.cs
@@ -3,16 +3,18 @@ using MediatR;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Common;
 using Endatix.Api.Infrastructure;
-using Endatix.Core.Infrastructure.Paging;
-using Endatix.Core.UseCases.FormDefinitions.List;
 using Endatix.Core.Abstractions.Authorization;
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Paging;
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.UseCases.FormDefinitions.List;
 
 namespace Endatix.Api.Endpoints.FormDefinitions;
 
 /// <summary>
 /// Endpoint for listing form definitions.
 /// </summary>
-public class List(IMediator mediator) : Endpoint<FormDefinitionsListRequest, Results<Ok<IEnumerable<FormDefinitionModel>>, BadRequest, NotFound>>
+public class List(IMediator mediator) : Endpoint<FormDefinitionsListRequest, Results<Ok<Paged<FormDefinitionModel>>, BadRequest, NotFound>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -25,7 +27,15 @@ public class List(IMediator mediator) : Endpoint<FormDefinitionsListRequest, Res
         {
             s.Summary = "List form definitions";
             s.Description =
-                "Lists form definitions for a given form with optional pagination, sort, and created/modified date bounds.";
+                "Lists form definitions for a given form as a paged envelope (items, page, pageSize, totalRecords, totalPages). Optional sort and created/modified date bounds. Empty form returns 404.";
+            s.ExampleRequest = new FormDefinitionsListRequest
+            {
+                FormId = 1,
+                Page = 1,
+                PageSize = 20,
+                SortBy = FormDefinitionListSortBy.CreatedAt,
+                SortDir = SortDirection.Desc,
+            };
             s.Responses[200] = "Form definitions retrieved successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form not found.";
@@ -33,7 +43,9 @@ public class List(IMediator mediator) : Endpoint<FormDefinitionsListRequest, Res
     }
 
     /// <inheritdoc />
-    public override async Task<Results<Ok<IEnumerable<FormDefinitionModel>>, BadRequest, NotFound>> ExecuteAsync(FormDefinitionsListRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<Paged<FormDefinitionModel>>, BadRequest, NotFound>> ExecuteAsync(
+        FormDefinitionsListRequest request,
+        CancellationToken ct)
     {
         var sort = request.ToSortRequest(FormDefinitionListSortBy.CreatedAt, SortDirection.Desc);
         var result = await mediator.Send(
@@ -45,10 +57,13 @@ public class List(IMediator mediator) : Endpoint<FormDefinitionsListRequest, Res
                 sort.IsDescending,
                 request.ToCreatedRange(),
                 request.ToModifiedRange()),
-            cancellationToken);
+            ct);
 
         return TypedResultsBuilder
-            .MapResult(result, FormDefinitionMapper.Map<FormDefinitionModel>)
-            .SetTypedResults<Ok<IEnumerable<FormDefinitionModel>>, BadRequest, NotFound>();
+            .MapResult(result, Map)
+            .SetTypedResults<Ok<Paged<FormDefinitionModel>>, BadRequest, NotFound>();
     }
+
+    private static Paged<FormDefinitionModel> Map(Paged<FormDefinition> paged) =>
+        paged.MapToPaged(FormDefinitionMapper.Map<FormDefinitionModel>);
 }

--- a/src/Endatix.Core/Specifications/FormDefinitionsByFormIdSpec.cs
+++ b/src/Endatix.Core/Specifications/FormDefinitionsByFormIdSpec.cs
@@ -1,47 +1,17 @@
 using Ardalis.Specification;
 using Endatix.Core.Entities;
-using Endatix.Core.Infrastructure.Paging;
-using Endatix.Core.Specifications.Common;
-using Endatix.Core.Specifications.Parameters;
-using Endatix.Core.UseCases.FormDefinitions.List;
 
 namespace Endatix.Core.Specifications;
 
+/// <summary>
+/// All definitions for a form (existence checks; no paging).
+/// </summary>
 public sealed class FormDefinitionsByFormIdSpec : Specification<FormDefinition>
 {
-    public FormDefinitionsByFormIdSpec(
-        long formId,
-        PagingParameters? pagingParams = null,
-        FormDefinitionListSortBy sortBy = FormDefinitionListSortBy.CreatedAt,
-        bool sortDescending = true,
-        UtcDateTimeRange created = default,
-        UtcDateTimeRange modified = default)
+    public FormDefinitionsByFormIdSpec(long formId)
     {
         Query
             .Where(fd => fd.FormId == formId)
-            .WhereUtcRange(x => x.CreatedAt, created)
-            .WhereUtcRange(x => x.ModifiedAt, modified);
-
-        ApplyOrdering(Query, sortBy, sortDescending);
-
-        Query
-            .Paginate(pagingParams!)
             .AsNoTracking();
-    }
-
-    private static void ApplyOrdering(
-        ISpecificationBuilder<FormDefinition> query,
-        FormDefinitionListSortBy sortBy,
-        bool sortDescending)
-    {
-        switch (sortBy)
-        {
-            case FormDefinitionListSortBy.ModifiedAt:
-                query.OrderByWithIdTiebreaker(x => x.ModifiedAt, sortDescending);
-                break;
-            default:
-                query.OrderByWithIdTiebreaker(x => x.CreatedAt, sortDescending);
-                break;
-        }
     }
 }

--- a/src/Endatix.Core/Specifications/FormDefinitionsListFilterSpec.cs
+++ b/src/Endatix.Core/Specifications/FormDefinitionsListFilterSpec.cs
@@ -1,0 +1,24 @@
+using Ardalis.Specification;
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Paging;
+using Endatix.Core.Specifications.Common;
+
+namespace Endatix.Core.Specifications;
+
+/// <summary>
+/// Applies form-id and calendar date bounds without pagination (for counts).
+/// </summary>
+public sealed class FormDefinitionsListFilterSpec : Specification<FormDefinition>
+{
+    public FormDefinitionsListFilterSpec(
+        long formId,
+        UtcDateTimeRange created = default,
+        UtcDateTimeRange modified = default)
+    {
+        Query
+            .Where(fd => fd.FormId == formId)
+            .WhereUtcRange(x => x.CreatedAt, created)
+            .WhereUtcRange(x => x.ModifiedAt, modified)
+            .AsNoTracking();
+    }
+}

--- a/src/Endatix.Core/Specifications/FormDefinitionsListSpec.cs
+++ b/src/Endatix.Core/Specifications/FormDefinitionsListSpec.cs
@@ -1,0 +1,50 @@
+using Ardalis.Specification;
+using Endatix.Core.Entities;
+using Endatix.Core.Infrastructure.Paging;
+using Endatix.Core.Specifications.Common;
+using Endatix.Core.Specifications.Parameters;
+using Endatix.Core.UseCases.FormDefinitions.List;
+
+namespace Endatix.Core.Specifications;
+
+/// <summary>
+/// Paged list of form definitions for a form, with sort and calendar date bounds.
+/// </summary>
+public sealed class FormDefinitionsListSpec : Specification<FormDefinition>
+{
+    public FormDefinitionsListSpec(
+        long formId,
+        PagingParameters pagingParams,
+        FormDefinitionListSortBy sortBy = FormDefinitionListSortBy.CreatedAt,
+        bool sortDescending = true,
+        UtcDateTimeRange created = default,
+        UtcDateTimeRange modified = default)
+    {
+        Query
+            .Where(fd => fd.FormId == formId)
+            .WhereUtcRange(x => x.CreatedAt, created)
+            .WhereUtcRange(x => x.ModifiedAt, modified);
+
+        ApplyOrdering(Query, sortBy, sortDescending);
+
+        Query
+            .Paginate(pagingParams)
+            .AsNoTracking();
+    }
+
+    private static void ApplyOrdering(
+        ISpecificationBuilder<FormDefinition> query,
+        FormDefinitionListSortBy sortBy,
+        bool sortDescending)
+    {
+        switch (sortBy)
+        {
+            case FormDefinitionListSortBy.ModifiedAt:
+                query.OrderByWithIdTiebreaker(x => x.ModifiedAt, sortDescending);
+                break;
+            default:
+                query.OrderByWithIdTiebreaker(x => x.CreatedAt, sortDescending);
+                break;
+        }
+    }
+}

--- a/src/Endatix.Core/UseCases/FormDefinitions/List/ListFormDefinitionsHandler.cs
+++ b/src/Endatix.Core/UseCases/FormDefinitions/List/ListFormDefinitionsHandler.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
-using Endatix.Core.Entities;
+﻿using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
@@ -10,24 +7,46 @@ using Endatix.Core.Specifications.Parameters;
 
 namespace Endatix.Core.UseCases.FormDefinitions.List;
 
-public class ListFormDefinitionsHandler(IRepository<FormDefinition> _repository) : IQueryHandler<ListFormDefinitionsQuery, Result<IEnumerable<FormDefinition>>>
+/// <summary>
+/// Handler for retrieving form definitions as a paged envelope.
+/// Returns NotFound when the form has no matching definitions.
+/// </summary>
+public class ListFormDefinitionsHandler(IRepository<FormDefinition> repository)
+    : IQueryHandler<ListFormDefinitionsQuery, Result<Paged<FormDefinition>>>
 {
-    public async Task<Result<IEnumerable<FormDefinition>>> Handle(ListFormDefinitionsQuery request, CancellationToken cancellationToken)
+    public async Task<Result<Paged<FormDefinition>>> Handle(
+        ListFormDefinitionsQuery request,
+        CancellationToken cancellationToken)
     {
         var pagingParams = new PagingParameters(request.Page, request.PageSize);
-        var spec = new FormDefinitionsByFormIdSpec(
+        var countSpec = new FormDefinitionsListFilterSpec(
             request.FormId,
-            pagingParams,
+            request.Created,
+            request.Modified);
+        var totalRecords = await repository.CountAsync(countSpec, cancellationToken);
+        if (totalRecords == 0)
+        {
+            return Result.NotFound("Form not found.");
+        }
+
+        var page = Paged<FormDefinition>.ResolvePage(
+            pagingParams.Page,
+            pagingParams.PageSize,
+            totalRecords);
+
+        var spec = new FormDefinitionsListSpec(
+            request.FormId,
+            new PagingParameters(page, pagingParams.PageSize),
             request.SortBy,
             request.SortDescending,
             request.Created,
             request.Modified);
-        IEnumerable<FormDefinition> formDefinitions = await _repository.ListAsync(spec, cancellationToken);
-        if (formDefinitions.Any())
-        {
-            return Result.Success(formDefinitions);
-        }
+        IReadOnlyList<FormDefinition> items = [.. await repository.ListAsync(spec, cancellationToken)];
 
-        return Result.NotFound("Form not found.");
+        return Result.Success(Paged<FormDefinition>.FromPage(
+            page,
+            pagingParams.PageSize,
+            totalRecords,
+            items));
     }
 }

--- a/src/Endatix.Core/UseCases/FormDefinitions/List/ListFormDefinitionsQuery.cs
+++ b/src/Endatix.Core/UseCases/FormDefinitions/List/ListFormDefinitionsQuery.cs
@@ -7,9 +7,9 @@ using Endatix.Core.Infrastructure.Result;
 namespace Endatix.Core.UseCases.FormDefinitions.List;
 
 /// <summary>
-/// Query for listing form definitions with pagination, sort, and date bounds.
+/// Query for listing form definitions as a paged envelope.
 /// </summary>
-public sealed record ListFormDefinitionsQuery : IQuery<Result<IEnumerable<FormDefinition>>>
+public sealed record ListFormDefinitionsQuery : IQuery<Result<Paged<FormDefinition>>>
 {
     public long FormId { get; init; }
     public int? Page { get; init; }

--- a/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/ListTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/ListTests.cs
@@ -40,17 +40,18 @@ public class ListTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_ValidRequest_ReturnsOkWithFormDefinitions()
+    public async Task ExecuteAsync_ValidRequest_ReturnsOkWithPagedFormDefinitions()
     {
         // Arrange
         var formId = 1L;
         var request = new FormDefinitionsListRequest { FormId = formId };
         var formDefinitions = new List<FormDefinition>
         {
-            FormDefinitionFactory.CreateForTesting(true,"{ }", formId, 1),
-            FormDefinitionFactory.CreateForTesting(false,"{ }", formId, 2)
+            FormDefinitionFactory.CreateForTesting(true, "{ }", formId, 1),
+            FormDefinitionFactory.CreateForTesting(false, "{ }", formId, 2)
         };
-        var result = Result.Success(formDefinitions.AsEnumerable());
+        var paged = Paged<FormDefinition>.FromPage(1, 10, 2, formDefinitions);
+        var result = Result.Success(paged);
 
         _mediator.Send(Arg.Any<ListFormDefinitionsQuery>(), Arg.Any<CancellationToken>())
             .Returns(result);
@@ -59,10 +60,29 @@ public class ListTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var okResult = response.Result as Ok<IEnumerable<FormDefinitionModel>>;
+        var okResult = response.Result as Ok<Paged<FormDefinitionModel>>;
         okResult.Should().NotBeNull();
         okResult!.Value.Should().NotBeNull();
-        okResult!.Value!.Count().Should().Be(2);
+        okResult.Value!.Items.Should().HaveCount(2);
+        okResult.Value.TotalRecords.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FormNotFound_ReturnsNotFound()
+    {
+        // Arrange
+        var request = new FormDefinitionsListRequest { FormId = 1 };
+        var result = Result<Paged<FormDefinition>>.NotFound("Form not found.");
+
+        _mediator.Send(Arg.Any<ListFormDefinitionsQuery>(), Arg.Any<CancellationToken>())
+            .Returns(result);
+
+        // Act
+        var response = await _endpoint.ExecuteAsync(request, default);
+
+        // Assert
+        var notFoundResult = response.Result as NotFound;
+        notFoundResult.Should().NotBeNull();
     }
 
     [Fact]
@@ -75,7 +95,11 @@ public class ListTests
             Page = 2,
             PageSize = 20
         };
-        var result = Result.Success(Enumerable.Empty<FormDefinition>());
+        var result = Result.Success(Paged<FormDefinition>.FromPage(
+            1,
+            20,
+            1,
+            [FormDefinitionFactory.CreateForTesting(true, "{ }", 123, 1)]));
 
         _mediator.Send(Arg.Any<ListFormDefinitionsQuery>(), Arg.Any<CancellationToken>())
             .Returns(result);

--- a/tests/Endatix.Core.Tests/UseCases/FormDefinitions/List/ListFormDefinitionsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/FormDefinitions/List/ListFormDefinitionsHandlerTests.cs
@@ -18,7 +18,29 @@ public class ListFormDefinitionsHandlerTests
     }
 
     [Fact]
-    public async Task Handle_ValidRequest_ReturnsFormDefinitions()
+    public async Task Handle_NoDefinitions_ReturnsNotFound()
+    {
+        // Arrange
+        var request = new ListFormDefinitionsQuery(1, 1, 10);
+        _repository.CountAsync(
+            Arg.Any<FormDefinitionsListFilterSpec>(),
+            Arg.Any<CancellationToken>())
+            .Returns(0);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Status.Should().Be(ResultStatus.NotFound);
+
+        await _repository.DidNotReceive().ListAsync(
+            Arg.Any<FormDefinitionsListSpec>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_ReturnsPagedFormDefinitions()
     {
         // Arrange
         var form = Form.Create(new FormCreateArgs(TenantId: SampleData.TENANT_ID, Name: "Test Form"));
@@ -33,8 +55,12 @@ public class ListFormDefinitionsHandlerTests
             formDefinition2
         };
         var request = new ListFormDefinitionsQuery(1, 1, 10);
+        _repository.CountAsync(
+            Arg.Any<FormDefinitionsListFilterSpec>(),
+            Arg.Any<CancellationToken>())
+            .Returns(2);
         _repository.ListAsync(
-            Arg.Any<FormDefinitionsByFormIdSpec>(),
+            Arg.Any<FormDefinitionsListSpec>(),
             Arg.Any<CancellationToken>()
         ).Returns(formDefinitions);
 
@@ -45,6 +71,8 @@ public class ListFormDefinitionsHandlerTests
         result.Should().NotBeNull();
         result.Status.Should().Be(ResultStatus.Ok);
         result.Value.Should().NotBeNull();
-        result.Value.Should().BeEquivalentTo(formDefinitions);
+        result.Value.Items.Should().BeEquivalentTo(formDefinitions);
+        result.Value.TotalRecords.Should().Be(2);
+        result.Value.Page.Should().Be(1);
     }
 }


### PR DESCRIPTION
# feat(e993)!: apply Paged metadata envelope to GET FormDefinitions

## Description
- Apply `Paged<FormDefinitionModel>` and replace `IEnumerable<FormDefinitionModel>` for the happy path. Supports for sorting, count and filtering
- Update docs

## Related Issues
- closes #993 

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [x] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
