### PR TITLE
feat(e168)!: unify FluentValidation and unhandled errors on ProblemDetails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,11 +50,31 @@ Substitute `IRepository<T>` (+ `IMediator` if publishing). Cover: not found · h
 
 ## Error HTTP contract (API)
 
-- Handler failures → RFC7807 `application/problem+json` via `TypedResultsBuilder` + `ProblemHttpResult`.
+Canonical JSON for **all** API errors (handler `ToProblem`, FluentValidation, unhandled exceptions, export stream errors):
+
+```json
+{
+  "type": "https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request",
+  "title": "There was a problem with your request",
+  "status": 400,
+  "detail": "Name is required.",
+  "instance": "/api/forms",
+  "traceId": "0HMPNHL0JHL76:00000001",
+  "errorCode": "NotEmptyValidator",
+  "fields": { "name": ["Name is required."] }
+}
+```
+
+- Handler failures → RFC7807 `application/problem+json` via `TypedResultsBuilder` + `ProblemHttpResult` / `ToProblem`.
 - `ToProblem` maps Invalid → 400, NotFound → 404, Conflict → 409, Unauthorized → 401, Forbidden → 403, Error/CriticalError → 500, Unavailable → 503.
 - **`detail` is always a non-empty string**, falling back to the title when the result carries no errors. Consumers treat it as required (Hub's `ProblemDetailsSchema` types it non-optional) — never emit `"detail": ""`.
+- FastEndpoints FluentValidation uses `c.Errors.ResponseBuilder` → `EndatixProblemDetails` (`fields` dictionary). Do **not** use stock `UseProblemDetails()` (wrong `errors` array shape).
+- Unhandled exceptions → `EndatixExceptionHandler` (`IExceptionHandler`); 500 body never includes exception text.
+- **No 5xx body ever echoes handler- or exception-derived text.** `EndatixProblemDetails.Create` replaces any `>= 500` detail with the generic title and logs the original (correlate via `traceId`). Handlers that wrap `ex.Message` into `Result.Error(...)` are safe by construction — do not add a bypass. If a 5xx message must reach the user, model the failure as a 4xx/503 instead.
+- Writing a problem body by hand? Pass `contentType: "application/problem+json"` to `WriteAsJsonAsync`; it otherwise overwrites `Response.ContentType` with `application/json`.
 - `SetErrorMessage(...)` overrides the problem **title for every status**, so set it only on the branch it describes (see `Auth/VerifyEmail.cs`) — otherwise a 404 inherits a 400-shaped message.
-- OpenAPI: `Description(b => b.Produces<T>(...).ProducesProblem(400).ProducesProblem(404))` listing exactly the statuses the endpoint's `Summary(s => s.Responses[...])` declares — every endpoint returning `ProblemHttpResult` must have one.
+- OpenAPI: `Description(b => b.Produces<T>(...).ProducesProblem(400).ProducesProblem(404))` listing exactly the statuses the endpoint's `Summary(s => s.Responses[...])` declares — every endpoint returning `ProblemHttpResult` must have one. FE validators set `ProducesMetadataType = typeof(ProblemDetails)`.
+
 ### Uniform failure responses (OWASP A07)
 
 Account-facing failures must be **indistinguishable to the caller**: same status, same message, whatever the real cause. Log the real reason server-side instead — never return it.
@@ -65,8 +85,6 @@ Account-facing failures must be **indistinguishable to the caller**: same status
 - Token flows (verify-email, invite activation) answer **400 for every token failure** - unknown, dangling, expired, used. Never `NotFound`: a 404-vs-400 split tells the caller whether the token ever existed.
 - Equalize work, not just payloads: run the password KDF on the unknown-account path too (`AuthService.BurnPasswordHashingWork`), or response time leaks what the body does not.
 - Pair each with a `#region Security and Privacy Tests` test asserting the disallowed strings are absent. References: `LoginHandler.INVALID_CREDENTIALS_MESSAGE`, `EmailVerificationService.INVALID_VERIFICATION_TOKEN_MESSAGE`, `ForgotPasswordHandler.GENERAL_SUCCESS_MESSAGE`, `SendVerificationEmailHandler` (returns `Success` for unknown users), `UserPasswordManageServiceTests` (`DoesNotLeakUserExistence`).
-
-- **Known gap:** FastEndpoints request-validation failures still return FE's `{statusCode, message, errors}` shape, not problem+json. Closing that needs `c.Errors.UseProblemDetails()` in `ApiApplicationBuilderExtensions` — tracked separately; don't assume a 400 is RFC7807 yet.
 
 ## Run (examples)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Canonical JSON for **all** API errors (handler `ToProblem`, FluentValidation, un
 
 ```json
 {
-  "type": "https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request",
+  "type": "https://www.rfc-editor.org/rfc/rfc9110.html#name-400-bad-request",
   "title": "There was a problem with your request",
   "status": 400,
   "detail": "Name is required.",

--- a/src/Endatix.Api/Builders/ApiConfigurationBuilder.cs
+++ b/src/Endatix.Api/Builders/ApiConfigurationBuilder.cs
@@ -80,6 +80,10 @@ public class ApiConfigurationBuilder
         // Add default JSON options
         AddDefaultJsonOptions();
 
+        // Unhandled exceptions → canonical ProblemDetails (no exception text leak).
+        Services.AddExceptionHandler<EndatixExceptionHandler>();
+        Services.AddProblemDetails();
+
         // Register FastEndpoints for the core API assembly only.
         // Module assemblies are added via ScanAssemblies so feature-flagged modules
         // do not get endpoint discovery without their DI registrations.

--- a/src/Endatix.Api/Builders/ApiConfigurationBuilder.cs
+++ b/src/Endatix.Api/Builders/ApiConfigurationBuilder.cs
@@ -81,6 +81,7 @@ public class ApiConfigurationBuilder
         AddDefaultJsonOptions();
 
         // Unhandled exceptions → canonical ProblemDetails (no exception text leak).
+        Services.AddHttpContextAccessor();
         Services.AddExceptionHandler<EndatixExceptionHandler>();
         Services.AddProblemDetails();
 

--- a/src/Endatix.Api/Endpoints/Account/ForgotPassword.cs
+++ b/src/Endatix.Api/Endpoints/Account/ForgotPassword.cs
@@ -20,11 +20,13 @@ public class ForgotPassword(IMediator mediator) :
             s.Description = "Sends a password reset email to the user.";
             s.Responses[200] = "Password reset email sent successfully.";
             s.Responses[400] = "Invalid request or email.";
+            s.Responses[503] = "The email provider is unavailable. Retry later.";
             s.ExampleRequest = new { Email = "user@example.com" };
         });
         Description(builder => builder
             .Produces<ForgotPasswordResponse>(StatusCodes.Status200OK, "application/json")
-            .ProducesProblem(StatusCodes.Status400BadRequest));
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status503ServiceUnavailable));
     }
 
     public override async Task<Results<Ok<ForgotPasswordResponse>, ProblemHttpResult>> ExecuteAsync(ForgotPasswordRequest request, CancellationToken ct)

--- a/src/Endatix.Api/Endpoints/Submissions/Export.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/Export.cs
@@ -1,6 +1,7 @@
 using FastEndpoints;
 using Microsoft.AspNetCore.Http;
 using Endatix.Api.Common;
+using Endatix.Api.Infrastructure;
 using Endatix.Core.UseCases.Submissions.Export;
 using Endatix.Core.Abstractions.Exporting;
 using Endatix.Core.Abstractions.Repositories;
@@ -451,21 +452,18 @@ public partial class Export : Endpoint<ExportRequest>
         HttpContext.Response.ContentType = "application/problem+json";
 
         // Emit RFC7807 camelCase so Hub (and other clients) can surface Detail in the UI.
-        var problem = new Microsoft.AspNetCore.Mvc.ProblemDetails
-        {
-            Title = "Export failed",
-            Detail = message,
-            Status = resolvedStatus,
-            Type = resolvedStatus switch
-            {
-                StatusCodes.Status400BadRequest => "https://tools.ietf.org/html/rfc7231#section-6.5.1",
-                StatusCodes.Status404NotFound => "https://tools.ietf.org/html/rfc7231#section-6.5.4",
-                StatusCodes.Status409Conflict => "https://tools.ietf.org/html/rfc7231#section-6.5.8",
-                _ => "https://tools.ietf.org/html/rfc7231#section-6.6.1",
-            },
-        };
+        var problem = EndatixProblemDetails.Create(
+            statusCode: resolvedStatus,
+            title: "Export failed",
+            detail: message,
+            httpContext: HttpContext);
 
-        await HttpContext.Response.WriteAsJsonAsync(problem);
+        // WriteAsJsonAsync overwrites Content-Type with application/json unless it is passed
+        // explicitly, which silently undid the problem+json set above.
+        await HttpContext.Response.WriteAsJsonAsync(
+            problem,
+            options: null,
+            contentType: "application/problem+json");
     }
 
     private async Task CompletePipeIfNeeded(PipeWriter? pipeWriter, Exception? exception, string fallbackMessage)

--- a/src/Endatix.Api/Infrastructure/EndatixExceptionHandler.cs
+++ b/src/Endatix.Api/Infrastructure/EndatixExceptionHandler.cs
@@ -1,0 +1,36 @@
+using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Endatix.Api.Infrastructure;
+
+/// <summary>
+/// Writes the canonical ProblemDetails envelope for unhandled exceptions without leaking exception text.
+/// </summary>
+public sealed class EndatixExceptionHandler(ILogger<EndatixExceptionHandler> logger) : IExceptionHandler
+{
+    public async ValueTask<bool> TryHandleAsync(
+        HttpContext httpContext,
+        Exception exception,
+        CancellationToken cancellationToken)
+    {
+        logger.LogError(exception, "Unhandled exception for {Method} {Path}",
+            httpContext.Request.Method,
+            httpContext.Request.Path.Value);
+
+        if (httpContext.Response.HasStarted)
+        {
+            return false;
+        }
+
+        var problem = EndatixProblemDetails.ForUnhandledException(httpContext);
+        httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
+        await httpContext.Response.WriteAsJsonAsync(
+            problem,
+            options: null,
+            contentType: "application/problem+json",
+            cancellationToken);
+            
+        return true;
+    }
+}

--- a/src/Endatix.Api/Infrastructure/EndatixExceptionHandler.cs
+++ b/src/Endatix.Api/Infrastructure/EndatixExceptionHandler.cs
@@ -15,8 +15,8 @@ public sealed class EndatixExceptionHandler(ILogger<EndatixExceptionHandler> log
         CancellationToken cancellationToken)
     {
         logger.LogError(exception, "Unhandled exception for {Method} {Path}",
-            httpContext.Request.Method,
-            httpContext.Request.Path.Value);
+            RequestLogSanitizer.Sanitize(httpContext.Request.Method),
+            RequestLogSanitizer.Sanitize(httpContext.Request.Path.Value));
 
         if (httpContext.Response.HasStarted)
         {

--- a/src/Endatix.Api/Infrastructure/EndatixProblemDetails.cs
+++ b/src/Endatix.Api/Infrastructure/EndatixProblemDetails.cs
@@ -15,15 +15,19 @@ namespace Endatix.Api.Infrastructure;
 public static class EndatixProblemDetails
 {
     private static IHttpContextAccessor? _httpContextAccessor;
+    private static ILoggerFactory? _loggerFactory;
 
     /// <summary>
     /// Wires the request-scoped <see cref="IHttpContextAccessor"/> so static helpers
     /// (e.g. <c>ToProblem</c>) can enrich <c>instance</c> / <c>traceId</c>.
     /// </summary>
-    public static void Configure(IHttpContextAccessor httpContextAccessor)
+    public static void Configure(
+        IHttpContextAccessor httpContextAccessor,
+        ILoggerFactory? loggerFactory = null)
     {
         ArgumentNullException.ThrowIfNull(httpContextAccessor);
         _httpContextAccessor = httpContextAccessor;
+        _loggerFactory = loggerFactory;
     }
 
     /// <summary>
@@ -63,7 +67,7 @@ public static class EndatixProblemDetails
         return Create(
             statusCode: statusCode,
             title: null,
-            detail: string.Join(Environment.NewLine, messages),
+            detail: string.Join('\n', messages),
             httpContext: httpContext,
             errorCode: errorCode,
             fields: fields.Count > 0 ? fields : null);
@@ -146,10 +150,14 @@ public static class EndatixProblemDetails
     /// </summary>
     private static void LogSuppressedDetail(HttpContext? httpContext, int statusCode, string detail)
     {
-        var logger = httpContext?.RequestServices
-            ?.GetService<ILoggerFactory>()
-            ?.CreateLogger(typeof(EndatixProblemDetails).FullName!);
+        ILoggerFactory? loggerFactory = null;
+        if (httpContext?.RequestServices is not null)
+        {
+            loggerFactory = httpContext.RequestServices.GetService<ILoggerFactory>();
+        }
 
+        loggerFactory ??= _loggerFactory;
+        var logger = loggerFactory?.CreateLogger(typeof(EndatixProblemDetails));
         if (logger is null)
         {
             return;
@@ -158,23 +166,23 @@ public static class EndatixProblemDetails
         logger.LogError(
             "Suppressed {StatusCode} problem detail for {Method} {Path} (traceId {TraceId}): {SuppressedDetail}",
             statusCode,
-            httpContext?.Request.Method,
-            httpContext?.Request.Path.Value,
+            RequestLogSanitizer.Sanitize(httpContext?.Request.Method),
+            RequestLogSanitizer.Sanitize(httpContext?.Request.Path.Value),
             Activity.Current?.Id ?? httpContext?.TraceIdentifier,
-            detail);
+            RequestLogSanitizer.Sanitize(detail));
     }
 
     internal static string TypeForStatus(int statusCode) =>
         statusCode switch
         {
-            StatusCodes.Status400BadRequest => "https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request",
-            StatusCodes.Status401Unauthorized => "https://www.rfc-editor.org/rfc/rfc9110#name-401-unauthorized",
-            StatusCodes.Status403Forbidden => "https://www.rfc-editor.org/rfc/rfc9110#name-403-forbidden",
-            StatusCodes.Status404NotFound => "https://www.rfc-editor.org/rfc/rfc9110#name-404-not-found",
-            StatusCodes.Status409Conflict => "https://www.rfc-editor.org/rfc/rfc9110#name-409-conflict",
-            StatusCodes.Status429TooManyRequests => "https://www.rfc-editor.org/rfc/rfc6585#section-4",
-            StatusCodes.Status500InternalServerError => "https://www.rfc-editor.org/rfc/rfc9110#name-500-internal-server-error",
-            StatusCodes.Status503ServiceUnavailable => "https://www.rfc-editor.org/rfc/rfc9110#name-503-service-unavailable",
+            StatusCodes.Status400BadRequest => "https://www.rfc-editor.org/rfc/rfc9110.html#name-400-bad-request",
+            StatusCodes.Status401Unauthorized => "https://www.rfc-editor.org/rfc/rfc9110.html#name-401-unauthorized",
+            StatusCodes.Status403Forbidden => "https://www.rfc-editor.org/rfc/rfc9110.html#name-403-forbidden",
+            StatusCodes.Status404NotFound => "https://www.rfc-editor.org/rfc/rfc9110.html#name-404-not-found",
+            StatusCodes.Status409Conflict => "https://www.rfc-editor.org/rfc/rfc9110.html#name-409-conflict",
+            StatusCodes.Status429TooManyRequests => "https://www.rfc-editor.org/rfc/rfc6585.html#section-4",
+            StatusCodes.Status500InternalServerError => "https://www.rfc-editor.org/rfc/rfc9110.html#name-500-internal-server-error",
+            StatusCodes.Status503ServiceUnavailable => "https://www.rfc-editor.org/rfc/rfc9110.html#name-503-service-unavailable",
             _ => "about:blank",
         };
 
@@ -186,7 +194,26 @@ public static class EndatixProblemDetails
             StatusCodes.Status403Forbidden => ResultTitles.FORBIDDEN,
             StatusCodes.Status404NotFound => ResultTitles.NOT_FOUND,
             StatusCodes.Status409Conflict => ResultTitles.CONFLICT,
+            StatusCodes.Status429TooManyRequests => ResultTitles.TOO_MANY_REQUESTS,
             StatusCodes.Status503ServiceUnavailable => ResultTitles.SERVICE_UNAVAILABLE,
+            >= StatusCodes.Status400BadRequest and < StatusCodes.Status500InternalServerError
+                => ResultTitles.BAD_REQUEST,
             _ => ResultTitles.INTERNAL_SERVER_ERROR,
         };
+}
+
+/// <summary>
+/// Strips CR/LF from request-derived values before they are written to logs (CodeQL log injection).
+/// </summary>
+internal static class RequestLogSanitizer
+{
+    public static string Sanitize(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return string.Empty;
+        }
+
+        return value.Replace('\r', ' ').Replace('\n', ' ');
+    }
 }

--- a/src/Endatix.Api/Infrastructure/EndatixProblemDetails.cs
+++ b/src/Endatix.Api/Infrastructure/EndatixProblemDetails.cs
@@ -1,0 +1,192 @@
+using System.Diagnostics;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using static Endatix.Api.Infrastructure.ResultExtensions;
+
+namespace Endatix.Api.Infrastructure;
+
+/// <summary>
+/// Builds the canonical RFC7807 ProblemDetails envelope used by handler <c>ToProblem</c>,
+/// FastEndpoints FluentValidation, unhandled exceptions, and streaming export errors.
+/// </summary>
+public static class EndatixProblemDetails
+{
+    private static IHttpContextAccessor? _httpContextAccessor;
+
+    /// <summary>
+    /// Wires the request-scoped <see cref="IHttpContextAccessor"/> so static helpers
+    /// (e.g. <c>ToProblem</c>) can enrich <c>instance</c> / <c>traceId</c>.
+    /// </summary>
+    public static void Configure(IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    /// <summary>
+    /// Creates ProblemDetails from FastEndpoints / FluentValidation failures.
+    /// Sets <c>application/problem+json</c> on the response when the body has not started.
+    /// </summary>
+    public static ProblemDetails FromValidationFailures(
+        List<ValidationFailure> failures,
+        HttpContext httpContext,
+        int statusCode)
+    {
+        ArgumentNullException.ThrowIfNull(failures);
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        if (!httpContext.Response.HasStarted)
+        {
+            httpContext.Response.ContentType = "application/problem+json";
+        }
+
+        var fields = failures
+            .Where(failure => !string.IsNullOrWhiteSpace(failure.PropertyName))
+            .GroupBy(failure => failure.PropertyName, StringComparer.Ordinal)
+            .ToDictionary(
+                group => group.Key,
+                group => group.Select(failure => failure.ErrorMessage).ToArray(),
+                StringComparer.Ordinal);
+
+        var messages = failures
+            .Select(failure => failure.ErrorMessage)
+            .Where(message => !string.IsNullOrWhiteSpace(message))
+            .ToList();
+
+        var errorCode = failures
+            .Select(failure => failure.ErrorCode)
+            .FirstOrDefault(code => !string.IsNullOrWhiteSpace(code));
+
+        return Create(
+            statusCode: statusCode,
+            title: null,
+            detail: string.Join(Environment.NewLine, messages),
+            httpContext: httpContext,
+            errorCode: errorCode,
+            fields: fields.Count > 0 ? fields : null);
+    }
+
+    /// <summary>
+    /// Generic unhandled-exception ProblemDetails. Never includes exception text.
+    /// </summary>
+    public static ProblemDetails ForUnhandledException(HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        return Create(
+            statusCode: StatusCodes.Status500InternalServerError,
+            title: ResultTitles.INTERNAL_SERVER_ERROR,
+            detail: ResultTitles.INTERNAL_SERVER_ERROR,
+            httpContext: httpContext);
+    }
+
+    /// <summary>
+    /// Builds ProblemDetails for an arbitrary status/detail (e.g. export stream errors).
+    /// Uses the current request context when <paramref name="httpContext"/> is null.
+    /// </summary>
+    public static ProblemDetails Create(
+        int statusCode,
+        string? title,
+        string? detail,
+        HttpContext? httpContext = null,
+        string? errorCode = null,
+        IReadOnlyDictionary<string, string[]>? fields = null)
+    {
+        var resolvedContext = httpContext ?? _httpContextAccessor?.HttpContext;
+        var resolvedTitle = title ?? TitleForStatus(statusCode);
+        var resolvedDetail = string.IsNullOrWhiteSpace(detail) ? resolvedTitle : detail;
+
+        // A 5xx body must never carry handler- or exception-derived text. Handlers routinely
+        // wrap `ex.Message` into Result.Error(...) (DB/EF text, file paths, provider errors),
+        // which ToProblem would otherwise echo to the caller. The generic title goes to the
+        // client; the real text is logged so operators keep the diagnostics.
+        if (statusCode >= StatusCodes.Status500InternalServerError
+            && !string.Equals(resolvedDetail, resolvedTitle, StringComparison.Ordinal))
+        {
+            LogSuppressedDetail(resolvedContext, statusCode, resolvedDetail);
+            resolvedDetail = resolvedTitle;
+        }
+
+        var problem = new ProblemDetails
+        {
+            Type = TypeForStatus(statusCode),
+            Title = resolvedTitle,
+            Status = statusCode,
+            Detail = resolvedDetail,
+            Instance = resolvedContext?.Request.Path.Value,
+        };
+
+        var traceId = Activity.Current?.Id ?? resolvedContext?.TraceIdentifier;
+        if (!string.IsNullOrWhiteSpace(traceId))
+        {
+            problem.Extensions["traceId"] = traceId;
+        }
+
+        if (!string.IsNullOrWhiteSpace(errorCode))
+        {
+            problem.Extensions["errorCode"] = errorCode;
+        }
+
+        if (fields is { Count: > 0 })
+        {
+            problem.Extensions["fields"] = fields is Dictionary<string, string[]> dictionary
+                ? dictionary
+                : fields.ToDictionary(pair => pair.Key, pair => pair.Value, StringComparer.Ordinal);
+        }
+
+        return problem;
+    }
+
+    /// <summary>
+    /// Records the client-suppressed 5xx detail so the diagnostic is not lost. Correlate with
+    /// the response via <c>traceId</c>.
+    /// </summary>
+    private static void LogSuppressedDetail(HttpContext? httpContext, int statusCode, string detail)
+    {
+        var logger = httpContext?.RequestServices
+            ?.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(EndatixProblemDetails).FullName!);
+
+        if (logger is null)
+        {
+            return;
+        }
+
+        logger.LogError(
+            "Suppressed {StatusCode} problem detail for {Method} {Path} (traceId {TraceId}): {SuppressedDetail}",
+            statusCode,
+            httpContext?.Request.Method,
+            httpContext?.Request.Path.Value,
+            Activity.Current?.Id ?? httpContext?.TraceIdentifier,
+            detail);
+    }
+
+    internal static string TypeForStatus(int statusCode) =>
+        statusCode switch
+        {
+            StatusCodes.Status400BadRequest => "https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request",
+            StatusCodes.Status401Unauthorized => "https://www.rfc-editor.org/rfc/rfc9110#name-401-unauthorized",
+            StatusCodes.Status403Forbidden => "https://www.rfc-editor.org/rfc/rfc9110#name-403-forbidden",
+            StatusCodes.Status404NotFound => "https://www.rfc-editor.org/rfc/rfc9110#name-404-not-found",
+            StatusCodes.Status409Conflict => "https://www.rfc-editor.org/rfc/rfc9110#name-409-conflict",
+            StatusCodes.Status429TooManyRequests => "https://www.rfc-editor.org/rfc/rfc6585#section-4",
+            StatusCodes.Status500InternalServerError => "https://www.rfc-editor.org/rfc/rfc9110#name-500-internal-server-error",
+            StatusCodes.Status503ServiceUnavailable => "https://www.rfc-editor.org/rfc/rfc9110#name-503-service-unavailable",
+            _ => "about:blank",
+        };
+
+    internal static string TitleForStatus(int statusCode) =>
+        statusCode switch
+        {
+            StatusCodes.Status400BadRequest => ResultTitles.BAD_REQUEST,
+            StatusCodes.Status401Unauthorized => ResultTitles.UNAUTHORIZED,
+            StatusCodes.Status403Forbidden => ResultTitles.FORBIDDEN,
+            StatusCodes.Status404NotFound => ResultTitles.NOT_FOUND,
+            StatusCodes.Status409Conflict => ResultTitles.CONFLICT,
+            StatusCodes.Status503ServiceUnavailable => ResultTitles.SERVICE_UNAVAILABLE,
+            _ => ResultTitles.INTERNAL_SERVER_ERROR,
+        };
+}

--- a/src/Endatix.Api/Infrastructure/ResultExtensions.cs
+++ b/src/Endatix.Api/Infrastructure/ResultExtensions.cs
@@ -17,6 +17,7 @@ public static partial class ResultExtensions
         public const string BAD_REQUEST = "There was a problem with your request";
         public const string INTERNAL_SERVER_ERROR = "An unexpected error occurred";
         public const string SERVICE_UNAVAILABLE = "Service unavailable";
+        public const string TOO_MANY_REQUESTS = "Too many requests";
     }
 
     /// <summary>
@@ -69,7 +70,7 @@ public static partial class ResultExtensions
         // `detail` is always populated - never an empty string. Consumers (Hub's
         // ProblemDetailsSchema included) treat it as a required, human-readable message,
         // so a result carrying no errors falls back to the title.
-        var detail = string.Join(Environment.NewLine, messages.Where(message => !string.IsNullOrWhiteSpace(message)));
+        var detail = string.Join('\n', messages.Where(message => !string.IsNullOrWhiteSpace(message)));
 
         var problem = EndatixProblemDetails.Create(
             statusCode: status,

--- a/src/Endatix.Api/Infrastructure/ResultExtensions.cs
+++ b/src/Endatix.Api/Infrastructure/ResultExtensions.cs
@@ -1,4 +1,3 @@
-using Microsoft.AspNetCore.Mvc;
 using Endatix.Core.Infrastructure.Result;
 using AppDomain = Endatix.Core.Infrastructure.Result;
 using Microsoft.AspNetCore.Http;
@@ -25,6 +24,7 @@ public static partial class ResultExtensions
     /// Maps Invalid → 400, NotFound → 404, Conflict → 409, Unauthorized → 401, Forbidden → 403,
     /// Error/CriticalError → 500, Unavailable → 503.
     /// <c>detail</c> is always populated, falling back to the title when the result carries no errors.
+    /// When an HTTP context is available, also sets <c>type</c>, <c>instance</c>, and <c>traceId</c>.
     /// </summary>
     public static ProblemHttpResult ToProblem(this AppDomain.IResult result, string? title = null)
     {
@@ -43,32 +43,26 @@ public static partial class ResultExtensions
         };
 
         var resolvedTitle = title ?? defaultTitle;
-        var problemResult = TypedResults.Problem(
-            title: resolvedTitle,
-            statusCode: status);
-
         var messages = new List<string>(result.Errors);
+        string? errorCode = null;
+        Dictionary<string, string[]>? fields = null;
 
         if (result.IsInvalid())
         {
             messages.AddRange(result.ValidationErrors.Select(error => error.ErrorMessage));
 
-            var errorCode = result.ValidationErrors.FirstOrDefault()?.ErrorCode;
-            if (errorCode != null)
-            {
-                problemResult.ProblemDetails.Extensions.Add("errorCode", errorCode);
-            }
+            errorCode = result.ValidationErrors.FirstOrDefault()?.ErrorCode;
 
-            var fields = result.ValidationErrors
+            fields = result.ValidationErrors
                 .Where(error => !string.IsNullOrWhiteSpace(error.Identifier))
                 .GroupBy(error => error.Identifier)
                 .ToDictionary(
                     group => group.Key,
                     group => group.Select(error => error.ErrorMessage).ToArray());
 
-            if (fields.Count > 0)
+            if (fields.Count == 0)
             {
-                problemResult.ProblemDetails.Extensions.Add("fields", fields);
+                fields = null;
             }
         }
 
@@ -76,9 +70,15 @@ public static partial class ResultExtensions
         // ProblemDetailsSchema included) treat it as a required, human-readable message,
         // so a result carrying no errors falls back to the title.
         var detail = string.Join(Environment.NewLine, messages.Where(message => !string.IsNullOrWhiteSpace(message)));
-        problemResult.ProblemDetails.Detail = string.IsNullOrWhiteSpace(detail) ? resolvedTitle : detail;
 
-        return problemResult;
+        var problem = EndatixProblemDetails.Create(
+            statusCode: status,
+            title: resolvedTitle,
+            detail: detail,
+            errorCode: errorCode,
+            fields: fields);
+
+        return TypedResults.Problem(problem);
     }
 }
 #endif

--- a/src/Endatix.Api/Setup/ApiApplicationBuilderExtensions.cs
+++ b/src/Endatix.Api/Setup/ApiApplicationBuilderExtensions.cs
@@ -1,10 +1,12 @@
 using System.Security.Claims;
 using Endatix.Api.Builders;
+using Endatix.Api.Infrastructure;
 using Endatix.Framework.Serialization;
 using Endatix.Infrastructure.Identity;
 using FastEndpoints;
 using FastEndpoints.Swagger;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -85,10 +87,16 @@ public static class ApiApplicationBuilderExtensions
     /// <param name="options">The middleware options.</param>
     private static void ConfigureApiMiddleware(IApplicationBuilder app, ApiOptions options)
     {
-        // Apply exception handling middleware if enabled
+        var httpContextAccessor = app.ApplicationServices.GetService<IHttpContextAccessor>();
+        if (httpContextAccessor is not null)
+        {
+            EndatixProblemDetails.Configure(httpContextAccessor);
+        }
+
+        // Prefer IExceptionHandler (canonical ProblemDetails) over the legacy /error path redirect.
         if (options.UseExceptionHandler)
         {
-            app.UseExceptionHandler(options.ExceptionHandlerPath);
+            app.UseExceptionHandler();
         }
 
         // Apply FastEndpoints middleware with configuration
@@ -104,6 +112,11 @@ public static class ApiApplicationBuilderExtensions
             // Apply security configuration
             c.Security.RoleClaimType = ClaimTypes.Role;
             c.Security.PermissionsClaimType = ClaimNames.Permission;
+
+            // Unify FluentValidation 400s with handler ToProblem (fields dict, not FE stock errors[]).
+            c.Errors.ResponseBuilder = (failures, ctx, statusCode) =>
+                EndatixProblemDetails.FromValidationFailures(failures, ctx, statusCode);
+            c.Errors.ProducesMetadataType = typeof(Microsoft.AspNetCore.Mvc.ProblemDetails);
 
             // Apply any custom configuration
             options.ConfigureFastEndpoints?.Invoke(c);

--- a/src/Endatix.Api/Setup/ApiApplicationBuilderExtensions.cs
+++ b/src/Endatix.Api/Setup/ApiApplicationBuilderExtensions.cs
@@ -6,6 +6,7 @@ using Endatix.Infrastructure.Identity;
 using FastEndpoints;
 using FastEndpoints.Swagger;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -87,15 +88,14 @@ public static class ApiApplicationBuilderExtensions
     /// <param name="options">The middleware options.</param>
     private static void ConfigureApiMiddleware(IApplicationBuilder app, ApiOptions options)
     {
-        var httpContextAccessor = app.ApplicationServices.GetService<IHttpContextAccessor>();
-        if (httpContextAccessor is not null)
-        {
-            EndatixProblemDetails.Configure(httpContextAccessor);
-        }
+        var httpContextAccessor = app.ApplicationServices.GetRequiredService<IHttpContextAccessor>();
+        var loggerFactory = app.ApplicationServices.GetService<ILoggerFactory>();
+        EndatixProblemDetails.Configure(httpContextAccessor, loggerFactory);
 
         // Prefer IExceptionHandler (canonical ProblemDetails) over the legacy /error path redirect.
         if (options.UseExceptionHandler)
         {
+            EnsureExceptionHandlerRegistered(app);
             app.UseExceptionHandler();
         }
 
@@ -164,6 +164,17 @@ public static class ApiApplicationBuilderExtensions
     public static IApplicationBuilder UseApiEndpoints(this IApplicationBuilder app, Action<ApiOptions> configureApi)
     {
         return app.UseEndatixApi(configureApi);
+    }
+
+    private static void EnsureExceptionHandlerRegistered(IApplicationBuilder app)
+    {
+        if (app.ApplicationServices.GetService<IExceptionHandler>() is not null)
+        {
+            return;
+        }
+
+        throw new InvalidOperationException(
+            "IExceptionHandler is not registered. Call ApiConfigurationBuilder.UseDefaults() (or equivalent) before UseExceptionHandler().");
     }
 
     private static ApiOptions GetApiOptions(IApplicationBuilder app)

--- a/src/Endatix.Core/UseCases/Account/ForgotPassword/ForgotPasswordHandler.cs
+++ b/src/Endatix.Core/UseCases/Account/ForgotPassword/ForgotPasswordHandler.cs
@@ -32,7 +32,10 @@ public class ForgotPasswordHandler(
             catch (Exception ex)
             {
                 logger.LogError(ex, "Failed to send forgot password email to {Email}", SensitiveValue.Email(request.Email));
-                return Result.Error(FAILED_TO_SEND_EMAIL_MESSAGE);
+
+                // The email provider is an upstream dependency: 503 is the accurate status and
+                // signals the caller may retry. A bare 500 implied a fault in this service.
+                return Result.Unavailable(FAILED_TO_SEND_EMAIL_MESSAGE);
             }
         }
 

--- a/src/Endatix.Hosting/Builders/EndatixMiddlewareBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixMiddlewareBuilder.cs
@@ -109,6 +109,12 @@ public class EndatixMiddlewareBuilder
     public EndatixMiddlewareBuilder UseExceptionHandler()
     {
         _logger?.LogInformation("Adding exception handler middleware (IExceptionHandler)");
+        if (App.ApplicationServices.GetService<Microsoft.AspNetCore.Diagnostics.IExceptionHandler>() is null)
+        {
+            throw new InvalidOperationException(
+                "IExceptionHandler is not registered. Call ApiConfigurationBuilder.UseDefaults() before UseExceptionHandler().");
+        }
+
         App.UseExceptionHandler();
         return this;
     }

--- a/src/Endatix.Hosting/Builders/EndatixMiddlewareBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixMiddlewareBuilder.cs
@@ -102,14 +102,14 @@ public class EndatixMiddlewareBuilder
     }
 
     /// <summary>
-    /// Adds exception handling middleware.
+    /// Adds exception handling middleware that uses registered <c>IExceptionHandler</c>
+    /// implementations (canonical ProblemDetails via <c>EndatixExceptionHandler</c>).
     /// </summary>
-    /// <param name="path">The path for exception handling.</param>
     /// <returns>The builder for chaining.</returns>
-    public EndatixMiddlewareBuilder UseExceptionHandler(string path = "/error")
+    public EndatixMiddlewareBuilder UseExceptionHandler()
     {
-        _logger?.LogInformation($"Adding exception handler middleware with path: {path}");
-        App.UseExceptionHandler(path);
+        _logger?.LogInformation("Adding exception handler middleware (IExceptionHandler)");
+        App.UseExceptionHandler();
         return this;
     }
 

--- a/tests/Endatix.Api.Tests/Endpoints/Account/ForgotPasswordTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Account/ForgotPasswordTests.cs
@@ -1,3 +1,4 @@
+using static Endatix.Api.Infrastructure.ResultExtensions;
 using Endatix.Api.Endpoints.Account;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.Account.ForgotPassword;
@@ -63,12 +64,12 @@ public class ForgotPasswordTests
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithSystemErrorDuringEmailSending_ReturnsProblemResult()
+    public async Task ExecuteAsync_WithEmailProviderFailure_ReturnsServiceUnavailableProblem()
     {
         // Arrange
         var request = new ForgotPasswordRequest { Email = "user@example.com" };
         var forgotPasswordCommand = new ForgotPasswordCommand(request.Email);
-        var errorResult = Result.Error(ForgotPasswordHandler.FAILED_TO_SEND_EMAIL_MESSAGE);
+        var errorResult = Result<string>.Unavailable(ForgotPasswordHandler.FAILED_TO_SEND_EMAIL_MESSAGE);
 
         _mediator.Send(forgotPasswordCommand)
            .Returns(errorResult);
@@ -76,10 +77,12 @@ public class ForgotPasswordTests
         // Act
         var response = await _endpoint.ExecuteAsync(request, default);
 
-        // Assert
+        // Assert - an upstream provider failure is 503, not 500.
         var problemResult = response!.Result as ProblemHttpResult;
         problemResult.Should().NotBeNull();
-        problemResult!.StatusCode.Should().Be(500);
-        problemResult!.ProblemDetails.Detail.Should().Contain(ForgotPasswordHandler.FAILED_TO_SEND_EMAIL_MESSAGE);
+        problemResult!.StatusCode.Should().Be(503);
+        problemResult!.ProblemDetails.Title.Should().Be(ResultTitles.SERVICE_UNAVAILABLE);
+        // 5xx detail stays generic so handler text cannot leak.
+        problemResult!.ProblemDetails.Detail.Should().Be(ResultTitles.SERVICE_UNAVAILABLE);
     }
 }

--- a/tests/Endatix.Api.Tests/Endpoints/Account/ResetPasswordTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Account/ResetPasswordTests.cs
@@ -1,3 +1,4 @@
+using static Endatix.Api.Infrastructure.ResultExtensions;
 using Endatix.Api.Endpoints.Account;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.Account.ResetPassword;
@@ -105,6 +106,7 @@ public class ResetPasswordTests
         var problemResult = response!.Result as ProblemHttpResult;
         problemResult.Should().NotBeNull();
         problemResult!.StatusCode.Should().Be(500);
-        problemResult!.ProblemDetails.Detail.Should().Contain("Could not reset password. Please try again or contact support.");
+        // 5xx detail is suppressed to the generic title so handler text cannot leak.
+        problemResult!.ProblemDetails.Detail.Should().Be(ResultTitles.INTERNAL_SERVER_ERROR);
     }
 }

--- a/tests/Endatix.Api.Tests/Endpoints/MyAccount/ChangePasswordTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/MyAccount/ChangePasswordTests.cs
@@ -96,7 +96,8 @@ public class ChangePasswordTests
         Assert.NotNull(problemDetailsResult);
         Assert.NotNull(problemDetailsResult.ProblemDetails);
         problemDetailsResult.ProblemDetails.Title.Should().Be(ResultTitles.INTERNAL_SERVER_ERROR);
-        problemDetailsResult.ProblemDetails.Detail.Should().Contain("Failed to change password");
+        // 5xx detail is suppressed to the generic title so handler text cannot leak.
+        problemDetailsResult.ProblemDetails.Detail.Should().Be(ResultTitles.INTERNAL_SERVER_ERROR);
         problemDetailsResult.ProblemDetails.Status.Should().Be(500);
     }
 

--- a/tests/Endatix.Api.Tests/Infrastructure/EndatixExceptionHandlerTests.cs
+++ b/tests/Endatix.Api.Tests/Infrastructure/EndatixExceptionHandlerTests.cs
@@ -1,0 +1,78 @@
+using System.Text.Json;
+using Endatix.Api.Infrastructure;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging.Abstractions;
+using static Endatix.Api.Infrastructure.ResultExtensions;
+
+namespace Endatix.Api.Tests.Infrastructure;
+
+public class EndatixExceptionHandlerTests
+{
+    [Fact]
+    public async Task TryHandleAsync_WritesGeneric500ProblemJson_WithoutExceptionMessage()
+    {
+        // Arrange
+        const string secretMessage = "Secret DB connection string leaked";
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Method = "GET";
+        httpContext.Request.Path = "/api/forms";
+        httpContext.TraceIdentifier = "trace-exception";
+        httpContext.Response.Body = new MemoryStream();
+
+        var handler = new EndatixExceptionHandler(NullLogger<EndatixExceptionHandler>.Instance);
+        var exception = new InvalidOperationException(secretMessage);
+
+        // Act
+        bool handled = await handler.TryHandleAsync(httpContext, exception, TestContext.Current.CancellationToken);
+
+        // Assert
+        handled.Should().BeTrue();
+        httpContext.Response.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+        httpContext.Response.ContentType.Should().Be("application/problem+json");
+
+        httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+        using var document = await JsonDocument.ParseAsync(
+            httpContext.Response.Body,
+            cancellationToken: TestContext.Current.CancellationToken);
+        JsonElement root = document.RootElement;
+
+        root.GetProperty("status").GetInt32().Should().Be(500);
+        root.GetProperty("title").GetString().Should().Be(ResultTitles.INTERNAL_SERVER_ERROR);
+        root.GetProperty("detail").GetString().Should().Be(ResultTitles.INTERNAL_SERVER_ERROR);
+        root.GetProperty("detail").GetString().Should().NotContain(secretMessage);
+        root.GetProperty("instance").GetString().Should().Be("/api/forms");
+        root.GetProperty("traceId").GetString().Should().Be("trace-exception");
+    }
+
+    [Fact]
+    public async Task TryHandleAsync_WhenResponseHasStarted_ReturnsFalse()
+    {
+        // Arrange
+        var httpContext = new DefaultHttpContext();
+        httpContext.Response.Body = new MemoryStream();
+        httpContext.Features.Set<IHttpResponseFeature>(new StartedHttpResponseFeature());
+
+        var handler = new EndatixExceptionHandler(NullLogger<EndatixExceptionHandler>.Instance);
+
+        // Act
+        bool handled = await handler.TryHandleAsync(
+            httpContext,
+            new Exception("after start"),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        handled.Should().BeFalse();
+    }
+
+    private sealed class StartedHttpResponseFeature : IHttpResponseFeature
+    {
+        public int StatusCode { get; set; } = 200;
+        public string? ReasonPhrase { get; set; }
+        public IHeaderDictionary Headers { get; set; } = new HeaderDictionary();
+        public Stream Body { get; set; } = Stream.Null;
+        public bool HasStarted => true;
+        public void OnStarting(Func<object, Task> callback, object state) { }
+        public void OnCompleted(Func<object, Task> callback, object state) { }
+    }
+}

--- a/tests/Endatix.Api.Tests/Infrastructure/EndatixProblemDetailsTests.cs
+++ b/tests/Endatix.Api.Tests/Infrastructure/EndatixProblemDetailsTests.cs
@@ -1,0 +1,223 @@
+using Endatix.Api.Infrastructure;
+using Endatix.Core.Infrastructure.Result;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using static Endatix.Api.Infrastructure.ResultExtensions;
+
+namespace Endatix.Api.Tests.Infrastructure;
+
+public class EndatixProblemDetailsTests
+{
+    [Fact]
+    public void FromValidationFailures_WithPropertyErrors_ReturnsCanonicalProblemDetails()
+    {
+        // Arrange
+        var httpContext = CreateHttpContext("/api/forms", "trace-abc");
+        var failures = new List<ValidationFailure>
+        {
+            new("Name", "Name is required.") { ErrorCode = "NotEmptyValidator" },
+            new("Name", "Name must be at least 2 characters."),
+            new("IsEnabled", "IsEnabled is required."),
+        };
+
+        // Act
+        ProblemDetails problem = EndatixProblemDetails.FromValidationFailures(
+            failures,
+            httpContext,
+            StatusCodes.Status400BadRequest);
+
+        // Assert
+        problem.Status.Should().Be(StatusCodes.Status400BadRequest);
+        problem.Title.Should().Be(ResultTitles.BAD_REQUEST);
+        problem.Type.Should().Be("https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request");
+        problem.Instance.Should().Be("/api/forms");
+        problem.Detail.Should().Contain("Name is required.");
+        problem.Detail.Should().NotBeNullOrWhiteSpace();
+        problem.Extensions.Should().ContainKey("traceId");
+        problem.Extensions["traceId"].Should().Be("trace-abc");
+        problem.Extensions.Should().ContainKey("errorCode");
+        problem.Extensions["errorCode"].Should().Be("NotEmptyValidator");
+        problem.Extensions.Should().ContainKey("fields");
+        var fields = problem.Extensions["fields"].Should().BeOfType<Dictionary<string, string[]>>().Subject;
+        fields.Should().ContainKey("Name");
+        fields["Name"].Should().HaveCount(2);
+        fields.Should().ContainKey("IsEnabled");
+        httpContext.Response.ContentType.Should().Be("application/problem+json");
+    }
+
+    [Fact]
+    public void FromValidationFailures_WithEmptyFailures_FallsBackDetailToTitle()
+    {
+        // Arrange
+        var httpContext = CreateHttpContext("/api/forms", "trace-empty");
+
+        // Act
+        ProblemDetails problem = EndatixProblemDetails.FromValidationFailures(
+            [],
+            httpContext,
+            StatusCodes.Status400BadRequest);
+
+        // Assert
+        problem.Detail.Should().Be(ResultTitles.BAD_REQUEST);
+        problem.Extensions.Should().NotContainKey("fields");
+        problem.Extensions.Should().NotContainKey("errorCode");
+    }
+
+    [Fact]
+    public void Create_WithoutHttpContext_StillReturnsStatusAndDetail()
+    {
+        // Act
+        ProblemDetails problem = EndatixProblemDetails.Create(
+            statusCode: StatusCodes.Status404NotFound,
+            title: null,
+            detail: "Form not found");
+
+        // Assert
+        problem.Status.Should().Be(StatusCodes.Status404NotFound);
+        problem.Title.Should().Be(ResultTitles.NOT_FOUND);
+        problem.Detail.Should().Be("Form not found");
+        problem.Type.Should().Be("https://www.rfc-editor.org/rfc/rfc9110#name-404-not-found");
+    }
+
+    [Fact]
+    public void ForUnhandledException_DoesNotIncludeExceptionText()
+    {
+        // Arrange
+        var httpContext = CreateHttpContext("/api/boom", "trace-500");
+
+        // Act
+        ProblemDetails problem = EndatixProblemDetails.ForUnhandledException(httpContext);
+
+        // Assert
+        problem.Status.Should().Be(StatusCodes.Status500InternalServerError);
+        problem.Title.Should().Be(ResultTitles.INTERNAL_SERVER_ERROR);
+        problem.Detail.Should().Be(ResultTitles.INTERNAL_SERVER_ERROR);
+        problem.Instance.Should().Be("/api/boom");
+        problem.Extensions["traceId"].Should().Be("trace-500");
+    }
+
+    [Fact]
+    public void ToProblem_WithHttpContextAccessor_IncludesTypeInstanceTraceId()
+    {
+        // Arrange
+        var httpContext = CreateHttpContext("/api/forms/99", "trace-to-problem");
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(httpContext);
+        EndatixProblemDetails.Configure(accessor);
+
+        var result = Result.NotFound("Form not found");
+
+        // Act
+        var httpResult = result.ToProblem();
+
+        // Assert
+        httpResult.StatusCode.Should().Be(StatusCodes.Status404NotFound);
+        httpResult.ProblemDetails.Type.Should().Be("https://www.rfc-editor.org/rfc/rfc9110#name-404-not-found");
+        httpResult.ProblemDetails.Instance.Should().Be("/api/forms/99");
+        httpResult.ProblemDetails.Extensions.Should().ContainKey("traceId");
+        httpResult.ProblemDetails.Extensions["traceId"].Should().Be("trace-to-problem");
+    }
+
+    [Fact]
+    public void ToProblem_WithoutHttpContext_DoesNotThrow()
+    {
+        // Arrange — clear accessor by configuring a null-context accessor
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns((HttpContext?)null);
+        EndatixProblemDetails.Configure(accessor);
+
+        var result = Result.Invalid(new ValidationError("Name", "Name is required.", "NotEmptyValidator", ValidationSeverity.Error));
+
+        // Act
+        var act = () => result.ToProblem();
+
+        // Assert
+        act.Should().NotThrow();
+        var httpResult = act();
+        httpResult.StatusCode.Should().Be(StatusCodes.Status400BadRequest);
+        httpResult.ProblemDetails.Detail.Should().Contain("Name is required.");
+        httpResult.ProblemDetails.Extensions.Should().ContainKey("errorCode");
+        httpResult.ProblemDetails.Extensions.Should().ContainKey("fields");
+    }
+
+    #region Security and Privacy Tests
+
+    /// <summary>
+    /// Handlers wrap `ex.Message` into Result.Error(...) in ~17 places. A 5xx body must never
+    /// echo it back — DB/EF text, file paths and provider errors would reach the caller.
+    /// </summary>
+    [Theory]
+    [InlineData(ResultStatus.Error, StatusCodes.Status500InternalServerError)]
+    [InlineData(ResultStatus.CriticalError, StatusCodes.Status500InternalServerError)]
+    [InlineData(ResultStatus.Unavailable, StatusCodes.Status503ServiceUnavailable)]
+    public void ToProblem_ServerError_DoesNotEchoHandlerSuppliedDetail(ResultStatus status, int expectedStatusCode)
+    {
+        // Arrange
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(CreateHttpContext("/api/folders/1", "trace-5xx"));
+        EndatixProblemDetails.Configure(accessor);
+
+        const string leak = "Error deleting folder: 23503 violates foreign key \"FK_Forms_Folders\" on table forms";
+        Core.Infrastructure.Result.IResult result = status switch
+        {
+            ResultStatus.CriticalError => Result.CriticalError(leak),
+            ResultStatus.Unavailable => Result.Unavailable(leak),
+            _ => Result.Error(leak),
+        };
+
+        // Act
+        var httpResult = result.ToProblem();
+
+        // Assert
+        httpResult.StatusCode.Should().Be(expectedStatusCode);
+        httpResult.ProblemDetails.Detail.Should().NotContain("foreign key");
+        httpResult.ProblemDetails.Detail.Should().NotContain("FK_Forms_Folders");
+        httpResult.ProblemDetails.Detail.Should().Be(httpResult.ProblemDetails.Title);
+    }
+
+    /// <summary>
+    /// 4xx detail is author-written and user-actionable, so it must still reach the client.
+    /// </summary>
+    [Fact]
+    public void ToProblem_ClientError_KeepsDetail()
+    {
+        // Arrange
+        var accessor = Substitute.For<IHttpContextAccessor>();
+        accessor.HttpContext.Returns(CreateHttpContext("/api/forms/9", "trace-404"));
+        EndatixProblemDetails.Configure(accessor);
+
+        // Act
+        var httpResult = Result.NotFound("Form not found.").ToProblem();
+
+        // Assert
+        httpResult.ProblemDetails.Detail.Should().Be("Form not found.");
+    }
+
+    [Fact]
+    public void Create_ServerError_SuppressesDetailForExportAndOtherDirectCallers()
+    {
+        // Act
+        var problem = EndatixProblemDetails.Create(
+            statusCode: StatusCodes.Status500InternalServerError,
+            title: "Export failed",
+            detail: "Export failed: Object reference not set to an instance of an object.",
+            httpContext: CreateHttpContext("/api/forms/1/submissions/export", "trace-export"));
+
+        // Assert
+        problem.Detail.Should().Be("Export failed");
+        problem.Detail.Should().NotContain("Object reference");
+    }
+
+    #endregion
+
+    private static DefaultHttpContext CreateHttpContext(string path, string traceId)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Path = path;
+        httpContext.TraceIdentifier = traceId;
+        httpContext.Response.Body = new MemoryStream();
+        return httpContext;
+    }
+}

--- a/tests/Endatix.Api.Tests/Infrastructure/EndatixProblemDetailsTests.cs
+++ b/tests/Endatix.Api.Tests/Infrastructure/EndatixProblemDetailsTests.cs
@@ -31,9 +31,10 @@ public class EndatixProblemDetailsTests
         // Assert
         problem.Status.Should().Be(StatusCodes.Status400BadRequest);
         problem.Title.Should().Be(ResultTitles.BAD_REQUEST);
-        problem.Type.Should().Be("https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request");
+        problem.Type.Should().Be("https://www.rfc-editor.org/rfc/rfc9110.html#name-400-bad-request");
         problem.Instance.Should().Be("/api/forms");
         problem.Detail.Should().Contain("Name is required.");
+        problem.Detail.Should().NotContain("\r");
         problem.Detail.Should().NotBeNullOrWhiteSpace();
         problem.Extensions.Should().ContainKey("traceId");
         problem.Extensions["traceId"].Should().Be("trace-abc");
@@ -78,7 +79,7 @@ public class EndatixProblemDetailsTests
         problem.Status.Should().Be(StatusCodes.Status404NotFound);
         problem.Title.Should().Be(ResultTitles.NOT_FOUND);
         problem.Detail.Should().Be("Form not found");
-        problem.Type.Should().Be("https://www.rfc-editor.org/rfc/rfc9110#name-404-not-found");
+        problem.Type.Should().Be("https://www.rfc-editor.org/rfc/rfc9110.html#name-404-not-found");
     }
 
     [Fact]
@@ -114,7 +115,7 @@ public class EndatixProblemDetailsTests
 
         // Assert
         httpResult.StatusCode.Should().Be(StatusCodes.Status404NotFound);
-        httpResult.ProblemDetails.Type.Should().Be("https://www.rfc-editor.org/rfc/rfc9110#name-404-not-found");
+        httpResult.ProblemDetails.Type.Should().Be("https://www.rfc-editor.org/rfc/rfc9110.html#name-404-not-found");
         httpResult.ProblemDetails.Instance.Should().Be("/api/forms/99");
         httpResult.ProblemDetails.Extensions.Should().ContainKey("traceId");
         httpResult.ProblemDetails.Extensions["traceId"].Should().Be("trace-to-problem");
@@ -208,6 +209,15 @@ public class EndatixProblemDetailsTests
         // Assert
         problem.Detail.Should().Be("Export failed");
         problem.Detail.Should().NotContain("Object reference");
+    }
+
+    [Fact]
+    public void TitleForStatus_RateLimit_DoesNotUseInternalServerErrorTitle()
+    {
+        EndatixProblemDetails.TitleForStatus(StatusCodes.Status429TooManyRequests)
+            .Should().Be(ResultTitles.TOO_MANY_REQUESTS);
+        EndatixProblemDetails.TitleForStatus(StatusCodes.Status422UnprocessableEntity)
+            .Should().Be(ResultTitles.BAD_REQUEST);
     }
 
     #endregion

--- a/tests/Endatix.Api.Tests/Infrastructure/ResultExtensionsTests.cs
+++ b/tests/Endatix.Api.Tests/Infrastructure/ResultExtensionsTests.cs
@@ -119,7 +119,8 @@ public class ResultExtensionsTests
             Assert.Fail("Problem details are null");
         }
         problemDetails.Title.Should().Be(DEFAULT_UNEXPECTED_ERROR_TITLE);
-        problemDetails.Detail.Should().Contain("General error");
+        // 5xx detail is suppressed to the title; "General error" must not reach the client.
+        problemDetails.Detail.Should().Be(DEFAULT_UNEXPECTED_ERROR_TITLE);
         problemDetails.Extensions.Should().NotContainKey("errorCode");
     }
 
@@ -283,7 +284,7 @@ public class ResultExtensionsTests
             Assert.Fail("Problem details are null");
         }
         problemDetails.Title.Should().Be(DEFAULT_UNEXPECTED_ERROR_TITLE);
-        problemDetails.Detail.Should().Contain("Error occurred");
+        problemDetails.Detail.Should().Be(DEFAULT_UNEXPECTED_ERROR_TITLE);
     }
 
     [Fact]
@@ -309,14 +310,14 @@ public class ResultExtensionsTests
             Assert.Fail("Problem details are null");
         }
         problemDetails.Title.Should().Be(customTitle);
-        problemDetails.Detail.Should().Contain("Error occurred");
+        problemDetails.Detail.Should().Be(customTitle);
     }
 
     [Fact]
     public void ToProblem_WithMultipleErrors_CombinesAllErrorMessages()
     {
-        // Arrange
-        var result = Result.Error(new ErrorList(["First error", "Second error"]));
+        // Arrange - a 4xx, since 5xx detail is deliberately suppressed.
+        var result = Result.Conflict("First error", "Second error");
 
         // Act
         var httpResult = result.ToProblem();
@@ -326,14 +327,14 @@ public class ResultExtensionsTests
         httpResult.Should().BeOfType<ProblemHttpResult>();
 
         var statusCode = httpResult.StatusCode;
-        statusCode.Should().Be(StatusCodes.Status500InternalServerError);
+        statusCode.Should().Be(StatusCodes.Status409Conflict);
 
         var problemDetails = httpResult.ProblemDetails;
         if (problemDetails is null)
         {
             Assert.Fail("Problem details are null");
         }
-        problemDetails.Title.Should().Be(DEFAULT_UNEXPECTED_ERROR_TITLE);
+        problemDetails.Title.Should().Be(DEFAULT_CONFLICT_TITLE);
         problemDetails.Detail.Should().Contain("First error");
         problemDetails.Detail.Should().Contain("Second error");
     }

--- a/tests/Endatix.Core.Tests/UseCases/Account/ForgotPassword/ForgotPasswordHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Account/ForgotPassword/ForgotPasswordHandlerTests.cs
@@ -76,7 +76,8 @@ public class ForgotPasswordHandlerTests
 
         // Assert
         result.Should().NotBeNull();
-        result.Status.Should().Be(ResultStatus.Error);
+        // Email provider is an upstream dependency: Unavailable -> 503, not a 500.
+        result.Status.Should().Be(ResultStatus.Unavailable);
         result.Errors.Should().Contain(ForgotPasswordHandler.FAILED_TO_SEND_EMAIL_MESSAGE);
 
         await _userPasswordManageService.Received(1).GeneratePasswordResetTokenAsync(email, Arg.Any<CancellationToken>());
@@ -103,7 +104,8 @@ public class ForgotPasswordHandlerTests
 
         // Assert
         result.Should().NotBeNull();
-        result.Status.Should().Be(ResultStatus.Error);
+        // Email provider is an upstream dependency: Unavailable -> 503, not a 500.
+        result.Status.Should().Be(ResultStatus.Unavailable);
         result.Errors.Should().Contain(ForgotPasswordHandler.FAILED_TO_SEND_EMAIL_MESSAGE);
 
         await _userPasswordManageService.Received(1).GeneratePasswordResetTokenAsync(email, Arg.Any<CancellationToken>());
@@ -133,7 +135,8 @@ public class ForgotPasswordHandlerTests
 
         // Assert
         result.Should().NotBeNull();
-        result.Status.Should().Be(ResultStatus.Error);
+        // Email provider is an upstream dependency: Unavailable -> 503, not a 500.
+        result.Status.Should().Be(ResultStatus.Unavailable);
         result.Errors.Should().Contain(ForgotPasswordHandler.FAILED_TO_SEND_EMAIL_MESSAGE);
     }
 

--- a/tests/Endatix.IntegrationTests.Shared/IntegrationAuthClients.cs
+++ b/tests/Endatix.IntegrationTests.Shared/IntegrationAuthClients.cs
@@ -108,7 +108,12 @@ public static class IntegrationAuthClients
             new { email, password },
             cancellationToken);
 
-        response.EnsureSuccessStatusCode();
+        if (!response.IsSuccessStatusCode)
+        {
+            string body = await response.Content.ReadAsStringAsync(cancellationToken);
+            throw new HttpRequestException(
+                $"Login failed with {(int)response.StatusCode} {response.StatusCode}. Body: {body}");
+        }
 
         var payload = await response.Content.ReadFromJsonAsync<LoginTokenPayload>(cancellationToken);
         if (payload is null || string.IsNullOrWhiteSpace(payload.AccessToken))

--- a/tests/Endatix.IntegrationTests/AGENTS.md
+++ b/tests/Endatix.IntegrationTests/AGENTS.md
@@ -34,6 +34,7 @@ public sealed class MyFlowTests(EndatixIntegrationWebHostFixture fixture)
 | `AuthLoginFlowTests`                  | CriticalPath, `PrepareWorldAsync`, `IntegrationAuthMode.Login` |
 | `FormNotFoundProblemDetailsFlowTests` | FeatureFlow, 404 + problem+json on missing form / definitions (`type`/`instance`/`traceId`) |
 | `FormValidationProblemDetailsFlowTests` | FeatureFlow, FE FluentValidation 400 + problem+json with `fields` (not FE ErrorResponse) |
+| `ProblemDetailsContractFlowTests`     | FeatureFlow, unhandled 500 / export / 409 conflict + documented empty-body 401/403 |
 | `HealthCheckTests`                    | Host smoke, provider-agnostic                                  |
 | `StartupMigrationTests`               | DB-only, provider-agnostic migrations                          |
 | `SqlServerMigrationArtifactTests`     | `DbSpecific=SqlServer` stored proc / seed checks               |

--- a/tests/Endatix.IntegrationTests/AGENTS.md
+++ b/tests/Endatix.IntegrationTests/AGENTS.md
@@ -32,7 +32,8 @@ public sealed class MyFlowTests(EndatixIntegrationWebHostFixture fixture)
 | Test                                  | Pattern                                                        |
 | ------------------------------------- | -------------------------------------------------------------- |
 | `AuthLoginFlowTests`                  | CriticalPath, `PrepareWorldAsync`, `IntegrationAuthMode.Login` |
-| `FormNotFoundProblemDetailsFlowTests` | FeatureFlow, 404 + problem+json on missing form / definitions  |
+| `FormNotFoundProblemDetailsFlowTests` | FeatureFlow, 404 + problem+json on missing form / definitions (`type`/`instance`/`traceId`) |
+| `FormValidationProblemDetailsFlowTests` | FeatureFlow, FE FluentValidation 400 + problem+json with `fields` (not FE ErrorResponse) |
 | `HealthCheckTests`                    | Host smoke, provider-agnostic                                  |
 | `StartupMigrationTests`               | DB-only, provider-agnostic migrations                          |
 | `SqlServerMigrationArtifactTests`     | `DbSpecific=SqlServer` stored proc / seed checks               |

--- a/tests/Endatix.IntegrationTests/FeatureFlows/Api/ProblemDetailsContractFlowTests.cs
+++ b/tests/Endatix.IntegrationTests/FeatureFlows/Api/ProblemDetailsContractFlowTests.cs
@@ -1,0 +1,220 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Endatix.IntegrationTests.Infrastructure;
+using Endatix.IntegrationTests.Shared;
+
+namespace Endatix.IntegrationTests;
+
+/// <summary>
+/// Pins the RFC7807 contract on the paths the per-feature flow tests do not reach: unhandled
+/// exceptions, the streaming export writer, authentication/authorization rejections, and a
+/// domain conflict.
+/// </summary>
+[Collection(nameof(EndatixIntegrationTestCollection))]
+[Trait("Category", "FeatureFlow")]
+[Trait("Priority", "P1")]
+public sealed class ProblemDetailsContractFlowTests
+{
+    private const string SeedPassword = "Password123!";
+    private const long MissingFormId = 9_999_999_999L;
+
+    private static readonly string[] VolatileMembers = ["traceId"];
+
+    private readonly EndatixIntegrationWebHostFixture _fixture;
+
+    public ProblemDetailsContractFlowTests(EndatixIntegrationWebHostFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    /// <summary>
+    /// The headline guarantee: a fault that nothing catches still answers with the canonical
+    /// envelope, and the exception text never reaches the caller.
+    /// </summary>
+    [Fact]
+    public async Task UnhandledException_ReturnsGenericProblemAndLeaksNothing()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using HttpClient client = await CreateClientAsync(TestPersona.TenantAdmin, cancellationToken);
+
+        // Act
+        using HttpResponseMessage response = await client.GetAsync(
+            new Uri(UnhandledExceptionRouteStartupFilter.Path, UriKind.Relative),
+            cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+
+        string body = await response.Content.ReadAsStringAsync(cancellationToken);
+        Assert.DoesNotContain(
+            UnhandledExceptionRouteStartupFilter.SensitiveMarker,
+            body,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("InvalidOperationException", body, StringComparison.Ordinal);
+        Assert.DoesNotContain("StackTrace", body, StringComparison.OrdinalIgnoreCase);
+
+        string expected = ProblemDetailsJson.Shape(
+            $$"""
+            {
+              "type": "https://www.rfc-editor.org/rfc/rfc9110#name-500-internal-server-error",
+              "title": "An unexpected error occurred",
+              "status": 500,
+              "detail": "An unexpected error occurred",
+              "instance": "{{UnhandledExceptionRouteStartupFilter.Path}}",
+              "traceId": "<string>"
+            }
+            """,
+            VolatileMembers);
+
+        string actual = await ProblemDetailsJson.ReadShapeAsync(response, cancellationToken, VolatileMembers);
+
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// The export endpoint writes its own body instead of returning a typed result, so it is the
+    /// one path where the problem+json content type can be lost to WriteAsJsonAsync's default.
+    /// </summary>
+    [Fact]
+    public async Task Export_ForMissingForm_ReturnsCanonicalProblemJson()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using HttpClient client = await CreateClientAsync(TestPersona.TenantAdmin, cancellationToken);
+
+        // Act
+        using HttpResponseMessage response = await client.PostAsJsonAsync(
+            $"/api/forms/{MissingFormId}/submissions/export",
+            new { },
+            cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        string expected = ProblemDetailsJson.Shape(
+            $$"""
+            {
+              "type": "https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request",
+              "title": "Export failed",
+              "status": 400,
+              "detail": "Form with ID {{MissingFormId}} not found",
+              "instance": "/api/forms/{{MissingFormId}}/submissions/export",
+              "traceId": "<string>"
+            }
+            """,
+            VolatileMembers);
+
+        string actual = await ProblemDetailsJson.ReadShapeAsync(response, cancellationToken, VolatileMembers);
+
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// A domain conflict must carry its message: 4xx detail is author-written and actionable,
+    /// unlike 5xx which is deliberately generic.
+    /// </summary>
+    [Fact]
+    public async Task PartialUpdateForm_PublicSingleSubmission_ReturnsCanonicalConflictProblem()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        using HttpClient client = await CreateClientAsync(TestPersona.TenantAdmin, cancellationToken);
+        string formId = await CreateFormAsync(client, cancellationToken);
+
+        // Act - a single-submission form cannot also be public.
+        using HttpResponseMessage response = await client.PatchAsJsonAsync(
+            $"/api/forms/{formId}",
+            new { isPublic = true, limitOnePerUser = true },
+            cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+
+        string expected = ProblemDetailsJson.Shape(
+            $$"""
+            {
+              "type": "https://www.rfc-editor.org/rfc/rfc9110#name-409-conflict",
+              "title": "There was a conflict",
+              "status": 409,
+              "detail": "A single-submission form cannot be made public.",
+              "instance": "/api/forms/{{formId}}",
+              "traceId": "<string>"
+            }
+            """,
+            VolatileMembers);
+
+        string actual = await ProblemDetailsJson.ReadShapeAsync(response, cancellationToken, VolatileMembers);
+
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// Documents a known gap: 401 and 403 are produced by the authentication and authorization
+    /// middleware, which never reaches <c>EndatixProblemDetails</c>. They answer with an empty
+    /// body, so they are the two statuses outside the canonical envelope. If this test starts
+    /// failing because a body appeared, bring that body into the envelope rather than relaxing
+    /// the assertion.
+    /// </summary>
+    [Theory]
+    [InlineData("/api/forms", HttpStatusCode.Unauthorized, false)]
+    [InlineData("/api/admin/tenants", HttpStatusCode.Forbidden, true)]
+    public async Task AuthRejections_AreOutsideTheProblemDetailsEnvelope(
+        string path,
+        HttpStatusCode expectedStatus,
+        bool authenticated)
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        IntegrationTestWorld world = await PrepareWorldAsync(cancellationToken);
+        using HttpClient client = authenticated
+            ? await world.AsAsync(TestPersona.TenantAdmin, cancellationToken: cancellationToken)
+            : world.AnonymousClient();
+
+        // Act
+        using HttpResponseMessage response = await client.GetAsync(new Uri(path, UriKind.Relative), cancellationToken);
+
+        // Assert
+        Assert.Equal(expectedStatus, response.StatusCode);
+
+        string body = await response.Content.ReadAsStringAsync(cancellationToken);
+        Assert.True(
+            string.IsNullOrWhiteSpace(body),
+            $"Expected an empty body for {(int)expectedStatus}, got: {body}");
+    }
+
+    private async Task<IntegrationTestWorld> PrepareWorldAsync(CancellationToken cancellationToken) =>
+        await _fixture.PrepareWorldAsync(
+            IntegrationWorldOptions.SingleTenant with { DefaultPassword = SeedPassword },
+            cancellationToken);
+
+    private async Task<HttpClient> CreateClientAsync(TestPersona persona, CancellationToken cancellationToken)
+    {
+        IntegrationTestWorld world = await PrepareWorldAsync(cancellationToken);
+        return await world.AsAsync(persona, cancellationToken: cancellationToken);
+    }
+
+    private static async Task<string> CreateFormAsync(HttpClient client, CancellationToken cancellationToken)
+    {
+        using HttpResponseMessage created = await client.PostAsJsonAsync(
+            "/api/forms",
+            new
+            {
+                name = "Problem details conflict fixture",
+                isEnabled = true,
+                formDefinitionJsonData = """{"pages":[{"name":"page1","elements":[{"type":"text","name":"q1"}]}]}"""
+            },
+            cancellationToken);
+
+        Assert.Equal(HttpStatusCode.Created, created.StatusCode);
+
+        using JsonDocument? document = await created.Content.ReadFromJsonAsync<JsonDocument>(cancellationToken);
+        Assert.NotNull(document);
+
+        string? id = document.RootElement.GetProperty("id").GetString();
+        Assert.False(string.IsNullOrWhiteSpace(id), "Created form did not return an id.");
+
+        return id!;
+    }
+}

--- a/tests/Endatix.IntegrationTests/FeatureFlows/Api/ProblemDetailsContractFlowTests.cs
+++ b/tests/Endatix.IntegrationTests/FeatureFlows/Api/ProblemDetailsContractFlowTests.cs
@@ -58,7 +58,7 @@ public sealed class ProblemDetailsContractFlowTests
         string expected = ProblemDetailsJson.Shape(
             $$"""
             {
-              "type": "https://www.rfc-editor.org/rfc/rfc9110#name-500-internal-server-error",
+              "type": "https://www.rfc-editor.org/rfc/rfc9110.html#name-500-internal-server-error",
               "title": "An unexpected error occurred",
               "status": 500,
               "detail": "An unexpected error occurred",
@@ -96,7 +96,7 @@ public sealed class ProblemDetailsContractFlowTests
         string expected = ProblemDetailsJson.Shape(
             $$"""
             {
-              "type": "https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request",
+              "type": "https://www.rfc-editor.org/rfc/rfc9110.html#name-400-bad-request",
               "title": "Export failed",
               "status": 400,
               "detail": "Form with ID {{MissingFormId}} not found",
@@ -135,7 +135,7 @@ public sealed class ProblemDetailsContractFlowTests
         string expected = ProblemDetailsJson.Shape(
             $$"""
             {
-              "type": "https://www.rfc-editor.org/rfc/rfc9110#name-409-conflict",
+              "type": "https://www.rfc-editor.org/rfc/rfc9110.html#name-409-conflict",
               "title": "There was a conflict",
               "status": 409,
               "detail": "A single-submission form cannot be made public.",

--- a/tests/Endatix.IntegrationTests/FeatureFlows/Forms/FormNotFoundProblemDetailsFlowTests.cs
+++ b/tests/Endatix.IntegrationTests/FeatureFlows/Forms/FormNotFoundProblemDetailsFlowTests.cs
@@ -45,7 +45,7 @@ public sealed class FormNotFoundProblemDetailsFlowTests
         string expected = ProblemDetailsJson.Shape(
             $$"""
             {
-              "type": "https://www.rfc-editor.org/rfc/rfc9110#name-404-not-found",
+              "type": "https://www.rfc-editor.org/rfc/rfc9110.html#name-404-not-found",
               "title": "Resource not found",
               "status": 404,
               "detail": "Form not found.",
@@ -78,7 +78,7 @@ public sealed class FormNotFoundProblemDetailsFlowTests
         string expected = ProblemDetailsJson.Shape(
             $$"""
             {
-              "type": "https://www.rfc-editor.org/rfc/rfc9110#name-404-not-found",
+              "type": "https://www.rfc-editor.org/rfc/rfc9110.html#name-404-not-found",
               "title": "Resource not found",
               "status": 404,
               "detail": "Form not found.",

--- a/tests/Endatix.IntegrationTests/FeatureFlows/Forms/FormNotFoundProblemDetailsFlowTests.cs
+++ b/tests/Endatix.IntegrationTests/FeatureFlows/Forms/FormNotFoundProblemDetailsFlowTests.cs
@@ -1,12 +1,13 @@
 using System.Net;
-using System.Net.Http.Json;
-using System.Text.Json;
+using Endatix.IntegrationTests.Infrastructure;
 using Endatix.IntegrationTests.Shared;
 
 namespace Endatix.IntegrationTests;
 
 /// <summary>
-/// Verifies resource GETs return RFC7807 problem+json for missing entities (API 0.7.5 error shape).
+/// Pins the RFC7807 problem+json body returned for missing entities. The whole envelope is
+/// compared against a literal, so the error shape is visible in the test and any extra or
+/// renamed member fails here.
 /// </summary>
 [Collection(nameof(EndatixIntegrationTestCollection))]
 [Trait("Category", "FeatureFlow")]
@@ -14,6 +15,11 @@ namespace Endatix.IntegrationTests;
 public sealed class FormNotFoundProblemDetailsFlowTests
 {
     private const string SeedPassword = "Password123!";
+    private const long MissingFormId = 9_999_999_999L;
+
+    /// <summary>`traceId` is per-request; everything else is ours and asserted verbatim.</summary>
+    private static readonly string[] VolatileMembers = ["traceId"];
+
     private readonly EndatixIntegrationWebHostFixture _fixture;
 
     public FormNotFoundProblemDetailsFlowTests(EndatixIntegrationWebHostFixture fixture)
@@ -22,74 +28,77 @@ public sealed class FormNotFoundProblemDetailsFlowTests
     }
 
     [Fact]
-    public async Task GetById_MissingForm_Returns404ProblemJson()
+    public async Task GetById_MissingForm_ReturnsCanonicalNotFoundProblem()
     {
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
-        IntegrationTestWorld world = await _fixture.PrepareWorldAsync(
-            IntegrationWorldOptions.SingleTenant with { DefaultPassword = SeedPassword },
-            cancellationToken);
-        using HttpClient client = await world.AsAsync(TestPersona.TenantAdmin, cancellationToken: cancellationToken);
-        const long missingFormId = 9_999_999_999L;
+        using HttpClient client = await CreateTenantAdminClientAsync(cancellationToken);
 
         // Act
         using HttpResponseMessage response = await client.GetAsync(
-            new Uri($"/api/forms/{missingFormId}", UriKind.Relative),
+            new Uri($"/api/forms/{MissingFormId}", UriKind.Relative),
             cancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        await AssertProblemDetailsAsync(response, expectedStatus: 404, cancellationToken);
+
+        string expected = ProblemDetailsJson.Shape(
+            $$"""
+            {
+              "type": "https://www.rfc-editor.org/rfc/rfc9110#name-404-not-found",
+              "title": "Resource not found",
+              "status": 404,
+              "detail": "Form not found.",
+              "instance": "/api/forms/{{MissingFormId}}",
+              "traceId": "<string>"
+            }
+            """,
+            VolatileMembers);
+
+        string actual = await ProblemDetailsJson.ReadShapeAsync(response, cancellationToken, VolatileMembers);
+
+        Assert.Equal(expected, actual);
     }
 
     [Fact]
-    public async Task ListDefinitions_MissingForm_Returns404ProblemJson()
+    public async Task ListDefinitions_MissingForm_ReturnsCanonicalNotFoundProblem()
     {
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
-        IntegrationTestWorld world = await _fixture.PrepareWorldAsync(
-            IntegrationWorldOptions.SingleTenant with { DefaultPassword = SeedPassword },
-            cancellationToken);
-        using HttpClient client = await world.AsAsync(TestPersona.TenantAdmin, cancellationToken: cancellationToken);
-        const long missingFormId = 9_999_999_999L;
+        using HttpClient client = await CreateTenantAdminClientAsync(cancellationToken);
 
         // Act
         using HttpResponseMessage response = await client.GetAsync(
-            new Uri($"/api/forms/{missingFormId}/definitions", UriKind.Relative),
+            new Uri($"/api/forms/{MissingFormId}/definitions", UriKind.Relative),
             cancellationToken);
 
         // Assert
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
-        await AssertProblemDetailsAsync(response, expectedStatus: 404, cancellationToken);
+
+        string expected = ProblemDetailsJson.Shape(
+            $$"""
+            {
+              "type": "https://www.rfc-editor.org/rfc/rfc9110#name-404-not-found",
+              "title": "Resource not found",
+              "status": 404,
+              "detail": "Form not found.",
+              "instance": "/api/forms/{{MissingFormId}}/definitions",
+              "traceId": "<string>"
+            }
+            """,
+            VolatileMembers);
+
+        string actual = await ProblemDetailsJson.ReadShapeAsync(response, cancellationToken, VolatileMembers);
+
+        Assert.Equal(expected, actual);
     }
 
-    private static async Task AssertProblemDetailsAsync(
-        HttpResponseMessage response,
-        int expectedStatus,
-        CancellationToken cancellationToken)
+    private async Task<HttpClient> CreateTenantAdminClientAsync(CancellationToken cancellationToken)
     {
-        string? mediaType = response.Content.Headers.ContentType?.MediaType;
-        Assert.True(
-            mediaType is "application/problem+json",
-            $"Expected application/problem+json content type, got '{mediaType}'.");
+        IntegrationTestWorld world = await _fixture.PrepareWorldAsync(
+            IntegrationWorldOptions.SingleTenant with { DefaultPassword = SeedPassword },
+            cancellationToken);
 
-        using JsonDocument? document = await response.Content.ReadFromJsonAsync<JsonDocument>(cancellationToken);
-        Assert.NotNull(document);
-
-        JsonElement root = document.RootElement;
-        Assert.True(root.TryGetProperty("status", out JsonElement statusElement), "ProblemDetails.status missing.");
-        Assert.Equal(expectedStatus, statusElement.GetInt32());
-
-        // Both members must be present AND non-empty. Asserting them separately matters:
-        // an `||` short-circuits on a present-but-empty `detail` and never checks `title`.
-        Assert.True(root.TryGetProperty("title", out JsonElement titleElement), "ProblemDetails.title missing.");
-        Assert.False(
-            string.IsNullOrWhiteSpace(titleElement.GetString()),
-            "ProblemDetails.title must not be empty.");
-
-        Assert.True(root.TryGetProperty("detail", out JsonElement detailElement), "ProblemDetails.detail missing.");
-        Assert.False(
-            string.IsNullOrWhiteSpace(detailElement.GetString()),
-            "ProblemDetails.detail must not be empty; ToProblem falls back to the title.");
+        return await world.AsAsync(TestPersona.TenantAdmin, cancellationToken: cancellationToken);
     }
 }

--- a/tests/Endatix.IntegrationTests/FeatureFlows/Forms/FormValidationProblemDetailsFlowTests.cs
+++ b/tests/Endatix.IntegrationTests/FeatureFlows/Forms/FormValidationProblemDetailsFlowTests.cs
@@ -1,0 +1,163 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Endatix.IntegrationTests.Infrastructure;
+using Endatix.IntegrationTests.Shared;
+
+namespace Endatix.IntegrationTests;
+
+/// <summary>
+/// Pins the RFC7807 problem+json body returned for FastEndpoints/FluentValidation failures.
+/// The envelope must be identical to the one handler <c>ToProblem</c> produces, with the extra
+/// <c>fields</c> dictionary - never the stock FastEndpoints <c>ErrorResponse</c>. Comparing the
+/// whole document means a resurrected <c>statusCode</c> / <c>message</c> / <c>errors</c> member
+/// fails here without a separate absence assertion.
+/// </summary>
+[Collection(nameof(EndatixIntegrationTestCollection))]
+[Trait("Category", "FeatureFlow")]
+[Trait("Priority", "P1")]
+public sealed class FormValidationProblemDetailsFlowTests
+{
+    private const string SeedPassword = "Password123!";
+
+    /// <summary>
+    /// `traceId` is per-request. `detail` and the messages under `fields` are FluentValidation's
+    /// wording, which we do not own - the member and its structure are asserted, the prose is not.
+    /// The `fields` keys are camelCase (`name`, not `Name`): FastEndpoints camelCases the
+    /// validation property name, which is what a JSON client needs to map errors back to inputs.
+    /// </summary>
+    private static readonly string[] VolatileMembers = ["traceId", "detail", "fields"];
+
+    /// <summary>Used where the messages themselves are the point of the test.</summary>
+    private static readonly string[] TraceIdOnly = ["traceId"];
+
+    private readonly EndatixIntegrationWebHostFixture _fixture;
+
+    public FormValidationProblemDetailsFlowTests(EndatixIntegrationWebHostFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task CreateForm_MissingName_ReturnsCanonicalValidationProblem()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        IntegrationTestWorld world = await _fixture.PrepareWorldAsync(
+            IntegrationWorldOptions.SingleTenant with { DefaultPassword = SeedPassword },
+            cancellationToken);
+        using HttpClient client = await world.AsAsync(TestPersona.TenantAdmin, cancellationToken: cancellationToken);
+
+        // Act - `name` omitted; everything else is valid so `Name` is the only failing rule.
+        using HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/forms",
+            new
+            {
+                isEnabled = true,
+                formDefinitionJsonData = """{"pages":[{"name":"page1","elements":[{"type":"text","name":"q1"}]}]}"""
+            },
+            cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        string expected = ProblemDetailsJson.Shape(
+            """
+            {
+              "type": "https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request",
+              "title": "There was a problem with your request",
+              "status": 400,
+              "detail": "<string>",
+              "instance": "/api/forms",
+              "traceId": "<string>",
+              "errorCode": "NotEmptyValidator",
+              "fields": {
+                "name": ["<string>"]
+              }
+            }
+            """,
+            VolatileMembers);
+
+        string actual = await ProblemDetailsJson.ReadShapeAsync(response, cancellationToken, VolatileMembers);
+
+        Assert.Equal(expected, actual);
+    }
+
+    /// <summary>
+    /// Documents the multi-error shape end to end: several failing properties, and a property
+    /// that fails two rules at once, all in one response.
+    ///
+    /// Unlike the single-error test above, the messages are asserted verbatim - this test is
+    /// intended to be read as the reference example of the payload a client receives, so the
+    /// wording is part of what it documents. A FluentValidation upgrade that rewords a built-in
+    /// message will fail here by design; update the literal.
+    ///
+    /// Two things worth noticing in the expected body:
+    ///   * `fields` keys are camelCase (`name`, `isEnabled`) EXCEPT `FormDefinition`, which is
+    ///     PascalCase because the rule sets it explicitly via `WithName("FormDefinition")` and
+    ///     FastEndpoints only camelCases names it derives itself. A client mapping `fields` keys
+    ///     onto form inputs has to special-case it - see the note in the test body.
+    ///   * `errorCode` carries only the FIRST failure's code, so it cannot be used to
+    ///     discriminate between the individual field errors; `fields` is the machine-readable part.
+    /// </summary>
+    [Fact]
+    public async Task CreateForm_MultipleInvalidFields_ReturnsEveryFailureGroupedByProperty()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        IntegrationTestWorld world = await _fixture.PrepareWorldAsync(
+            IntegrationWorldOptions.SingleTenant with { DefaultPassword = SeedPassword },
+            cancellationToken);
+        using HttpClient client = await world.AsAsync(TestPersona.TenantAdmin, cancellationToken: cancellationToken);
+
+        // Act - four properties fail; `name` fails two rules (NotEmpty and MinimumLength(2)),
+        // `isEnabled` is omitted, the form definition is missing entirely, `metadata` is not JSON.
+        using HttpResponseMessage response = await client.PostAsJsonAsync(
+            "/api/forms",
+            new { name = "", metadata = "not-json" },
+            cancellationToken);
+
+        // Assert
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        string expected = ProblemDetailsJson.Shape(
+            """
+            {
+              "type": "https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request",
+              "title": "There was a problem with your request",
+              "status": 400,
+              "detail": "'name' must not be empty.\nThe length of 'name' must be at least 2 characters. You entered 0 characters.\n'is Enabled' must not be empty.\nEither FormDefinitionJsonData or FormDefinitionSchema must be provided.\nmetadata must be a valid JSON string.",
+              "instance": "/api/forms",
+              "traceId": "<string>",
+              "errorCode": "NotEmptyValidator",
+              "fields": {
+                "name": [
+                  "'name' must not be empty.",
+                  "The length of 'name' must be at least 2 characters. You entered 0 characters."
+                ],
+                "isEnabled": [
+                  "'is Enabled' must not be empty."
+                ],
+                "FormDefinition": [
+                  "Either FormDefinitionJsonData or FormDefinitionSchema must be provided."
+                ],
+                "metadata": [
+                  "metadata must be a valid JSON string."
+                ]
+              }
+            }
+            """,
+            TraceIdOnly);
+
+        string actual = await ProblemDetailsJson.ReadShapeAsync(response, cancellationToken, TraceIdOnly);
+
+        Assert.Equal(expected, actual);
+
+        // `detail` is every message joined by a newline, in rule-declaration order. It is a
+        // human-readable summary only - clients should render `fields`, which preserves the
+        // property grouping and the per-property ordering.
+        using JsonDocument document = JsonDocument.Parse(actual);
+        string detail = document.RootElement.GetProperty("detail").GetString()!;
+        Assert.Equal(5, detail.Split('\n').Length);
+    }
+}

--- a/tests/Endatix.IntegrationTests/FeatureFlows/Forms/FormValidationProblemDetailsFlowTests.cs
+++ b/tests/Endatix.IntegrationTests/FeatureFlows/Forms/FormValidationProblemDetailsFlowTests.cs
@@ -64,7 +64,7 @@ public sealed class FormValidationProblemDetailsFlowTests
         string expected = ProblemDetailsJson.Shape(
             """
             {
-              "type": "https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request",
+              "type": "https://www.rfc-editor.org/rfc/rfc9110.html#name-400-bad-request",
               "title": "There was a problem with your request",
               "status": 400,
               "detail": "<string>",
@@ -123,7 +123,7 @@ public sealed class FormValidationProblemDetailsFlowTests
         string expected = ProblemDetailsJson.Shape(
             """
             {
-              "type": "https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request",
+              "type": "https://www.rfc-editor.org/rfc/rfc9110.html#name-400-bad-request",
               "title": "There was a problem with your request",
               "status": 400,
               "detail": "'name' must not be empty.\nThe length of 'name' must be at least 2 characters. You entered 0 characters.\n'is Enabled' must not be empty.\nEither FormDefinitionJsonData or FormDefinitionSchema must be provided.\nmetadata must be a valid JSON string.",

--- a/tests/Endatix.IntegrationTests/Infrastructure/EndatixWebApplicationFactory.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/EndatixWebApplicationFactory.cs
@@ -1,8 +1,10 @@
 extern alias EndatixWebHost;
 
+using Endatix.IntegrationTests.Infrastructure;
 using Endatix.IntegrationTests.Shared;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Endatix.IntegrationTests;
@@ -36,6 +38,10 @@ internal static class EndatixWebApplicationFactoryConfiguration
     public static void ConfigureCommon(IWebHostBuilder builder, string connectionString, TestDatabaseProvider provider)
     {
         builder.UseEnvironment(Environments.Staging);
+
+        // Test-only throwing route; see UnhandledExceptionRouteStartupFilter.
+        builder.ConfigureServices(services =>
+            services.AddSingleton<IStartupFilter, UnhandledExceptionRouteStartupFilter>());
 
         builder.UseSetting("ConnectionStrings:DefaultConnection", connectionString);
         builder.UseSetting("ConnectionStrings:DefaultConnection_DbProvider", provider.ToString());

--- a/tests/Endatix.IntegrationTests/Infrastructure/ProblemDetailsJson.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/ProblemDetailsJson.cs
@@ -13,7 +13,7 @@ namespace Endatix.IntegrationTests.Infrastructure;
 /// comparison order- and whitespace-insensitive; the placeholder keeps values that we do not
 /// own (trace ids, third-party validator wording) out of the assertion while still proving the
 /// member is present and is a string. String values are also newline-normalized to LF so
-/// multi-line members (a `detail` joined with <see cref="Environment.NewLine"/>) compare equal
+/// multi-line members (a `detail` joined with <c>\\n</c>) compare equal
 /// across operating systems.
 ///
 /// Because the comparison is an exact match, an unexpected member (e.g. a resurrected

--- a/tests/Endatix.IntegrationTests/Infrastructure/ProblemDetailsJson.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/ProblemDetailsJson.cs
@@ -1,0 +1,125 @@
+using System.Text;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+
+namespace Endatix.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Renders a problem+json response as canonical JSON so a test can assert the whole error
+/// envelope against a literal, rather than probing one member at a time.
+///
+/// Canonical form: keys sorted ordinally, two-space indentation, and every member listed in
+/// <c>volatileMembers</c> reduced to <see cref="AnyString"/>. Sorting and indentation make the
+/// comparison order- and whitespace-insensitive; the placeholder keeps values that we do not
+/// own (trace ids, third-party validator wording) out of the assertion while still proving the
+/// member is present and is a string. String values are also newline-normalized to LF so
+/// multi-line members (a `detail` joined with <see cref="Environment.NewLine"/>) compare equal
+/// across operating systems.
+///
+/// Because the comparison is an exact match, an unexpected member (e.g. a resurrected
+/// FastEndpoints <c>statusCode</c> / <c>message</c> / <c>errors</c>) fails the test on its own -
+/// no separate absence assertions needed.
+/// </summary>
+internal static class ProblemDetailsJson
+{
+    /// <summary>Placeholder substituted for every string value under a volatile member.</summary>
+    public const string AnyString = "<string>";
+
+    public const string ProblemJsonMediaType = "application/problem+json";
+
+    /// <summary>
+    /// Asserts the response is problem+json and returns its canonical rendering.
+    /// </summary>
+    public static async Task<string> ReadShapeAsync(
+        HttpResponseMessage response,
+        CancellationToken cancellationToken,
+        params string[] volatileMembers)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+
+        string? mediaType = response.Content.Headers.ContentType?.MediaType;
+        Assert.True(
+            mediaType == ProblemJsonMediaType,
+            $"Expected '{ProblemJsonMediaType}' content type, got '{mediaType}'.");
+
+        string body = await response.Content.ReadAsStringAsync(cancellationToken);
+        Assert.False(string.IsNullOrWhiteSpace(body), "Problem details body was empty.");
+
+        return Shape(body, volatileMembers);
+    }
+
+    /// <summary>
+    /// Canonicalizes a JSON literal the same way <see cref="ReadShapeAsync"/> does, so the
+    /// expected block in a test can be written in readable form.
+    /// </summary>
+    public static string Shape(string json, params string[] volatileMembers)
+    {
+        var volatileSet = new HashSet<string>(volatileMembers ?? [], StringComparer.Ordinal);
+
+        using var document = JsonDocument.Parse(json);
+        var buffer = new MemoryStream();
+        // Relaxed escaping keeps the rendering readable: the default encoder escapes `<` and `>`,
+        // turning the placeholder into \u003Cstring\u003E and the `type` URIs into noise. This is
+        // test-only rendering, never a response body, so the XSS-hardened encoder buys nothing.
+        var writerOptions = new JsonWriterOptions
+        {
+            Indented = true,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+        };
+
+        using (var writer = new Utf8JsonWriter(buffer, writerOptions))
+        {
+            WriteCanonical(document.RootElement, writer, volatileSet, redactStrings: false);
+        }
+
+        return Encoding.UTF8.GetString(buffer.ToArray());
+    }
+
+    private static void WriteCanonical(
+        JsonElement element,
+        Utf8JsonWriter writer,
+        HashSet<string> volatileMembers,
+        bool redactStrings)
+    {
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                writer.WriteStartObject();
+                foreach (JsonProperty property in element.EnumerateObject()
+                             .OrderBy(property => property.Name, StringComparer.Ordinal))
+                {
+                    writer.WritePropertyName(property.Name);
+                    WriteCanonical(
+                        property.Value,
+                        writer,
+                        volatileMembers,
+                        // Redaction is inherited: marking `fields` volatile keeps its keys
+                        // (the property names that failed) but blanks the messages underneath.
+                        redactStrings || volatileMembers.Contains(property.Name));
+                }
+                writer.WriteEndObject();
+                break;
+
+            case JsonValueKind.Array:
+                writer.WriteStartArray();
+                foreach (JsonElement item in element.EnumerateArray())
+                {
+                    WriteCanonical(item, writer, volatileMembers, redactStrings);
+                }
+                writer.WriteEndArray();
+                break;
+
+            case JsonValueKind.String:
+                // CRLF -> LF so a `detail` built with Environment.NewLine compares equal on
+                // every OS. Without this, asserting a multi-error detail would pass on Linux
+                // and fail on Windows.
+                writer.WriteStringValue(
+                    redactStrings ? AnyString : element.GetString()?.Replace("\r\n", "\n", StringComparison.Ordinal));
+                break;
+
+            default:
+                element.WriteTo(writer);
+                break;
+        }
+    }
+}

--- a/tests/Endatix.IntegrationTests/Infrastructure/ProblemDetailsJsonTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/ProblemDetailsJsonTests.cs
@@ -1,0 +1,80 @@
+using Endatix.IntegrationTests.Infrastructure;
+
+namespace Endatix.IntegrationTests;
+
+/// <summary>
+/// Unit tests for the shape helper. No host or database - the flow tests that depend on it
+/// cannot run without infrastructure, so its behaviour is pinned here.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class ProblemDetailsJsonTests
+{
+    [Fact]
+    public void Shape_IsInsensitiveToMemberOrderAndWhitespace()
+    {
+        string a = ProblemDetailsJson.Shape("""{"status":404,"title":"Resource not found"}""");
+        string b = ProblemDetailsJson.Shape("""
+            {
+              "title": "Resource not found",
+              "status": 404
+            }
+            """);
+
+        Assert.Equal(a, b);
+    }
+
+    [Fact]
+    public void Shape_RedactsVolatileScalarButKeepsTheMember()
+    {
+        string actual = ProblemDetailsJson.Shape(
+            """{"detail":"Form not found.","traceId":"00-abc-def-01"}""",
+            "traceId");
+
+        Assert.Contains("\"traceId\": \"<string>\"", actual);
+        Assert.Contains("\"detail\": \"Form not found.\"", actual);
+        Assert.DoesNotContain("00-abc-def-01", actual);
+    }
+
+    [Fact]
+    public void Shape_RedactsNestedMessagesButKeepsFieldKeys()
+    {
+        string actual = ProblemDetailsJson.Shape(
+            """{"fields":{"Name":["'Name' must not be empty.","too short"]}}""",
+            "fields");
+
+        Assert.Contains("\"Name\"", actual);
+        Assert.DoesNotContain("must not be empty", actual);
+        Assert.DoesNotContain("too short", actual);
+        Assert.Equal(2, actual.Split("<string>").Length - 1);
+    }
+
+    [Fact]
+    public void Shape_DiffersWhenAnUnexpectedMemberIsPresent()
+    {
+        string canonical = ProblemDetailsJson.Shape("""{"status":400,"title":"Bad"}""");
+        string withLegacyMember = ProblemDetailsJson.Shape(
+            """{"status":400,"title":"Bad","errors":{"Name":["x"]}}""");
+
+        // The exact-match assertion is what catches a resurrected FastEndpoints ErrorResponse.
+        Assert.NotEqual(canonical, withLegacyMember);
+    }
+
+    [Fact]
+    public void Shape_NormalizesWindowsNewlinesSoMultiLineDetailIsOsIndependent()
+    {
+        string crlf = ProblemDetailsJson.Shape("{\"detail\":\"first\\r\\nsecond\"}");
+        string lf = ProblemDetailsJson.Shape("{\"detail\":\"first\\nsecond\"}");
+
+        Assert.Equal(lf, crlf);
+    }
+
+    [Fact]
+    public void Shape_LeavesNonStringValuesIntact()
+    {
+        string actual = ProblemDetailsJson.Shape("""{"status":404,"flag":true,"nothing":null}""");
+
+        Assert.Contains("\"status\": 404", actual);
+        Assert.Contains("\"flag\": true", actual);
+        Assert.Contains("\"nothing\": null", actual);
+    }
+}

--- a/tests/Endatix.IntegrationTests/Infrastructure/UnhandledExceptionRouteStartupFilter.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/UnhandledExceptionRouteStartupFilter.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+
+namespace Endatix.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Test-host-only route that throws, so the unhandled-exception contract can be proven through
+/// the real middleware pipeline rather than by unit-testing the handler in isolation.
+///
+/// The middleware is appended <em>after</em> the application's own pipeline, which places it
+/// downstream of <c>UseExceptionHandler()</c>. A throw here therefore unwinds into
+/// <c>EndatixExceptionHandler</c> exactly as a genuine fault in an endpoint would.
+/// </summary>
+internal sealed class UnhandledExceptionRouteStartupFilter : IStartupFilter
+{
+    /// <summary>Unmatched by any real endpoint, so it falls through to the appended middleware.</summary>
+    public const string Path = "/api/__integration-test__/throw";
+
+    /// <summary>
+    /// Stand-in for the kind of text that must never surface: connection strings, SQL, file
+    /// paths. The test asserts this string is absent from the response body.
+    /// </summary>
+    public const string SensitiveMarker = "Server=db;Password=SENSITIVE-a7f3c1;";
+
+    public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next) => app =>
+    {
+        next(app);
+
+        app.Use(async (HttpContext context, RequestDelegate continuation) =>
+        {
+            if (string.Equals(context.Request.Path.Value, Path, StringComparison.Ordinal))
+            {
+                throw new InvalidOperationException($"Simulated unhandled fault. {SensitiveMarker}");
+            }
+
+            await continuation(context);
+        });
+    };
+}


### PR DESCRIPTION
# feat(e168)!: Unify FluentValidation and unhandled errors on ProblemDetails

## Summary
- Closes remaining endatix/endatix#168 for the API: one RFC7807 body for handler `ToProblem`, FastEndpoints FluentValidation, unhandled exceptions, and export stream errors.
- Adds `EndatixProblemDetails` factory; FE uses custom `c.Errors.ResponseBuilder` (not stock `UseProblemDetails()` — wrong `errors[]` shape).
- Replaces `/error` path with `EndatixExceptionHandler` (`IExceptionHandler`); 500 never leaks `ex.Message`.

## Breaking
Request-validation **400** is now `application/problem+json` with `fields: { prop: string[] }`.
No more `{ statusCode, message, errors }`.

<img width="773" height="258" alt="image" src="https://github.com/user-attachments/assets/92616128-2a2d-49fc-a914-6ba875317c3e" />

## Canonical body
`type`, `title`, `status`, `detail`, `instance`, `traceId`, optional `errorCode` / `fields`.

## Test plan
- [x] Unit: factory, `ToProblem` + accessor, exception handler (no leak)
- [x] Integration: `POST /api/forms` missing name → 400 problem+json + `fields`; GET missing form → 404 with `type`/`instance`/`traceId`
- [x] Swagger: 400 schema = ProblemDetails on validated routes
- [x] Pair with Hub PR https://github.com/endatix/endatix-hub/pull/913

## Links
- closes #168 
- Related: endatix/endatix#998
- Hub floor: build that drops `ValidationProblemDetailsSchema`

## Examples

### Returning 400 from the server (e.g. Result.Invalid -> ProblemHttpResponse)

```json
{
    "type": "https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request",
    "title": "Invalid or expired token.",
    "status": 400,
    "detail": "The supplied refresh token is invalid!",
    "instance": "/api/auth/refresh-token",
    "traceId": "00-a205a43f4266cda2a28d50f604008b80-3b5639c3b699583b-00"
}
```

### Validation Response

Returning from FluentValidaiton with multiple responses
```json
{
    "type": "https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request",
    "title": "There was a problem with your request",
    "status": 400,
    "detail": "'email' is not a valid email address.\nPassword must contain at least one uppercase letter\nPassword must contain at least one number",
    "instance": "/api/auth/register",
    "traceId": "00-3e8ae15ae4ce3ba348e17b096f2991f6-3b194d24e8d42867-00",
    "errorCode": "EmailValidator",
    "fields": {
        "email": [
            "'email' is not a valid email address."
        ],
        "password": [
            "Password must contain at least one uppercase letter",
            "Password must contain at least one number"
        ]
    }
}
```

FluentValidation failure - one field
```json
{
    "type": "https://www.rfc-editor.org/rfc/rfc9110#name-400-bad-request",
    "title": "There was a problem with your request",
    "status": 400,
    "detail": "A data list with the name 'Cities' already exists.",
    "instance": "/api/data-lists",
    "traceId": "00-bb29a4fd61d29100d81c5fcb277e9c50-6b39628de1cb727e-00",
    "errorCode": "data_list_name_already_exists",
    "fields": {
        "Name": [
            "A data list with the name 'Cities' already exists."
        ]
    }
}
```

### Unhandled Exception

e.g. throw ArgumentException without catch

```json
{
    "type": "https://www.rfc-editor.org/rfc/rfc9110#name-500-internal-server-error",
    "title": "An unexpected error occurred",
    "status": 500,
    "detail": "An unexpected error occurred",
    "instance": "/api/auth/login",
    "traceId": "00-b74a00b5b080cf05810a8505c7aecf63-6974494aea89db86-00"
}
```


## Type of Change
Check all that apply.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized API errors using RFC 7807 `application/problem+json` responses.
  * Validation errors now include consistent details, field-level messages, trace IDs, and error codes.
  * Unhandled server errors return generic responses without exposing sensitive exception or provider details.
* **Bug Fixes**
  * Email delivery failures now return a retryable 503 Service Unavailable response.
  * Export errors now use the standardized problem response format.
* **Documentation**
  * Updated API error contract and OpenAPI documentation, including 503 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->