### PR TITLE
feat(e998)!: return ProblemDetails on resource API errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,17 @@ Substitute `IRepository<T>` (+ `IMediator` if publishing). Cover: not found · h
 - **`detail` is always a non-empty string**, falling back to the title when the result carries no errors. Consumers treat it as required (Hub's `ProblemDetailsSchema` types it non-optional) — never emit `"detail": ""`.
 - `SetErrorMessage(...)` overrides the problem **title for every status**, so set it only on the branch it describes (see `Auth/VerifyEmail.cs`) — otherwise a 404 inherits a 400-shaped message.
 - OpenAPI: `Description(b => b.Produces<T>(...).ProducesProblem(400).ProducesProblem(404))` listing exactly the statuses the endpoint's `Summary(s => s.Responses[...])` declares — every endpoint returning `ProblemHttpResult` must have one.
+### Uniform failure responses (OWASP A07)
+
+Account-facing failures must be **indistinguishable to the caller**: same status, same message, whatever the real cause. Log the real reason server-side instead — never return it.
+
+- Applies to: login, registration, forgot/reset password, send-verification-email, verify-email, invite activation. Unknown account, unconfirmed email and wrong password all collapse to **one** `Result.Invalid` with one message.
+- Normalize at the **handler/service boundary**, not at the endpoint. `IAuthService` / `IUserPasswordManageService` are public abstractions — an external IdP implementation returning `NotFound` must not become a 404 that a wrong password would not produce.
+- **Do not `ToErrorResult<T>()` / propagate an upstream status on a credential path.** It is correct for post-authentication infrastructure errors (e.g. session persistence), which reveal nothing about the account.
+- Token flows (verify-email, invite activation) answer **400 for every token failure** - unknown, dangling, expired, used. Never `NotFound`: a 404-vs-400 split tells the caller whether the token ever existed.
+- Equalize work, not just payloads: run the password KDF on the unknown-account path too (`AuthService.BurnPasswordHashingWork`), or response time leaks what the body does not.
+- Pair each with a `#region Security and Privacy Tests` test asserting the disallowed strings are absent. References: `LoginHandler.INVALID_CREDENTIALS_MESSAGE`, `EmailVerificationService.INVALID_VERIFICATION_TOKEN_MESSAGE`, `ForgotPasswordHandler.GENERAL_SUCCESS_MESSAGE`, `SendVerificationEmailHandler` (returns `Success` for unknown users), `UserPasswordManageServiceTests` (`DoesNotLeakUserExistence`).
+
 - **Known gap:** FastEndpoints request-validation failures still return FE's `{statusCode, message, errors}` shape, not problem+json. Closing that needs `c.Errors.UseProblemDetails()` in `ApiApplicationBuilderExtensions` — tracked separately; don't assume a 400 is RFC7807 yet.
 
 ## Run (examples)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,27 +6,27 @@ Clean Architecture + vertical slices in `oss/`. Architecture/testing rules of re
 
 **Do not duplicate the full decision tree here.** Use:
 
-| Need | Doc |
-| --- | --- |
-| When unit vs integration, naming (`UnitOfWork_Scenario_ExpectedBehavior`), AAA | [endatix-api-rules.mdc → Testing](../.cursor/rules/endatix-api-rules.mdc) |
-| Testcontainers, Respawn, traits (`Category` / `Priority` / `DbSpecific`), how to run | [`tests/README.md`](tests/README.md) |
+| Need                                                                                 | Doc                                                                       |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| When unit vs integration, naming (`UnitOfWork_Scenario_ExpectedBehavior`), AAA       | [endatix-api-rules.mdc → Testing](../.cursor/rules/endatix-api-rules.mdc) |
+| Testcontainers, Respawn, traits (`Category` / `Priority` / `DbSpecific`), how to run | [`tests/README.md`](tests/README.md)                                      |
 
 **Short rule of thumb**
 
-* **Unit** — domain, handlers, validators, mappers, endpoint `ExecuteAsync` mapping; mocks/substitutes only.
-* **Integration** — HTTP + auth + EF + real DB (`WebApplicationFactory` / Testcontainers). Prefer `CriticalPaths/` · `FeatureFlows/` · `Infrastructure/`.
+- **Unit** — domain, handlers, validators, mappers, endpoint `ExecuteAsync` mapping; mocks/substitutes only.
+- **Integration** — HTTP + auth + EF + real DB (`WebApplicationFactory` / Testcontainers). Prefer `CriticalPaths/` · `FeatureFlows/` · `Infrastructure/`.
 
 ## Unit test placement (OSS)
 
-| Layer | Project | Folder | Reference |
-| --- | --- | --- | --- |
-| FastEndpoints | `Endatix.Api.Tests` | `Endpoints/{Feature}/` | `Forms/DeleteTests.cs`, `DataLists/*LocaleTests.cs` |
-| Handlers / commands | `Endatix.Core.Tests` | `UseCases/{Feature}/{Action}/` | `Forms/Delete/DeleteFormHandlerTests.cs`, `DataLists/Locales/*Locale*Tests.cs` |
-| Domain | `Endatix.Core.Tests` | `Entities/` | `DataListLocaleCatalogTests.cs` |
-| Infrastructure | `Endatix.Infrastructure.Tests` | Mirror source | `Data/Querying/...` |
+| Layer               | Project                        | Folder                         | Reference                                                                      |
+| ------------------- | ------------------------------ | ------------------------------ | ------------------------------------------------------------------------------ |
+| FastEndpoints       | `Endatix.Api.Tests`            | `Endpoints/{Feature}/`         | `Forms/DeleteTests.cs`, `DataLists/*LocaleTests.cs`                            |
+| Handlers / commands | `Endatix.Core.Tests`           | `UseCases/{Feature}/{Action}/` | `Forms/Delete/DeleteFormHandlerTests.cs`, `DataLists/Locales/*Locale*Tests.cs` |
+| Domain              | `Endatix.Core.Tests`           | `Entities/`                    | `DataListLocaleCatalogTests.cs`                                                |
+| Infrastructure      | `Endatix.Infrastructure.Tests` | Mirror source                  | `Data/Querying/...`                                                            |
 
-* **Class:** `{Sut}Tests`. **Methods:** `Method_State_ExpectedBehavior`.
-* Always `// Arrange` · `// Act` · `// Assert`.
+- **Class:** `{Sut}Tests`. **Methods:** `Method_State_ExpectedBehavior`.
+- Always `// Arrange` · `// Act` · `// Assert`.
 
 ### FastEndpoints (`Endatix.Api.Tests`)
 
@@ -34,9 +34,28 @@ Pattern: substitute `IMediator` → `Factory.Create<TEndpoint>(_mediator)` → a
 
 Minimum cases: invalid → 400 · not found → 404 (if applicable) · success payload · request→command via `Received`/`Arg.Is`. Skip FluentValidation re-tests unless validation is the SUT.
 
+**Error HTTP contract:** resource endpoints return `Results<Ok|Created<T>, ProblemHttpResult>`. Assert failures as:
+
+```csharp
+var problemResult = response.Result as ProblemHttpResult;
+problemResult.Should().NotBeNull();
+problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound); // or 400
+```
+
+Do **not** assert empty-body `BadRequest` / `NotFound`. References: `FormDefinitions/GetActiveTests.cs`, `Forms/Delete.cs` (OpenAPI `Produces` + `ProducesProblem`).
+
 ### Handlers (`Endatix.Core.Tests`)
 
 Substitute `IRepository<T>` (+ `IMediator` if publishing). Cover: not found · happy path + persist · domain `Invalid` (no persist) · event reason/payload. Prefer real aggregates. Thin command-ctor tests when `Guard.Against.*` matters.
+
+## Error HTTP contract (API)
+
+- Handler failures → RFC7807 `application/problem+json` via `TypedResultsBuilder` + `ProblemHttpResult`.
+- `ToProblem` maps Invalid → 400, NotFound → 404, Conflict → 409, Unauthorized → 401, Forbidden → 403, Error/CriticalError → 500, Unavailable → 503.
+- **`detail` is always a non-empty string**, falling back to the title when the result carries no errors. Consumers treat it as required (Hub's `ProblemDetailsSchema` types it non-optional) — never emit `"detail": ""`.
+- `SetErrorMessage(...)` overrides the problem **title for every status**, so set it only on the branch it describes (see `Auth/VerifyEmail.cs`) — otherwise a 404 inherits a 400-shaped message.
+- OpenAPI: `Description(b => b.Produces<T>(...).ProducesProblem(400).ProducesProblem(404))` listing exactly the statuses the endpoint's `Summary(s => s.Responses[...])` declares — every endpoint returning `ProblemHttpResult` must have one.
+- **Known gap:** FastEndpoints request-validation failures still return FE's `{statusCode, message, errors}` shape, not problem+json. Closing that needs `c.Errors.UseProblemDetails()` in `ApiApplicationBuilderExtensions` — tracked separately; don't assume a 400 is RFC7807 yet.
 
 ## Run (examples)
 
@@ -49,5 +68,5 @@ dotnet test tests/Endatix.Core.Tests/Endatix.Core.Tests.csproj --filter "FullyQu
 
 ## Related
 
-* SaaS / Hub agent rules: [`../.cursor/AGENTS.md`](../.cursor/AGENTS.md)
-* Integration contributor notes: `tests/Endatix.IntegrationTests/AGENTS.md` (linked from `tests/README.md`)
+- SaaS / Hub agent rules: [`../.cursor/AGENTS.md`](../.cursor/AGENTS.md)
+- Integration contributor notes: `tests/Endatix.IntegrationTests/AGENTS.md` (linked from `tests/README.md`)

--- a/docs/endatix-docs/docs/building-your-solution/authorization/index.mdx
+++ b/docs/endatix-docs/docs/building-your-solution/authorization/index.mdx
@@ -68,7 +68,7 @@ Permission names follow the pattern: `{category}.{action}.{scope}`
 For a comprehensive guide showing which API endpoints require which permissions, see the [API Permissions Reference](/docs/guides/api-permissions-reference).
 :::
 
-  #### Access-Level Permissions
+#### Access-Level Permissions
 
 These are access-level permissions (not action-based):
 
@@ -144,13 +144,14 @@ Tenant-specific management permissions:
 
 ### Basic Authorization Setup
 
-Built-in default authorization is automatically configured when you set up Endatix application. This also includes the system roles and permissions mentioned above. 
+Built-in default authorization is automatically configured when you set up Endatix application. This also includes the system roles and permissions mentioned above.
 
 ### Using Roles in Your Code
 
 Once authorization is configured, you can use roles in your Fast endpoints using the `Permissions()` method (Claims, Roles, Policies, etc work as well).
 
 Use simple permission e.g. "forms.create". Note that it's accessed via convenient `Actions` class.
+
 ```csharp
 public class CreateForm(IMediator mediator) : Endpoint<CreateFormRequest, Results<Created<FormModel>, BadRequest>>
 {
@@ -165,7 +166,7 @@ public class CreateForm(IMediator mediator) : Endpoint<CreateFormRequest, Result
         });
     }
 
-    public override async Task<Results<Created<FormModel>, BadRequest>> ExecuteAsync(
+    public override async Task<Results<Created<FormModel>, ProblemHttpResult>> ExecuteAsync(
         CreateFormRequest request, CancellationToken cancellationToken)
     {
         // Only users with forms.create permission will reach this endpoint. Note that Admins will also pass this permission check
@@ -174,7 +175,7 @@ public class CreateForm(IMediator mediator) : Endpoint<CreateFormRequest, Result
 
         return TypedResultsBuilder
             .MapResult(result, Mapper.Map<FormModel>)
-            .SetTypedResults<Created<FormModel>, BadRequest>();
+            .SetTypedResults<Created<FormModel>, ProblemHttpResult>();
     }
 }
 ```

--- a/src/Endatix.Api/Endpoints/Access/GetFormAccess.cs
+++ b/src/Endatix.Api/Endpoints/Access/GetFormAccess.cs
@@ -6,6 +6,7 @@ using Endatix.Infrastructure.Caching;
 using Endatix.Infrastructure.Features.AccessControl;
 using FastEndpoints;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.Access;
@@ -30,6 +31,11 @@ public sealed class GetFormAccess(
             s.Responses[401] = "Authentication required.";
             s.Responses[403] = "Forbidden.";
         });
+        Description(builder => builder
+            .Produces<GetFormAccessResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden));
     }
 
     public override async Task<Results<Ok<GetFormAccessResponse>, ProblemHttpResult>> ExecuteAsync(

--- a/src/Endatix.Api/Endpoints/Access/GetFormTemplateAccess.cs
+++ b/src/Endatix.Api/Endpoints/Access/GetFormTemplateAccess.cs
@@ -6,6 +6,7 @@ using Endatix.Infrastructure.Caching;
 using Endatix.Infrastructure.Features.AccessControl;
 using FastEndpoints;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.Access;
@@ -31,6 +32,13 @@ public sealed class GetFormTemplateAccess(
             s.Responses[401] = "Authentication required.";
             s.Responses[403] = "Forbidden.";
         });
+
+        Description(builder => builder
+
+            .Produces<GetFormTemplateAccessResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden));
     }
 
     public override async Task<Results<Ok<GetFormTemplateAccessResponse>, ProblemHttpResult>> ExecuteAsync(

--- a/src/Endatix.Api/Endpoints/Access/GetSubmissionAccess.cs
+++ b/src/Endatix.Api/Endpoints/Access/GetSubmissionAccess.cs
@@ -5,6 +5,7 @@ using Endatix.Core.Infrastructure;
 using Endatix.Infrastructure.Features.AccessControl;
 using FastEndpoints;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.Access;
@@ -29,6 +30,11 @@ public class GetSubmissionAccess(
             s.Responses[401] = "Authentication required.";
             s.Responses[403] = "Forbidden.";
         });
+        Description(builder => builder
+            .Produces<GetSubmissionAccessResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden));
     }
 
     public override async Task<Results<Ok<GetSubmissionAccessResponse>, ProblemHttpResult>> ExecuteAsync(

--- a/src/Endatix.Api/Endpoints/Account/ForgotPassword.cs
+++ b/src/Endatix.Api/Endpoints/Account/ForgotPassword.cs
@@ -2,6 +2,7 @@ using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.Account.ForgotPassword;
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.Account;
@@ -21,12 +22,15 @@ public class ForgotPassword(IMediator mediator) :
             s.Responses[400] = "Invalid request or email.";
             s.ExampleRequest = new { Email = "user@example.com" };
         });
+        Description(builder => builder
+            .Produces<ForgotPasswordResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
-    public override async Task<Results<Ok<ForgotPasswordResponse>, ProblemHttpResult>> ExecuteAsync(ForgotPasswordRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<ForgotPasswordResponse>, ProblemHttpResult>> ExecuteAsync(ForgotPasswordRequest request, CancellationToken ct)
     {
         var forgotPasswordCommand = new ForgotPasswordCommand(request.Email);
-        var result = await mediator.Send(forgotPasswordCommand, cancellationToken);
+        var result = await mediator.Send(forgotPasswordCommand, ct);
 
         return TypedResultsBuilder
                  .MapResult(result, (message) => new ForgotPasswordResponse { Message = message })

--- a/src/Endatix.Api/Endpoints/Account/ResetPassword.cs
+++ b/src/Endatix.Api/Endpoints/Account/ResetPassword.cs
@@ -2,6 +2,7 @@ using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.Account.ResetPassword;
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.Account;
@@ -20,13 +21,16 @@ public class ResetPassword(
             s.Description = "Resets a user's password.";
             s.Responses[200] = "Password reset successfully.";
         });
+        Description(builder => builder
+            .Produces<string>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<string>, ProblemHttpResult>> ExecuteAsync(ResetPasswordRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<string>, ProblemHttpResult>> ExecuteAsync(ResetPasswordRequest request, CancellationToken ct)
     {
         var resetPasswordCommand = new ResetPasswordCommand(request.Email, request.ResetCode, request.NewPassword);
-        var result = await mediator.Send(resetPasswordCommand, cancellationToken);
+        var result = await mediator.Send(resetPasswordCommand, ct);
 
         return TypedResultsBuilder
                 .FromResult(result)

--- a/src/Endatix.Api/Endpoints/Admin/Auth/GetAuthSettings.cs
+++ b/src/Endatix.Api/Endpoints/Admin/Auth/GetAuthSettings.cs
@@ -27,8 +27,8 @@ public sealed class GetAuthSettings(IMediator mediator)
             s.Responses[400] = "Invalid request.";
         });
         Description(builder => builder
-            .Produces<AuthSettingsDto>(200, "application/json")
-            .ProducesProblem(400));
+            .Produces<AuthSettingsDto>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc />

--- a/src/Endatix.Api/Endpoints/Admin/Email/GetEmailSettings.cs
+++ b/src/Endatix.Api/Endpoints/Admin/Email/GetEmailSettings.cs
@@ -29,8 +29,8 @@ public class GetEmailSettings(IMediator mediator)
             s.Responses[400] = "Invalid request or tenant context.";
         });
         Description(builder => builder
-            .Produces<EmailSettingsDto>(200, "application/json")
-            .ProducesProblem(400));
+            .Produces<EmailSettingsDto>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Admin/Email/ListTemplates.cs
+++ b/src/Endatix.Api/Endpoints/Admin/Email/ListTemplates.cs
@@ -31,7 +31,9 @@ public class ListTemplates(IMediator mediator)
             s.Responses[403] = "Forbidden - insufficient privileges (PlatformAdmin required).";
         });
         Description(builder => builder
-            .Produces<IEnumerable<EmailTemplateSummaryDto>>(200, "application/json"));
+            .Produces<IEnumerable<EmailTemplateSummaryDto>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Admin/Email/SendTestEmail.cs
+++ b/src/Endatix.Api/Endpoints/Admin/Email/SendTestEmail.cs
@@ -36,9 +36,9 @@ public class SendTestEmail(IMediator mediator)
             s.Responses[503] = "Email provider is not configured.";
         });
         Description(builder => builder
-            .Produces<string>(200, "application/json")
-            .ProducesProblem(400)
-            .ProducesProblem(503));
+            .Produces<string>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status503ServiceUnavailable));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Admin/PlatformAdmins/Grant.cs
+++ b/src/Endatix.Api/Endpoints/Admin/PlatformAdmins/Grant.cs
@@ -4,6 +4,7 @@ using Endatix.Infrastructure.Identity.Authorization;
 using FastEndpoints;
 using FluentValidation;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.Admin.PlatformAdmins;
@@ -27,6 +28,11 @@ public sealed class Grant(IMediator mediator)
             s.Responses[403] = "The current user is not allowed to grant platform administrator access.";
             s.Responses[404] = "User not found.";
         });
+        Description(builder => builder
+            .Produces<PlatformAdminOperation>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc />

--- a/src/Endatix.Api/Endpoints/Admin/PlatformAdmins/List.cs
+++ b/src/Endatix.Api/Endpoints/Admin/PlatformAdmins/List.cs
@@ -8,6 +8,7 @@ using Endatix.Infrastructure.Features.PlatformAdmin.ListPlatformAdmins;
 using Endatix.Infrastructure.Identity.Authorization;
 using FastEndpoints;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.Admin.PlatformAdmins;
@@ -38,6 +39,9 @@ public sealed class List(ListPlatformAdmins listPlatformAdmins)
             s.Responses[200] = "Platform administrators retrieved successfully.";
             s.Responses[400] = "Invalid request.";
         });
+        Description(builder => builder
+            .Produces<Paged<PlatformAdminUserResponse>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc />

--- a/src/Endatix.Api/Endpoints/Admin/PlatformAdmins/Revoke.cs
+++ b/src/Endatix.Api/Endpoints/Admin/PlatformAdmins/Revoke.cs
@@ -4,6 +4,7 @@ using Endatix.Core.UseCases.PlatformAdmin.RevokePlatformAdmin;
 using FastEndpoints;
 using FluentValidation;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.Admin.PlatformAdmins;
@@ -28,6 +29,12 @@ public sealed class Revoke(IMediator mediator)
             s.Responses[404] = "User not found.";
             s.Responses[409] = "Revocation would leave the platform without an active platform administrator.";
         });
+        Description(builder => builder
+            .Produces<PlatformAdminOperation>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict));
     }
 
     public override async Task<Results<Ok<PlatformAdminOperation>, ProblemHttpResult>> ExecuteAsync(

--- a/src/Endatix.Api/Endpoints/Admin/Tenants/List.cs
+++ b/src/Endatix.Api/Endpoints/Admin/Tenants/List.cs
@@ -5,6 +5,7 @@ using Endatix.Core.Infrastructure.Result;
 using Endatix.Infrastructure.Features.PlatformAdmin.ListPlatformTenants;
 using Endatix.Infrastructure.Identity.Authorization;
 using FastEndpoints;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.Admin.Tenants;
@@ -27,6 +28,9 @@ public sealed class List(IListPlatformTenants listPlatformTenants)
             s.Responses[200] = "Tenants retrieved successfully.";
             s.Responses[400] = "Invalid request.";
         });
+        Description(builder => builder
+            .Produces<Paged<PlatformTenantListItem>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc />

--- a/src/Endatix.Api/Endpoints/Auth/ActivateInvite.cs
+++ b/src/Endatix.Api/Endpoints/Auth/ActivateInvite.cs
@@ -38,8 +38,8 @@ public sealed class ActivateInvite(IMediator mediator)
             s.Responses[400] = "Invalid input data or invitation token.";
         });
         Description(builder => builder
-            .Produces<ActivateInviteResponse>(200, "application/json")
-            .ProducesProblem(400));
+            .Produces<ActivateInviteResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Auth/GetInviteDetails.cs
+++ b/src/Endatix.Api/Endpoints/Auth/GetInviteDetails.cs
@@ -34,8 +34,8 @@ public sealed class GetInviteDetails(IEmailVerificationService emailVerification
             s.Responses[400] = "Invalid or expired invitation token.";
         });
         Description(builder => builder
-            .Produces<GetInviteDetailsResponse>(200, "application/json")
-            .ProducesProblem(400));
+            .Produces<GetInviteDetailsResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Auth/Login.LoginRequest.cs
+++ b/src/Endatix.Api/Endpoints/Auth/Login.LoginRequest.cs
@@ -3,14 +3,14 @@
 namespace Endatix.Api.Endpoints.Auth;
 
 /// <summary>
-/// This Represents the request for the "/login" endpoint, handled by the <see cref="Login.HandleAsync"/> method.
+/// This Represents the request for the "/login" endpoint, handled by the <see cref="Login.ExecuteAsync"/> method.
 /// </summary>
 public record LoginRequest(string Email, string Password)
 {
-    [Sensitive(SensitivityType.Email)]
     /// <summary>
     /// The Email of the user. Must be a valid email address
     /// </summary>
+    [Sensitive(SensitivityType.Email)]
     public string Email { get; init; } = Email;
 
     /// <summary>

--- a/src/Endatix.Api/Endpoints/Auth/Login.cs
+++ b/src/Endatix.Api/Endpoints/Auth/Login.cs
@@ -36,10 +36,10 @@ public class Login(IMediator mediator) : Endpoint<LoginRequest, Results<Ok<Login
     }
 
     /// <inheritdoc />
-    public override async Task<Results<Ok<LoginResponse>, ProblemHttpResult>> ExecuteAsync(LoginRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<LoginResponse>, ProblemHttpResult>> ExecuteAsync(LoginRequest request, CancellationToken ct)
     {
         var loginCommand = new LoginCommand(request.Email, request.Password);
-        var result = await mediator.Send(loginCommand, cancellationToken);
+        var result = await mediator.Send(loginCommand, ct);
 
         return TypedResultsBuilder
             .MapResult(result, tokenDto => new LoginResponse(request.Email, tokenDto.AccessToken.Token, tokenDto.RefreshToken.Token))

--- a/src/Endatix.Api/Endpoints/Auth/Login.cs
+++ b/src/Endatix.Api/Endpoints/Auth/Login.cs
@@ -1,5 +1,6 @@
 ﻿using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.UseCases.Identity.Login;
 using Endatix.Api.Infrastructure;
@@ -21,8 +22,17 @@ public class Login(IMediator mediator) : Endpoint<LoginRequest, Results<Ok<Login
             s.Description = "Authenticates a user based on valid credentials and returns JWT token and refresh token";
             s.Responses[200] = "User has been successfully authenticated";
             s.Responses[400] = "The supplied credentials are invalid!";
+            s.Responses[500] = "The login session could not be persisted.";
             s.ExampleRequest = new LoginRequest("user@example.com", "Password123!");
+            s.ResponseExamples[200] = new LoginResponse(
+                "user@example.com",
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.access-token",
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.refresh-token");
         });
+        Description(builder => builder
+            .Produces<LoginResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status500InternalServerError));
     }
 
     /// <inheritdoc />

--- a/src/Endatix.Api/Endpoints/Auth/Logout.cs
+++ b/src/Endatix.Api/Endpoints/Auth/Logout.cs
@@ -1,13 +1,13 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.Identity.Login;
-using Endatix.Core.Abstractions.Authorization;
 
 namespace Endatix.Api.Endpoints.Auth;
 
-public class Logout(IMediator mediator) : EndpointWithoutRequest<Results<Ok<LogoutResponse>, BadRequest>>
+public class Logout(IMediator mediator) : EndpointWithoutRequest<Results<Ok<LogoutResponse>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings for the logout functionality.
@@ -21,21 +21,24 @@ public class Logout(IMediator mediator) : EndpointWithoutRequest<Results<Ok<Logo
             s.Description = "Initiates the logout process for the authenticated user.";
             s.Responses[200] = "User logged out successfully.";
             s.Responses[400] = "Invalid request or authentication state.";
+            s.ResponseExamples[200] = new LogoutResponse("User logged out successfully.");
         });
+        Description(builder => builder
+            .Produces<LogoutResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <summary>
     /// Executes the logout functionality
     /// </summary>
-    /// <param name="cancellationToken">Cancellation token for the async operation.</param>
-    public override async Task<Results<Ok<LogoutResponse>, BadRequest>> ExecuteAsync(CancellationToken cancellationToken)
+    /// <param name="ct">Cancellation token for the async operation.</param>
+    public override async Task<Results<Ok<LogoutResponse>, ProblemHttpResult>> ExecuteAsync(CancellationToken ct)
     {
-
         var logoutUserCmd = new LogoutCommand(User);
-        var logoutResult = await mediator.Send(logoutUserCmd, cancellationToken);
+        var logoutResult = await mediator.Send(logoutUserCmd, ct);
 
         return TypedResultsBuilder
                 .MapResult(logoutResult, (message) => new LogoutResponse(message))
-                .SetTypedResults<Ok<LogoutResponse>, BadRequest>();
+                .SetTypedResults<Ok<LogoutResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Auth/Me.cs
+++ b/src/Endatix.Api/Endpoints/Auth/Me.cs
@@ -26,10 +26,10 @@ public class Me(ICurrentUserAuthorizationService authorizationService)
     }
 
     public override async Task<Results<Ok<AuthorizationData>, UnauthorizedHttpResult>> ExecuteAsync(
-        CancellationToken cancellationToken)
+        CancellationToken ct)
     {
         // Get user roles and permissions from AuthorizationService
-        var authorizationDataResult = await authorizationService.GetAuthorizationDataAsync(cancellationToken);
+        var authorizationDataResult = await authorizationService.GetAuthorizationDataAsync(ct);
         if (!authorizationDataResult.IsSuccess)
         {
             return TypedResults.Unauthorized();

--- a/src/Endatix.Api/Endpoints/Auth/RefreshToken.cs
+++ b/src/Endatix.Api/Endpoints/Auth/RefreshToken.cs
@@ -1,6 +1,6 @@
 using FastEndpoints;
 using MediatR;
-using Errors = Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.Identity.RefreshToken;
@@ -10,7 +10,7 @@ namespace Endatix.Api.Endpoints.Auth;
 /// <summary>
 /// Endpoint for refreshing the access token using a refresh token
 /// </summary>
-public class RefreshToken(IMediator mediator) : Endpoint<RefreshTokenRequest, Results<Ok<RefreshTokenResponse>, BadRequest<Errors.ProblemDetails>>>
+public class RefreshToken(IMediator mediator) : Endpoint<RefreshTokenRequest, Results<Ok<RefreshTokenResponse>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint
@@ -26,11 +26,15 @@ public class RefreshToken(IMediator mediator) : Endpoint<RefreshTokenRequest, Re
             s.Responses[200] = "Access token successfully refreshed.";
             s.Responses[400] = "Invalid or expired refresh token.";
             s.ExampleRequest = new { RefreshToken = "example-refresh-token" };
+            s.ResponseExamples[200] = new RefreshTokenResponse("access-token", "refresh-token");
         });
+        Description(builder => builder
+            .Produces<RefreshTokenResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<RefreshTokenResponse>, BadRequest<Errors.ProblemDetails>>> ExecuteAsync(RefreshTokenRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<RefreshTokenResponse>, ProblemHttpResult>> ExecuteAsync(RefreshTokenRequest request, CancellationToken cancellationToken)
     {
         var authHeader = request.Authorization;
         var accessToken = authHeader!["Bearer ".Length..].Trim();
@@ -40,6 +44,6 @@ public class RefreshToken(IMediator mediator) : Endpoint<RefreshTokenRequest, Re
         return TypedResultsBuilder
                 .MapResult(result, (tokenDto) => new RefreshTokenResponse(tokenDto.AccessToken.Token, tokenDto.RefreshToken.Token))
                 .SetErrorMessage("Invalid or expired token.")
-                .SetTypedResults<Ok<RefreshTokenResponse>, BadRequest<Errors.ProblemDetails>>();
+                .SetTypedResults<Ok<RefreshTokenResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Auth/RefreshToken.cs
+++ b/src/Endatix.Api/Endpoints/Auth/RefreshToken.cs
@@ -34,12 +34,12 @@ public class RefreshToken(IMediator mediator) : Endpoint<RefreshTokenRequest, Re
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<RefreshTokenResponse>, ProblemHttpResult>> ExecuteAsync(RefreshTokenRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<RefreshTokenResponse>, ProblemHttpResult>> ExecuteAsync(RefreshTokenRequest request, CancellationToken ct)
     {
         var authHeader = request.Authorization;
         var accessToken = authHeader!["Bearer ".Length..].Trim();
         var refreshCommand = new RefreshTokenCommand(accessToken, request.RefreshToken!);
-        var result = await mediator.Send(refreshCommand, cancellationToken);
+        var result = await mediator.Send(refreshCommand, ct);
 
         return TypedResultsBuilder
                 .MapResult(result, (tokenDto) => new RefreshTokenResponse(tokenDto.AccessToken.Token, tokenDto.RefreshToken.Token))

--- a/src/Endatix.Api/Endpoints/Auth/Register.RegisterRequest.cs
+++ b/src/Endatix.Api/Endpoints/Auth/Register.RegisterRequest.cs
@@ -3,7 +3,7 @@ using Endatix.Core.Infrastructure.Logging;
 namespace Endatix.Api.Endpoints.Auth;
 
 /// <summary>
-/// Represents the request for the "/register" endpoint, handled by the <see cref="Register.HandleAsync"/> method.
+/// Represents the request for the "/register" endpoint, handled by the <see cref="Register.ExecuteAsync"/> method.
 /// </summary>
 public record RegisterRequest(string Email, string Password, string ConfirmPassword)
 {

--- a/src/Endatix.Api/Endpoints/Auth/Register.RegisterResponse.cs
+++ b/src/Endatix.Api/Endpoints/Auth/Register.RegisterResponse.cs
@@ -1,7 +1,7 @@
 namespace Endatix.Api.Endpoints.Auth;
 
 /// <summary>
-/// The response type for the "/register" endpoint returned by the <see cref="Register.HandleAsync"/> method.
+/// The response type for the "/register" endpoint returned by the <see cref="Register.ExecuteAsync"/> method.
 /// </summary>
 public record RegisterResponse(bool Success, string Message)
 {

--- a/src/Endatix.Api/Endpoints/Auth/Register.cs
+++ b/src/Endatix.Api/Endpoints/Auth/Register.cs
@@ -1,7 +1,7 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
-using Errors = Microsoft.AspNetCore.Mvc;
 using Endatix.Core.UseCases.Identity.Register;
 using Endatix.Api.Infrastructure;
 
@@ -10,7 +10,7 @@ namespace Endatix.Api.Endpoints.Auth;
 /// <summary>
 /// Endpoint for registering new user
 /// </summary>
-public class Register(IMediator mediator) : Endpoint<RegisterRequest, Results<Ok<RegisterResponse>, BadRequest<Errors.ProblemDetails>>>
+public class Register(IMediator mediator) : Endpoint<RegisterRequest, Results<Ok<RegisterResponse>, ProblemHttpResult>>
 {
     public override void Configure()
     {
@@ -23,11 +23,15 @@ public class Register(IMediator mediator) : Endpoint<RegisterRequest, Results<Ok
             s.Responses[200] = "User has been successfully registered.";
             s.Responses[400] = "Registration failed. Please check your input and try again.";
             s.ExampleRequest = new RegisterRequest("user@example.com", "Password123!", "Password123!");
+            s.ResponseExamples[200] = new RegisterResponse(Success: true, Message: "User has been successfully registered");
         });
+        Description(builder => builder
+            .Produces<RegisterResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<RegisterResponse>, BadRequest<Errors.ProblemDetails>>> ExecuteAsync(RegisterRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<RegisterResponse>, ProblemHttpResult>> ExecuteAsync(RegisterRequest request, CancellationToken cancellationToken)
     {
         var registerUserCommand = new RegisterCommand(request.Email, request.Password);
         var userRegistrationResult = await mediator.Send(registerUserCommand, cancellationToken);
@@ -45,6 +49,6 @@ public class Register(IMediator mediator) : Endpoint<RegisterRequest, Results<Ok
         return TypedResultsBuilder
                 .MapResult(userRegistrationResult, (user) => new RegisterResponse(Success: true, Message: "User has been successfully registered"))
                 .SetErrorMessage(errorMessage)
-                .SetTypedResults<Ok<RegisterResponse>, BadRequest<Errors.ProblemDetails>>();
+                .SetTypedResults<Ok<RegisterResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Auth/Register.cs
+++ b/src/Endatix.Api/Endpoints/Auth/Register.cs
@@ -31,10 +31,10 @@ public class Register(IMediator mediator) : Endpoint<RegisterRequest, Results<Ok
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<RegisterResponse>, ProblemHttpResult>> ExecuteAsync(RegisterRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<RegisterResponse>, ProblemHttpResult>> ExecuteAsync(RegisterRequest request, CancellationToken ct)
     {
         var registerUserCommand = new RegisterCommand(request.Email, request.Password);
-        var userRegistrationResult = await mediator.Send(registerUserCommand, cancellationToken);
+        var userRegistrationResult = await mediator.Send(registerUserCommand, ct);
 
         var errorMessage = "Registration failed. ";
         if (userRegistrationResult.Status == Core.Infrastructure.Result.ResultStatus.Invalid && userRegistrationResult.ValidationErrors.Any())

--- a/src/Endatix.Api/Endpoints/Auth/SendVerificationEmail.cs
+++ b/src/Endatix.Api/Endpoints/Auth/SendVerificationEmail.cs
@@ -31,10 +31,10 @@ public class SendVerificationEmail(IMediator mediator) : Endpoint<SendVerificati
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<string>, ProblemHttpResult>> ExecuteAsync(SendVerificationEmailRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<string>, ProblemHttpResult>> ExecuteAsync(SendVerificationEmailRequest request, CancellationToken ct)
     {
         var sendVerificationEmailCommand = new SendVerificationEmailCommand(request.Email);
-        var result = await mediator.Send(sendVerificationEmailCommand, cancellationToken);
+        var result = await mediator.Send(sendVerificationEmailCommand, ct);
 
         return TypedResultsBuilder
                 .MapResult(result, result => "Verification email sent successfully")

--- a/src/Endatix.Api/Endpoints/Auth/SendVerificationEmail.cs
+++ b/src/Endatix.Api/Endpoints/Auth/SendVerificationEmail.cs
@@ -1,7 +1,7 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
-using Errors = Microsoft.AspNetCore.Mvc;
 using Endatix.Core.UseCases.Identity.SendVerificationEmail;
 using Endatix.Api.Infrastructure;
 
@@ -10,7 +10,7 @@ namespace Endatix.Api.Endpoints.Auth;
 /// <summary>
 /// Endpoint for sending verification emails to users.
 /// </summary>
-public class SendVerificationEmail(IMediator mediator) : Endpoint<SendVerificationEmailRequest, Results<Ok<string>, BadRequest<Errors.ProblemDetails>>>
+public class SendVerificationEmail(IMediator mediator) : Endpoint<SendVerificationEmailRequest, Results<Ok<string>, ProblemHttpResult>>
 {
     public override void Configure()
     {
@@ -23,17 +23,21 @@ public class SendVerificationEmail(IMediator mediator) : Endpoint<SendVerificati
             s.Responses[200] = "Verification email has been sent successfully.";
             s.Responses[400] = "Invalid email address.";
             s.ExampleRequest = new SendVerificationEmailRequest("user@example.com");
+            s.ResponseExamples[200] = "Verification email sent successfully";
         });
+        Description(builder => builder
+            .Produces<string>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<string>, BadRequest<Errors.ProblemDetails>>> ExecuteAsync(SendVerificationEmailRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<string>, ProblemHttpResult>> ExecuteAsync(SendVerificationEmailRequest request, CancellationToken cancellationToken)
     {
         var sendVerificationEmailCommand = new SendVerificationEmailCommand(request.Email);
         var result = await mediator.Send(sendVerificationEmailCommand, cancellationToken);
 
         return TypedResultsBuilder
                 .MapResult(result, result => "Verification email sent successfully")
-                .SetTypedResults<Ok<string>, BadRequest<Errors.ProblemDetails>>();
+                .SetTypedResults<Ok<string>, ProblemHttpResult>();
     }
-} 
+}

--- a/src/Endatix.Api/Endpoints/Auth/VerifyEmail.cs
+++ b/src/Endatix.Api/Endpoints/Auth/VerifyEmail.cs
@@ -33,10 +33,10 @@ public class VerifyEmail(IMediator mediator) : Endpoint<VerifyEmailRequest, Resu
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<string>, ProblemHttpResult>> ExecuteAsync(VerifyEmailRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<string>, ProblemHttpResult>> ExecuteAsync(VerifyEmailRequest request, CancellationToken ct)
     {
         var verifyEmailCommand = new VerifyEmailCommand(request.Token);
-        var emailVerificationResult = await mediator.Send(verifyEmailCommand, cancellationToken);
+        var emailVerificationResult = await mediator.Send(verifyEmailCommand, ct);
 
         var builder = TypedResultsBuilder.MapResult(emailVerificationResult, user => user.Id.ToString());
 

--- a/src/Endatix.Api/Endpoints/Auth/VerifyEmail.cs
+++ b/src/Endatix.Api/Endpoints/Auth/VerifyEmail.cs
@@ -1,7 +1,7 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
-using Errors = Microsoft.AspNetCore.Mvc;
 using Endatix.Core.UseCases.Identity.VerifyEmail;
 using Endatix.Api.Infrastructure;
 
@@ -10,7 +10,7 @@ namespace Endatix.Api.Endpoints.Auth;
 /// <summary>
 /// Endpoint for verifying user email addresses.
 /// </summary>
-public class VerifyEmail(IMediator mediator) : Endpoint<VerifyEmailRequest, Results<Ok<string>, BadRequest<Errors.ProblemDetails>, NotFound>>
+public class VerifyEmail(IMediator mediator) : Endpoint<VerifyEmailRequest, Results<Ok<string>, ProblemHttpResult>>
 {
     public override void Configure()
     {
@@ -21,31 +21,36 @@ public class VerifyEmail(IMediator mediator) : Endpoint<VerifyEmailRequest, Resu
             s.Summary = "Verify email address";
             s.Description = "Verifies a user's email address using a verification token.";
             s.Responses[200] = "Email has been successfully verified. Returns the user ID.";
+            // Every token failure - unknown, expired, already used - answers 400 with the same
+            // shape on purpose, so the response cannot be used to probe token or account state.
             s.Responses[400] = "Invalid or expired verification token.";
-            s.Responses[404] = "Verification token not found.";
             s.ExampleRequest = new VerifyEmailRequest("abc123def456...");
+            s.ResponseExamples[200] = "1";
         });
+        Description(builder => builder
+            .Produces<string>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<string>, BadRequest<Errors.ProblemDetails>, NotFound>> ExecuteAsync(VerifyEmailRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<string>, ProblemHttpResult>> ExecuteAsync(VerifyEmailRequest request, CancellationToken cancellationToken)
     {
         var verifyEmailCommand = new VerifyEmailCommand(request.Token);
         var emailVerificationResult = await mediator.Send(verifyEmailCommand, cancellationToken);
 
-        var errorMessage = string.Empty;
-        if (emailVerificationResult.Status == Core.Infrastructure.Result.ResultStatus.Invalid && emailVerificationResult.ValidationErrors.Any())
+        var builder = TypedResultsBuilder.MapResult(emailVerificationResult, user => user.Id.ToString());
+
+        // Only override the problem title for validation failures. Other statuses (404 in
+        // particular) keep ToProblem's status-derived title instead of a 400-shaped message.
+        if (emailVerificationResult.Status == Core.Infrastructure.Result.ResultStatus.Invalid)
         {
-            errorMessage += emailVerificationResult.ValidationErrors.First().ErrorMessage;
-        }
-        else
-        {
-            errorMessage += "Please check the verification token and try again.";
+            var validationMessage = emailVerificationResult.ValidationErrors
+                .Select(error => error.ErrorMessage)
+                .FirstOrDefault(message => !string.IsNullOrWhiteSpace(message));
+
+            builder.SetErrorMessage(validationMessage ?? "Please check the verification token and try again.");
         }
 
-        return TypedResultsBuilder
-                .MapResult(emailVerificationResult, user => user.Id.ToString())
-                .SetErrorMessage(errorMessage)
-                .SetTypedResults<Ok<string>, BadRequest<Errors.ProblemDetails>, NotFound>();
+        return builder.SetTypedResults<Ok<string>, ProblemHttpResult>();
     }
-} 
+}

--- a/src/Endatix.Api/Endpoints/CustomQuestions/Create/Create.cs
+++ b/src/Endatix.Api/Endpoints/CustomQuestions/Create/Create.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.Abstractions.Authorization;
@@ -10,7 +11,8 @@ namespace Endatix.Api.Endpoints.CustomQuestions;
 /// <summary>
 /// Endpoint for creating a new custom question.
 /// </summary>
-public class Create(IMediator mediator) : Endpoint<CreateCustomQuestionRequest, Results<Created<CreateCustomQuestionResponse>, BadRequest>>
+public class Create(IMediator mediator)
+    : Endpoint<CreateCustomQuestionRequest, Results<Created<CreateCustomQuestionResponse>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -23,22 +25,40 @@ public class Create(IMediator mediator) : Endpoint<CreateCustomQuestionRequest, 
         {
             s.Summary = "Create a new custom question";
             s.Description = "Creates a new custom question with the provided data.";
+            s.ExampleRequest = new CreateCustomQuestionRequest
+            {
+                Name = "NPS score",
+                Description = "Net promoter score question.",
+                JsonData = "{ \"type\": \"rating\" }",
+            };
+            s.ResponseExamples[201] = new CreateCustomQuestionResponse
+            {
+                Id = "1",
+                Name = "NPS score",
+                Description = "Net promoter score question.",
+                JsonData = "{ \"type\": \"rating\" }",
+            };
             s.Responses[201] = "Custom question created successfully.";
             s.Responses[400] = "Invalid input data.";
         });
+        Description(builder => builder
+            .Produces<CreateCustomQuestionResponse>(StatusCodes.Status201Created, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Created<CreateCustomQuestionResponse>, BadRequest>> ExecuteAsync(CreateCustomQuestionRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Created<CreateCustomQuestionResponse>, ProblemHttpResult>> ExecuteAsync(
+        CreateCustomQuestionRequest request,
+        CancellationToken cancellationToken)
     {
         var command = new CreateCustomQuestionCommand(
             request.Name!,
             request.JsonData!,
             request.Description);
         var result = await mediator.Send(command, cancellationToken);
-        
+
         return TypedResultsBuilder
             .MapResult(result, CustomQuestionMapper.Map<CreateCustomQuestionResponse>)
-            .SetTypedResults<Created<CreateCustomQuestionResponse>, BadRequest>();
+            .SetTypedResults<Created<CreateCustomQuestionResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/CustomQuestions/Create/Create.cs
+++ b/src/Endatix.Api/Endpoints/CustomQuestions/Create/Create.cs
@@ -49,13 +49,13 @@ public class Create(IMediator mediator)
     /// <inheritdoc/>
     public override async Task<Results<Created<CreateCustomQuestionResponse>, ProblemHttpResult>> ExecuteAsync(
         CreateCustomQuestionRequest request,
-        CancellationToken cancellationToken)
+        CancellationToken ct)
     {
         var command = new CreateCustomQuestionCommand(
             request.Name!,
             request.JsonData!,
             request.Description);
-        var result = await mediator.Send(command, cancellationToken);
+        var result = await mediator.Send(command, ct);
 
         return TypedResultsBuilder
             .MapResult(result, CustomQuestionMapper.Map<CreateCustomQuestionResponse>)

--- a/src/Endatix.Api/Endpoints/CustomQuestions/List/List.cs
+++ b/src/Endatix.Api/Endpoints/CustomQuestions/List/List.cs
@@ -7,6 +7,7 @@ using Endatix.Core.UseCases.CustomQuestions.List;
 using FastEndpoints;
 using FluentValidation;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.CustomQuestions;
@@ -15,7 +16,7 @@ namespace Endatix.Api.Endpoints.CustomQuestions;
 /// Endpoint for listing custom questions.
 /// </summary>
 public class List(IMediator mediator)
-    : Endpoint<CustomQuestionsListRequest, Results<Ok<Paged<CustomQuestionModel>>, BadRequest>>
+    : Endpoint<CustomQuestionsListRequest, Results<Ok<Paged<CustomQuestionModel>>, ProblemHttpResult>>
 {
     public const int DefaultPageSize = 25;
 
@@ -38,13 +39,30 @@ public class List(IMediator mediator)
                 SortBy = CustomQuestionListSortBy.CreatedAt,
                 SortDir = SortDirection.Desc
             };
+            s.ResponseExamples[200] = new Paged<CustomQuestionModel>(
+                page: 1,
+                pageSize: DefaultPageSize,
+                totalRecords: 1,
+                totalPages: 1,
+                items:
+                [
+                    new CustomQuestionModel
+                    {
+                        Id = "1",
+                        Name = "NPS score",
+                        JsonData = "{ \"type\": \"rating\" }",
+                    },
+                ]);
             s.Responses[200] = "Custom questions retrieved successfully.";
             s.Responses[400] = "Invalid input data.";
         });
+        Description(builder => builder
+            .Produces<Paged<CustomQuestionModel>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<Paged<CustomQuestionModel>>, BadRequest>> ExecuteAsync(
+    public override async Task<Results<Ok<Paged<CustomQuestionModel>>, ProblemHttpResult>> ExecuteAsync(
         CustomQuestionsListRequest request,
         CancellationToken ct)
     {
@@ -60,7 +78,7 @@ public class List(IMediator mediator)
 
         return TypedResultsBuilder
             .MapResult(result, Map)
-            .SetTypedResults<Ok<Paged<CustomQuestionModel>>, BadRequest>();
+            .SetTypedResults<Ok<Paged<CustomQuestionModel>>, ProblemHttpResult>();
     }
 
     private static Paged<CustomQuestionModel> Map(Paged<Core.Entities.CustomQuestion> paged)

--- a/src/Endatix.Api/Endpoints/Folders/Create.cs
+++ b/src/Endatix.Api/Endpoints/Folders/Create.cs
@@ -6,6 +6,7 @@ using Endatix.Infrastructure.Data.Config;
 using FastEndpoints;
 using FluentValidation;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.Folders;
@@ -25,6 +26,9 @@ public sealed class Create(IMediator mediator)
             s.Responses[201] = "Folder created successfully.";
             s.Responses[400] = "Invalid input data.";
         });
+        Description(builder => builder
+            .Produces<FolderModel>(StatusCodes.Status201Created, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Folders/Delete.cs
+++ b/src/Endatix.Api/Endpoints/Folders/Delete.cs
@@ -4,6 +4,7 @@ using Endatix.Core.UseCases.Folders.Delete;
 using FastEndpoints;
 using FluentValidation;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.Folders;
@@ -28,6 +29,10 @@ public sealed class Delete(IMediator mediator)
             s.Responses[404] = "Folder not found.";
             s.Responses[409] = "Folder is locked and cannot be deleted.";
         });
+        Description(builder => builder
+            .Produces<string>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Folders/GetBySlug.cs
+++ b/src/Endatix.Api/Endpoints/Folders/GetBySlug.cs
@@ -6,6 +6,7 @@ using Endatix.Infrastructure.Data.Config;
 using FastEndpoints;
 using FluentValidation;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.Folders;
@@ -29,6 +30,10 @@ public sealed class GetBySlug(IMediator mediator)
             s.Responses[400] = "Invalid request or access data.";
             s.Responses[404] = "Folder not found.";
         });
+        Description(builder => builder
+            .Produces<FolderModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Folders/List.cs
+++ b/src/Endatix.Api/Endpoints/Folders/List.cs
@@ -3,6 +3,7 @@ using Endatix.Core.Abstractions.Authorization;
 using Endatix.Core.UseCases.Folders.List;
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.Folders;
@@ -29,6 +30,11 @@ public sealed class List(ICurrentUserAuthorizationService authorizationService, 
             s.Responses[403] = "Forbidden. User does not have permission to manage folders.";
             s.Responses[404] = "Not found. The requested resource was not found.";
         });
+        Description(builder => builder
+            .Produces<IEnumerable<FolderModel>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status403Forbidden)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     public override async Task<Results<Ok<IEnumerable<FolderModel>>, ProblemHttpResult>> ExecuteAsync(

--- a/src/Endatix.Api/Endpoints/Folders/PartialUpdate.cs
+++ b/src/Endatix.Api/Endpoints/Folders/PartialUpdate.cs
@@ -6,6 +6,7 @@ using Endatix.Infrastructure.Data.Config;
 using FastEndpoints;
 using FluentValidation;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.Folders;
@@ -30,6 +31,11 @@ public sealed class PartialUpdate(IMediator mediator)
             s.Responses[404] = "Folder not found.";
             s.Responses[409] = "Folder is locked and cannot be updated.";
         });
+        Description(builder => builder
+            .Produces<FolderModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/FormDefinitions/Create.cs
+++ b/src/Endatix.Api/Endpoints/FormDefinitions/Create.cs
@@ -1,5 +1,6 @@
 ﻿using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.FormDefinitions.Create;
@@ -10,7 +11,7 @@ namespace Endatix.Api.Endpoints.FormDefinitions;
 /// <summary>
 /// Endpoint for creating a new form definition.
 /// </summary>
-public class Create(IMediator mediator) : Endpoint<CreateFormDefinitionRequest, Results<Created<CreateFormDefinitionResponse>, BadRequest, NotFound>>
+public class Create(IMediator mediator) : Endpoint<CreateFormDefinitionRequest, Results<Created<CreateFormDefinitionResponse>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -23,21 +24,38 @@ public class Create(IMediator mediator) : Endpoint<CreateFormDefinitionRequest, 
         {
             s.Summary = "Create a new form definition";
             s.Description = "Creates a new form definition for a given form.";
+            s.ExampleRequest = new CreateFormDefinitionRequest
+            {
+                FormId = 1,
+                IsDraft = true,
+                JsonData = "{}",
+            };
+            s.ResponseExamples[201] = new CreateFormDefinitionResponse
+            {
+                Id = "1",
+                FormId = "1",
+                IsDraft = true,
+                JsonData = "{}",
+            };
             s.Responses[201] = "Form definition created successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form not found.";
         });
+        Description(builder => builder
+            .Produces<CreateFormDefinitionResponse>(StatusCodes.Status201Created, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Created<CreateFormDefinitionResponse>, BadRequest, NotFound>> ExecuteAsync(CreateFormDefinitionRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Created<CreateFormDefinitionResponse>, ProblemHttpResult>> ExecuteAsync(CreateFormDefinitionRequest request, CancellationToken ct)
     {
         var result = await mediator.Send(
             new CreateFormDefinitionCommand(request.FormId, request.IsDraft!.Value, request.JsonData!),
-            cancellationToken);
+            ct);
 
         return TypedResultsBuilder
             .MapResult(result, FormDefinitionMapper.Map<CreateFormDefinitionResponse>)
-            .SetTypedResults<Created<CreateFormDefinitionResponse>, BadRequest, NotFound>();
+            .SetTypedResults<Created<CreateFormDefinitionResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/FormDefinitions/GetActive.cs
+++ b/src/Endatix.Api/Endpoints/FormDefinitions/GetActive.cs
@@ -1,5 +1,6 @@
 ﻿using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.FormDefinitions.GetActive;
@@ -24,10 +25,22 @@ public class GetActive(IMediator mediator, IUserContext userContext) : Endpoint<
         {
             s.Summary = "Get the active form definition";
             s.Description = "Gets the active form definition for a given form.";
+            s.ExampleRequest = new GetActiveFormDefinitionRequest { FormId = 1 };
+            s.ResponseExamples[200] = new FormDefinitionModel
+            {
+                Id = "1",
+                FormId = "1",
+                IsDraft = false,
+                JsonData = "{}",
+            };
             s.Responses[200] = "Active form definition retrieved successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form not found.";
         });
+        Description(builder => builder
+            .Produces<FormDefinitionModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/FormDefinitions/GetById.cs
+++ b/src/Endatix.Api/Endpoints/FormDefinitions/GetById.cs
@@ -1,5 +1,6 @@
 ﻿using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.FormDefinitions.GetById;
@@ -10,7 +11,7 @@ namespace Endatix.Api.Endpoints.FormDefinitions;
 /// <summary>
 /// Endpoint for getting a form definition by ID.
 /// </summary>
-public class GetById(IMediator mediator) : Endpoint<GetFormDefinitionByIdRequest, Results<Ok<FormDefinitionModel>, BadRequest, NotFound>>
+public class GetById(IMediator mediator) : Endpoint<GetFormDefinitionByIdRequest, Results<Ok<FormDefinitionModel>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -23,21 +24,33 @@ public class GetById(IMediator mediator) : Endpoint<GetFormDefinitionByIdRequest
         {
             s.Summary = "Get a form definition by ID";
             s.Description = "Gets a form definition by its ID for a given form.";
+            s.ExampleRequest = new GetFormDefinitionByIdRequest { FormId = 1, DefinitionId = 1 };
+            s.ResponseExamples[200] = new FormDefinitionModel
+            {
+                Id = "1",
+                FormId = "1",
+                IsDraft = false,
+                JsonData = "{}",
+            };
             s.Responses[200] = "Form definition retrieved successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form definition or form not found.";
         });
+        Description(builder => builder
+            .Produces<FormDefinitionModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc />
-    public override async Task<Results<Ok<FormDefinitionModel>, BadRequest, NotFound>> ExecuteAsync(GetFormDefinitionByIdRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<FormDefinitionModel>, ProblemHttpResult>> ExecuteAsync(GetFormDefinitionByIdRequest request, CancellationToken ct)
     {
         var result = await mediator.Send(
             new GetFormDefinitionByIdQuery(request.FormId, request.DefinitionId),
-            cancellationToken);
+            ct);
 
         return TypedResultsBuilder
             .MapResult(result, FormDefinitionMapper.Map<FormDefinitionModel>)
-            .SetTypedResults<Ok<FormDefinitionModel>, BadRequest, NotFound>();
+            .SetTypedResults<Ok<FormDefinitionModel>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/FormDefinitions/GetFields.cs
+++ b/src/Endatix.Api/Endpoints/FormDefinitions/GetFields.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.Abstractions.Authorization;
@@ -26,15 +27,19 @@ public class GetFields(IMediator mediator) : Endpoint<GetFieldsRequest, Results<
             s.Responses[400] = "Invalid form ID.";
             s.Responses[404] = "Form not found.";
         });
+        Description(builder => builder
+            .Produces<IEnumerable<DefinitionFieldModel>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
     public override async Task<Results<Ok<IEnumerable<DefinitionFieldModel>>, ProblemHttpResult>> ExecuteAsync(
         GetFieldsRequest request,
-        CancellationToken cancellationToken)
+        CancellationToken ct)
     {
         var query = new GetFormDefinitionFieldsQuery(request.FormId);
-        var result = await mediator.Send(query, cancellationToken);
+        var result = await mediator.Send(query, ct);
 
         return TypedResultsBuilder
             .MapResult(result, FormDefinitionMapper.Map)

--- a/src/Endatix.Api/Endpoints/FormDefinitions/List.cs
+++ b/src/Endatix.Api/Endpoints/FormDefinitions/List.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Common;
 using Endatix.Api.Infrastructure;
@@ -14,7 +15,7 @@ namespace Endatix.Api.Endpoints.FormDefinitions;
 /// <summary>
 /// Endpoint for listing form definitions.
 /// </summary>
-public class List(IMediator mediator) : Endpoint<FormDefinitionsListRequest, Results<Ok<Paged<FormDefinitionModel>>, BadRequest, NotFound>>
+public class List(IMediator mediator) : Endpoint<FormDefinitionsListRequest, Results<Ok<Paged<FormDefinitionModel>>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -36,14 +37,33 @@ public class List(IMediator mediator) : Endpoint<FormDefinitionsListRequest, Res
                 SortBy = FormDefinitionListSortBy.CreatedAt,
                 SortDir = SortDirection.Desc,
             };
+            s.ResponseExamples[200] = new Paged<FormDefinitionModel>(
+                page: 1,
+                pageSize: 20,
+                totalRecords: 1,
+                totalPages: 1,
+                items:
+                [
+                    new FormDefinitionModel
+                    {
+                        Id = "1",
+                        FormId = "1",
+                        IsDraft = false,
+                        JsonData = "{}",
+                    },
+                ]);
             s.Responses[200] = "Form definitions retrieved successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form not found.";
         });
+        Description(builder => builder
+            .Produces<Paged<FormDefinitionModel>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc />
-    public override async Task<Results<Ok<Paged<FormDefinitionModel>>, BadRequest, NotFound>> ExecuteAsync(
+    public override async Task<Results<Ok<Paged<FormDefinitionModel>>, ProblemHttpResult>> ExecuteAsync(
         FormDefinitionsListRequest request,
         CancellationToken ct)
     {
@@ -61,7 +81,7 @@ public class List(IMediator mediator) : Endpoint<FormDefinitionsListRequest, Res
 
         return TypedResultsBuilder
             .MapResult(result, Map)
-            .SetTypedResults<Ok<Paged<FormDefinitionModel>>, BadRequest, NotFound>();
+            .SetTypedResults<Ok<Paged<FormDefinitionModel>>, ProblemHttpResult>();
     }
 
     private static Paged<FormDefinitionModel> Map(Paged<FormDefinition> paged) =>

--- a/src/Endatix.Api/Endpoints/FormDefinitions/PartialUpdate.cs
+++ b/src/Endatix.Api/Endpoints/FormDefinitions/PartialUpdate.cs
@@ -1,5 +1,6 @@
 ﻿using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.FormDefinitions.PartialUpdate;
@@ -10,7 +11,7 @@ namespace Endatix.Api.Endpoints.FormDefinitions;
 /// <summary>
 /// Endpoint for partially updating a form definition.
 /// </summary>
-public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateFormDefinitionRequest, Results<Ok<PartialUpdateFormDefinitionResponse>, BadRequest, NotFound>>
+public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateFormDefinitionRequest, Results<Ok<PartialUpdateFormDefinitionResponse>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -23,21 +24,38 @@ public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateFormDefin
         {
             s.Summary = "Partially update a form definition";
             s.Description = "Partially updates a form definition for a given form.";
+            s.ExampleRequest = new PartialUpdateFormDefinitionRequest
+            {
+                FormId = 1,
+                DefinitionId = 1,
+                IsDraft = true,
+            };
+            s.ResponseExamples[200] = new PartialUpdateFormDefinitionResponse
+            {
+                Id = "1",
+                FormId = "1",
+                IsDraft = true,
+                JsonData = "{}",
+            };
             s.Responses[200] = "Form definition updated successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form definition or form not found.";
         });
+        Description(builder => builder
+            .Produces<PartialUpdateFormDefinitionResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc />
-    public override async Task<Results<Ok<PartialUpdateFormDefinitionResponse>, BadRequest, NotFound>> ExecuteAsync(PartialUpdateFormDefinitionRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<PartialUpdateFormDefinitionResponse>, ProblemHttpResult>> ExecuteAsync(PartialUpdateFormDefinitionRequest request, CancellationToken ct)
     {
         var result = await mediator.Send(
             new PartialUpdateFormDefinitionCommand(request.FormId, request.DefinitionId, request.IsDraft, request.JsonData),
-            cancellationToken);
+            ct);
 
         return TypedResultsBuilder
             .MapResult(result, FormDefinitionMapper.Map<PartialUpdateFormDefinitionResponse>)
-            .SetTypedResults<Ok<PartialUpdateFormDefinitionResponse>, BadRequest, NotFound>();
+            .SetTypedResults<Ok<PartialUpdateFormDefinitionResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/FormDefinitions/PartialUpdateActive.cs
+++ b/src/Endatix.Api/Endpoints/FormDefinitions/PartialUpdateActive.cs
@@ -1,5 +1,6 @@
 ﻿using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.FormDefinitions.PartialUpdateActive;
@@ -10,7 +11,7 @@ namespace Endatix.Api.Endpoints.FormDefinitions;
 /// <summary>
 /// Endpoint for partially updating the active form definition.
 /// </summary>
-public class PartialUpdateActive(IMediator mediator) : Endpoint<PartialUpdateActiveFormDefinitionRequest, Results<Ok<PartialUpdateActiveFormDefinitionResponse>, BadRequest, NotFound>>
+public class PartialUpdateActive(IMediator mediator) : Endpoint<PartialUpdateActiveFormDefinitionRequest, Results<Ok<PartialUpdateActiveFormDefinitionResponse>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -23,21 +24,37 @@ public class PartialUpdateActive(IMediator mediator) : Endpoint<PartialUpdateAct
         {
             s.Summary = "Partially update the active form definition";
             s.Description = "Partially updates the active form definition for a given form.";
+            s.ExampleRequest = new PartialUpdateActiveFormDefinitionRequest
+            {
+                FormId = 1,
+                IsDraft = true,
+            };
+            s.ResponseExamples[200] = new PartialUpdateActiveFormDefinitionResponse
+            {
+                Id = "1",
+                FormId = "1",
+                IsDraft = true,
+                JsonData = "{}",
+            };
             s.Responses[200] = "Active form definition updated successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form not found.";
         });
+        Description(builder => builder
+            .Produces<PartialUpdateActiveFormDefinitionResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc />
-    public override async Task<Results<Ok<PartialUpdateActiveFormDefinitionResponse>, BadRequest, NotFound>> ExecuteAsync(PartialUpdateActiveFormDefinitionRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<PartialUpdateActiveFormDefinitionResponse>, ProblemHttpResult>> ExecuteAsync(PartialUpdateActiveFormDefinitionRequest request, CancellationToken ct)
     {
         var result = await mediator.Send(
             new PartialUpdateActiveFormDefinitionCommand(request.FormId, request.IsDraft, request.JsonData),
-            cancellationToken);
+            ct);
 
         return TypedResultsBuilder
             .MapResult(result, FormDefinitionMapper.Map<PartialUpdateActiveFormDefinitionResponse>)
-            .SetTypedResults<Ok<PartialUpdateActiveFormDefinitionResponse>, BadRequest, NotFound>();
+            .SetTypedResults<Ok<PartialUpdateActiveFormDefinitionResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/FormDefinitions/Update.cs
+++ b/src/Endatix.Api/Endpoints/FormDefinitions/Update.cs
@@ -1,5 +1,6 @@
 ﻿using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.FormDefinitions.Update;
@@ -10,7 +11,7 @@ namespace Endatix.Api.Endpoints.FormDefinitions;
 /// <summary>
 /// Endpoint for updating a form definition.
 /// </summary>
-public class Update(IMediator mediator) : Endpoint<UpdateFormDefinitionRequest, Results<Ok<UpdateFormDefinitionResponse>, BadRequest, NotFound>>
+public class Update(IMediator mediator) : Endpoint<UpdateFormDefinitionRequest, Results<Ok<UpdateFormDefinitionResponse>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -23,21 +24,39 @@ public class Update(IMediator mediator) : Endpoint<UpdateFormDefinitionRequest, 
         {
             s.Summary = "Update a form definition";
             s.Description = "Updates a form definition for a given form.";
+            s.ExampleRequest = new UpdateFormDefinitionRequest
+            {
+                FormId = 1,
+                DefinitionId = 1,
+                IsDraft = false,
+                JsonData = "{}",
+            };
+            s.ResponseExamples[200] = new UpdateFormDefinitionResponse
+            {
+                Id = "1",
+                FormId = "1",
+                IsDraft = false,
+                JsonData = "{}",
+            };
             s.Responses[200] = "Form definition updated successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form definition or form not found.";
         });
+        Description(builder => builder
+            .Produces<UpdateFormDefinitionResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc />
-    public override async Task<Results<Ok<UpdateFormDefinitionResponse>, BadRequest, NotFound>> ExecuteAsync(UpdateFormDefinitionRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<UpdateFormDefinitionResponse>, ProblemHttpResult>> ExecuteAsync(UpdateFormDefinitionRequest request, CancellationToken ct)
     {
         var result = await mediator.Send(
             new UpdateFormDefinitionCommand(request.FormId, request.DefinitionId, request.IsDraft!.Value, request.JsonData!),
-            cancellationToken);
+            ct);
 
         return TypedResultsBuilder
             .MapResult(result, FormDefinitionMapper.Map<UpdateFormDefinitionResponse>)
-            .SetTypedResults<Ok<UpdateFormDefinitionResponse>, BadRequest, NotFound>();
+            .SetTypedResults<Ok<UpdateFormDefinitionResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/FormDefinitions/UpdateActive.cs
+++ b/src/Endatix.Api/Endpoints/FormDefinitions/UpdateActive.cs
@@ -1,5 +1,6 @@
 ﻿using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.FormDefinitions.UpdateActive;
@@ -10,7 +11,7 @@ namespace Endatix.Api.Endpoints.FormDefinitions;
 /// <summary>
 /// Endpoint for updating the active form definition.
 /// </summary>
-public class UpdateActive(IMediator mediator) : Endpoint<UpdateActiveFormDefinitionRequest, Results<Ok<UpdateActiveFormDefinitionResponse>, BadRequest, NotFound>>
+public class UpdateActive(IMediator mediator) : Endpoint<UpdateActiveFormDefinitionRequest, Results<Ok<UpdateActiveFormDefinitionResponse>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -23,21 +24,38 @@ public class UpdateActive(IMediator mediator) : Endpoint<UpdateActiveFormDefinit
         {
             s.Summary = "Update the active form definition";
             s.Description = "Updates the active form definition for a given form.";
+            s.ExampleRequest = new UpdateActiveFormDefinitionRequest
+            {
+                FormId = 1,
+                IsDraft = false,
+                JsonData = "{}",
+            };
+            s.ResponseExamples[200] = new UpdateActiveFormDefinitionResponse
+            {
+                Id = "1",
+                FormId = "1",
+                IsDraft = false,
+                JsonData = "{}",
+            };
             s.Responses[200] = "Active form definition updated successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form not found.";
         });
+        Description(builder => builder
+            .Produces<UpdateActiveFormDefinitionResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc />
-    public override async Task<Results<Ok<UpdateActiveFormDefinitionResponse>, BadRequest, NotFound>> ExecuteAsync(UpdateActiveFormDefinitionRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<UpdateActiveFormDefinitionResponse>, ProblemHttpResult>> ExecuteAsync(UpdateActiveFormDefinitionRequest request, CancellationToken ct)
     {
         var result = await mediator.Send(
             new UpdateActiveFormDefinitionCommand(request.FormId, request.IsDraft!.Value, request.JsonData!),
-            cancellationToken);
+            ct);
 
         return TypedResultsBuilder
             .MapResult(result, FormDefinitionMapper.Map<UpdateActiveFormDefinitionResponse>)
-            .SetTypedResults<Ok<UpdateActiveFormDefinitionResponse>, BadRequest, NotFound>();
+            .SetTypedResults<Ok<UpdateActiveFormDefinitionResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/FormTemplates/Create.cs
+++ b/src/Endatix.Api/Endpoints/FormTemplates/Create.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.FormTemplates.Create;
@@ -24,13 +25,30 @@ public class Create(IMediator mediator) : Endpoint<CreateFormTemplateRequest, Re
         {
             s.Summary = "Create a new form template";
             s.Description = "Creates a new form template.";
+            s.ExampleRequest = new CreateFormTemplateRequest
+            {
+                Name = "Customer satisfaction",
+                Description = "A reusable customer satisfaction survey template.",
+                JsonData = "{}",
+            };
+            s.ResponseExamples[201] = new CreateFormTemplateResponse
+            {
+                Id = "1",
+                Name = "Customer satisfaction",
+                JsonData = "{}",
+            };
             s.Responses[201] = "Form template created successfully.";
             s.Responses[400] = "Invalid input data.";
         });
+        Description(builder => builder
+            .Produces<CreateFormTemplateResponse>(StatusCodes.Status201Created, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Created<CreateFormTemplateResponse>, ProblemHttpResult>> ExecuteAsync(CreateFormTemplateRequest request, CancellationToken ct)
+    public override async Task<Results<Created<CreateFormTemplateResponse>, ProblemHttpResult>> ExecuteAsync(
+        CreateFormTemplateRequest request,
+        CancellationToken ct)
     {
         var folderId = request.FolderId.ParseToLong();
 

--- a/src/Endatix.Api/Endpoints/FormTemplates/Delete.cs
+++ b/src/Endatix.Api/Endpoints/FormTemplates/Delete.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.FormTemplates.Delete;
@@ -10,7 +11,7 @@ namespace Endatix.Api.Endpoints.FormTemplates;
 /// <summary>
 /// Endpoint for deleting a form template.
 /// </summary>
-public class Delete(IMediator mediator) : Endpoint<DeleteFormTemplateRequest, Results<Ok<string>, BadRequest, NotFound>>
+public class Delete(IMediator mediator) : Endpoint<DeleteFormTemplateRequest, Results<Ok<string>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -23,14 +24,22 @@ public class Delete(IMediator mediator) : Endpoint<DeleteFormTemplateRequest, Re
         {
             s.Summary = "Delete a form template";
             s.Description = "Deletes a form template.";
-            s.Responses[204] = "Form template deleted successfully.";
+            s.ExampleRequest = new DeleteFormTemplateRequest { FormTemplateId = 1 };
+            s.ResponseExamples[200] = "1";
+            s.Responses[200] = "Form template deleted successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form template not found.";
         });
+        Description(builder => builder
+            .Produces<string>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<string>, BadRequest, NotFound>> ExecuteAsync(DeleteFormTemplateRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<string>, ProblemHttpResult>> ExecuteAsync(
+        DeleteFormTemplateRequest request,
+        CancellationToken cancellationToken)
     {
         var result = await mediator.Send(
             new DeleteFormTemplateCommand(request.FormTemplateId),
@@ -38,6 +47,6 @@ public class Delete(IMediator mediator) : Endpoint<DeleteFormTemplateRequest, Re
 
         return TypedResultsBuilder
             .MapResult(result, template => template.Id.ToString())
-            .SetTypedResults<Ok<string>, BadRequest, NotFound>();
+            .SetTypedResults<Ok<string>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/FormTemplates/Delete.cs
+++ b/src/Endatix.Api/Endpoints/FormTemplates/Delete.cs
@@ -39,11 +39,11 @@ public class Delete(IMediator mediator) : Endpoint<DeleteFormTemplateRequest, Re
     /// <inheritdoc/>
     public override async Task<Results<Ok<string>, ProblemHttpResult>> ExecuteAsync(
         DeleteFormTemplateRequest request,
-        CancellationToken cancellationToken)
+        CancellationToken ct)
     {
         var result = await mediator.Send(
             new DeleteFormTemplateCommand(request.FormTemplateId),
-            cancellationToken);
+            ct);
 
         return TypedResultsBuilder
             .MapResult(result, template => template.Id.ToString())

--- a/src/Endatix.Api/Endpoints/FormTemplates/GetById.cs
+++ b/src/Endatix.Api/Endpoints/FormTemplates/GetById.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.FormTemplates.GetById;
@@ -10,7 +11,7 @@ namespace Endatix.Api.Endpoints.FormTemplates;
 /// <summary>
 /// Endpoint for getting a form template by ID. 
 /// </summary>
-public class GetById(IMediator mediator) : Endpoint<GetFormTemplateByIdRequest, Results<Ok<FormTemplateModel>, BadRequest, NotFound>>
+public class GetById(IMediator mediator) : Endpoint<GetFormTemplateByIdRequest, Results<Ok<FormTemplateModel>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -23,21 +24,34 @@ public class GetById(IMediator mediator) : Endpoint<GetFormTemplateByIdRequest, 
         {
             s.Summary = "Get a form template by ID";
             s.Description = "Gets a form template by its ID.";
+            s.ExampleRequest = new GetFormTemplateByIdRequest { FormTemplateId = 1 };
+            s.ResponseExamples[200] = new FormTemplateModel
+            {
+                Id = "1",
+                Name = "Customer satisfaction",
+                JsonData = "{}",
+            };
             s.Responses[200] = "Form template retrieved successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form template not found.";
         });
+        Description(builder => builder
+            .Produces<FormTemplateModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<FormTemplateModel>, BadRequest, NotFound>> ExecuteAsync(GetFormTemplateByIdRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<FormTemplateModel>, ProblemHttpResult>> ExecuteAsync(
+        GetFormTemplateByIdRequest request,
+        CancellationToken ct)
     {
         var result = await mediator.Send(
             new GetFormTemplateByIdQuery(request.FormTemplateId),
-            cancellationToken);
+            ct);
 
         return TypedResultsBuilder
             .MapResult(result, formTemplate => formTemplate.ToFormTemplateModel<FormTemplateModel>())
-            .SetTypedResults<Ok<FormTemplateModel>, BadRequest, NotFound>();
+            .SetTypedResults<Ok<FormTemplateModel>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/FormTemplates/List.cs
+++ b/src/Endatix.Api/Endpoints/FormTemplates/List.cs
@@ -1,5 +1,6 @@
 using MediatR;
 using FastEndpoints;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.UseCases.FormTemplates.List;
 using Endatix.Api.Infrastructure;
@@ -14,7 +15,8 @@ namespace Endatix.Api.Endpoints.FormTemplates;
 /// <summary>
 /// Endpoint for listing form templates.
 /// </summary>
-public class List(IMediator mediator) : Endpoint<FormTemplatesListRequest, Results<Ok<Paged<FormTemplateModelWithoutJsonData>>, BadRequest>>
+public class List(IMediator mediator)
+    : Endpoint<FormTemplatesListRequest, Results<Ok<Paged<FormTemplateModelWithoutJsonData>>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -35,13 +37,29 @@ public class List(IMediator mediator) : Endpoint<FormTemplatesListRequest, Resul
                 SortBy = FormTemplateListSortBy.Name,
                 SortDir = SortDirection.Asc,
             };
+            s.ResponseExamples[200] = new Paged<FormTemplateModelWithoutJsonData>(
+                page: 1,
+                pageSize: 20,
+                totalRecords: 1,
+                totalPages: 1,
+                items:
+                [
+                    new FormTemplateModelWithoutJsonData
+                    {
+                        Id = "1",
+                        Name = "Customer satisfaction",
+                    },
+                ]);
             s.Responses[200] = "Form templates retrieved successfully.";
             s.Responses[400] = "Invalid input data.";
         });
+        Description(builder => builder
+            .Produces<Paged<FormTemplateModelWithoutJsonData>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<Paged<FormTemplateModelWithoutJsonData>>, BadRequest>> ExecuteAsync(
+    public override async Task<Results<Ok<Paged<FormTemplateModelWithoutJsonData>>, ProblemHttpResult>> ExecuteAsync(
         FormTemplatesListRequest request,
         CancellationToken ct)
     {
@@ -60,7 +78,7 @@ public class List(IMediator mediator) : Endpoint<FormTemplatesListRequest, Resul
 
         return TypedResultsBuilder
             .MapResult(result, Map)
-            .SetTypedResults<Ok<Paged<FormTemplateModelWithoutJsonData>>, BadRequest>();
+            .SetTypedResults<Ok<Paged<FormTemplateModelWithoutJsonData>>, ProblemHttpResult>();
     }
 
     private static Paged<FormTemplateModelWithoutJsonData> Map(Paged<FormTemplateDto> paged) =>

--- a/src/Endatix.Api/Endpoints/FormTemplates/PartialUpdate.cs
+++ b/src/Endatix.Api/Endpoints/FormTemplates/PartialUpdate.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.FormTemplates.PartialUpdate;
@@ -11,7 +12,8 @@ namespace Endatix.Api.Endpoints.FormTemplates;
 /// <summary>
 /// Endpoint for partially updating a form template.
 /// </summary>
-public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateFormTemplateRequest, Results<Ok<PartialUpdateFormTemplateResponse>, ProblemHttpResult>>
+public class PartialUpdate(IMediator mediator)
+    : Endpoint<PartialUpdateFormTemplateRequest, Results<Ok<PartialUpdateFormTemplateResponse>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -24,14 +26,33 @@ public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateFormTempl
         {
             s.Summary = "Partially update a form template";
             s.Description = "Partially updates a form template.";
+            s.ExampleRequest = new PartialUpdateFormTemplateRequest
+            {
+                FormTemplateId = 1,
+                Name = "Customer satisfaction",
+                Description = "Updated description.",
+            };
+            s.ResponseExamples[200] = new PartialUpdateFormTemplateResponse
+            {
+                Id = "1",
+                Name = "Customer satisfaction",
+                Description = "Updated description.",
+                JsonData = "{}",
+            };
             s.Responses[200] = "Form template updated successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form template not found.";
         });
+        Description(builder => builder
+            .Produces<PartialUpdateFormTemplateResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<PartialUpdateFormTemplateResponse>, ProblemHttpResult>> ExecuteAsync(PartialUpdateFormTemplateRequest request, CancellationToken ct)
+    public override async Task<Results<Ok<PartialUpdateFormTemplateResponse>, ProblemHttpResult>> ExecuteAsync(
+        PartialUpdateFormTemplateRequest request,
+        CancellationToken ct)
     {
         var folderId = request.FolderId.ParseToLong();
 
@@ -44,10 +65,9 @@ public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateFormTempl
             ct);
 
         return TypedResultsBuilder
-         .MapResult(
-            result,
-            formTemplate => formTemplate.ToFormTemplateModel<PartialUpdateFormTemplateResponse>()
-        )
-        .SetTypedResults<Ok<PartialUpdateFormTemplateResponse>, ProblemHttpResult>();
+            .MapResult(
+                result,
+                formTemplate => formTemplate.ToFormTemplateModel<PartialUpdateFormTemplateResponse>())
+            .SetTypedResults<Ok<PartialUpdateFormTemplateResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Forms/Create.cs
+++ b/src/Endatix.Api/Endpoints/Forms/Create.cs
@@ -1,5 +1,6 @@
 ﻿using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Common;
 using Endatix.Api.Infrastructure;
@@ -25,9 +26,26 @@ public class Create(IMediator mediator) : Endpoint<CreateFormRequest, Results<Cr
         {
             s.Summary = "Create a new form";
             s.Description = "Creates a new form and an active form definition for it.";
+            s.ExampleRequest = new CreateFormRequest
+            {
+                Name = "Customer satisfaction",
+                Description = "A customer satisfaction survey.",
+                IsEnabled = true,
+                FormDefinitionSchema = JsonSerializer.Deserialize<JsonElement>("{}"),
+            };
+            s.ResponseExamples[201] = new CreateFormResponse
+            {
+                Id = "1",
+                Name = "Customer satisfaction",
+                IsEnabled = true,
+                IsPublic = false,
+            };
             s.Responses[201] = "Form created successfully.";
             s.Responses[400] = "Invalid input data.";
         });
+        Description(builder => builder
+            .Produces<CreateFormResponse>(StatusCodes.Status201Created, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Forms/Delete.cs
+++ b/src/Endatix.Api/Endpoints/Forms/Delete.cs
@@ -25,23 +25,23 @@ public class Delete(IMediator mediator) : Endpoint<DeleteFormRequest, Results<Ok
             s.Summary = "Delete a form";
             s.Description = "Deletes a form and all its definitions and submissions.";
             s.ExampleRequest = new DeleteFormRequest { FormId = 1 };
-            s.ResponseExamples[204] = new { Message = "Form deleted successfully." };
-            s.Responses[204] = "Form deleted successfully.";
+            s.ResponseExamples[200] = "1";
+            s.Responses[200] = "Form deleted successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form not found.";
         });
         Description(builder => builder
-            .Produces<string>(200, "application/json")
-            .ProducesProblem(404)
-            .ProducesProblem(400));
+            .Produces<string>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<string>, ProblemHttpResult>> ExecuteAsync(DeleteFormRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<string>, ProblemHttpResult>> ExecuteAsync(DeleteFormRequest request, CancellationToken ct)
     {
         var result = await mediator.Send(
             new DeleteFormCommand(request.FormId),
-            cancellationToken);
+            ct);
 
         return TypedResultsBuilder
             .MapResult(result, form => form.Id.ToString())

--- a/src/Endatix.Api/Endpoints/Forms/GetById.cs
+++ b/src/Endatix.Api/Endpoints/Forms/GetById.cs
@@ -1,5 +1,6 @@
 ﻿using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.Forms.GetById;
@@ -10,7 +11,7 @@ namespace Endatix.Api.Endpoints.Forms;
 /// <summary>
 /// Endpoint for getting a form by ID.
 /// </summary>
-public class GetById(IMediator mediator) : Endpoint<GetFormByIdRequest, Results<Ok<FormModel>, BadRequest, NotFound>>
+public class GetById(IMediator mediator) : Endpoint<GetFormByIdRequest, Results<Ok<FormModel>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -27,17 +28,21 @@ public class GetById(IMediator mediator) : Endpoint<GetFormByIdRequest, Results<
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form not found.";
         });
+        Description(builder => builder
+            .Produces<FormModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<FormModel>, BadRequest, NotFound>> ExecuteAsync(GetFormByIdRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<FormModel>, ProblemHttpResult>> ExecuteAsync(GetFormByIdRequest request, CancellationToken ct)
     {
         var result = await mediator.Send(
             new GetFormByIdQuery(request.FormId),
-            cancellationToken);
+            ct);
 
         return TypedResultsBuilder
             .MapResult(result, form => form.ToFormModel(includeWebHookSettings: true))
-            .SetTypedResults<Ok<FormModel>, BadRequest, NotFound>();
+            .SetTypedResults<Ok<FormModel>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Forms/PartialUpdate.cs
+++ b/src/Endatix.Api/Endpoints/Forms/PartialUpdate.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Common;
 using Endatix.Api.Infrastructure;
-using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.Forms.PartialUpdate;
 using Endatix.Core.Abstractions.Authorization;
 
@@ -26,14 +25,31 @@ public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateFormReque
         {
             s.Summary = "Partially update a form";
             s.Description = "Partially updates a form.";
+            s.ExampleRequest = new PartialUpdateFormRequest
+            {
+                FormId = 1,
+                Name = "Customer satisfaction",
+                IsEnabled = true,
+            };
+            s.ResponseExamples[200] = new PartialUpdateFormResponse
+            {
+                Id = "1",
+                Name = "Customer satisfaction",
+                IsEnabled = true,
+                IsPublic = false,
+            };
             s.Responses[200] = "Form updated successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form not found.";
         });
+        Description(builder => builder
+            .Produces<PartialUpdateFormResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<PartialUpdateFormResponse>, ProblemHttpResult>> ExecuteAsync(PartialUpdateFormRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<PartialUpdateFormResponse>, ProblemHttpResult>> ExecuteAsync(PartialUpdateFormRequest request, CancellationToken ct)
     {
         var folderId = request.FolderId.ParseToLong();
 
@@ -53,14 +69,10 @@ public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateFormReque
                 ClearFolderId = request.ClearFolderId,
                 FolderId = folderId,
             },
-            cancellationToken);
+            ct);
 
-        var mappedResult = result.Map(FormMapper.Map<PartialUpdateFormResponse>);
-
-        return mappedResult.Status switch
-        {
-            ResultStatus.Ok => TypedResults.Ok(mappedResult.Value),
-            _ => mappedResult.ToProblem()
-        };
+        return TypedResultsBuilder
+            .MapResult(result, FormMapper.Map<PartialUpdateFormResponse>)
+            .SetTypedResults<Ok<PartialUpdateFormResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Forms/Update.cs
+++ b/src/Endatix.Api/Endpoints/Forms/Update.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Common;
 using Endatix.Api.Infrastructure;
-using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.Forms.Update;
 using Endatix.Core.Abstractions.Authorization;
 
@@ -26,14 +25,33 @@ public class Update(IMediator mediator) : Endpoint<UpdateFormRequest, Results<Ok
         {
             s.Summary = "Update a form";
             s.Description = "Updates a form.";
+            s.ExampleRequest = new UpdateFormRequest
+            {
+                FormId = 1,
+                Name = "Customer satisfaction",
+                Description = "Updated description.",
+                IsEnabled = true,
+            };
+            s.ResponseExamples[200] = new UpdateFormResponse
+            {
+                Id = "1",
+                Name = "Customer satisfaction",
+                Description = "Updated description.",
+                IsEnabled = true,
+                IsPublic = false,
+            };
             s.Responses[200] = "Form updated successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form not found.";
         });
+        Description(builder => builder
+            .Produces<UpdateFormResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<UpdateFormResponse>, ProblemHttpResult>> ExecuteAsync(UpdateFormRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<UpdateFormResponse>, ProblemHttpResult>> ExecuteAsync(UpdateFormRequest request, CancellationToken ct)
     {
         var folderId = request.FolderId.ParseToLong();
 
@@ -49,14 +67,10 @@ public class Update(IMediator mediator) : Endpoint<UpdateFormRequest, Results<Ok
                 request.ClearSubmissionTokenExpiryHours,
                 request.Metadata,
                 folderId),
-            cancellationToken);
+            ct);
 
-        var mappedResult = result.Map(FormMapper.Map<UpdateFormResponse>);
-
-        return mappedResult.Status switch
-        {
-            ResultStatus.Ok => TypedResults.Ok(mappedResult.Value),
-            _ => mappedResult.ToProblem()
-        };
+        return TypedResultsBuilder
+            .MapResult(result, FormMapper.Map<UpdateFormResponse>)
+            .SetTypedResults<Ok<UpdateFormResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Integrations/SlackToken.cs
+++ b/src/Endatix.Api/Endpoints/Integrations/SlackToken.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Microsoft.Extensions.Logging;
@@ -10,7 +11,7 @@ namespace Endatix.Api.Endpoints.Integrations;
 /// <summary>
 /// Endpoint for receiving the slack token.
 /// </summary>
-public class SlackToken(ILogger<SlackToken> logger, IEmailSender emailSender) : Endpoint<SlackTokenRequest, Results<Ok<string>, BadRequest>>
+public class SlackToken(ILogger<SlackToken> logger, IEmailSender emailSender) : Endpoint<SlackTokenRequest, Results<Ok<string>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -24,13 +25,17 @@ public class SlackToken(ILogger<SlackToken> logger, IEmailSender emailSender) : 
         {
             s.Summary = "Receives a Slack token";
             s.Description = "Receives a Slack token";
-            s.Responses[201] = "Token received successfully.";
+            s.Responses[200] = "Token received successfully.";
             s.Responses[400] = "Invalid input data.";
+            s.ResponseExamples[200] = "ok";
         });
+        Description(builder => builder
+            .Produces<string>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<string>, BadRequest>> ExecuteAsync(SlackTokenRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<string>, ProblemHttpResult>> ExecuteAsync(SlackTokenRequest request, CancellationToken ct)
     {
         logger.LogInformation($"Received slack token: {request.Token}");
 
@@ -43,12 +48,12 @@ public class SlackToken(ILogger<SlackToken> logger, IEmailSender emailSender) : 
             PlainTextBody = request.Token
         };
 
-        await emailSender.SendEmailAsync(email, cancellationToken);
+        await emailSender.SendEmailAsync(email, ct);
 
         var operationResult = Result.Success("ok");
 
         return TypedResultsBuilder
             .FromResult(operationResult)
-            .SetTypedResults<Ok<string>, BadRequest>();
+            .SetTypedResults<Ok<string>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/MyAccount/ChangePassword.cs
+++ b/src/Endatix.Api/Endpoints/MyAccount/ChangePassword.cs
@@ -1,6 +1,7 @@
 using FastEndpoints;
 using MediatR;
 using Errors = Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.MyAccount.ChangePassword;
@@ -27,14 +28,17 @@ public class ChangePassword(IMediator mediator, IUserContext userContext) : Endp
             s.Responses[200] = "Password changed successfully.";
             s.Responses[400] = "Invalid request or current password.";
         });
+        Description(builder => builder
+            .Produces<ChangePasswordResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <summary>
     /// Executes the password change functionality
     /// </summary>
     /// <param name="request">The password change request containing the current and new password</param>
-    /// <param name="cancellationToken">Cancellation token for the async operation</param>
-    public override async Task<Results<Ok<ChangePasswordResponse>, ProblemHttpResult>> ExecuteAsync(ChangePasswordRequest request, CancellationToken cancellationToken)
+    /// <param name="ct">Cancellation token for the async operation</param>
+    public override async Task<Results<Ok<ChangePasswordResponse>, ProblemHttpResult>> ExecuteAsync(ChangePasswordRequest request, CancellationToken ct)
     {
         var userIdString = userContext.GetCurrentUserId();
 
@@ -44,7 +48,7 @@ public class ChangePassword(IMediator mediator, IUserContext userContext) : Endp
             request.NewPassword
         );
 
-        var result = await mediator.Send(changePasswordCmd, cancellationToken);
+        var result = await mediator.Send(changePasswordCmd, ct);
 
         return TypedResultsBuilder
             .MapResult(result, message => new ChangePasswordResponse(message))

--- a/src/Endatix.Api/Endpoints/Permissions/ListPermissions.cs
+++ b/src/Endatix.Api/Endpoints/Permissions/ListPermissions.cs
@@ -30,8 +30,8 @@ public sealed class ListPermissions(IMediator mediator)
             s.Responses[400] = "Invalid request.";
         });
         Description(builder => builder
-            .Produces<IEnumerable<ListPermissionsResponse>>(200, "application/json")
-            .ProducesProblem(400));
+            .Produces<IEnumerable<ListPermissionsResponse>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Public/DataLists/GetChoiceDisplayValues.cs
+++ b/src/Endatix.Api/Endpoints/Public/DataLists/GetChoiceDisplayValues.cs
@@ -41,6 +41,11 @@ public sealed class GetChoiceDisplayValues(
             s.Responses[404] = "Form not found.";
 
         });
+        Description(builder => builder
+            .Produces<IReadOnlyCollection<DataListPublicChoiceModel>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc />

--- a/src/Endatix.Api/Endpoints/Public/DataLists/Search.cs
+++ b/src/Endatix.Api/Endpoints/Public/DataLists/Search.cs
@@ -45,6 +45,11 @@ public sealed class Search(
             s.Responses[404] = "Form not found.";
 
         });
+        Description(builder => builder
+            .Produces<Paged<DataListPublicChoiceModel>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc />

--- a/src/Endatix.Api/Endpoints/Public/Forms/CreateFormAccessToken.cs
+++ b/src/Endatix.Api/Endpoints/Public/Forms/CreateFormAccessToken.cs
@@ -5,6 +5,7 @@ using Endatix.Core.UseCases.Authorization.PublicForm;
 using FastEndpoints;
 using FluentValidation;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.Public.Forms;
@@ -30,6 +31,10 @@ public sealed class CreateFormAccessToken(IMediator mediator)
             s.Responses[400] = "Invalid request or access data.";
             s.Responses[404] = "Form not found.";
         });
+        Description(builder => builder
+            .Produces<CreateFormAccessTokenResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc />

--- a/src/Endatix.Api/Endpoints/Public/Forms/GetFormPublicAccess.cs
+++ b/src/Endatix.Api/Endpoints/Public/Forms/GetFormPublicAccess.cs
@@ -5,6 +5,7 @@ using Endatix.Core.Infrastructure;
 using Endatix.Infrastructure.Features.AccessControl;
 using FastEndpoints;
 using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.Public.Forms;
@@ -30,6 +31,10 @@ public sealed class GetFormPublicAccess(
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form not found.";
         });
+        Description(builder => builder
+            .Produces<GetFormPublicAccessResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     public override async Task<Results<Ok<GetFormPublicAccessResponse>, ProblemHttpResult>> ExecuteAsync(

--- a/src/Endatix.Api/Endpoints/Roles/CreateRole.cs
+++ b/src/Endatix.Api/Endpoints/Roles/CreateRole.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Abstractions.Authorization;
 using Endatix.Core.UseCases.Identity.CreateRole;
@@ -27,15 +28,18 @@ public class CreateRole(IMediator mediator)
             s.Responses[201] = "Role created successfully.";
             s.Responses[400] = "Invalid request or role creation failed.";
         });
+        Description(builder => builder
+            .Produces<CreateRoleResponse>(StatusCodes.Status201Created, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>
     public override async Task<Results<Created<CreateRoleResponse>, ProblemHttpResult>> ExecuteAsync(
         CreateRoleRequest request,
-        CancellationToken cancellationToken)
+        CancellationToken ct)
     {
         var command = new CreateRoleCommand(request.Name!, request.Description, request.Permissions);
-        var result = await mediator.Send(command, cancellationToken);
+        var result = await mediator.Send(command, ct);
 
         return TypedResultsBuilder
             .MapResult(result, (message) => new CreateRoleResponse(message))

--- a/src/Endatix.Api/Endpoints/Roles/DeleteRole.cs
+++ b/src/Endatix.Api/Endpoints/Roles/DeleteRole.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Abstractions.Authorization;
 using Endatix.Core.UseCases.Identity.DeleteRole;
@@ -28,15 +29,19 @@ public class DeleteRole(IMediator mediator)
             s.Responses[400] = "Invalid request or role deletion failed.";
             s.Responses[404] = "Role not found.";
         });
+        Description(builder => builder
+            .Produces<DeleteRoleResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
     public override async Task<Results<Ok<DeleteRoleResponse>, ProblemHttpResult>> ExecuteAsync(
         DeleteRoleRequest request,
-        CancellationToken cancellationToken)
+        CancellationToken ct)
     {
         var command = new DeleteRoleCommand(request.RoleName);
-        var result = await mediator.Send(command, cancellationToken);
+        var result = await mediator.Send(command, ct);
 
         return TypedResultsBuilder
             .MapResult(result, (message) => new DeleteRoleResponse(message))

--- a/src/Endatix.Api/Endpoints/Roles/ListRoles.cs
+++ b/src/Endatix.Api/Endpoints/Roles/ListRoles.cs
@@ -42,8 +42,8 @@ public sealed class ListRoles(IMediator mediator)
             s.Responses[400] = "Invalid request.";
         });
         Description(builder => builder
-            .Produces<Paged<ListRolesResponse>>(200, "application/json")
-            .ProducesProblem(400));
+            .Produces<Paged<ListRolesResponse>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Roles/UpdateRole.cs
+++ b/src/Endatix.Api/Endpoints/Roles/UpdateRole.cs
@@ -37,9 +37,9 @@ public sealed class UpdateRole(IMediator mediator)
             s.Responses[404] = "Role not found.";
         });
         Description(builder => builder
-            .Produces<UpdateRoleResponse>(200, "application/json")
-            .ProducesProblem(400)
-            .ProducesProblem(404));
+            .Produces<UpdateRoleResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Stats/GetDashboard/GetDashboard.cs
+++ b/src/Endatix.Api/Endpoints/Stats/GetDashboard/GetDashboard.cs
@@ -5,6 +5,7 @@ using Endatix.Core.UseCases.Stats.GetDashboard;
 using Endatix.Core.UseCases.Stats.Models;
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.Stats.GetDashboard;
@@ -20,6 +21,9 @@ public class GetDashboard(IMediator mediator, ITenantContext tenantContext) : En
             s.Summary = "Get storage statistics dashboard";
             s.Description = "Returns a comprehensive view of database storage usage for the current tenant.";
         });
+        Description(builder => builder
+            .Produces<StorageDashboardModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     public override async Task<Results<Ok<StorageDashboardModel>, ProblemHttpResult>> ExecuteAsync(CancellationToken ct)

--- a/src/Endatix.Api/Endpoints/Submissions/Create.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/Create.cs
@@ -29,10 +29,10 @@ public sealed class Create(IMediator mediator)
             s.Responses[409] = "A submission already exists for this user and form.";
         });
         Description(builder => builder
-            .Produces<SubmissionModel>(201, "application/json")
-            .ProducesProblem(400)
-            .ProducesProblem(404)
-            .ProducesProblem(409));
+            .Produces<SubmissionModel>(StatusCodes.Status201Created, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound)
+            .ProducesProblem(StatusCodes.Status409Conflict));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Submissions/CreateAccessToken.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/CreateAccessToken.cs
@@ -43,15 +43,15 @@ public class CreateAccessToken(IMediator mediator)
             s.Responses[404] = "Submission not found.";
         });
         Description(builder => builder
-            .Produces<CreateAccessTokenResponse>(200, "application/json")
-            .ProducesProblem(400)
-            .ProducesProblem(404));
+            .Produces<CreateAccessTokenResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
     public override async Task<Results<Ok<CreateAccessTokenResponse>, ProblemHttpResult>> ExecuteAsync(
         CreateAccessTokenRequest request,
-        CancellationToken cancellationToken)
+        CancellationToken ct)
     {
         var command = new CreateAccessTokenCommand(
             request.FormId,
@@ -59,7 +59,7 @@ public class CreateAccessToken(IMediator mediator)
             request.ExpiryMinutes!.Value,
             request.Permissions!
         );
-        var result = await mediator.Send(command, cancellationToken);
+        var result = await mediator.Send(command, ct);
 
         return TypedResultsBuilder
             .MapResult(result, dto => new CreateAccessTokenResponse(dto.Token, dto.ExpiresAt, dto.Permissions))

--- a/src/Endatix.Api/Endpoints/Submissions/CreateOnBehalf.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/CreateOnBehalf.cs
@@ -30,9 +30,9 @@ public sealed class CreateOnBehalf(IMediator mediator)
             s.Responses[404] = "Form not found. Cannot create a submission.";
         });
         Description(builder => builder
-            .Produces<SubmissionModel>(201, "application/json")
-            .ProducesProblem(400)
-            .ProducesProblem(404));
+            .Produces<SubmissionModel>(StatusCodes.Status201Created, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Submissions/Delete.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/Delete.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.Submissions.Delete;
@@ -30,14 +31,18 @@ public class Delete(IMediator mediator) : Endpoint<DeleteSubmissionRequest, Resu
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Submission not found.";
         });
+        Description(builder => builder
+            .Produces<string>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<string>, ProblemHttpResult>> ExecuteAsync(DeleteSubmissionRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<string>, ProblemHttpResult>> ExecuteAsync(DeleteSubmissionRequest request, CancellationToken ct)
     {
         var result = await mediator.Send(
             new DeleteSubmissionCommand(request.FormId, request.SubmissionId),
-            cancellationToken);
+            ct);
 
         return TypedResultsBuilder
             .MapResult(result, submission => submission.Id.ToString())

--- a/src/Endatix.Api/Endpoints/Submissions/GetByAccessToken.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/GetByAccessToken.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.Submissions.GetByAccessToken;
@@ -27,15 +28,19 @@ public class GetByAccessToken(IMediator mediator)
             s.Responses[400] = "Invalid token or permissions";
             s.Responses[404] = "Submission not found";
         });
+        Description(builder => builder
+            .Produces<SubmissionDetailsModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
     public override async Task<Results<Ok<SubmissionDetailsModel>, ProblemHttpResult>> ExecuteAsync(
         GetByAccessTokenRequest request,
-        CancellationToken cancellationToken)
+        CancellationToken ct)
     {
         var query = new GetByAccessTokenQuery(request.FormId, request.Token!);
-        var result = await mediator.Send(query, cancellationToken);
+        var result = await mediator.Send(query, ct);
 
         return TypedResultsBuilder
             .MapResult(result, SubmissionMapper.MapToSubmissionDetails)

--- a/src/Endatix.Api/Endpoints/Submissions/GetById.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/GetById.cs
@@ -1,5 +1,6 @@
 ﻿using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.Abstractions.Authorization;
@@ -10,7 +11,7 @@ namespace Endatix.Api.Endpoints.Submissions;
 /// <summary>
 /// Endpoint for getting a form submission by ID.
 /// </summary>
-public class GetById(IMediator mediator) : Endpoint<GetByIdRequest, Results<Ok<SubmissionDetailsModel>, BadRequest, NotFound>>
+public class GetById(IMediator mediator) : Endpoint<GetByIdRequest, Results<Ok<SubmissionDetailsModel>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -27,17 +28,20 @@ public class GetById(IMediator mediator) : Endpoint<GetByIdRequest, Results<Ok<S
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form submission not found";
         });
+        Description(builder => builder
+            .Produces<SubmissionDetailsModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<SubmissionDetailsModel>, BadRequest, NotFound>> ExecuteAsync(GetByIdRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<SubmissionDetailsModel>, ProblemHttpResult>> ExecuteAsync(GetByIdRequest request, CancellationToken ct)
     {
         var getSubmissionByIdQuery = new GetByIdQuery(request.FormId, request.SubmissionId);
-        var result = await mediator.Send(getSubmissionByIdQuery, cancellationToken);
+        var result = await mediator.Send(getSubmissionByIdQuery, ct);
 
         return TypedResultsBuilder
-                    .MapResult(result, SubmissionMapper.MapToSubmissionDetails)
-                    .SetTypedResults<Ok<SubmissionModel>, BadRequest, NotFound>();
-
+            .MapResult(result, SubmissionMapper.MapToSubmissionDetails)
+            .SetTypedResults<Ok<SubmissionDetailsModel>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Submissions/GetByToken.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/GetByToken.cs
@@ -1,16 +1,16 @@
 ﻿using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.Submissions.GetByToken;
-using Errors = Microsoft.AspNetCore.Mvc;
 
 namespace Endatix.Api.Endpoints.Submissions;
 
 /// <summary>
 /// Endpoint for getting a form submission by ID.
 /// </summary>
-public class GetByToken(IMediator mediator) : Endpoint<GetByTokenRequest, Results<Ok<SubmissionModel>, BadRequest<Errors.ProblemDetails>, NotFound>>
+public class GetByToken(IMediator mediator) : Endpoint<GetByTokenRequest, Results<Ok<SubmissionModel>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -27,17 +27,20 @@ public class GetByToken(IMediator mediator) : Endpoint<GetByTokenRequest, Result
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form submission not found";
         });
+        Description(builder => builder
+            .Produces<SubmissionModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<SubmissionModel>, BadRequest<Errors.ProblemDetails>, NotFound>> ExecuteAsync(GetByTokenRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<SubmissionModel>, ProblemHttpResult>> ExecuteAsync(GetByTokenRequest request, CancellationToken ct)
     {
         var query = new GetByTokenQuery(request.FormId, request.SubmissionToken!);
-        var result = await mediator.Send(query, cancellationToken);
+        var result = await mediator.Send(query, ct);
 
         return TypedResultsBuilder
-                    .MapResult(result, SubmissionMapper.Map<SubmissionModel>)
-                    .SetTypedResults<Ok<SubmissionModel>, BadRequest<Errors.ProblemDetails>, NotFound>();
-
+            .MapResult(result, SubmissionMapper.Map<SubmissionModel>)
+            .SetTypedResults<Ok<SubmissionModel>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Submissions/ListByFormId.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/ListByFormId.cs
@@ -1,12 +1,12 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Common;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.Submissions.ListByFormId;
 using Endatix.Core.Abstractions.Authorization;
 using Endatix.Core.Infrastructure.Result;
-
 using Endatix.Core.Infrastructure.Paging;
 
 namespace Endatix.Api.Endpoints.Submissions;
@@ -30,10 +30,14 @@ public class ListByFormId(IMediator mediator) : Endpoint<ListByFormIdRequest, Re
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Form not found. Pass correct formId";
         });
+        Description(builder => builder
+            .Produces<Paged<SubmissionModel>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<Paged<SubmissionModel>>, ProblemHttpResult>> ExecuteAsync(ListByFormIdRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<Paged<SubmissionModel>>, ProblemHttpResult>> ExecuteAsync(ListByFormIdRequest request, CancellationToken ct)
     {
         var sort = request.ToNullableSortRequest(SubmissionListSortBy.CreatedAt, SortDirection.Desc);
         var getSubmissionsQuery = new ListByFormIdQuery(
@@ -48,7 +52,7 @@ public class ListByFormId(IMediator mediator) : Endpoint<ListByFormIdRequest, Re
             request.ToStartedRange(),
             request.ToCompletedRange());
 
-        var result = await mediator.Send(getSubmissionsQuery, cancellationToken);
+        var result = await mediator.Send(getSubmissionsQuery, ct);
 
         return TypedResultsBuilder
             .MapResult(result, submissions => submissions.MapToPaged(SubmissionMapper.MapFromDto))

--- a/src/Endatix.Api/Endpoints/Submissions/PartialUpdate.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/PartialUpdate.cs
@@ -1,5 +1,6 @@
 ﻿using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.Submissions.PartialUpdate;
@@ -10,7 +11,7 @@ namespace Endatix.Api.Endpoints.Submissions;
 /// <summary>
 /// Endpoint for partially updating a form submission.
 /// </summary>
-public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateSubmissionRequest, Results<Ok<PartialUpdateSubmissionResponse>, BadRequest, NotFound>>
+public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateSubmissionRequest, Results<Ok<PartialUpdateSubmissionResponse>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -27,10 +28,14 @@ public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateSubmissio
             s.Responses[400] = "Bad request";
             s.Responses[404] = "Form submission not found";
         });
+        Description(builder => builder
+            .Produces<PartialUpdateSubmissionResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<PartialUpdateSubmissionResponse>, BadRequest, NotFound>> ExecuteAsync(PartialUpdateSubmissionRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<PartialUpdateSubmissionResponse>, ProblemHttpResult>> ExecuteAsync(PartialUpdateSubmissionRequest request, CancellationToken ct)
     {
         var updateSubmissionCommand = new PartialUpdateSubmissionCommand(
                     request.SubmissionId,
@@ -41,10 +46,10 @@ public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateSubmissio
                     request.Metadata
                 );
 
-        var result = await mediator.Send(updateSubmissionCommand, cancellationToken);
+        var result = await mediator.Send(updateSubmissionCommand, ct);
 
         return TypedResultsBuilder
             .MapResult(result, SubmissionMapper.Map<PartialUpdateSubmissionResponse>)
-            .SetTypedResults<Ok<PartialUpdateSubmissionResponse>, BadRequest, NotFound>();
+            .SetTypedResults<Ok<PartialUpdateSubmissionResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Submissions/PartialUpdateByAccessToken.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/PartialUpdateByAccessToken.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.Submissions.PartialUpdateByAccessToken;
@@ -27,11 +28,15 @@ public class PartialUpdateByAccessToken(IMediator mediator)
             s.Responses[400] = "Bad request or invalid token/permissions";
             s.Responses[404] = "Submission not found";
         });
+        Description(builder => builder
+            .Produces<PartialUpdateSubmissionByTokenResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
     public override async Task<Results<Ok<PartialUpdateSubmissionByTokenResponse>, ProblemHttpResult>>
-        ExecuteAsync(PartialUpdateByAccessTokenRequest request, CancellationToken cancellationToken)
+        ExecuteAsync(PartialUpdateByAccessTokenRequest request, CancellationToken ct)
     {
         var command = new PartialUpdateByAccessTokenCommand(
             request.Token!,
@@ -42,7 +47,7 @@ public class PartialUpdateByAccessToken(IMediator mediator)
             request.Metadata
         );
 
-        var result = await mediator.Send(command, cancellationToken);
+        var result = await mediator.Send(command, ct);
 
         return TypedResultsBuilder
             .MapResult(result, SubmissionMapper.Map<PartialUpdateSubmissionByTokenResponse>)

--- a/src/Endatix.Api/Endpoints/Submissions/PartialUpdateByToken.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/PartialUpdateByToken.cs
@@ -1,8 +1,8 @@
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.Submissions.PartialUpdateByToken;
-using Errors = Microsoft.AspNetCore.Mvc;
 using FastEndpoints;
 
 namespace Endatix.Api.Endpoints.Submissions;
@@ -10,7 +10,7 @@ namespace Endatix.Api.Endpoints.Submissions;
 /// <summary>
 /// Endpoint for partially updating a form submission by token.
 /// </summary>
-public class PartialUpdateByToken(IMediator mediator) : Endpoint<PartialUpdateSubmissionByTokenRequest, Results<Ok<PartialUpdateSubmissionByTokenResponse>, BadRequest<Errors.ProblemDetails>, NotFound>>
+public class PartialUpdateByToken(IMediator mediator) : Endpoint<PartialUpdateSubmissionByTokenRequest, Results<Ok<PartialUpdateSubmissionByTokenResponse>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -27,10 +27,14 @@ public class PartialUpdateByToken(IMediator mediator) : Endpoint<PartialUpdateSu
             s.Responses[400] = "Bad request";
             s.Responses[404] = "Form submission not found or invalid token";
         });
+        Description(builder => builder
+            .Produces<PartialUpdateSubmissionByTokenResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<PartialUpdateSubmissionByTokenResponse>, BadRequest<Errors.ProblemDetails>, NotFound>> ExecuteAsync(PartialUpdateSubmissionByTokenRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<PartialUpdateSubmissionByTokenResponse>, ProblemHttpResult>> ExecuteAsync(PartialUpdateSubmissionByTokenRequest request, CancellationToken ct)
     {
         var updateSubmissionCommand = new PartialUpdateSubmissionByTokenCommand(
             request.SubmissionToken,
@@ -42,10 +46,10 @@ public class PartialUpdateByToken(IMediator mediator) : Endpoint<PartialUpdateSu
             request.ReCaptchaToken
         );
 
-        var result = await mediator.Send(updateSubmissionCommand, cancellationToken);
+        var result = await mediator.Send(updateSubmissionCommand, ct);
 
         return TypedResultsBuilder
             .MapResult(result, SubmissionMapper.Map<PartialUpdateSubmissionByTokenResponse>)
-            .SetTypedResults<Ok<PartialUpdateSubmissionByTokenResponse>, BadRequest<Errors.ProblemDetails>, NotFound>();
+            .SetTypedResults<Ok<PartialUpdateSubmissionByTokenResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Submissions/Update.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/Update.cs
@@ -1,5 +1,6 @@
 ﻿using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.Submissions;
@@ -10,7 +11,7 @@ namespace Endatix.Api.Endpoints.Submissions;
 /// <summary>
 /// Endpoint for updating a form submission.
 /// </summary>
-public class Update(IMediator mediator) : Endpoint<UpdateSubmissionRequest, Results<Ok<UpdateSubmissionResponse>, BadRequest, NotFound>>
+public class Update(IMediator mediator) : Endpoint<UpdateSubmissionRequest, Results<Ok<UpdateSubmissionResponse>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -27,10 +28,14 @@ public class Update(IMediator mediator) : Endpoint<UpdateSubmissionRequest, Resu
             s.Responses[400] = "Bad request";
             s.Responses[404] = "Form submission not found";
         });
+        Description(builder => builder
+            .Produces<UpdateSubmissionResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<UpdateSubmissionResponse>, BadRequest, NotFound>> ExecuteAsync(UpdateSubmissionRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<UpdateSubmissionResponse>, ProblemHttpResult>> ExecuteAsync(UpdateSubmissionRequest request, CancellationToken ct)
     {
         var updateSubmissionCommand = new UpdateSubmissionCommand(
             request.SubmissionId,
@@ -41,10 +46,10 @@ public class Update(IMediator mediator) : Endpoint<UpdateSubmissionRequest, Resu
             request.Metadata
         );
 
-        var result = await mediator.Send(updateSubmissionCommand, cancellationToken);
+        var result = await mediator.Send(updateSubmissionCommand, ct);
 
         return TypedResultsBuilder
             .MapResult(result, SubmissionMapper.Map<UpdateSubmissionResponse>)
-            .SetTypedResults<Ok<UpdateSubmissionResponse>, BadRequest, NotFound>();
+            .SetTypedResults<Ok<UpdateSubmissionResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Submissions/UpdateStatus.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/UpdateStatus.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.Submissions.UpdateStatus;
@@ -10,7 +11,7 @@ namespace Endatix.Api.Endpoints.Submissions;
 /// <summary>
 /// Endpoint for updating the status of a form submission.
 /// </summary>
-public class UpdateStatus(IMediator mediator) : Endpoint<UpdateStatusRequest, Results<Ok<UpdateStatusResponse>, BadRequest, NotFound>>
+public class UpdateStatus(IMediator mediator) : Endpoint<UpdateStatusRequest, Results<Ok<UpdateStatusResponse>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -27,12 +28,16 @@ public class UpdateStatus(IMediator mediator) : Endpoint<UpdateStatusRequest, Re
             s.Responses[400] = "Invalid status or business rule violation";
             s.Responses[404] = "Submission not found";
         });
+        Description(builder => builder
+            .Produces<UpdateStatusResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<UpdateStatusResponse>, BadRequest, NotFound>> ExecuteAsync(
+    public override async Task<Results<Ok<UpdateStatusResponse>, ProblemHttpResult>> ExecuteAsync(
         UpdateStatusRequest request,
-        CancellationToken cancellationToken)
+        CancellationToken ct)
     {
         var command = new UpdateStatusCommand(
             request.SubmissionId,
@@ -40,10 +45,10 @@ public class UpdateStatus(IMediator mediator) : Endpoint<UpdateStatusRequest, Re
             request.Status
         );
 
-        var result = await mediator.Send(command, cancellationToken);
+        var result = await mediator.Send(command, ct);
 
         return TypedResultsBuilder
             .MapResult(result, result => new UpdateStatusResponse(result.Id, result.Status))
-            .SetTypedResults<Ok<UpdateStatusResponse>, BadRequest, NotFound>();
+            .SetTypedResults<Ok<UpdateStatusResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/TenantSettings/GetTenantSettings.cs
+++ b/src/Endatix.Api/Endpoints/TenantSettings/GetTenantSettings.cs
@@ -3,6 +3,7 @@ using Endatix.Core.Abstractions.Authorization;
 using Endatix.Core.UseCases.TenantSettings.Get;
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.TenantSettings;
@@ -28,12 +29,16 @@ public class GetTenantSettings(IMediator mediator) : EndpointWithoutRequest<Resu
             s.Responses[400] = "Invalid request or tenant context.";
             s.Responses[404] = "Tenant settings not found.";
         });
+        Description(builder => builder
+            .Produces<TenantSettingsModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<TenantSettingsModel>, ProblemHttpResult>> ExecuteAsync(CancellationToken cancellationToken)
+    public override async Task<Results<Ok<TenantSettingsModel>, ProblemHttpResult>> ExecuteAsync(CancellationToken ct)
     {
-        var result = await mediator.Send(new GetTenantSettingsQuery(), cancellationToken);
+        var result = await mediator.Send(new GetTenantSettingsQuery(), ct);
 
         return TypedResultsBuilder
             .MapResult(result, TenantSettingsMapper.Map)

--- a/src/Endatix.Api/Endpoints/TenantSettings/PartialUpdate.cs
+++ b/src/Endatix.Api/Endpoints/TenantSettings/PartialUpdate.cs
@@ -4,6 +4,7 @@ using Endatix.Core.UseCases.TenantSettings.PartialUpdate;
 using FastEndpoints;
 using FluentValidation;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.TenantSettings;
@@ -27,6 +28,10 @@ public sealed class PartialUpdate(IMediator mediator)
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Tenant settings not found.";
         });
+        Description(builder => builder
+            .Produces<TenantSettingsModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Themes/Create.cs
+++ b/src/Endatix.Api/Endpoints/Themes/Create.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.Abstractions.Authorization;
@@ -10,7 +11,7 @@ namespace Endatix.Api.Endpoints.Themes;
 /// <summary>
 /// Endpoint for creating a new theme.
 /// </summary>
-public class Create(IMediator mediator) : Endpoint<CreateRequest, Results<Created<CreateResponse>, BadRequest>>
+public class Create(IMediator mediator) : Endpoint<CreateRequest, Results<Created<CreateResponse>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -23,23 +24,43 @@ public class Create(IMediator mediator) : Endpoint<CreateRequest, Results<Create
         {
             s.Summary = "Create a new theme";
             s.Description = "Creates a new theme with the provided data.";
+            s.ExampleRequest = new CreateRequest
+            {
+                Name = "Corporate Blue",
+                Description = "Default corporate theme",
+                JsonData = "{\"primaryColor\":\"#0066cc\"}",
+            };
+            s.ResponseExamples[201] = new CreateResponse
+            {
+                Id = "1",
+                Name = "Corporate Blue",
+                Description = "Default corporate theme",
+                JsonData = "{\"primaryColor\":\"#0066cc\"}",
+                CreatedAt = new DateTime(2024, 1, 15, 10, 0, 0, DateTimeKind.Utc),
+                FormsCount = 0,
+            };
             s.Responses[201] = "Theme created successfully.";
             s.Responses[400] = "Invalid input data.";
         });
+        Description(builder => builder
+            .Produces<CreateResponse>(StatusCodes.Status201Created, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Created<CreateResponse>, BadRequest>> ExecuteAsync(CreateRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Created<CreateResponse>, ProblemHttpResult>> ExecuteAsync(
+        CreateRequest request,
+        CancellationToken ct)
     {
         var command = new CreateThemeCommand(
             request.Name!,
             request.Description,
             request.JsonData);
 
-        var result = await mediator.Send(command, cancellationToken);
+        var result = await mediator.Send(command, ct);
 
         return TypedResultsBuilder
             .MapResult(result, ThemeMapper.Map<CreateResponse>)
-            .SetTypedResults<Created<CreateResponse>, BadRequest>();
+            .SetTypedResults<Created<CreateResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Themes/Delete.cs
+++ b/src/Endatix.Api/Endpoints/Themes/Delete.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Abstractions.Authorization;
 using Endatix.Core.UseCases.Themes.Delete;
@@ -10,7 +11,7 @@ namespace Endatix.Api.Endpoints.Themes;
 /// <summary>
 /// Endpoint for deleting a theme.
 /// </summary>
-public class Delete(IMediator mediator) : Endpoint<DeleteRequest, Results<Ok<string>, BadRequest, NotFound>>
+public class Delete(IMediator mediator) : Endpoint<DeleteRequest, Results<Ok<string>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -23,20 +24,28 @@ public class Delete(IMediator mediator) : Endpoint<DeleteRequest, Results<Ok<str
         {
             s.Summary = "Delete a theme";
             s.Description = "Deletes a theme by its ID.";
-            s.Responses[204] = "Theme deleted successfully.";
+            s.ExampleRequest = new DeleteRequest { ThemeId = 1 };
+            s.ResponseExamples[200] = "1";
+            s.Responses[200] = "Theme deleted successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Theme not found.";
         });
+        Description(builder => builder
+            .Produces<string>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<string>, BadRequest, NotFound>> ExecuteAsync(DeleteRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<string>, ProblemHttpResult>> ExecuteAsync(
+        DeleteRequest request,
+        CancellationToken ct)
     {
         var command = new DeleteThemeCommand(request.ThemeId);
-        var result = await mediator.Send(command, cancellationToken);
+        var result = await mediator.Send(command, ct);
 
         return TypedResultsBuilder
             .FromResult(result)
-            .SetTypedResults<Ok<string>, BadRequest, NotFound>();
+            .SetTypedResults<Ok<string>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Themes/GetById.cs
+++ b/src/Endatix.Api/Endpoints/Themes/GetById.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Core.Abstractions.Authorization;
@@ -10,7 +11,7 @@ namespace Endatix.Api.Endpoints.Themes;
 /// <summary>
 /// Endpoint for getting a theme by ID.
 /// </summary>
-public class GetById(IMediator mediator) : Endpoint<GetByIdRequest, Results<Ok<ThemeModel>, BadRequest, NotFound>>
+public class GetById(IMediator mediator) : Endpoint<GetByIdRequest, Results<Ok<ThemeModel>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -23,20 +24,37 @@ public class GetById(IMediator mediator) : Endpoint<GetByIdRequest, Results<Ok<T
         {
             s.Summary = "Get a theme by ID";
             s.Description = "Gets a theme by its ID.";
+            s.ExampleRequest = new GetByIdRequest { ThemeId = 1 };
+            s.ResponseExamples[200] = new ThemeModel
+            {
+                Id = "1",
+                Name = "Corporate Blue",
+                Description = "Default corporate theme",
+                JsonData = "{\"primaryColor\":\"#0066cc\"}",
+                CreatedAt = new DateTime(2024, 1, 15, 10, 0, 0, DateTimeKind.Utc),
+                ModifiedAt = new DateTime(2024, 6, 1, 14, 30, 0, DateTimeKind.Utc),
+                FormsCount = 3,
+            };
             s.Responses[200] = "Theme retrieved successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Theme not found.";
         });
+        Description(builder => builder
+            .Produces<ThemeModel>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<ThemeModel>, BadRequest, NotFound>> ExecuteAsync(GetByIdRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<ThemeModel>, ProblemHttpResult>> ExecuteAsync(
+        GetByIdRequest request,
+        CancellationToken ct)
     {
         var query = new GetThemeByIdQuery(request.ThemeId);
-        var result = await mediator.Send(query, cancellationToken);
+        var result = await mediator.Send(query, ct);
 
         return TypedResultsBuilder
             .MapResult(result, ThemeMapper.Map<ThemeModel>)
-            .SetTypedResults<Ok<ThemeModel>, BadRequest, NotFound>();
+            .SetTypedResults<Ok<ThemeModel>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Themes/List.cs
+++ b/src/Endatix.Api/Endpoints/Themes/List.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
 using Endatix.Api.Common;
@@ -14,7 +15,7 @@ namespace Endatix.Api.Endpoints.Themes;
 /// <summary>
 /// Endpoint for listing themes.
 /// </summary>
-public class List(IMediator mediator) : Endpoint<ListRequest, Results<Ok<Paged<ThemeModel>>, BadRequest>>
+public class List(IMediator mediator) : Endpoint<ListRequest, Results<Ok<Paged<ThemeModel>>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -35,13 +36,34 @@ public class List(IMediator mediator) : Endpoint<ListRequest, Results<Ok<Paged<T
                 SortBy = ThemeListSortBy.Name,
                 SortDir = SortDirection.Asc,
             };
+            s.ResponseExamples[200] = new Paged<ThemeModel>(
+                page: 1,
+                pageSize: 20,
+                totalRecords: 1,
+                totalPages: 1,
+                items:
+                [
+                    new ThemeModel
+                    {
+                        Id = "1",
+                        Name = "Corporate Blue",
+                        Description = "Default corporate theme",
+                        JsonData = "{\"primaryColor\":\"#0066cc\"}",
+                        CreatedAt = new DateTime(2024, 1, 15, 10, 0, 0, DateTimeKind.Utc),
+                        ModifiedAt = new DateTime(2024, 6, 1, 14, 30, 0, DateTimeKind.Utc),
+                        FormsCount = 3,
+                    },
+                ]);
             s.Responses[200] = "Themes retrieved successfully.";
             s.Responses[400] = "Invalid input data.";
         });
+        Description(builder => builder
+            .Produces<Paged<ThemeModel>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<Paged<ThemeModel>>, BadRequest>> ExecuteAsync(
+    public override async Task<Results<Ok<Paged<ThemeModel>>, ProblemHttpResult>> ExecuteAsync(
         ListRequest request,
         CancellationToken ct)
     {
@@ -57,7 +79,7 @@ public class List(IMediator mediator) : Endpoint<ListRequest, Results<Ok<Paged<T
 
         return TypedResultsBuilder
             .MapResult(result, Map)
-            .SetTypedResults<Ok<Paged<ThemeModel>>, BadRequest>();
+            .SetTypedResults<Ok<Paged<ThemeModel>>, ProblemHttpResult>();
     }
 
     private static Paged<ThemeModel> Map(Paged<Theme> paged) =>

--- a/src/Endatix.Api/Endpoints/Themes/PartialUpdate.cs
+++ b/src/Endatix.Api/Endpoints/Themes/PartialUpdate.cs
@@ -1,11 +1,9 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
-using Endatix.Core.Models.Themes;
 using Endatix.Core.Abstractions.Authorization;
-using System.Text.Json;
-using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.Themes.PartialUpdate;
 
 namespace Endatix.Api.Endpoints.Themes;
@@ -13,7 +11,7 @@ namespace Endatix.Api.Endpoints.Themes;
 /// <summary>
 /// Endpoint for partially updating a theme.
 /// </summary>
-public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateRequest, Results<Ok<PartialUpdateResponse>, BadRequest, NotFound>>
+public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateRequest, Results<Ok<PartialUpdateResponse>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -26,14 +24,35 @@ public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateRequest, 
         {
             s.Summary = "Partially update a theme";
             s.Description = "Updates specific fields of a theme as provided in the request.";
+            s.ExampleRequest = new PartialUpdateRequest
+            {
+                ThemeId = 1,
+                Name = "Corporate Blue",
+            };
+            s.ResponseExamples[200] = new PartialUpdateResponse
+            {
+                Id = "1",
+                Name = "Corporate Blue",
+                Description = "Default corporate theme",
+                JsonData = "{\"primaryColor\":\"#0066cc\"}",
+                CreatedAt = new DateTime(2024, 1, 15, 10, 0, 0, DateTimeKind.Utc),
+                ModifiedAt = new DateTime(2024, 6, 1, 14, 30, 0, DateTimeKind.Utc),
+                FormsCount = 3,
+            };
             s.Responses[200] = "Theme updated successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Theme not found.";
         });
+        Description(builder => builder
+            .Produces<PartialUpdateResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<PartialUpdateResponse>, BadRequest, NotFound>> ExecuteAsync(PartialUpdateRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<PartialUpdateResponse>, ProblemHttpResult>> ExecuteAsync(
+        PartialUpdateRequest request,
+        CancellationToken ct)
     {
         var command = new PartialUpdateThemeCommand(
             request.ThemeId,
@@ -41,10 +60,10 @@ public class PartialUpdate(IMediator mediator) : Endpoint<PartialUpdateRequest, 
             request.Description,
             request.JsonData);
 
-        var result = await mediator.Send(command, cancellationToken);
+        var result = await mediator.Send(command, ct);
 
         return TypedResultsBuilder
             .MapResult(result, ThemeMapper.Map<PartialUpdateResponse>)
-            .SetTypedResults<Ok<PartialUpdateResponse>, BadRequest, NotFound>();
+            .SetTypedResults<Ok<PartialUpdateResponse>, ProblemHttpResult>();
     }
 }

--- a/src/Endatix.Api/Endpoints/Themes/Update.cs
+++ b/src/Endatix.Api/Endpoints/Themes/Update.cs
@@ -1,11 +1,9 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Infrastructure;
-using Endatix.Core.Models.Themes;
 using Endatix.Core.Abstractions.Authorization;
-using System.Text.Json;
-using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.Themes.Update;
 
 namespace Endatix.Api.Endpoints.Themes;
@@ -13,7 +11,7 @@ namespace Endatix.Api.Endpoints.Themes;
 /// <summary>
 /// Endpoint for updating a theme.
 /// </summary>
-public class Update(IMediator mediator) : Endpoint<UpdateRequest, Results<Ok<UpdateResponse>, BadRequest, NotFound>>
+public class Update(IMediator mediator) : Endpoint<UpdateRequest, Results<Ok<UpdateResponse>, ProblemHttpResult>>
 {
     /// <summary>
     /// Configures the endpoint settings.
@@ -26,14 +24,37 @@ public class Update(IMediator mediator) : Endpoint<UpdateRequest, Results<Ok<Upd
         {
             s.Summary = "Update a theme";
             s.Description = "Updates a theme with the provided data.";
+            s.ExampleRequest = new UpdateRequest
+            {
+                ThemeId = 1,
+                Name = "Corporate Blue",
+                Description = "Updated corporate theme",
+                JsonData = "{\"primaryColor\":\"#004499\"}",
+            };
+            s.ResponseExamples[200] = new UpdateResponse
+            {
+                Id = "1",
+                Name = "Corporate Blue",
+                Description = "Updated corporate theme",
+                JsonData = "{\"primaryColor\":\"#004499\"}",
+                CreatedAt = new DateTime(2024, 1, 15, 10, 0, 0, DateTimeKind.Utc),
+                ModifiedAt = new DateTime(2024, 6, 1, 14, 30, 0, DateTimeKind.Utc),
+                FormsCount = 3,
+            };
             s.Responses[200] = "Theme updated successfully.";
             s.Responses[400] = "Invalid input data.";
             s.Responses[404] = "Theme not found.";
         });
+        Description(builder => builder
+            .Produces<UpdateResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
-    public override async Task<Results<Ok<UpdateResponse>, BadRequest, NotFound>> ExecuteAsync(UpdateRequest request, CancellationToken cancellationToken)
+    public override async Task<Results<Ok<UpdateResponse>, ProblemHttpResult>> ExecuteAsync(
+        UpdateRequest request,
+        CancellationToken ct)
     {
         var command = new UpdateThemeCommand(
             request.ThemeId,
@@ -41,10 +62,10 @@ public class Update(IMediator mediator) : Endpoint<UpdateRequest, Results<Ok<Upd
             request.Description,
             request.JsonData);
 
-        var result = await mediator.Send(command, cancellationToken);
+        var result = await mediator.Send(command, ct);
 
         return TypedResultsBuilder
             .MapResult(result, ThemeMapper.Map<UpdateResponse>)
-            .SetTypedResults<Ok<UpdateResponse>, BadRequest, NotFound>();
+            .SetTypedResults<Ok<UpdateResponse>, ProblemHttpResult>();
     }
-} 
+}

--- a/src/Endatix.Api/Endpoints/Users/CancelUserInvite.cs
+++ b/src/Endatix.Api/Endpoints/Users/CancelUserInvite.cs
@@ -30,8 +30,8 @@ public sealed class CancelUserInvite(IMediator mediator)
             s.Responses[404] = "User or invite not found.";
         });
         Description(builder => builder
-            .Produces<UserOperation>(200, "application/json")
-            .ProducesProblem(404));
+            .Produces<UserOperation>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Users/GetById.cs
+++ b/src/Endatix.Api/Endpoints/Users/GetById.cs
@@ -33,9 +33,9 @@ public sealed class GetById(IMediator mediator)
             s.Responses[404] = "User not found.";
         });
         Description(builder => builder
-            .Produces<GetUserByIdResponse>(200, "application/json")
-            .ProducesProblem(400)
-            .ProducesProblem(404));
+            .Produces<GetUserByIdResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Users/GetUserRoles.cs
+++ b/src/Endatix.Api/Endpoints/Users/GetUserRoles.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Abstractions.Authorization;
 using Endatix.Core.UseCases.Identity.GetUserRoles;
@@ -27,15 +28,18 @@ public class GetUserRoles(IMediator mediator)
             s.Responses[200] = "Roles retrieved successfully.";
             s.Responses[404] = "User not found.";
         });
+        Description(builder => builder
+            .Produces<IList<string>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
     public override async Task<Results<Ok<IList<string>>, ProblemHttpResult>> ExecuteAsync(
         GetUserRolesRequest request,
-        CancellationToken cancellationToken)
+        CancellationToken ct)
     {
         var query = new GetUserRolesQuery(request.UserId);
-        var result = await mediator.Send(query, cancellationToken);
+        var result = await mediator.Send(query, ct);
 
         return TypedResultsBuilder
             .FromResult(result)

--- a/src/Endatix.Api/Endpoints/Users/InviteUser.cs
+++ b/src/Endatix.Api/Endpoints/Users/InviteUser.cs
@@ -37,8 +37,8 @@ public sealed class InviteUser(IMediator mediator, IRoleManagementService roleMa
             s.Responses[400] = "Invalid input data.";
         });
         Description(builder => builder
-            .Produces<InviteUserResponse>(200, "application/json")
-            .ProducesProblem(400));
+            .Produces<InviteUserResponse>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Users/List.cs
+++ b/src/Endatix.Api/Endpoints/Users/List.cs
@@ -46,8 +46,8 @@ public sealed class List(IMediator mediator)
             s.Responses[400] = "Invalid input data.";
         });
         Description(builder => builder
-            .Produces<Paged<ListUsersResponse>>(200, "application/json")
-            .ProducesProblem(400));
+            .Produces<Paged<ListUsersResponse>>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Users/LockoutUser.cs
+++ b/src/Endatix.Api/Endpoints/Users/LockoutUser.cs
@@ -28,8 +28,8 @@ public sealed class LockoutUser(IMediator mediator)
             s.Responses[404] = "User not found.";
         });
         Description(builder => builder
-            .Produces<UserOperation>(200, "application/json")
-            .ProducesProblem(404));
+            .Produces<UserOperation>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc />

--- a/src/Endatix.Api/Endpoints/Users/RemoveUserAccess.cs
+++ b/src/Endatix.Api/Endpoints/Users/RemoveUserAccess.cs
@@ -30,8 +30,8 @@ public sealed class RemoveUserAccess(IMediator mediator)
             s.Responses[404] = "User not found.";
         });
         Description(builder => builder
-            .Produces<UserOperation>(200, "application/json")
-            .ProducesProblem(404));
+            .Produces<UserOperation>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Users/ReplaceUserRoles.cs
+++ b/src/Endatix.Api/Endpoints/Users/ReplaceUserRoles.cs
@@ -4,6 +4,7 @@ using Endatix.Core.UseCases.Identity.ReplaceUserRoles;
 using FastEndpoints;
 using FluentValidation;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Endatix.Api.Endpoints.Users;
@@ -29,15 +30,19 @@ public sealed class ReplaceUserRoles(IMediator mediator)
             s.Responses[400] = "Invalid request or role replacement failed.";
             s.Responses[404] = "User not found.";
         });
+        Description(builder => builder
+            .Produces<UserOperation>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>
     public override async Task<Results<Ok<UserOperation>, ProblemHttpResult>> ExecuteAsync(
         ReplaceUserRolesRequest request,
-        CancellationToken cancellationToken)
+        CancellationToken ct)
     {
         var command = new ReplaceUserRolesCommand(request.UserId, request.RoleNames);
-        var result = await mediator.Send(command, cancellationToken);
+        var result = await mediator.Send(command, ct);
 
         return TypedResultsBuilder
             .MapResult(result, message => UserOperation.Success(message))

--- a/src/Endatix.Api/Endpoints/Users/ResendUserInvitation.cs
+++ b/src/Endatix.Api/Endpoints/Users/ResendUserInvitation.cs
@@ -31,9 +31,9 @@ public sealed class ResendUserInvitation(IMediator mediator)
             s.Responses[404] = "User not found.";
         });
         Description(builder => builder
-            .Produces<UserOperation>(200, "application/json")
-            .ProducesProblem(400)
-            .ProducesProblem(404));
+            .Produces<UserOperation>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Api/Endpoints/Users/UnlockUser.cs
+++ b/src/Endatix.Api/Endpoints/Users/UnlockUser.cs
@@ -28,8 +28,8 @@ public sealed class UnlockUser(IMediator mediator)
             s.Responses[404] = "User not found.";
         });
         Description(builder => builder
-            .Produces<UserOperation>(200, "application/json")
-            .ProducesProblem(404));
+            .Produces<UserOperation>(StatusCodes.Status200OK, "application/json")
+            .ProducesProblem(StatusCodes.Status404NotFound));
     }
 
     /// <inheritdoc />

--- a/src/Endatix.Api/Infrastructure/ResultExtensions.cs
+++ b/src/Endatix.Api/Infrastructure/ResultExtensions.cs
@@ -1,4 +1,3 @@
-using System.Text;
 using Microsoft.AspNetCore.Mvc;
 using Endatix.Core.Infrastructure.Result;
 using AppDomain = Endatix.Core.Infrastructure.Result;
@@ -22,67 +21,11 @@ public static partial class ResultExtensions
     }
 
     /// <summary>
-    /// Converts an IResult from an operation to a NotFound HTTP IResult with ProblemDetails.
+    /// Converts an operation <see cref="AppDomain.IResult"/> to a RFC7807 <see cref="ProblemHttpResult"/>.
+    /// Maps Invalid → 400, NotFound → 404, Conflict → 409, Unauthorized → 401, Forbidden → 403,
+    /// Error/CriticalError → 500, Unavailable → 503.
+    /// <c>detail</c> is always populated, falling back to the title when the result carries no errors.
     /// </summary>
-    /// <param name="result">The IResult to convert.</param>
-    /// <returns>A NotFound HTTP IResult with ProblemDetails.</returns>
-    public static NotFound<ProblemDetails> ToNotFound(this AppDomain.IResult result)
-    {
-        var details = new StringBuilder("Next error(s) occurred:");
-
-        if (result.Errors.Any())
-        {
-            foreach (var error in result.Errors)
-            {
-                details.Append("* ").Append(error).AppendLine();
-            }
-        }
-        else
-        {
-            details.Append("* ").Append(ResultTitles.NOT_FOUND).AppendLine();
-        }
-
-        return TypedResults.NotFound(new ProblemDetails
-        {
-            Title = ResultTitles.NOT_FOUND,
-            Detail = details.ToString(),
-            Status = StatusCodes.Status404NotFound
-        });
-    }
-
-    /// <summary>
-    /// Converts an IResult from an operation to a BadRequest HTTP IResult with ProblemDetails.
-    /// This method constructs a BadRequest response with ProblemDetails, including a title and detail.
-    /// The title defaults to "There was a problem with your request." if not provided.
-    /// The detail includes a list of validation errors if present, otherwise, it defaults to the default title.
-    /// </summary>
-    /// <param name="result">The IResult to convert.</param>
-    /// <param name="title">Optional title for the BadRequest response. Defaults to "There was a problem with your request."</param>
-    /// <returns>A BadRequest HTTP IResult with ProblemDetails.</returns>
-    public static BadRequest<ProblemDetails> ToBadRequest(this AppDomain.IResult result, string? title = null)
-    {
-        var details = ResultTitles.BAD_REQUEST;
-        var validationError = result.ValidationErrors.FirstOrDefault();
-        if (validationError != null)
-        {
-            details = validationError.ErrorMessage;
-        }
-
-        var problemDetails = new ProblemDetails
-        {
-            Title = title ?? ResultTitles.BAD_REQUEST,
-            Detail = details.ToString(),
-            Status = StatusCodes.Status400BadRequest
-        };
-
-        if (validationError?.ErrorCode != null)
-        {
-            problemDetails.Extensions.Add("errorCode", validationError.ErrorCode);
-        }
-
-        return TypedResults.BadRequest(problemDetails);
-    }
-
     public static ProblemHttpResult ToProblem(this AppDomain.IResult result, string? title = null)
     {
         var (status, defaultTitle) = result.Status switch
@@ -93,27 +36,22 @@ public static partial class ResultExtensions
             ResultStatus.Unauthorized => (StatusCodes.Status401Unauthorized, ResultTitles.UNAUTHORIZED),
             ResultStatus.Forbidden => (StatusCodes.Status403Forbidden, ResultTitles.FORBIDDEN),
             ResultStatus.Error => (StatusCodes.Status500InternalServerError, ResultTitles.INTERNAL_SERVER_ERROR),
+            ResultStatus.CriticalError => (StatusCodes.Status500InternalServerError, ResultTitles.INTERNAL_SERVER_ERROR),
             ResultStatus.Unavailable => (StatusCodes.Status503ServiceUnavailable, ResultTitles.SERVICE_UNAVAILABLE),
+            // Ok/Created/NoContent must never reach here; treat as a server-side mapping fault.
             _ => (StatusCodes.Status500InternalServerError, ResultTitles.INTERNAL_SERVER_ERROR)
         };
 
+        var resolvedTitle = title ?? defaultTitle;
         var problemResult = TypedResults.Problem(
-            title: title ?? defaultTitle,
+            title: resolvedTitle,
             statusCode: status);
 
-        var details = new StringBuilder();
-
-        foreach (var error in result.Errors)
-        {
-            details.Append(error).AppendLine();
-        }
+        var messages = new List<string>(result.Errors);
 
         if (result.IsInvalid())
         {
-            foreach (var error in result.ValidationErrors)
-            {
-                details.Append(error.ErrorMessage).AppendLine();
-            }
+            messages.AddRange(result.ValidationErrors.Select(error => error.ErrorMessage));
 
             var errorCode = result.ValidationErrors.FirstOrDefault()?.ErrorCode;
             if (errorCode != null)
@@ -134,199 +72,13 @@ public static partial class ResultExtensions
             }
         }
 
-        problemResult.ProblemDetails.Detail = details.ToString();
+        // `detail` is always populated - never an empty string. Consumers (Hub's
+        // ProblemDetailsSchema included) treat it as a required, human-readable message,
+        // so a result carrying no errors falls back to the title.
+        var detail = string.Join(Environment.NewLine, messages.Where(message => !string.IsNullOrWhiteSpace(message)));
+        problemResult.ProblemDetails.Detail = string.IsNullOrWhiteSpace(detail) ? resolvedTitle : detail;
 
         return problemResult;
-    }
-
-    /// <summary>
-    /// Convert a <see cref="Result{TEntity}"/> to an instance of <c>Microsoft.AspNetCore.Http.HttpResults.Results&lt;,...,&gt;</c>
-    /// </summary>
-    /// <typeparam name="TResults">The Results object listing all the possible status endpoint responses</typeparam>
-    /// <typeparam name="TEntity">The result entity type being received</typeparam>
-    /// <typeparam name="TResponseModel">The HTTP endpoint response model value type being returned</typeparam>
-    /// <param name="result">The command/query result to convert to an <c>Microsoft.AspNetCore.Http.HttpResults.Results&lt;,...,&gt;</c></param>
-    /// <param name="mapper">The mapper to convert from command/query result to HTTP endpoint response model</param>
-    /// <returns></returns>
-    internal static TResults ToEndpointResponse<TResults, TEntity, TResponseModel>(this AppDomain.IResult result, Func<TEntity, TResponseModel> mapper)
-    {
-        var httpResult = result.Status switch
-        {
-            ResultStatus.Ok => result is AppDomain.Result ?
-                TypedResults.Ok() :
-                TypedResults.Ok(mapper((TEntity)result.GetValue())),
-            ResultStatus.Created => TypedResults.Created("", mapper((TEntity)result.GetValue())),
-            ResultStatus.NoContent => TypedResults.NoContent(),
-            ResultStatus.NotFound => NotFoundEntity(result),
-            ResultStatus.Unauthorized => UnAuthorized(result),
-            ResultStatus.Forbidden => Forbidden(result),
-            ResultStatus.Invalid => TypedResults.BadRequest(result.ValidationErrors),
-            ResultStatus.Error => UnprocessableEntity(result),
-            ResultStatus.Conflict => ConflictEntity(result),
-            ResultStatus.Unavailable => UnavailableEntity(result),
-            ResultStatus.CriticalError => CriticalEntity(result),
-            _ => throw new NotSupportedException($"Result {result.Status} conversion is not supported."),
-        };
-
-        return (TResults)(dynamic)httpResult;
-    }
-
-    private static Microsoft.AspNetCore.Http.IResult UnprocessableEntity(AppDomain.IResult result)
-    {
-        var details = new StringBuilder("Next error(s) occurred:");
-
-        foreach (var error in result.Errors)
-        {
-            details.Append("* ").Append(error).AppendLine();
-        }
-
-        return TypedResults.UnprocessableEntity(new ProblemDetails
-        {
-            Title = ResultTitles.INTERNAL_SERVER_ERROR,
-            Detail = details.ToString()
-        });
-    }
-
-    private static Microsoft.AspNetCore.Http.IResult NotFoundEntity(AppDomain.IResult result)
-    {
-        var details = new StringBuilder("Next error(s) occurred:");
-
-        if (result.Errors.Any())
-        {
-            foreach (var error in result.Errors)
-            {
-                details.Append("* ").Append(error).AppendLine();
-            }
-
-            return TypedResults.NotFound(new ProblemDetails
-            {
-                Title = "Resource not found.",
-                Detail = details.ToString()
-            });
-        }
-        else
-        {
-            return TypedResults.NotFound();
-        }
-    }
-
-    private static Microsoft.AspNetCore.Http.IResult ConflictEntity(AppDomain.IResult result)
-    {
-        var details = new StringBuilder("Next error(s) occurred:");
-
-        if (result.Errors.Any())
-        {
-            foreach (var error in result.Errors)
-            {
-                details.Append("* ").Append(error).AppendLine();
-            }
-
-            return TypedResults.Conflict(new ProblemDetails
-            {
-                Title = "There was a conflict.",
-                Detail = details.ToString()
-            });
-        }
-        else
-        {
-            return TypedResults.Conflict();
-        }
-    }
-
-    private static Microsoft.AspNetCore.Http.IResult CriticalEntity(AppDomain.IResult result)
-    {
-        var details = new StringBuilder("Next error(s) occurred:");
-
-        if (result.Errors.Any())
-        {
-            foreach (var error in result.Errors)
-            {
-                details.Append("* ").Append(error).AppendLine();
-            }
-
-            return TypedResults.Problem(new ProblemDetails()
-            {
-                Title = ResultTitles.INTERNAL_SERVER_ERROR,
-                Detail = details.ToString(),
-                Status = StatusCodes.Status500InternalServerError
-            });
-        }
-        else
-        {
-            return TypedResults.StatusCode(StatusCodes.Status500InternalServerError);
-        }
-    }
-
-    private static Microsoft.AspNetCore.Http.IResult UnavailableEntity(AppDomain.IResult result)
-    {
-        var details = new StringBuilder("Next error(s) occurred:");
-
-        if (result.Errors.Any())
-        {
-            foreach (var error in result.Errors)
-            {
-                details.Append("* ").Append(error).AppendLine();
-            }
-
-            return TypedResults.Problem(new ProblemDetails
-            {
-                Title = ResultTitles.SERVICE_UNAVAILABLE,
-                Detail = details.ToString(),
-                Status = StatusCodes.Status503ServiceUnavailable
-            });
-        }
-        else
-        {
-            return TypedResults.StatusCode(StatusCodes.Status503ServiceUnavailable);
-        }
-    }
-
-    private static Microsoft.AspNetCore.Http.IResult Forbidden(AppDomain.IResult result)
-    {
-        var details = new StringBuilder("Next error(s) occurred:");
-
-        if (result.Errors.Any())
-        {
-            foreach (var error in result.Errors)
-            {
-                details.Append("* ").Append(error).AppendLine();
-            }
-
-            return TypedResults.Problem(new ProblemDetails
-            {
-                Title = ResultTitles.FORBIDDEN,
-                Detail = details.ToString(),
-                Status = StatusCodes.Status403Forbidden
-            });
-        }
-        else
-        {
-            return TypedResults.Forbid();
-        }
-    }
-
-    private static Microsoft.AspNetCore.Http.IResult UnAuthorized(AppDomain.IResult result)
-    {
-        var details = new StringBuilder("Next error(s) occurred:");
-
-        if (result.Errors.Any())
-        {
-            foreach (var error in result.Errors)
-            {
-                details.Append("* ").Append(error).AppendLine();
-            }
-
-            return TypedResults.Problem(new ProblemDetails
-            {
-                Title = ResultTitles.UNAUTHORIZED,
-                Detail = details.ToString(),
-                Status = StatusCodes.Status401Unauthorized
-            });
-        }
-        else
-        {
-            return TypedResults.Unauthorized();
-        }
     }
 }
 #endif

--- a/src/Endatix.Api/Infrastructure/TypedResultsBuilder.cs
+++ b/src/Endatix.Api/Infrastructure/TypedResultsBuilder.cs
@@ -3,7 +3,6 @@ using HttpResults = Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http;
 using Ardalis.GuardClauses;
 using Endatix.Core.Infrastructure.Result;
-using Microsoft.AspNetCore.Mvc;
 
 namespace Endatix.Api.Infrastructure;
 
@@ -96,22 +95,6 @@ public class TypedResultsBuilder<TData> : TypedResultsBuilder
           where TResult2 : HttpResults.IResult
     {
         return new TypedResultsBuilder<TData, TResult1, TResult2>(SourceResult, ErrorMessage);
-
-    }
-
-    /// <summary>
-    /// Produces a new TypedResultsBuilder instance that can map to additional result types.
-    /// </summary>
-    /// <typeparam name="TResult1">The first result type to map to.</typeparam>
-    /// <typeparam name="TResult2">The second result type to map to.</typeparam>
-    /// <typeparam name="TResult3">The thrid result type to map to.</typeparam>
-    /// <returns>A new instance of TypedResultsBuilder that can map to TResult1, TResult2 and TResult3.</returns>
-    public TypedResultsBuilder<TData, TResult1, TResult2, TResult3> SetTypedResults<TResult1, TResult2, TResult3>()
-          where TResult1 : HttpResults.IResult
-          where TResult2 : HttpResults.IResult
-          where TResult3 : HttpResults.IResult
-    {
-        return new TypedResultsBuilder<TData, TResult1, TResult2, TResult3>(SourceResult, ErrorMessage);
     }
 }
 
@@ -137,36 +120,6 @@ where TResult2 : HttpResults.IResult
     }
 
     /// <summary>
-    /// Implicitly converts the TypedResultsBuilder to a Results instance for Ok and BadRequest.
-    /// </summary>
-    /// <param name="resultMapper">The TypedResultsBuilder instance to convert.</param>
-    /// <returns>A Results instance for Ok and BadRequest.</returns>
-    public static implicit operator Results<Ok<TData>, BadRequest>(TypedResultsBuilder<TData, TResult1, TResult2> resultMapper)
-    {
-        return resultMapper.SourceResult.Status switch
-        {
-            ResultStatus.Ok => TypedResults.Ok(resultMapper.SourceResult.Value),
-            ResultStatus.Invalid => TypedResults.BadRequest(),
-            _ => throw new InvalidCastException($"Cannot cast the {resultMapper.SourceResult.ValueType} with status {resultMapper.SourceResult.Status}")
-        };
-    }
-
-    /// <summary>
-    /// Implicitly converts the TypedResultsBuilder to a Results instance for Ok and BadRequest.
-    /// </summary>
-    /// <param name="resultMapper">The TypedResultsBuilder instance to convert.</param>
-    /// <returns>A Results instance for Ok and BadRequest.</returns>
-    public static implicit operator Results<Ok<TData>, BadRequest<ProblemDetails>>(TypedResultsBuilder<TData, TResult1, TResult2> resultMapper)
-    {
-        return resultMapper.SourceResult.Status switch
-        {
-            ResultStatus.Ok => TypedResults.Ok(resultMapper.SourceResult.Value),
-            ResultStatus.Invalid => resultMapper.SourceResult.ToBadRequest(resultMapper.ErrorMessage),
-            _ => throw new InvalidCastException($"Cannot cast the {resultMapper.SourceResult.ValueType} with status {resultMapper.SourceResult.Status}")
-        };
-    }
-
-    /// <summary>
     /// Implicitly converts the TypedResultsBuilder to a Results instance for Ok and ProblemDetails.
     /// </summary>
     /// <param name="resultMapper">The TypedResultsBuilder instance to convert.</param>
@@ -176,40 +129,11 @@ where TResult2 : HttpResults.IResult
         return resultMapper.SourceResult.Status switch
         {
             ResultStatus.Ok => TypedResults.Ok(resultMapper.SourceResult.Value),
-            ResultStatus.Invalid => resultMapper.SourceResult.ToProblem(resultMapper.ErrorMessage),
-            ResultStatus.NotFound => resultMapper.SourceResult.ToProblem(resultMapper.ErrorMessage),
-            ResultStatus.Conflict => resultMapper.SourceResult.ToProblem(resultMapper.ErrorMessage),
-            ResultStatus.Unauthorized => resultMapper.SourceResult.ToProblem(resultMapper.ErrorMessage),
-            ResultStatus.Forbidden => resultMapper.SourceResult.ToProblem(resultMapper.ErrorMessage),
-            ResultStatus.Error => resultMapper.SourceResult.ToProblem(resultMapper.ErrorMessage),
-            ResultStatus.Unavailable => resultMapper.SourceResult.ToProblem(resultMapper.ErrorMessage),
-            ResultStatus.CriticalError => resultMapper.SourceResult.ToProblem(resultMapper.ErrorMessage),
-            _ => throw new InvalidCastException($"Cannot cast the {resultMapper.SourceResult.ValueType} with status {resultMapper.SourceResult.Status}")
-        };
-    }
-
-    /// <summary>
-    /// Implicitly converts the TypedResultsBuilder to a Results instance for Ok and NotFound.
-    /// </summary>
-    /// <param name="resultMapper">The TypedResultsBuilder instance to convert.</param>
-    /// <returns>A Results instance for Ok and NotFound.</returns>
-    public static implicit operator Results<Ok<TData>, NotFound>(TypedResultsBuilder<TData, TResult1, TResult2> resultMapper)
-    {
-        return resultMapper.SourceResult.Status switch
-        {
-            ResultStatus.Ok => TypedResults.Ok(resultMapper.SourceResult.Value),
-            ResultStatus.NotFound => TypedResults.NotFound(),
-            _ => throw new InvalidCastException($"Cannot cast the {resultMapper.SourceResult.ValueType} with status {resultMapper.SourceResult.Status}")
-        };
-    }
-
-    public static implicit operator Results<Created<TData>, BadRequest>(TypedResultsBuilder<TData, TResult1, TResult2> resultMapper)
-    {
-        return resultMapper.SourceResult.Status switch
-        {
-            ResultStatus.Created => TypedResults.Created(default(string), resultMapper.SourceResult.Value),
-            ResultStatus.Invalid => TypedResults.BadRequest(),
-            _ => throw new InvalidCastException($"Cannot cast the {resultMapper.SourceResult.ValueType} with status {resultMapper.SourceResult.Status}")
+            // Success statuses this union cannot express mean the endpoint declared the wrong
+            // Results<> signature - fail loudly rather than answer with a misleading status.
+            ResultStatus.Created or ResultStatus.NoContent => throw new InvalidCastException(BuildCastErrorMessage(resultMapper)),
+            // Every remaining status is a failure: RFC7807 problem+json, status picked by ToProblem.
+            _ => resultMapper.SourceResult.ToProblem(resultMapper.ErrorMessage)
         };
     }
 
@@ -223,114 +147,14 @@ where TResult2 : HttpResults.IResult
         return resultMapper.SourceResult.Status switch
         {
             ResultStatus.Created => TypedResults.Created(default(string), resultMapper.SourceResult.Value),
-            ResultStatus.Invalid => resultMapper.SourceResult.ToProblem(resultMapper.ErrorMessage),
-            ResultStatus.NotFound => resultMapper.SourceResult.ToProblem(resultMapper.ErrorMessage),
-            ResultStatus.Conflict => resultMapper.SourceResult.ToProblem(resultMapper.ErrorMessage),
-            ResultStatus.Unauthorized => resultMapper.SourceResult.ToProblem(resultMapper.ErrorMessage),
-            ResultStatus.Forbidden => resultMapper.SourceResult.ToProblem(resultMapper.ErrorMessage),
-            ResultStatus.Error => resultMapper.SourceResult.ToProblem(resultMapper.ErrorMessage),
-            ResultStatus.Unavailable => resultMapper.SourceResult.ToProblem(resultMapper.ErrorMessage),
-            ResultStatus.CriticalError => resultMapper.SourceResult.ToProblem(resultMapper.ErrorMessage),
-            _ => throw new InvalidCastException($"Cannot cast the {resultMapper.SourceResult.ValueType} with status {resultMapper.SourceResult.Status}")
-        };
-    }
-}
-
-
-/// <summary>
-/// Maps results to HTTP typed results for a specific data type and multiple result types.
-/// </summary>
-/// <typeparam name="TData">The type of the data in the result.</typeparam>
-/// <typeparam name="TResult1">The first result type to map to.</typeparam>
-/// <typeparam name="TResult2">The second result type to map to.</typeparam>
-/// <typeparam name="TResult3">The third result type to map to.</typeparam>
-public class TypedResultsBuilder<TData, TResult1, TResult2, TResult3> : TypedResultsBuilder<TData>
-where TData : class
-where TResult1 : HttpResults.IResult
-where TResult2 : HttpResults.IResult
-where TResult3 : HttpResults.IResult
-{
-    /// <summary>
-    /// Initializes a new instance of the TypedResultsBuilder with the specified source result.
-    /// </summary>
-    /// <param name="sourceResult">The source result to map.</param>
-    /// <param name="errorMessage">Optional error message to set.</param>
-    protected internal TypedResultsBuilder(Result<TData> sourceResult, string? errorMessage = null) : base(sourceResult)
-    {
-        ErrorMessage = errorMessage;
-    }
-
-    /// <summary>
-    /// Implicitly converts the TypedResultsBuilder to a Results instance for Created, BadRequest, and NotFound.
-    /// </summary>
-    /// <param name="resultMapper">The TypedResultsBuilder instance to convert.</param>
-    /// <returns>A Results instance for Created, BadRequest, and NotFound.</returns>
-    public static implicit operator Results<Created<TData>, BadRequest, NotFound>(TypedResultsBuilder<TData, TResult1, TResult2, TResult3> resultMapper)
-    {
-        return resultMapper.SourceResult.Status switch
-        {
-            ResultStatus.Created => TypedResults.Created(default(string), resultMapper.SourceResult.Value),
-            ResultStatus.Invalid => TypedResults.BadRequest(),
-            ResultStatus.NotFound => TypedResults.NotFound(),
-            _ => throw new InvalidCastException($"Cannot cast the {resultMapper.SourceResult.ValueType} with status {resultMapper.SourceResult.Status}")
+            // Success statuses this union cannot express mean the endpoint declared the wrong
+            // Results<> signature - fail loudly rather than answer with a misleading status.
+            ResultStatus.Ok or ResultStatus.NoContent => throw new InvalidCastException(BuildCastErrorMessage(resultMapper)),
+            // Every remaining status is a failure: RFC7807 problem+json, status picked by ToProblem.
+            _ => resultMapper.SourceResult.ToProblem(resultMapper.ErrorMessage)
         };
     }
 
-    /// <summary>
-    /// Implicitly converts the TypedResultsBuilder to a Results instance for Created, BadRequest with <see cref="ProblemDetails"/>, and NotFound.
-    /// </summary>
-    /// <param name="resultMapper">The TypedResultsBuilder instance to convert.</param>
-    /// <returns>A Results instance for Created, BadRequest with <see cref="ProblemDetails"/>, and NotFound.</returns>
-    public static implicit operator Results<Created<TData>, BadRequest<ProblemDetails>, NotFound>(TypedResultsBuilder<TData, TResult1, TResult2, TResult3> resultMapper)
-    {
-        return resultMapper.SourceResult.Status switch
-        {
-            ResultStatus.Created => TypedResults.Created(default(string), resultMapper.SourceResult.Value),
-            ResultStatus.Invalid => resultMapper.SourceResult.ToBadRequest(resultMapper.ErrorMessage),
-            ResultStatus.NotFound => TypedResults.NotFound(),
-            _ => throw new InvalidCastException($"Cannot cast the {resultMapper.SourceResult.ValueType} with status {resultMapper.SourceResult.Status}")
-        };
-    }
-
-    /// <summary>
-    /// Implicitly converts the TypedResultsBuilder to a Results instance for Ok, BadRequest, and NotFound.
-    /// </summary>
-    /// <param name="resultMapper">The TypedResultsBuilder instance to convert.</param>
-    /// <returns>A Results instance for Ok, BadRequest, and NotFound.</returns>
-    public static implicit operator Results<Ok<TData>, BadRequest, NotFound>(TypedResultsBuilder<TData, TResult1, TResult2, TResult3> resultMapper)
-    {
-        return resultMapper.SourceResult.Status switch
-        {
-            ResultStatus.Ok => TypedResults.Ok(resultMapper.SourceResult.Value),
-            ResultStatus.Invalid => TypedResults.BadRequest(),
-            ResultStatus.NotFound => TypedResults.NotFound(),
-            _ => throw new InvalidCastException($"Cannot cast the {resultMapper.SourceResult.ValueType} with status {resultMapper.SourceResult.Status}")
-        };
-    }
-
-    /// <summary>
-    /// Implicitly converts the TypedResultsBuilder to a Results instance for Ok, BadRequest, and NotFound with <see cref="ProblemDetails"/>.
-    /// </summary>
-    /// <param name="resultMapper">The TypedResultsBuilder instance to convert.</param>
-    /// <returns>A Results instance for Ok, BadRequest, and NotFound with <see cref="ProblemDetails"/>.</returns>
-    public static implicit operator Results<Ok<TData>, BadRequest, NotFound<ProblemDetails>>(TypedResultsBuilder<TData, TResult1, TResult2, TResult3> resultMapper) => resultMapper.SourceResult.Status switch
-    {
-        ResultStatus.Ok => TypedResults.Ok(resultMapper.SourceResult.Value),
-        ResultStatus.Invalid => TypedResults.BadRequest(),
-        ResultStatus.NotFound => resultMapper.SourceResult.ToNotFound(),
-        _ => throw new InvalidCastException($"Cannot cast the {resultMapper.SourceResult.ValueType} with status {resultMapper.SourceResult.Status}")
-    };
-
-    /// <summary>
-    /// Implicitly converts the TypedResultsBuilder to a Results instance for Ok, BadRequest with <see cref="ProblemDetails"/>, and NotFound.
-    /// </summary>
-    /// <param name="resultMapper">The TypedResultsBuilder instance to convert.</param>
-    /// <returns>A Results instance for Ok, BadRequest with <see cref="ProblemDetails"/>, and NotFound.</returns>
-    public static implicit operator Results<Ok<TData>, BadRequest<ProblemDetails>, NotFound>(TypedResultsBuilder<TData, TResult1, TResult2, TResult3> resultMapper) => resultMapper.SourceResult.Status switch
-    {
-        ResultStatus.Ok => TypedResults.Ok(resultMapper.SourceResult.Value),
-        ResultStatus.Invalid => resultMapper.SourceResult.ToBadRequest(resultMapper.ErrorMessage),
-        ResultStatus.NotFound => TypedResults.NotFound(),
-        _ => throw new InvalidCastException($"Cannot cast the {resultMapper.SourceResult.ValueType} with status {resultMapper.SourceResult.Status}")
-    };
+    private static string BuildCastErrorMessage(TypedResultsBuilder<TData, TResult1, TResult2> resultMapper) =>
+        $"Cannot cast the {resultMapper.SourceResult.ValueType} with status {resultMapper.SourceResult.Status}";
 }

--- a/src/Endatix.Core/UseCases/Identity/Login/LoginHandler.cs
+++ b/src/Endatix.Core/UseCases/Identity/Login/LoginHandler.cs
@@ -1,9 +1,12 @@
 ﻿using Endatix.Core.Abstractions;
 using Endatix.Core.Abstractions.Authorization;
+using Endatix.Core.Entities.Identity;
 using Endatix.Core.Events;
+using Endatix.Core.Infrastructure.Logging;
 using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
 using MediatR;
+using Microsoft.Extensions.Logging;
 
 namespace Endatix.Core.UseCases.Identity.Login;
 
@@ -14,9 +17,15 @@ internal sealed class LoginHandler(
     IAuthService authService,
     IUserTokenService tokenService,
     ICurrentUserAuthorizationService authorizationService,
-    IMediator mediator
+    IMediator mediator,
+    ILogger<LoginHandler> logger
     ) : ICommandHandler<LoginCommand, Result<AuthTokensDto>>
 {
+    /// <summary>
+    /// The single client-facing message for every authentication failure.
+    /// </summary>
+    public const string INVALID_CREDENTIALS_MESSAGE = "The supplied credentials are invalid";
+
     public async Task<Result<AuthTokensDto>> Handle(LoginCommand request, CancellationToken cancellationToken)
     {
         var validationResult = await authService.ValidateCredentials(
@@ -24,14 +33,21 @@ internal sealed class LoginHandler(
             request.Password,
             cancellationToken);
 
-        if (validationResult.IsInvalid())
-        {
-            return Result.Invalid(validationResult.ValidationErrors);
-        }
-
         if (!validationResult.IsSuccess)
         {
-            return Result.Error();
+            // OWASP (A07 - Identification and Authentication Failures): every credential
+            // failure must be indistinguishable to the caller. Unknown account, unconfirmed
+            // email and wrong password all collapse to one status and one message, so the
+            // response cannot be used to enumerate accounts. IAuthService is a public
+            // abstraction - never propagate an implementation's status (e.g. NotFound -> 404)
+            // to the client here. The real reason is logged instead.
+            logger.LogWarning(
+                "Login failed for {Email}. Status: {Status}. Reason: {Reason}",
+                SensitiveValue.Email(request.Email),
+                validationResult.Status,
+                DescribeFailure(validationResult));
+
+            return Result<AuthTokensDto>.Invalid(new ValidationError(INVALID_CREDENTIALS_MESSAGE));
         }
 
         var user = validationResult.Value;
@@ -42,14 +58,11 @@ internal sealed class LoginHandler(
             refreshToken.ExpireAt,
             cancellationToken);
 
-        if (persistResult.IsInvalid())
-        {
-            return Result.Invalid(persistResult.ValidationErrors);
-        }
-
         if (!persistResult.IsSuccess)
         {
-            return Result.Error();
+            // Post-authentication infrastructure failure: it reveals nothing about the
+            // account, so the underlying status and message are propagated verbatim.
+            return persistResult.ToErrorResult<AuthTokensDto>();
         }
 
         var accessToken = tokenService.IssueAccessToken(user);
@@ -61,5 +74,15 @@ internal sealed class LoginHandler(
         await mediator.Publish(new UserLoggedInEvent(user), cancellationToken);
 
         return Result.Success(new AuthTokensDto(accessToken, refreshToken));
+    }
+
+    private static string DescribeFailure(Result<User> result)
+    {
+        var messages = result.Errors
+            .Concat(result.ValidationErrors.Select(error => error.ErrorMessage))
+            .Where(message => !string.IsNullOrWhiteSpace(message));
+
+        var description = string.Join("; ", messages);
+        return string.IsNullOrWhiteSpace(description) ? "No reason supplied." : description;
     }
 }

--- a/src/Endatix.Infrastructure/Identity/Authentication/AuthService.cs
+++ b/src/Endatix.Infrastructure/Identity/Authentication/AuthService.cs
@@ -20,11 +20,10 @@ internal sealed class AuthService(UserManager<AppUser> userManager, IPasswordHas
     /// Placeholder used only to burn the same password-hashing work when no account matched.
     /// </summary>
     private static readonly AppUser DummyUser = new() { Email = "dummy@endatix.invalid" };
-    private const string DUMMY_PASSWORD = "N0tARea1Passw0rd!";
 
     /// <summary>
-    /// Hash of <see cref="DUMMY_PASSWORD"/>, computed once. A benign race just recomputes an
-    /// equivalent hash, so no locking is needed.
+    /// Throwaway hash (from a random GUID, never a real credential), computed once.
+    /// A benign race just recomputes an equivalent hash, so no locking is needed.
     /// </summary>
     private static string? _dummyPasswordHash;
 
@@ -40,7 +39,7 @@ internal sealed class AuthService(UserManager<AppUser> userManager, IPasswordHas
         // unconfirmed account skips the hash and answers measurably faster, which lets an
         // attacker enumerate accounts by response time even though the payloads are identical.
         var passwordVerified = user is null
-            ? BurnPasswordHashingWork(password)
+            ? BurnPasswordHashingWork(_passwordHasher, password)
             : await _userManager.CheckPasswordAsync(user, password);
 
         if (user is null || !user.EmailConfirmed || !passwordVerified)
@@ -55,10 +54,10 @@ internal sealed class AuthService(UserManager<AppUser> userManager, IPasswordHas
     /// Verifies the supplied password against a throwaway hash so the unknown-account path
     /// costs the same as a real verification. Always returns false.
     /// </summary>
-    private bool BurnPasswordHashingWork(string password)
+    private static bool BurnPasswordHashingWork(IPasswordHasher<AppUser> passwordHasher, string password)
     {
-        _dummyPasswordHash ??= _passwordHasher.HashPassword(DummyUser, DUMMY_PASSWORD);
-        _passwordHasher.VerifyHashedPassword(DummyUser, _dummyPasswordHash, password);
+        _dummyPasswordHash ??= passwordHasher.HashPassword(DummyUser, Guid.NewGuid().ToString("N"));
+        passwordHasher.VerifyHashedPassword(DummyUser, _dummyPasswordHash, password);
 
         return false;
     }

--- a/src/Endatix.Infrastructure/Identity/Authentication/AuthService.cs
+++ b/src/Endatix.Infrastructure/Identity/Authentication/AuthService.cs
@@ -16,6 +16,18 @@ internal sealed class AuthService(UserManager<AppUser> userManager, IPasswordHas
 
     public static readonly string INVALID_CREDENTIALS_ERROR_MESSAGE = "The supplied credentials are invalid";
 
+    /// <summary>
+    /// Placeholder used only to burn the same password-hashing work when no account matched.
+    /// </summary>
+    private static readonly AppUser DummyUser = new() { Email = "dummy@endatix.invalid" };
+    private const string DUMMY_PASSWORD = "N0tARea1Passw0rd!";
+
+    /// <summary>
+    /// Hash of <see cref="DUMMY_PASSWORD"/>, computed once. A benign race just recomputes an
+    /// equivalent hash, so no locking is needed.
+    /// </summary>
+    private static string? _dummyPasswordHash;
+
     /// <inheritdoc/>
     public async Task<Result<User>> ValidateCredentials(string email, string password, CancellationToken cancellationToken)
     {
@@ -24,18 +36,31 @@ internal sealed class AuthService(UserManager<AppUser> userManager, IPasswordHas
 
         var user = await _userManager.FindByEmailAsync(email);
 
-        if (user is null || !user.EmailConfirmed)
-        {
-            return Result.Invalid(new ValidationError(INVALID_CREDENTIALS_ERROR_MESSAGE));
-        }
+        // OWASP A07: run the password KDF on every path. Returning early for an unknown or
+        // unconfirmed account skips the hash and answers measurably faster, which lets an
+        // attacker enumerate accounts by response time even though the payloads are identical.
+        var passwordVerified = user is null
+            ? BurnPasswordHashingWork(password)
+            : await _userManager.CheckPasswordAsync(user, password);
 
-        var userVerified = await _userManager.CheckPasswordAsync(user, password);
-        if (!userVerified)
+        if (user is null || !user.EmailConfirmed || !passwordVerified)
         {
             return Result.Invalid(new ValidationError(INVALID_CREDENTIALS_ERROR_MESSAGE));
         }
 
         return Result.Success(user.ToUserEntity());
+    }
+
+    /// <summary>
+    /// Verifies the supplied password against a throwaway hash so the unknown-account path
+    /// costs the same as a real verification. Always returns false.
+    /// </summary>
+    private bool BurnPasswordHashingWork(string password)
+    {
+        _dummyPasswordHash ??= _passwordHasher.HashPassword(DummyUser, DUMMY_PASSWORD);
+        _passwordHasher.VerifyHashedPassword(DummyUser, _dummyPasswordHash, password);
+
+        return false;
     }
 
     /// <inheritdoc/>

--- a/src/Endatix.Infrastructure/Identity/EmailVerification/EmailVerificationService.cs
+++ b/src/Endatix.Infrastructure/Identity/EmailVerification/EmailVerificationService.cs
@@ -16,6 +16,17 @@ namespace Endatix.Infrastructure.Identity.EmailVerification;
 public class EmailVerificationService : IEmailVerificationService
 {
     private const int TOKEN_SIZE_BYTES = 32; // 256 bits
+
+    /// <summary>
+    /// Single client-facing message for every unresolvable verification token, so a caller
+    /// cannot tell an unknown token apart from one whose account no longer exists.
+    /// </summary>
+    public const string INVALID_VERIFICATION_TOKEN_MESSAGE = "Invalid verification token";
+
+    /// <summary>
+    /// Single client-facing message for every unresolvable invite token, for the same reason.
+    /// </summary>
+    public const string INVALID_INVITE_TOKEN_MESSAGE = "Invalid invite token";
     private readonly IRepository<EmailVerificationToken> _tokenRepository;
     private readonly UserManager<AppUser> _userManager;
     private readonly EmailVerificationOptions _options;
@@ -83,7 +94,9 @@ public class EmailVerificationService : IEmailVerificationService
 
         if (verificationToken == null)
         {
-            return Result.NotFound("Invalid verification token");
+            // Same status and message as the expired/used branches below: the response must not
+            // tell the caller whether the token ever existed.
+            return Result.Invalid(new ValidationError(INVALID_VERIFICATION_TOKEN_MESSAGE));
         }
 
         if (verificationToken.IsExpired)
@@ -99,7 +112,9 @@ public class EmailVerificationService : IEmailVerificationService
         var user = await _userManager.FindByIdAsync(verificationToken.UserId.ToString());
         if (user == null)
         {
-            return Result.NotFound("User not found");
+            // Report the same failure as an unknown token. A dangling token must not tell the
+            // caller that the token itself was genuine but the account behind it is gone.
+            return Result.Invalid(new ValidationError(INVALID_VERIFICATION_TOKEN_MESSAGE));
         }
 
         if (user.EmailConfirmed)
@@ -220,7 +235,7 @@ public class EmailVerificationService : IEmailVerificationService
 
         if (verificationToken == null)
         {
-            return Result.NotFound("Invalid invite token");
+            return Result.Invalid(new ValidationError(INVALID_INVITE_TOKEN_MESSAGE));
         }
 
         if (verificationToken.IsExpired)
@@ -236,7 +251,7 @@ public class EmailVerificationService : IEmailVerificationService
         var user = await _userManager.FindByIdAsync(verificationToken.UserId.ToString());
         if (user == null)
         {
-            return Result.NotFound("User not found");
+            return Result.Invalid(new ValidationError(INVALID_INVITE_TOKEN_MESSAGE));
         }
 
         if (user.EmailConfirmed)

--- a/tests/Endatix.Api.Tests/Endpoints/Auth/RefreshTokenTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Auth/RefreshTokenTests.cs
@@ -1,7 +1,7 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
-using Errors = Microsoft.AspNetCore.Mvc;
 using Endatix.Api.Endpoints.Auth;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.Identity;
@@ -59,9 +59,9 @@ public class RefreshTokenTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badResult = response?.Result as BadRequest<Errors.ProblemDetails>;
-        badResult.Should().NotBeNull();
-        badResult?.StatusCode.Should().Be(400);
-        badResult?.Value?.Title.Should().Be("Invalid or expired token.");
+        var problemResult = response?.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult?.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        problemResult?.ProblemDetails.Title.Should().Be("Invalid or expired token.");
     }
 }

--- a/tests/Endatix.Api.Tests/Endpoints/Auth/RegisterTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Auth/RegisterTests.cs
@@ -1,12 +1,10 @@
 using FastEndpoints;
 using MediatR;
 using Microsoft.AspNetCore.Http.HttpResults;
-using Errors = Microsoft.AspNetCore.Mvc;
 using Endatix.Api.Endpoints.Auth;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.Identity.Register;
 using Microsoft.AspNetCore.Http;
-using static Endatix.Api.Infrastructure.ResultExtensions;
 
 namespace Endatix.Api.Tests.Endpoints.Auth;
 
@@ -57,12 +55,11 @@ public class RegisterTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badResponse = response!.Result as BadRequest<Errors.ProblemDetails>;
+        var problemResult = response!.Result as ProblemHttpResult;
 
-        badResponse.Should().NotBeNull();
-        badResponse!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
-        badResponse!.Value!.Status.Should().Be(StatusCodes.Status400BadRequest);
-        badResponse!.Value!.Title.Should().Be("Registration failed. Please check your input and try again.");
-        badResponse!.Value!.Detail.Should().Be(ResultTitles.BAD_REQUEST);
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        problemResult!.ProblemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
+        problemResult!.ProblemDetails.Title.Should().Be("Registration failed. Please check your input and try again.");
     }
 }

--- a/tests/Endatix.Api.Tests/Endpoints/Auth/SendVerificationEmailTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Auth/SendVerificationEmailTests.cs
@@ -96,9 +96,9 @@ public class SendVerificationEmailTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badResponse = response!.Result as BadRequest<Microsoft.AspNetCore.Mvc.ProblemDetails>;
+        var problemResult = response!.Result as ProblemHttpResult;
 
-        badResponse.Should().NotBeNull();
-        badResponse!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 } 

--- a/tests/Endatix.Api.Tests/Endpoints/Auth/VerifyEmailTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Auth/VerifyEmailTests.cs
@@ -56,28 +56,32 @@ public class VerifyEmailTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badResponse = response!.Result as BadRequest<Microsoft.AspNetCore.Mvc.ProblemDetails>;
+        var problemResult = response!.Result as ProblemHttpResult;
 
-        badResponse.Should().NotBeNull();
-        badResponse!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
+    /// <summary>
+    /// An unknown token is reported exactly like an expired or already-used one: 400 with the
+    /// same message, so the response cannot be used to probe token or account state.
+    /// </summary>
     [Fact]
-    public async Task ExecuteAsync_WithNotFoundToken_ReturnsNotFound()
+    public async Task ExecuteAsync_WithUnknownToken_ReturnsSameProblemAsExpiredToken()
     {
         // Arrange
         var request = new VerifyEmailRequest("not-found-token");
-        var notFoundResult = Result.NotFound("Verification token not found");
-
         _mediator.Send(Arg.Any<VerifyEmailCommand>(), Arg.Any<CancellationToken>())
-            .Returns(notFoundResult);
+            .Returns(Result<User>.Invalid(new ValidationError("Invalid verification token")));
 
         // Act
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResponse = response!.Result as NotFound;
+        var problemResult = response!.Result as ProblemHttpResult;
 
-        notFoundResponse.Should().NotBeNull();
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        problemResult.ProblemDetails.Detail.Should().Be("Invalid verification token");
     }
 } 

--- a/tests/Endatix.Api.Tests/Endpoints/CustomQuestions/CreateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/CustomQuestions/CreateTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Entities;
@@ -20,7 +21,7 @@ public class CreateTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_InvalidRequest_ReturnsBadRequest()
+    public async Task ExecuteAsync_InvalidRequest_ReturnsProblemDetails()
     {
         // Arrange
         var request = new CreateCustomQuestionRequest
@@ -39,8 +40,9 @@ public class CreateTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/CustomQuestions/ListTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/CustomQuestions/ListTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Entities;
@@ -21,7 +22,7 @@ public class ListTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_InvalidRequest_ReturnsBadRequest()
+    public async Task ExecuteAsync_InvalidRequest_ReturnsProblemDetails()
     {
         // Arrange
         var request = new CustomQuestionsListRequest();
@@ -34,8 +35,9 @@ public class ListTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/CreateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/CreateTests.cs
@@ -83,9 +83,9 @@ public class CreateTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result.As<BadRequest>();
-        badRequestResult.Should().NotBeNull();
-        badRequestResult.StatusCode.Should().Be(400);
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]
@@ -113,8 +113,8 @@ public class CreateTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResponse = response.Result.As<NotFound>();
-        notFoundResponse.Should().NotBeNull();
-        notFoundResponse.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 }

--- a/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/GetByIdTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/GetByIdTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Entities;
@@ -36,8 +37,9 @@ public class GetByIdTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]
@@ -56,8 +58,9 @@ public class GetByIdTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/ListTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/ListTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Entities;
@@ -35,8 +36,9 @@ public class ListTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]
@@ -81,8 +83,9 @@ public class ListTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/PartialUpdateActiveTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/PartialUpdateActiveTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Entities;
@@ -35,8 +36,9 @@ public class PartialUpdateActiveTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]
@@ -54,8 +56,9 @@ public class PartialUpdateActiveTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/PartialUpdateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/PartialUpdateTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Entities;
@@ -36,8 +37,9 @@ public class PartialUpdateTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]
@@ -56,8 +58,9 @@ public class PartialUpdateTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/UpdateActiveTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/UpdateActiveTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Entities;
@@ -40,8 +41,9 @@ public class UpdateActiveTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]
@@ -64,8 +66,9 @@ public class UpdateActiveTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/UpdateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/FormDefinitions/UpdateTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Entities;
@@ -42,8 +43,9 @@ public class UpdateTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]
@@ -68,8 +70,9 @@ public class UpdateTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/FormTemplates/DeleteTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/FormTemplates/DeleteTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Entities;
@@ -20,7 +21,7 @@ public class DeleteTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_InvalidRequest_ReturnsBadRequest()
+    public async Task ExecuteAsync_InvalidRequest_ReturnsProblemDetails()
     {
         // Arrange
         var formTemplateId = 1L;
@@ -34,12 +35,13 @@ public class DeleteTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]
-    public async Task ExecuteAsync_FormTemplateNotFound_ReturnsNotFound()
+    public async Task ExecuteAsync_FormTemplateNotFound_ReturnsProblemDetails()
     {
         // Arrange
         var formTemplateId = 1L;
@@ -53,8 +55,9 @@ public class DeleteTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/FormTemplates/GetByIdTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/FormTemplates/GetByIdTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Entities;
@@ -20,7 +21,7 @@ public class GetByIdTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_InvalidRequest_ReturnsBadRequest()
+    public async Task ExecuteAsync_InvalidRequest_ReturnsProblemDetails()
     {
         // Arrange
         var formTemplateId = 1L;
@@ -34,12 +35,13 @@ public class GetByIdTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]
-    public async Task ExecuteAsync_FormTemplateNotFound_ReturnsNotFound()
+    public async Task ExecuteAsync_FormTemplateNotFound_ReturnsProblemDetails()
     {
         // Arrange
         var formTemplateId = 1L;
@@ -53,8 +55,9 @@ public class GetByIdTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/FormTemplates/ListTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/FormTemplates/ListTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Paging;
 using Endatix.Core.Infrastructure.Result;
@@ -21,7 +22,7 @@ public class ListTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_InvalidRequest_ReturnsBadRequest()
+    public async Task ExecuteAsync_InvalidRequest_ReturnsProblemDetails()
     {
         // Arrange
         var request = new FormTemplatesListRequest { Page = 1, PageSize = 10 };
@@ -34,8 +35,9 @@ public class ListTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/Forms/GetByIdTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Forms/GetByIdTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Api.Endpoints.Forms;
@@ -34,8 +35,9 @@ public class GetByIdTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]
@@ -53,8 +55,9 @@ public class GetByIdTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/Submissions/GetByIdTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Submissions/GetByIdTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Entities;
@@ -35,8 +36,9 @@ public class GetByIdTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]
@@ -55,8 +57,9 @@ public class GetByIdTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/Submissions/GetByTokenTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Submissions/GetByTokenTests.cs
@@ -1,11 +1,11 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Entities;
 using Endatix.Api.Endpoints.Submissions;
 using Endatix.Core.UseCases.Submissions.GetByToken;
-using Errors = Microsoft.AspNetCore.Mvc;
 using Endatix.Core.Abstractions.Submissions;
 
 namespace Endatix.Api.Tests.Endpoints.Submissions;
@@ -37,11 +37,11 @@ public class GetByTokenTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest<Errors.ProblemDetails>;
-        badRequestResult.Should().NotBeNull();
-        badRequestResult!.Value.Should().NotBeNull();
-        badRequestResult!.Value!.Detail.Should().Be(SubmissonTokenErrors.Messages.SUBMISSION_TOKEN_INVALID);
-        badRequestResult!.Value!.Extensions["errorCode"].Should().Be(SubmissonTokenErrors.ErrorCodes.SUBMISSION_TOKEN_INVALID);
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.ProblemDetails.Should().NotBeNull();
+        problemResult!.ProblemDetails.Detail.Should().Be(SubmissonTokenErrors.Messages.SUBMISSION_TOKEN_INVALID);
+        problemResult!.ProblemDetails.Extensions["errorCode"].Should().Be(SubmissonTokenErrors.ErrorCodes.SUBMISSION_TOKEN_INVALID);
     }
 
     [Fact]
@@ -60,8 +60,9 @@ public class GetByTokenTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/Submissions/PartialUpdateByTokenTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Submissions/PartialUpdateByTokenTests.cs
@@ -1,11 +1,11 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Entities;
 using Endatix.Api.Endpoints.Submissions;
 using Endatix.Core.UseCases.Submissions.PartialUpdateByToken;
-using Errors = Microsoft.AspNetCore.Mvc;
 using Endatix.Core.Features.ReCaptcha;
 using Endatix.Core.Abstractions.Submissions;
 
@@ -38,10 +38,10 @@ public class PartialUpdateByTokenTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest<Errors.ProblemDetails>;
-        badRequestResult.Should().NotBeNull();
-        badRequestResult!.Value!.Detail.Should().Be(SubmissonTokenErrors.Messages.SUBMISSION_TOKEN_INVALID);
-        badRequestResult!.Value!.Extensions["errorCode"].Should().Be(SubmissonTokenErrors.ErrorCodes.SUBMISSION_TOKEN_INVALID);
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.ProblemDetails.Detail.Trim().Should().Be(SubmissonTokenErrors.Messages.SUBMISSION_TOKEN_INVALID);
+        problemResult!.ProblemDetails.Extensions["errorCode"].Should().Be(SubmissonTokenErrors.ErrorCodes.SUBMISSION_TOKEN_INVALID);
     }
 
     [Fact]
@@ -60,8 +60,9 @@ public class PartialUpdateByTokenTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]
@@ -81,10 +82,10 @@ public class PartialUpdateByTokenTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest<Errors.ProblemDetails>;
-        badRequestResult.Should().NotBeNull();
-        badRequestResult!.Value!.Detail.Should().Be(ReCaptchaErrors.Messages.RECAPTCHA_VERIFICATION_FAILED);
-        badRequestResult!.Value!.Extensions["errorCode"].Should().Be(ReCaptchaErrors.ErrorCodes.RECAPTCHA_VERIFICATION_FAILED);
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.ProblemDetails.Detail.Trim().Should().Be(ReCaptchaErrors.Messages.RECAPTCHA_VERIFICATION_FAILED);
+        problemResult!.ProblemDetails.Extensions["errorCode"].Should().Be(ReCaptchaErrors.ErrorCodes.RECAPTCHA_VERIFICATION_FAILED);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/Submissions/PartialUpdateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Submissions/PartialUpdateTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Entities;
@@ -35,8 +36,9 @@ public class PartialUpdateTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]
@@ -55,8 +57,9 @@ public class PartialUpdateTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/Submissions/UpdateStatusTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Submissions/UpdateStatusTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Api.Endpoints.Submissions;
 using Endatix.Core.UseCases.Submissions.UpdateStatus;
@@ -58,7 +59,8 @@ public sealed class UpdateStatusTests
         var response = await _endpoint.ExecuteAsync(request, CancellationToken.None);
 
         // Assert
-        response.Result.Should().BeOfType<NotFound>();
+        var problemResult = response.Result.Should().BeOfType<ProblemHttpResult>().Subject;
+        problemResult.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]
@@ -75,7 +77,8 @@ public sealed class UpdateStatusTests
         var response = await _endpoint.ExecuteAsync(request, CancellationToken.None);
 
         // Assert
-        response.Result.Should().BeOfType<BadRequest>();
+        var problemResult = response.Result.Should().BeOfType<ProblemHttpResult>().Subject;
+        problemResult.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/Submissions/UpdateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Submissions/UpdateTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Entities;
@@ -27,7 +28,7 @@ public class UpdateTests
         var submissionId = 1L;
         var request = new UpdateSubmissionRequest { FormId = formId, SubmissionId = submissionId };
         var result = Result.Invalid();
-        
+
         _mediator.Send(Arg.Any<UpdateSubmissionCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);
 
@@ -35,8 +36,9 @@ public class UpdateTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]
@@ -55,8 +57,9 @@ public class UpdateTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]
@@ -66,8 +69,8 @@ public class UpdateTests
         var formId = 1L;
         var submissionId = 1L;
         var jsonData = "{ }";
-        var request = new UpdateSubmissionRequest 
-        { 
+        var request = new UpdateSubmissionRequest
+        {
             FormId = formId,
             SubmissionId = submissionId,
             JsonData = jsonData,
@@ -75,7 +78,7 @@ public class UpdateTests
             CurrentPage = 2,
             Metadata = "test metadata"
         };
-        
+
         var submission = new Submission(SampleData.TENANT_ID, jsonData, formId, 456) { Id = submissionId };
         var result = Result.Success(submission);
 
@@ -106,7 +109,7 @@ public class UpdateTests
             Metadata = """{ "key": "value" }"""
         };
         var result = Result.Success(new Submission(SampleData.TENANT_ID, """"{ "field": "value" }"""", 123, 456));
-        
+
         _mediator.Send(Arg.Any<UpdateSubmissionCommand>(), Arg.Any<CancellationToken>())
             .Returns(result);
 

--- a/tests/Endatix.Api.Tests/Endpoints/Themes/CreateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Themes/CreateTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Api.Endpoints.Themes;
@@ -21,7 +22,7 @@ public class CreateTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_InvalidRequest_ReturnsBadRequest()
+    public async Task ExecuteAsync_InvalidRequest_ReturnsProblemDetails()
     {
         // Arrange
         var invalidRequest = new CreateRequest
@@ -40,8 +41,9 @@ public class CreateTests
         var response = await _endpoint.ExecuteAsync(invalidRequest, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]
@@ -72,7 +74,7 @@ public class CreateTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_InvalidJsonData_ReturnsBadRequest()
+    public async Task ExecuteAsync_InvalidJsonData_ReturnsProblemDetails()
     {
         // Arrange
         var request = new CreateRequest
@@ -91,8 +93,9 @@ public class CreateTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/Themes/DeleteTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Themes/DeleteTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Api.Endpoints.Themes;
@@ -19,7 +20,7 @@ public class DeleteTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_ThemeNotFound_ReturnsNotFound()
+    public async Task ExecuteAsync_ThemeNotFound_ReturnsProblemDetails()
     {
         // Arrange
         var request = new DeleteRequest { ThemeId = 1 };
@@ -33,12 +34,13 @@ public class DeleteTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]
-    public async Task ExecuteAsync_InvalidRequest_ReturnsBadRequest()
+    public async Task ExecuteAsync_InvalidRequest_ReturnsProblemDetails()
     {
         // Arrange
         var request = new DeleteRequest { ThemeId = 0 }; // Invalid ID
@@ -51,8 +53,9 @@ public class DeleteTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/Themes/GetByIdTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Themes/GetByIdTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Entities;
@@ -20,7 +21,7 @@ public class GetByIdTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_ThemeNotFound_ReturnsNotFound()
+    public async Task ExecuteAsync_ThemeNotFound_ReturnsProblemDetails()
     {
         // Arrange
         var request = new GetByIdRequest { ThemeId = 1 };
@@ -33,12 +34,13 @@ public class GetByIdTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]
-    public async Task ExecuteAsync_InvalidRequest_ReturnsBadRequest()
+    public async Task ExecuteAsync_InvalidRequest_ReturnsProblemDetails()
     {
         // Arrange
         var request = new GetByIdRequest { ThemeId = 0 }; // Invalid ID
@@ -51,8 +53,9 @@ public class GetByIdTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/Themes/ListTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Themes/ListTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Paging;
 using Endatix.Core.Infrastructure.Result;
@@ -21,7 +22,7 @@ public class ListTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_InvalidRequest_ReturnsBadRequest()
+    public async Task ExecuteAsync_InvalidRequest_ReturnsProblemDetails()
     {
         // Arrange
         var request = new ListRequest();
@@ -34,8 +35,9 @@ public class ListTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/Themes/PartialUpdateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Themes/PartialUpdateTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Models.Themes;
@@ -22,7 +23,7 @@ public class PartialUpdateTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_ThemeNotFound_ReturnsNotFound()
+    public async Task ExecuteAsync_ThemeNotFound_ReturnsProblemDetails()
     {
         // Arrange
         var request = new PartialUpdateRequest
@@ -39,12 +40,13 @@ public class PartialUpdateTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]
-    public async Task ExecuteAsync_InvalidRequest_ReturnsBadRequest()
+    public async Task ExecuteAsync_InvalidRequest_ReturnsProblemDetails()
     {
         // Arrange
         var request = new PartialUpdateRequest
@@ -61,8 +63,9 @@ public class PartialUpdateTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Endpoints/Themes/UpdateTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Themes/UpdateTests.cs
@@ -1,5 +1,6 @@
 using FastEndpoints;
 using MediatR;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Entities;
@@ -20,7 +21,7 @@ public class UpdateTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_ThemeNotFound_ReturnsNotFound()
+    public async Task ExecuteAsync_ThemeNotFound_ReturnsProblemDetails()
     {
         // Arrange
         var request = new UpdateRequest
@@ -39,12 +40,13 @@ public class UpdateTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var notFoundResult = response.Result as NotFound;
-        notFoundResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]
-    public async Task ExecuteAsync_InvalidRequest_ReturnsBadRequest()
+    public async Task ExecuteAsync_InvalidRequest_ReturnsProblemDetails()
     {
         // Arrange
         var request = new UpdateRequest
@@ -63,8 +65,9 @@ public class UpdateTests
         var response = await _endpoint.ExecuteAsync(request, default);
 
         // Assert
-        var badRequestResult = response.Result as BadRequest;
-        badRequestResult.Should().NotBeNull();
+        var problemResult = response.Result as ProblemHttpResult;
+        problemResult.Should().NotBeNull();
+        problemResult!.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Infrastructure/ResultExtensionsTests.cs
+++ b/tests/Endatix.Api.Tests/Infrastructure/ResultExtensionsTests.cs
@@ -2,7 +2,6 @@ using Endatix.Api.Infrastructure;
 using Endatix.Core.Infrastructure.Result;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
-using Microsoft.AspNetCore.Mvc;
 using static Endatix.Api.Infrastructure.ResultExtensions;
 
 namespace Endatix.Api.Tests.Infrastructure;
@@ -11,131 +10,10 @@ public class ResultExtensionsTests
 {
     private const string DEFAULT_UNEXPECTED_ERROR_TITLE = ResultTitles.INTERNAL_SERVER_ERROR;
     private const string DEFAULT_BAD_REQUEST_TITLE = ResultTitles.BAD_REQUEST;
-    private const string DEFAULT_NOT_FOUND_TITLE = ResultTitles.NOT_FOUND;
     private const string DEFAULT_UNAUTHORIZED_TITLE = ResultTitles.UNAUTHORIZED;
     private const string DEFAULT_FORBIDDEN_TITLE = ResultTitles.FORBIDDEN;
     private const string DEFAULT_CONFLICT_TITLE = ResultTitles.CONFLICT;
     private const string DEFAULT_SERVICE_UNAVAILABLE_TITLE = ResultTitles.SERVICE_UNAVAILABLE;
-
-    [Fact]
-    public void ToNotFound_WithErrors_ReturnsProblemDetailsWithErrors()
-    {
-        // Arrange
-        var result = Result.NotFound("Resource not found", "Additional error");
-
-        // Act
-        var httpResult = result.ToNotFound();
-
-        // Assert
-        httpResult.Should().NotBeNull();
-        httpResult.Should().BeOfType<NotFound<ProblemDetails>>();
-
-        var problemDetails = httpResult.Value;
-        if (problemDetails is null)
-        {
-            Assert.Fail("Problem details are null");
-        }
-        problemDetails.Title.Should().Be(DEFAULT_NOT_FOUND_TITLE);
-        problemDetails.Status.Should().Be(StatusCodes.Status404NotFound);
-        problemDetails.Detail.Should().Contain("Resource not found");
-        problemDetails.Detail.Should().Contain("Additional error");
-    }
-
-    [Fact]
-    public void ToNotFound_WithoutErrors_ReturnsProblemDetailsWithDefaultMessage()
-    {
-        // Arrange
-        var result = Result.NotFound();
-
-        // Act
-        var httpResult = result.ToNotFound();
-
-        // Assert
-        httpResult.Should().NotBeNull();
-        httpResult.Should().BeOfType<NotFound<ProblemDetails>>();
-
-        var problemDetails = httpResult.Value;
-        if (problemDetails is null)
-        {
-            Assert.Fail("Problem details are null");
-        }
-        problemDetails.Title.Should().Be(DEFAULT_NOT_FOUND_TITLE);
-        problemDetails.Status.Should().Be(StatusCodes.Status404NotFound);
-        problemDetails.Detail.Should().Contain(DEFAULT_NOT_FOUND_TITLE);
-    }
-
-    [Fact]
-    public void ToBadRequest_WithValidationError_ReturnsProblemDetailsWithValidationError()
-    {
-        // Arrange
-        var validationError = new ValidationError("Field", "Invalid field value", "INVALID_FIELD", ValidationSeverity.Error);
-        var result = Result.Invalid(validationError);
-
-        // Act
-        var httpResult = result.ToBadRequest();
-
-        // Assert
-        httpResult.Should().NotBeNull();
-        httpResult.Should().BeOfType<BadRequest<ProblemDetails>>();
-
-        var problemDetails = httpResult.Value;
-        if (problemDetails is null)
-        {
-            Assert.Fail("Problem details are null");
-        }
-        problemDetails.Title.Should().Be(DEFAULT_BAD_REQUEST_TITLE);
-        problemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
-        problemDetails.Detail.Should().Be("Invalid field value");
-        problemDetails.Extensions.Should().ContainKey("errorCode");
-        problemDetails.Extensions["errorCode"].Should().Be("INVALID_FIELD");
-    }
-
-    [Fact]
-    public void ToBadRequest_WithCustomTitle_ReturnsProblemDetailsWithCustomTitle()
-    {
-        // Arrange
-        var validationError = new ValidationError("Field", "Invalid field value", "ERROR_CODE", ValidationSeverity.Error);
-        var result = Result.Invalid(validationError);
-        var customTitle = "Custom validation error";
-
-        // Act
-        var httpResult = result.ToBadRequest(customTitle);
-
-        // Assert
-        httpResult.Should().NotBeNull();
-        httpResult.Should().BeOfType<BadRequest<ProblemDetails>>();
-
-        var problemDetails = httpResult.Value;
-        if (problemDetails is null)
-        {
-            Assert.Fail("Problem details are null");
-        }
-        problemDetails.Title.Should().Be(customTitle);
-        problemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
-    }
-
-    [Fact]
-    public void ToBadRequest_WithoutValidationError_ReturnsProblemDetailsWithDefaultMessage()
-    {
-        // Arrange
-        var result = Result.Error("Some error occurred");
-
-        // Act
-        var httpResult = result.ToBadRequest();
-
-        // Assert
-        httpResult.Should().NotBeNull();
-        httpResult.Should().BeOfType<BadRequest<ProblemDetails>>();
-
-        var problemDetails = httpResult.Value;
-        if (problemDetails is null)
-        {
-            Assert.Fail("Problem details are null");
-        }
-        problemDetails.Title.Should().Be(DEFAULT_BAD_REQUEST_TITLE);
-        problemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
-        problemDetails.Detail.Should().Be(DEFAULT_BAD_REQUEST_TITLE);
-    }
 
     [Theory]
     [InlineData(ResultStatus.Invalid, StatusCodes.Status400BadRequest)]
@@ -299,7 +177,7 @@ public class ResultExtensionsTests
             Assert.Fail("Problem details are null");
         }
         problemDetails.Title.Should().Be(DEFAULT_UNEXPECTED_ERROR_TITLE);
-        problemDetails.Detail.Should().BeEmpty();
+        problemDetails.Detail.Should().Be(DEFAULT_UNEXPECTED_ERROR_TITLE);
     }
 
     [Fact]
@@ -380,7 +258,7 @@ public class ResultExtensionsTests
             Assert.Fail("Problem details are null");
         }
         problemDetails.Title.Should().Be(DEFAULT_UNEXPECTED_ERROR_TITLE);
-        problemDetails.Detail.Should().BeEmpty();
+        problemDetails.Detail.Should().Be(DEFAULT_UNEXPECTED_ERROR_TITLE);
     }
 
     [Fact]
@@ -513,7 +391,35 @@ public class ResultExtensionsTests
             Assert.Fail("Problem details are null");
         }
         problemDetails.Title.Should().Be(DEFAULT_UNEXPECTED_ERROR_TITLE);
-        problemDetails.Detail.Should().BeEmpty();
+        problemDetails.Detail.Should().Be(DEFAULT_UNEXPECTED_ERROR_TITLE);
+    }
+
+    [Fact]
+    public void ToProblem_NotFoundWithoutErrors_FallsBackToTitleForDetail()
+    {
+        // Arrange
+        var result = Result.NotFound();
+
+        // Act
+        var httpResult = result.ToProblem();
+
+        // Assert
+        httpResult.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        httpResult.ProblemDetails.Title.Should().Be(ResultTitles.NOT_FOUND);
+        httpResult.ProblemDetails.Detail.Should().Be(ResultTitles.NOT_FOUND);
+    }
+
+    [Fact]
+    public void ToProblem_WithErrors_DoesNotPadDetailWithWhitespace()
+    {
+        // Arrange
+        var result = Result.NotFound("Form not found.");
+
+        // Act
+        var httpResult = result.ToProblem();
+
+        // Assert
+        httpResult.ProblemDetails.Detail.Should().Be("Form not found.");
     }
 
     private static Core.Infrastructure.Result.IResult CreateResultWithStatus(ResultStatus status, params string[] errors)

--- a/tests/Endatix.Api.Tests/Infrastructure/TypedResultsBuilderTests.cs
+++ b/tests/Endatix.Api.Tests/Infrastructure/TypedResultsBuilderTests.cs
@@ -27,7 +27,7 @@ public class TypedResultsBuilderTests
     public void FromResult_NoResultPassed_Throws()
     {
         // Arrange
-        Result<BadRequest>? nullResult = null;
+        Result<string>? nullResult = null;
 
         // Act
         var action = () => TypedResultsBuilder.FromResult(nullResult);
@@ -97,21 +97,21 @@ public class TypedResultsBuilderTests
 
     [Theory]
     [MemberData(nameof(TestResultsCombinations.SuccessAndInvalidResults), MemberType = typeof(TestResultsCombinations))]
-    public void ConfigureResults_MatchedOkAndBadRequestSignature_PickedByImplicitCast(Result<Source> result)
+    public void ConfigureResults_MatchedOkAndProblemHttpResultSignature_PickedByImplicitCast(Result<Source> result)
     {
         // Arrange
         var resultsBuilder = TypedResultsBuilder
             .FromResult(result);
 
         // Act
-        Results<Ok<Source>, BadRequest> httpResult = resultsBuilder.SetTypedResults<Ok<Source>, BadRequest>();
+        Results<Ok<Source>, ProblemHttpResult> httpResult = resultsBuilder.SetTypedResults<Ok<Source>, ProblemHttpResult>();
 
         // Assert
-        Assert.IsType<Results<Ok<Source>, BadRequest>>(httpResult);
+        Assert.IsType<Results<Ok<Source>, ProblemHttpResult>>(httpResult);
     }
 
     [Fact]
-    public void ConfigureResults_UnMatchedOkAndBadRequestSignature_PickedByImplicitCastAndThrows()
+    public void ConfigureResults_NotFoundWithOkAndProblemHttpResultSignature_ReturnsNotFoundProblem()
     {
         // Arrange
         Result<Source> result = Result.NotFound();
@@ -119,13 +119,11 @@ public class TypedResultsBuilderTests
             .FromResult(result);
 
         // Act
-        var action = () =>
-        {
-            Results<Ok<Source>, BadRequest> httpResult = resultsBuilder.SetTypedResults<Ok<Source>, BadRequest>();
-        };
+        Results<Ok<Source>, ProblemHttpResult> httpResult = resultsBuilder.SetTypedResults<Ok<Source>, ProblemHttpResult>();
 
         // Assert
-        action.Should().Throw<InvalidCastException>();
+        httpResult.Result.Should().BeOfType<ProblemHttpResult>();
+        ((ProblemHttpResult)httpResult.Result).StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]

--- a/tests/Endatix.Core.Tests/UseCases/Identity/Login/LoginHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Identity/Login/LoginHandlerTests.cs
@@ -6,6 +6,7 @@ using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.Identity;
 using Endatix.Core.UseCases.Identity.Login;
 using Endatix.Core.Abstractions.Authorization;
+using Microsoft.Extensions.Logging;
 
 namespace Endatix.Core.Tests.UseCases.Identity.Login;
 
@@ -15,6 +16,7 @@ public class LoginHandlerTests
     private readonly IUserTokenService _tokenService;
     private readonly ICurrentUserAuthorizationService _authorizationService;
     private readonly IMediator _mediator;
+    private readonly ILogger<LoginHandler> _logger;
     private readonly LoginHandler _handler;
 
     public LoginHandlerTests()
@@ -23,7 +25,8 @@ public class LoginHandlerTests
         _tokenService = Substitute.For<IUserTokenService>();
         _mediator = Substitute.For<IMediator>();
         _authorizationService = Substitute.For<ICurrentUserAuthorizationService>();
-        _handler = new LoginHandler(_authService, _tokenService, _authorizationService, _mediator);
+        _logger = Substitute.For<ILogger<LoginHandler>>();
+        _handler = new LoginHandler(_authService, _tokenService, _authorizationService, _mediator, _logger);
     }
 
     [Fact]
@@ -40,25 +43,41 @@ public class LoginHandlerTests
 
         // Assert
         result.IsInvalid().Should().BeTrue();
-        result.ValidationErrors.Should().BeEquivalentTo(validationErrors);
         _tokenService.DidNotReceive().IssueRefreshToken();
     }
 
-    [Fact]
-    public async Task Handle_AuthServiceError_ReturnsErrorResult()
+    /// <summary>
+    /// OWASP A07: unknown account, unconfirmed email and wrong password must be
+    /// indistinguishable to the caller, whatever the IAuthService implementation returns.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(CredentialFailureResults))]
+    public async Task Handle_AnyCredentialFailure_ReturnsIdenticalInvalidResult(Result<User> authFailure)
     {
         // Arrange
         var command = new LoginCommand("test@example.com", "password");
         _authService.ValidateCredentials(command.Email, command.Password, Arg.Any<CancellationToken>())
-            .Returns(Result.Error());
+            .Returns(authFailure);
 
         // Act
         var result = await _handler.Handle(command, CancellationToken.None);
 
-        // Assert
-        result.IsError().Should().BeTrue();
+        // Assert - always Invalid (400), always the same single message.
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().ContainSingle()
+            .Which.ErrorMessage.Should().Be(LoginHandler.INVALID_CREDENTIALS_MESSAGE);
+        result.Errors.Should().BeEmpty();
         _tokenService.DidNotReceive().IssueRefreshToken();
     }
+
+    public static TheoryData<Result<User>> CredentialFailureResults() => new()
+    {
+        Result<User>.Invalid(new ValidationError("No such user")),
+        Result<User>.NotFound("User does not exist"),
+        Result<User>.Unauthorized("Account is locked"),
+        Result<User>.Forbidden("Email not confirmed"),
+        Result<User>.Error("Upstream identity provider failed"),
+    };
 
     [Fact]
     public async Task Handle_ValidCredentials_ReturnsSuccessResultWithTokens()
@@ -110,6 +129,32 @@ public class LoginHandlerTests
             Arg.Any<string>(),
             Arg.Any<DateTime>(),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_PersistSessionFails_PreservesUnderlyingErrorMessage()
+    {
+        // Arrange
+        var command = new LoginCommand("test@example.com", "password");
+        var user = new User(1, SampleData.TENANT_ID, "testuser", "test@example.com", true);
+        var refreshToken = new TokenDto("refresh_token", DateTime.UtcNow.AddDays(7));
+
+        _authService.ValidateCredentials(command.Email, command.Password, Arg.Any<CancellationToken>())
+            .Returns(Result<User>.Success(user));
+        _tokenService.IssueRefreshToken().Returns(refreshToken);
+        _authService.PersistLoginSessionAsync(
+                user.Id,
+                refreshToken.Token,
+                refreshToken.ExpireAt,
+                Arg.Any<CancellationToken>())
+            .Returns(Result.Error("Failed to persist login session."));
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsError().Should().BeTrue();
+        result.Errors.Should().Contain("Failed to persist login session.");
     }
 
     [Fact]

--- a/tests/Endatix.Infrastructure.Tests/Identity/Authentication/AuthServiceTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Identity/Authentication/AuthServiceTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Identity;
 using NSubstitute;
+using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Tests;
 using Endatix.Infrastructure.Identity;
 using Endatix.Infrastructure.Identity.Authentication;
@@ -101,6 +102,60 @@ public class AuthServiceTests
         result.ValidationErrors.Should().NotBeNull();
         result.ValidationErrors.First().ErrorMessage.Should().Contain(AuthService.INVALID_CREDENTIALS_ERROR_MESSAGE);
     }
+
+    #region Security and Privacy Tests
+
+    /// <summary>
+    /// OWASP A07: an unknown account must still pay the password-hashing cost, otherwise it
+    /// answers measurably faster than a wrong password and accounts become enumerable by timing.
+    /// </summary>
+    [Fact]
+    public async Task ValidateCredentials_UserNotFound_StillPerformsPasswordHashingWork()
+    {
+        // Arrange
+        _userManager.FindByEmailAsync(Arg.Any<string>()).Returns((AppUser?)null);
+
+        // Act
+        var result = await _authService.ValidateCredentials("ghost@example.com", "password", CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeFalse();
+        _passwordHasher.Received().VerifyHashedPassword(
+            Arg.Any<AppUser>(),
+            Arg.Any<string>(),
+            "password");
+    }
+
+    /// <summary>
+    /// Unknown account, unconfirmed email and wrong password must be indistinguishable.
+    /// </summary>
+    [Fact]
+    public async Task ValidateCredentials_AllFailureModes_ReturnIdenticalResponses()
+    {
+        // Arrange
+        var unconfirmed = new AppUser { EmailConfirmed = false };
+        var confirmed = new AppUser { EmailConfirmed = true };
+
+        _userManager.FindByEmailAsync("missing@example.com").Returns((AppUser?)null);
+        _userManager.FindByEmailAsync("unconfirmed@example.com").Returns(unconfirmed);
+        _userManager.FindByEmailAsync("wrongpass@example.com").Returns(confirmed);
+        _userManager.CheckPasswordAsync(Arg.Any<AppUser>(), Arg.Any<string>()).Returns(false);
+
+        // Act
+        var missing = await _authService.ValidateCredentials("missing@example.com", "password", CancellationToken.None);
+        var unconfirmedResult = await _authService.ValidateCredentials("unconfirmed@example.com", "password", CancellationToken.None);
+        var wrongPassword = await _authService.ValidateCredentials("wrongpass@example.com", "password", CancellationToken.None);
+
+        // Assert - same status, same single message, on every path.
+        foreach (var result in new[] { missing, unconfirmedResult, wrongPassword })
+        {
+            result.Status.Should().Be(ResultStatus.Invalid);
+            result.ValidationErrors.Should().ContainSingle()
+                .Which.ErrorMessage.Should().Be(AuthService.INVALID_CREDENTIALS_ERROR_MESSAGE);
+        }
+    }
+
+    #endregion
 
     [Fact]
     public async Task ValidateCredentials_UserEmailNotConfirmed_ReturnsInvalidResult()

--- a/tests/Endatix.Infrastructure.Tests/Identity/EmailVerification/EmailVerificationServiceTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Identity/EmailVerification/EmailVerificationServiceTests.cs
@@ -134,7 +134,7 @@ public class EmailVerificationServiceTests
     }
 
     [Fact]
-    public async Task VerifyEmailAsync_TokenNotFound_ReturnsNotFoundResult()
+    public async Task VerifyEmailAsync_TokenNotFound_ReturnsInvalidResult()
     {
         // Arrange
         var token = "not-found-token";
@@ -148,8 +148,39 @@ public class EmailVerificationServiceTests
         // Assert
         result.Should().NotBeNull();
         result.IsSuccess.Should().BeFalse();
-        result.Status.Should().Be(ResultStatus.NotFound);
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().ContainSingle()
+            .Which.ErrorMessage.Should().Be(EmailVerificationService.INVALID_VERIFICATION_TOKEN_MESSAGE);
     }
+
+    #region Security and Privacy Tests
+
+    /// <summary>
+    /// A token whose user record no longer exists must be indistinguishable from an unknown
+    /// token, so the response cannot confirm that the token itself was ever genuine.
+    /// </summary>
+    [Fact]
+    public async Task VerifyEmailAsync_TokenWithMissingUser_DoesNotLeakThatTokenWasGenuine()
+    {
+        // Arrange
+        var token = "dangling-token";
+        var verificationToken = new EmailVerificationToken(userId: 42, token, DateTime.UtcNow.AddHours(1));
+
+        _tokenRepository.FirstOrDefaultAsync(Arg.Any<EmailVerificationTokenByTokenSpec>(), Arg.Any<CancellationToken>())
+            .Returns(verificationToken);
+        _userManager.FindByIdAsync("42").Returns((AppUser?)null);
+
+        // Act
+        var result = await _sut.VerifyEmailAsync(token, CancellationToken.None);
+
+        // Assert - identical status and message to the unknown-token case.
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().ContainSingle()
+            .Which.ErrorMessage.Should().Be(EmailVerificationService.INVALID_VERIFICATION_TOKEN_MESSAGE);
+        result.ValidationErrors.Select(error => error.ErrorMessage).Should().NotContain("User not found");
+    }
+
+    #endregion
 
     [Fact]
     public async Task ActivateInviteAsync_ValidToken_SetsPasswordConfirmsEmailAndMarksTokenAsUsed()
@@ -192,7 +223,7 @@ public class EmailVerificationServiceTests
     }
 
     [Fact]
-    public async Task ActivateInviteAsync_TokenNotFound_ReturnsNotFoundResult()
+    public async Task ActivateInviteAsync_TokenNotFound_ReturnsInvalidResult()
     {
         // Arrange
         var token = "missing-token";
@@ -205,7 +236,9 @@ public class EmailVerificationServiceTests
 
         // Assert
         result.Should().NotBeNull();
-        result.Status.Should().Be(ResultStatus.NotFound);
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().ContainSingle()
+            .Which.ErrorMessage.Should().Be(EmailVerificationService.INVALID_INVITE_TOKEN_MESSAGE);
     }
 
     [Fact]

--- a/tests/Endatix.IntegrationTests/AGENTS.md
+++ b/tests/Endatix.IntegrationTests/AGENTS.md
@@ -29,13 +29,14 @@ public sealed class MyFlowTests(EndatixIntegrationWebHostFixture fixture)
 
 ## Reference tests
 
-| Test | Pattern |
-| --- | --- |
-| `AuthLoginFlowTests` | CriticalPath, `PrepareWorldAsync`, `IntegrationAuthMode.Login` |
-| `HealthCheckTests` | Host smoke, provider-agnostic |
-| `StartupMigrationTests` | DB-only, provider-agnostic migrations |
-| `SqlServerMigrationArtifactTests` | `DbSpecific=SqlServer` stored proc / seed checks |
-| `ReportingQueryFilterTests` | `DbSpecific=PostgreSql` module schema |
+| Test                                  | Pattern                                                        |
+| ------------------------------------- | -------------------------------------------------------------- |
+| `AuthLoginFlowTests`                  | CriticalPath, `PrepareWorldAsync`, `IntegrationAuthMode.Login` |
+| `FormNotFoundProblemDetailsFlowTests` | FeatureFlow, 404 + problem+json on missing form / definitions  |
+| `HealthCheckTests`                    | Host smoke, provider-agnostic                                  |
+| `StartupMigrationTests`               | DB-only, provider-agnostic migrations                          |
+| `SqlServerMigrationArtifactTests`     | `DbSpecific=SqlServer` stored proc / seed checks               |
+| `ReportingQueryFilterTests`           | `DbSpecific=PostgreSql` module schema                          |
 
 ## Shared infrastructure (`Endatix.IntegrationTests.Shared`)
 

--- a/tests/Endatix.IntegrationTests/FeatureFlows/Forms/FormNotFoundProblemDetailsFlowTests.cs
+++ b/tests/Endatix.IntegrationTests/FeatureFlows/Forms/FormNotFoundProblemDetailsFlowTests.cs
@@ -1,0 +1,95 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Endatix.IntegrationTests.Shared;
+
+namespace Endatix.IntegrationTests;
+
+/// <summary>
+/// Verifies resource GETs return RFC7807 problem+json for missing entities (API 0.7.5 error shape).
+/// </summary>
+[Collection(nameof(EndatixIntegrationTestCollection))]
+[Trait("Category", "FeatureFlow")]
+[Trait("Priority", "P1")]
+public sealed class FormNotFoundProblemDetailsFlowTests
+{
+    private const string SeedPassword = "Password123!";
+    private readonly EndatixIntegrationWebHostFixture _fixture;
+
+    public FormNotFoundProblemDetailsFlowTests(EndatixIntegrationWebHostFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task GetById_MissingForm_Returns404ProblemJson()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        IntegrationTestWorld world = await _fixture.PrepareWorldAsync(
+            IntegrationWorldOptions.SingleTenant with { DefaultPassword = SeedPassword },
+            cancellationToken);
+        using HttpClient client = await world.AsAsync(TestPersona.TenantAdmin, cancellationToken: cancellationToken);
+        const long missingFormId = 9_999_999_999L;
+
+        // Act
+        using HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/forms/{missingFormId}", UriKind.Relative),
+            cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        await AssertProblemDetailsAsync(response, expectedStatus: 404, cancellationToken);
+    }
+
+    [Fact]
+    public async Task ListDefinitions_MissingForm_Returns404ProblemJson()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        IntegrationTestWorld world = await _fixture.PrepareWorldAsync(
+            IntegrationWorldOptions.SingleTenant with { DefaultPassword = SeedPassword },
+            cancellationToken);
+        using HttpClient client = await world.AsAsync(TestPersona.TenantAdmin, cancellationToken: cancellationToken);
+        const long missingFormId = 9_999_999_999L;
+
+        // Act
+        using HttpResponseMessage response = await client.GetAsync(
+            new Uri($"/api/forms/{missingFormId}/definitions", UriKind.Relative),
+            cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        await AssertProblemDetailsAsync(response, expectedStatus: 404, cancellationToken);
+    }
+
+    private static async Task AssertProblemDetailsAsync(
+        HttpResponseMessage response,
+        int expectedStatus,
+        CancellationToken cancellationToken)
+    {
+        string? mediaType = response.Content.Headers.ContentType?.MediaType;
+        Assert.True(
+            mediaType is "application/problem+json",
+            $"Expected application/problem+json content type, got '{mediaType}'.");
+
+        using JsonDocument? document = await response.Content.ReadFromJsonAsync<JsonDocument>(cancellationToken);
+        Assert.NotNull(document);
+
+        JsonElement root = document.RootElement;
+        Assert.True(root.TryGetProperty("status", out JsonElement statusElement), "ProblemDetails.status missing.");
+        Assert.Equal(expectedStatus, statusElement.GetInt32());
+
+        // Both members must be present AND non-empty. Asserting them separately matters:
+        // an `||` short-circuits on a present-but-empty `detail` and never checks `title`.
+        Assert.True(root.TryGetProperty("title", out JsonElement titleElement), "ProblemDetails.title missing.");
+        Assert.False(
+            string.IsNullOrWhiteSpace(titleElement.GetString()),
+            "ProblemDetails.title must not be empty.");
+
+        Assert.True(root.TryGetProperty("detail", out JsonElement detailElement), "ProblemDetails.detail missing.");
+        Assert.False(
+            string.IsNullOrWhiteSpace(detailElement.GetString()),
+            "ProblemDetails.detail must not be empty; ToProblem falls back to the title.");
+    }
+}


### PR DESCRIPTION
# feat(e998)!: return ProblemDetails on resource API errors

## Description
-  All 103 endpoints return `Results<Ok|Created<T>, ProblemHttpResult>`. No endpoint  declares empty-body `BadRequest`/`NotFound` any more.
- `ToProblem` maps Invalid→400, NotFound→404, Conflict→409, Unauthorized→401,  Forbidden→403, Error/CriticalError→500, Unavailable→503.
- **`detail` is always a non-empty string**, falling back to the title when a result  carries no errors. Previously `Result.NotFound()` (16 call sites in `AppUserService`)  produced `"detail": ""`. Errors are joined with `Environment.NewLine` — no trailing  newline, so assertions no longer need `.Trim()`.
- `TypedResultsBuilder`: eight duplicated per-status arms per operator collapsed to   `_ => ToProblem(...)`, so any future `ResultStatus` maps to problem+json instead of   throwing. Success statuses a union cannot express still throw - that's a   mis-declared endpoint signature and should fail loudly.
- 29 endpoints gained `Description(b => b.Produces<T>(...).ProducesProblem(...))`,  derived per endpoint from its own `Results<>` union and declared `s.Responses[...]` not a blanket 400/404. `Folders/Delete` and Users/GetUserRoles` correctly carry  no 400; their handlers never return `Invalid`.

### Security — uniform failure responses (OWASP A07)
- **Login**: every credential failure collapses to one `Invalid` + one message,  regardless of what `IAuthService` returns. That interface is a public abstraction -  an external IdP returning `NotFound` would otherwise surface 404-for-unknown-account  vs 400-for-wrong-password. Real reason is logged with the email redacted.  Post-authentication persist failures still propagate verbatim (they reveal nothing  about the account, and previously lost their message to a bare `Result.Error()`).
- **Timing**: the password KDF now runs on the unknown-account path too. Identical  payloads were still enumerable by response time.
- **Token flows**: verify-email and invite activation answer 400 for *every* token  failure. The old 404-vs-400 split confirmed whether a token ever existed, and a dangling token leaked `"User not found"`. Also fixes an undocumented 404 on the  invite endpoints.
- `VerifyEmail` no longer applies its validation message as the problem *title* on  non-400 statuses.
 
### Dead code
- Removed `ToNotFound`, `ToBadRequest`, `ToEndpointResponse`, the 3-generic  `SetTypedResults`, and 6 superseded implicit operators (~430 lines). Verified no  live references remain in `endatix` or `endatix-saas`.
- Dropped an unused `using` in `Logout.cs` (never called `Permissions(...)`; endpoint  stays authenticated).

>[!WARNING]
>**Out of Scope**
>FastEndpoints request-validation failures from FluentValidation still return {statusCode, message, errors}, not problem+json, and closing it needs c.Errors.UseProblemDetails() in ApiApplicationBuilderExtensions. This is intentionally out of scope

## Related Issues
- closes #998 

## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [x] Refactoring (non-breaking change which improves code quality)
- [x] Security

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.
