### PR TITLE
fix(e1002): stop leaking exception text through Result error details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,11 +69,47 @@ Canonical JSON for **all** API errors (handler `ToProblem`, FluentValidation, un
 - `ToProblem` maps Invalid → 400, NotFound → 404, Conflict → 409, Unauthorized → 401, Forbidden → 403, Error/CriticalError → 500, Unavailable → 503.
 - **`detail` is always a non-empty string**, falling back to the title when the result carries no errors. Consumers treat it as required (Hub's `ProblemDetailsSchema` types it non-optional) — never emit `"detail": ""`.
 - FastEndpoints FluentValidation uses `c.Errors.ResponseBuilder` → `EndatixProblemDetails` (`fields` dictionary). Do **not** use stock `UseProblemDetails()` (wrong `errors` array shape).
-- Unhandled exceptions → `EndatixExceptionHandler` (`IExceptionHandler`); 500 body never includes exception text.
+- Unhandled exceptions → `EndatixExceptionHandler` (`IExceptionHandler`); 500 body never includes exception text. It is a safety net, not a status mapper — see below.
 - **No 5xx body ever echoes handler- or exception-derived text.** `EndatixProblemDetails.Create` replaces any `>= 500` detail with the generic title and logs the original (correlate via `traceId`). Handlers that wrap `ex.Message` into `Result.Error(...)` are safe by construction — do not add a bypass. If a 5xx message must reach the user, model the failure as a 4xx/503 instead.
 - Writing a problem body by hand? Pass `contentType: "application/problem+json"` to `WriteAsJsonAsync`; it otherwise overwrites `Response.ContentType` with `application/json`.
 - `SetErrorMessage(...)` overrides the problem **title for every status**, so set it only on the branch it describes (see `Auth/VerifyEmail.cs`) — otherwise a 404 inherits a 400-shaped message.
 - OpenAPI: `Description(b => b.Produces<T>(...).ProducesProblem(400).ProducesProblem(404))` listing exactly the statuses the endpoint's `Summary(s => s.Responses[...])` declares — every endpoint returning `ProblemHttpResult` must have one. FE validators set `ProducesMetadataType = typeof(ProblemDetails)`.
+
+### Exception text never reaches the caller (`IEndUserSafeError` / `SafeError`)
+
+`Result` error messages become RFC7807 `detail`, and 4xx `detail` is echoed verbatim. `ex.Message` — EF Core, Npgsql, `JsonException`, any BCL guard — carries connection strings, SQL and file paths, so it must never reach a `Result.*` factory or a `ValidationError`. `ResultFactoryMustNotInterpolateExceptionMessageTests` fails the build on it.
+
+Failure travels one way, and only `ToProblem` maps status:
+
+| Layer | Signals failure by | Becomes |
+|---|---|---|
+| Entity / value object | `throw Domain*Exception` (a void invariant has no other channel) | caught by its handler |
+| Handler / use case | `return Result.Invalid / NotFound / Conflict / Error` | `ToProblem` → status + `fields` |
+| Anything uncaught | — | opaque 500, logged (`EndatixExceptionHandler`) |
+
+The handler is the conversion point, and `SafeError` is how it recovers an author-written message there:
+
+```csharp
+// Domain (Endatix.Core/Exceptions): DomainValidationException : ArgumentException,
+// DomainRuleException : InvalidOperationException — both IEndUserSafeError, so existing catches still work.
+throw new DomainRuleException($"A data list cannot have more than {MaxAvailableCultures} cultures.");
+
+// Handler: no ex.Message, no re-derived reason, no severity decision.
+catch (ArgumentException ex)
+{
+    return Result.Invalid(new ValidationError
+    {
+        Identifier = nameof(Query.Locale),
+        ErrorMessage = SafeError.LogAndResolve(logger, ex, "Invalid locale.", $"searching data list {id}")
+    });
+}
+```
+
+- `SafeError.MessageOr` / `LogAndResolve` are the **only** places `EndUserMessage` may be read. `LogAndResolve` also picks the severity: `Information` for an opted-in rejection, `Error` **with the exception** otherwise.
+- **Never re-derive the reason in the handler** by re-inspecting input or sniffing `ex.Message` — that duplicates the domain's conditions and the copies drift. `ParamName` is for attribution (which field), never for the message.
+- **Never opt in a type that wraps a provider exception**, and never return `InnerException.Message`. `DomainValidationException` holds `EndUserMessage` separately because `ArgumentException` appends `" (Parameter 'x')"`.
+- **Prefer a real message over a mask.** "…cannot have more than 25 cultures." is actionable; "Could not add locale." is not. No safe message to author? Log and return a static string (`DefaultAuthorizationMapper`, `ReCaptchaHttpClient`, `ThemeJsonData`).
+- **The boundary is not a status mapper.** A `Domain*Exception` reaching `EndatixExceptionHandler` is a missing `catch`, and gets an opaque 500 so the defect surfaces. Prefer a Result-returning domain API where input is caller-supplied and validated in a loop (`DataListEnsureLocales.TryEnsure`) — it keeps throws off hot paths entirely.
 
 ### Uniform failure responses (OWASP A07)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ Canonical JSON for **all** API errors (handler `ToProblem`, FluentValidation, un
 - **`detail` is always a non-empty string**, falling back to the title when the result carries no errors. Consumers treat it as required (Hub's `ProblemDetailsSchema` types it non-optional) — never emit `"detail": ""`.
 - FastEndpoints FluentValidation uses `c.Errors.ResponseBuilder` → `EndatixProblemDetails` (`fields` dictionary). Do **not** use stock `UseProblemDetails()` (wrong `errors` array shape).
 - Unhandled exceptions → `EndatixExceptionHandler` (`IExceptionHandler`); 500 body never includes exception text. It is a safety net, not a status mapper — see below.
-- **No 5xx body ever echoes handler- or exception-derived text.** `EndatixProblemDetails.Create` replaces any `>= 500` detail with the generic title and logs the original (correlate via `traceId`). Handlers that wrap `ex.Message` into `Result.Error(...)` are safe by construction — do not add a bypass. If a 5xx message must reach the user, model the failure as a 4xx/503 instead.
+- **No 5xx body ever echoes handler- or exception-derived text.** `EndatixProblemDetails.Create` replaces any `>= 500` detail with the generic title and logs the original (correlate via `traceId`). Never pass `ex.Message` to a `Result.*` factory — including `Result.Error`: the 5xx scrub is defense in depth, not a license (see below). Log the exception, return author-written text. If a 5xx message must reach the user, model the failure as a 4xx/503 instead.
 - Writing a problem body by hand? Pass `contentType: "application/problem+json"` to `WriteAsJsonAsync`; it otherwise overwrites `Response.ContentType` with `application/json`.
 - `SetErrorMessage(...)` overrides the problem **title for every status**, so set it only on the branch it describes (see `Auth/VerifyEmail.cs`) — otherwise a 404 inherits a 400-shaped message.
 - OpenAPI: `Description(b => b.Produces<T>(...).ProducesProblem(400).ProducesProblem(404))` listing exactly the statuses the endpoint's `Summary(s => s.Responses[...])` declares — every endpoint returning `ProblemHttpResult` must have one. FE validators set `ProducesMetadataType = typeof(ProblemDetails)`.
@@ -81,11 +81,11 @@ Canonical JSON for **all** API errors (handler `ToProblem`, FluentValidation, un
 
 Failure travels one way, and only `ToProblem` maps status:
 
-| Layer | Signals failure by | Becomes |
-|---|---|---|
-| Entity / value object | `throw Domain*Exception` (a void invariant has no other channel) | caught by its handler |
-| Handler / use case | `return Result.Invalid / NotFound / Conflict / Error` | `ToProblem` → status + `fields` |
-| Anything uncaught | — | opaque 500, logged (`EndatixExceptionHandler`) |
+| Layer                 | Signals failure by                                               | Becomes                                        |
+| --------------------- | ---------------------------------------------------------------- | ---------------------------------------------- |
+| Entity / value object | `throw Domain*Exception` (a void invariant has no other channel) | caught by its handler                          |
+| Handler / use case    | `return Result.Invalid / NotFound / Conflict / Error`            | `ToProblem` → status + `fields`                |
+| Anything uncaught     | —                                                                | opaque 500, logged (`EndatixExceptionHandler`) |
 
 The handler is the conversion point, and `SafeError` is how it recovers an author-written message there:
 

--- a/src/Endatix.Api/Endpoints/Submissions/Export.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/Export.cs
@@ -107,7 +107,7 @@ public partial class Export : Endpoint<ExportRequest>
             {
                 _logger.LogWarning(ex, "Unsupported export format requested: {Format} for type {ItemType}",
                     validatedExportOperation.Format, validatedExportOperation.ItemType.Name);
-                await SetErrorResponse(ex.Message, StatusCodes.Status400BadRequest);
+                await SetErrorResponse("Unsupported export format.", StatusCodes.Status400BadRequest);
                 return;
             }
 

--- a/src/Endatix.Api/Endpoints/Submissions/GetSubmissionFiles.cs
+++ b/src/Endatix.Api/Endpoints/Submissions/GetSubmissionFiles.cs
@@ -5,13 +5,14 @@ using Endatix.Infrastructure.Utils;
 using Endatix.Core.UseCases.Submissions.GetFiles;
 using FluentValidation.Results;
 using Endatix.Core.Abstractions.Authorization;
+using Microsoft.Extensions.Logging;
 
 namespace Endatix.Api.Endpoints.Submissions;
 
 /// <summary>
 /// Endpoint for downloading files for a submission.
 /// </summary>
-public class GetSubmissionFiles(IMediator mediator) : Endpoint<GetSubmissionFilesRequest>
+public class GetSubmissionFiles(IMediator mediator, ILogger<GetSubmissionFiles> logger) : Endpoint<GetSubmissionFilesRequest>
 {
     /// <inheritdoc/>
     public override void Configure()
@@ -79,7 +80,8 @@ public class GetSubmissionFiles(IMediator mediator) : Endpoint<GetSubmissionFile
         }
         catch (Exception ex)
         {
-            ValidationFailures.Add(new ValidationFailure("error", ex.Message));
+            logger.LogError(ex, "Failed to download submission files");
+            ValidationFailures.Add(new ValidationFailure("error", "Failed to download submission files."));
             await Send.ErrorsAsync(500, cancellationToken);
         }
     }

--- a/src/Endatix.Api/Infrastructure/EndatixExceptionHandler.cs
+++ b/src/Endatix.Api/Infrastructure/EndatixExceptionHandler.cs
@@ -5,8 +5,14 @@ using Microsoft.Extensions.Logging;
 namespace Endatix.Api.Infrastructure;
 
 /// <summary>
-/// Writes the canonical ProblemDetails envelope for unhandled exceptions without leaking exception text.
+/// Last-resort safety net: logs an unhandled exception and writes an opaque 500.
 /// </summary>
+/// <remarks>
+/// Deliberately not a status mapper. Expected failures are modelled as <c>Result</c> and get their
+/// status from <c>ToProblem</c>; anything reaching here - including a domain exception that opted into
+/// <c>IEndUserSafeError</c> - is a handler that failed to convert, which is a defect. Answering it with
+/// a tidy 4xx would hide the defect and make throwing more ergonomic than returning a Result.
+/// </remarks>
 public sealed class EndatixExceptionHandler(ILogger<EndatixExceptionHandler> logger) : IExceptionHandler
 {
     public async ValueTask<bool> TryHandleAsync(
@@ -30,7 +36,7 @@ public sealed class EndatixExceptionHandler(ILogger<EndatixExceptionHandler> log
             options: null,
             contentType: "application/problem+json",
             cancellationToken);
-            
+
         return true;
     }
 }

--- a/src/Endatix.Core/Abstractions/Data/IUnitOfWork.cs
+++ b/src/Endatix.Core/Abstractions/Data/IUnitOfWork.cs
@@ -24,6 +24,13 @@ namespace Endatix.Core.Abstractions.Data
         /// <summary>
         /// Asynchronously rolls back the transaction.
         /// </summary>
+        /// <remarks>
+        /// Implementations must not throw and must not observe <paramref name="cancellationToken"/>.
+        /// Callers roll back from a <c>catch</c> block, where a second exception would replace the one
+        /// being handled, and a cancelled token would skip the cleanup altogether. Rolling back with no
+        /// active transaction is a no-op, so a failed <c>BeginTransactionAsync</c> still surfaces its
+        /// own cause. Failures are logged by the implementation.
+        /// </remarks>
         Task RollbackTransactionAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/src/Endatix.Core/Common/Translations/CultureCode.cs
+++ b/src/Endatix.Core/Common/Translations/CultureCode.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Ardalis.GuardClauses;
+using Endatix.Core.Exceptions;
 
 namespace Endatix.Core.Common.Translations;
 
@@ -40,7 +41,7 @@ public readonly partial record struct CultureCode
         Guard.Against.NullOrWhiteSpace(cultureCode);
         if (!TryParse(cultureCode, out var code))
         {
-            throw new ArgumentException($"'{cultureCode}' is not a valid culture code.", nameof(cultureCode));
+            throw new DomainValidationException($"'{cultureCode}' is not a valid culture code.", nameof(cultureCode));
         }
 
         return code;

--- a/src/Endatix.Core/Entities/DataList.cs
+++ b/src/Endatix.Core/Entities/DataList.cs
@@ -1,5 +1,6 @@
 using Ardalis.GuardClauses;
 using Endatix.Core.Common.Translations;
+using Endatix.Core.Exceptions;
 using Endatix.Core.Infrastructure.Domain;
 
 namespace Endatix.Core.Entities;
@@ -42,7 +43,7 @@ public class DataList : TenantEntity, IAggregateRoot, IHasTranslations
             defaultLocale ?? SurveyJsTranslationKeys.FallbackDefaultCulture);
         if (defaultCulture.IsSyntheticDefault)
         {
-            throw new ArgumentException(
+            throw new DomainValidationException(
                 "DefaultLocale must be a real culture code (e.g. 'en'), not the synthetic 'default' key.",
                 nameof(defaultLocale));
         }
@@ -110,12 +111,12 @@ public class DataList : TenantEntity, IAggregateRoot, IHasTranslations
     }
 
     /// <inheritdoc />
-    /// <exception cref="ArgumentException">Thrown when the culture code is the synthetic 'default' key.</exception>
+    /// <exception cref="DomainValidationException">Thrown when the culture code is the synthetic 'default' key. Its message is caller-safe.</exception>
     public void SetDefaultCulture(CultureCode cultureCode)
     {
         if (cultureCode.IsSyntheticDefault)
         {
-            throw new ArgumentException(
+            throw new DomainValidationException(
                 "DefaultCulture must be a real culture code (e.g. 'en'), not the synthetic 'default' key.",
                 nameof(cultureCode));
         }
@@ -124,13 +125,13 @@ public class DataList : TenantEntity, IAggregateRoot, IHasTranslations
     }
 
     /// <inheritdoc />
-    /// <exception cref="ArgumentException">Thrown when the culture code is the synthetic 'default' key.</exception>
-    /// <exception cref="InvalidOperationException">Thrown when the data list has more than the maximum allowed cultures.</exception>
+    /// <exception cref="DomainValidationException">Thrown when the culture code is the synthetic 'default' key. Its message is caller-safe.</exception>
+    /// <exception cref="DomainRuleException">Thrown when the data list already holds <see cref="MaxAvailableCultures"/> cultures. Its message is caller-safe.</exception>
     public void AddCulture(CultureCode cultureCode)
     {
         if (cultureCode.IsSyntheticDefault)
         {
-            throw new ArgumentException("The synthetic 'default' key cannot be added as a culture.", nameof(cultureCode));
+            throw new DomainValidationException("The synthetic 'default' key cannot be added as a culture.", nameof(cultureCode));
         }
 
         if (_availableLocales.Contains(cultureCode.Value, StringComparer.OrdinalIgnoreCase))
@@ -140,7 +141,7 @@ public class DataList : TenantEntity, IAggregateRoot, IHasTranslations
 
         if (_availableLocales.Count >= MaxAvailableCultures)
         {
-            throw new InvalidOperationException($"A data list cannot have more than {MaxAvailableCultures} cultures.");
+            throw new DomainRuleException($"A data list cannot have more than {MaxAvailableCultures} cultures.");
         }
 
         _availableLocales.Add(cultureCode.Value);
@@ -151,7 +152,7 @@ public class DataList : TenantEntity, IAggregateRoot, IHasTranslations
     {
         if (cultureCode.IsSyntheticDefault)
         {
-            throw new ArgumentException("The synthetic 'default' key cannot be removed.", nameof(cultureCode));
+            throw new DomainValidationException("The synthetic 'default' key cannot be removed.", nameof(cultureCode));
         }
 
         var removed = _availableLocales.RemoveAll(x =>
@@ -342,7 +343,7 @@ public class DataList : TenantEntity, IAggregateRoot, IHasTranslations
 
             if (!CultureCode.TryParse(key, out CultureCode culture) || !AllowsTranslationKey(culture))
             {
-                throw new ArgumentException(
+                throw new DomainValidationException(
                     $"Culture '{key}' is not in the data list culture catalog. Add the culture before assigning labels.",
                     key);
             }

--- a/src/Endatix.Core/Entities/DataListItem.cs
+++ b/src/Endatix.Core/Entities/DataListItem.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 using System.Text.Json;
 using Ardalis.GuardClauses;
 using Endatix.Core.Common.Translations;
+using Endatix.Core.Exceptions;
 
 namespace Endatix.Core.Entities;
 
@@ -162,7 +163,7 @@ public class DataListItem : BaseEntity
     {
         if (!labels.TryGetValue(DefaultLabelKey, out var defaultLabel) || string.IsNullOrWhiteSpace(defaultLabel))
         {
-            throw new ArgumentException("Labels must include a non-empty 'default' entry.", nameof(labels));
+            throw new DomainValidationException("Labels must include a non-empty 'default' entry.", nameof(labels));
         }
 
         Dictionary<string, string> normalized = new(StringComparer.Ordinal);
@@ -175,7 +176,7 @@ public class DataListItem : BaseEntity
 
             if (!CultureCode.TryParse(key, out var code))
             {
-                throw new ArgumentException($"'{key}' is not a valid culture code.", key);
+                throw new DomainValidationException($"'{key}' is not a valid culture code.", key);
             }
 
             normalized[code.Value] = EnforceLabelLength(value.Trim(), code.Value);
@@ -193,7 +194,7 @@ public class DataListItem : BaseEntity
     {
         if (trimmedLabel.Length > MAX_LABEL_LENGTH)
         {
-            throw new ArgumentException(
+            throw new DomainValidationException(
                 $"Each label value cannot exceed {MAX_LABEL_LENGTH} characters.",
                 labelKey);
         }

--- a/src/Endatix.Core/Exceptions/DomainRuleException.cs
+++ b/src/Endatix.Core/Exceptions/DomainRuleException.cs
@@ -1,0 +1,23 @@
+namespace Endatix.Core.Exceptions;
+
+/// <summary>
+/// A domain invariant the caller violated, carrying a message that is safe to return to them.
+/// </summary>
+/// <remarks>
+/// Derives from <see cref="InvalidOperationException"/> so that existing
+/// <c>catch (InvalidOperationException)</c> sites and tests keep working unchanged; the added
+/// <see cref="IEndUserSafeError"/> is what lets a handler surface the rule instead of masking it.
+/// </remarks>
+public class DomainRuleException : InvalidOperationException, IEndUserSafeError
+{
+    /// <param name="message">Author-written text describing the violated rule. Safe to show the caller.</param>
+    /// <param name="innerException">Optional cause. Its message is never surfaced.</param>
+    public DomainRuleException(string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+        EndUserMessage = message;
+    }
+
+    /// <inheritdoc />
+    public string EndUserMessage { get; }
+}

--- a/src/Endatix.Core/Exceptions/DomainValidationException.cs
+++ b/src/Endatix.Core/Exceptions/DomainValidationException.cs
@@ -1,0 +1,29 @@
+namespace Endatix.Core.Exceptions;
+
+/// <summary>
+/// An invalid argument the caller supplied, carrying a message that is safe to return to them.
+/// </summary>
+/// <remarks>
+/// Derives from <see cref="ArgumentException"/> so that existing <c>catch (ArgumentException)</c> sites
+/// and tests keep working unchanged; the added <see cref="IEndUserSafeError"/> is what lets a handler
+/// surface the reason instead of masking it.
+/// </remarks>
+public class DomainValidationException : ArgumentException, IEndUserSafeError
+{
+    /// <param name="message">Author-written text describing the rejection. Safe to show the caller.</param>
+    /// <param name="paramName">Internal parameter name. Used for field attribution, never emitted.</param>
+    /// <param name="innerException">Optional cause. Its message is never surfaced.</param>
+    public DomainValidationException(string message, string? paramName = null, Exception? innerException = null)
+        : base(message, paramName, innerException)
+    {
+        EndUserMessage = message;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Held separately from <see cref="Exception.Message"/> because
+    /// <see cref="ArgumentException"/> appends " (Parameter '...')" to it - an internal parameter name
+    /// that must not reach the caller.
+    /// </remarks>
+    public string EndUserMessage { get; }
+}

--- a/src/Endatix.Core/Exceptions/IEndUserSafeError.cs
+++ b/src/Endatix.Core/Exceptions/IEndUserSafeError.cs
@@ -1,0 +1,24 @@
+namespace Endatix.Core.Exceptions;
+
+/// <summary>
+/// Opt-in marker declaring that an exception's message was authored for the API caller and is safe to
+/// return verbatim.
+/// </summary>
+/// <remarks>
+/// Exception text never reaches an HTTP response by default: <see cref="Exception.Message"/> on a BCL or
+/// provider exception routinely carries connection strings, SQL and file paths, and a source-guard test
+/// fails the build on any <c>ex.Message</c> flowing into a <c>Result</c> factory. This interface is the
+/// one sanctioned exception, and it is explicit so intent is distinguishable from accident.
+/// <para>
+/// Implementing it claims <see cref="EndUserMessage"/> is a constant, or a format over values the caller
+/// supplied, with no server-side detail. Never implement it on a type wrapping a provider exception, and
+/// never return an inner exception's message. Read it only through <see cref="SafeError"/>.
+/// </para>
+/// </remarks>
+public interface IEndUserSafeError
+{
+    /// <summary>
+    /// Author-written text that is safe to return to the API caller verbatim.
+    /// </summary>
+    string EndUserMessage { get; }
+}

--- a/src/Endatix.Core/Exceptions/SafeError.cs
+++ b/src/Endatix.Core/Exceptions/SafeError.cs
@@ -1,0 +1,60 @@
+using Microsoft.Extensions.Logging;
+
+namespace Endatix.Core.Exceptions;
+
+/// <summary>
+/// The single sanctioned gate between a caught exception and client-visible error text.
+/// </summary>
+/// <remarks>
+/// A call here is self-documenting: it says the emitted detail is intentional, and it can only ever emit
+/// a message a type opted into via <see cref="IEndUserSafeError"/>. Anything else - a BCL argument guard,
+/// an EF Core translation failure, an Npgsql error - falls through to the caller's fallback, so widening
+/// a <c>catch</c> cannot introduce a leak.
+/// </remarks>
+public static class SafeError
+{
+    /// <summary>
+    /// Returns <paramref name="exception"/>'s author-written message when its type opted in via
+    /// <see cref="IEndUserSafeError"/>; otherwise <paramref name="fallback"/>.
+    /// </summary>
+    /// <param name="exception">The caught exception. May be <see langword="null"/>.</param>
+    /// <param name="fallback">Author-written text to use when the exception did not opt in.</param>
+    public static string MessageOr(Exception? exception, string fallback) =>
+        exception is IEndUserSafeError safeError && !string.IsNullOrWhiteSpace(safeError.EndUserMessage)
+            ? safeError.EndUserMessage
+            : fallback;
+
+    /// <summary>
+    /// <see cref="MessageOr"/> plus the severity the opt-in implies: an
+    /// <see cref="IEndUserSafeError"/> is the domain working as designed, so it is logged as
+    /// <c>Information</c> and its message returned; anything else is a defect and is logged as
+    /// <c>Error</c> with the full exception, the caller seeing only <paramref name="fallback"/>.
+    /// </summary>
+    /// <param name="logger">Logger of the calling handler.</param>
+    /// <param name="exception">The caught exception.</param>
+    /// <param name="fallback">Author-written text for the non-opted-in case.</param>
+    /// <param name="operation">
+    /// What was being attempted, with the identifiers worth correlating on
+    /// (e.g. <c>$"adding locale '{culture}' to data list {id}"</c>).
+    /// </param>
+    public static string LogAndResolve(
+        ILogger logger,
+        Exception? exception,
+        string fallback,
+        string operation)
+    {
+        ArgumentNullException.ThrowIfNull(logger);
+
+        var message = MessageOr(exception, fallback);
+        if (exception is IEndUserSafeError)
+        {
+            logger.LogInformation("Rejected {Operation}: {Reason}", operation, message);
+        }
+        else
+        {
+            logger.LogError(exception, "Unexpected failure while {Operation}", operation);
+        }
+
+        return message;
+    }
+}

--- a/src/Endatix.Core/Models/Themes/ThemeJsonData.cs
+++ b/src/Endatix.Core/Models/Themes/ThemeJsonData.cs
@@ -38,9 +38,9 @@ public sealed class ThemeJsonData
 
             return Result.Success(new ThemeJsonData(json, themeData));
         }
-        catch (JsonException ex)
+        catch (JsonException)
         {
-            return Result.Invalid(new ValidationError($"Invalid JSON: {ex.Message}"));
+            return Result.Invalid(new ValidationError("Theme JSON is invalid."));
         }
     }
 

--- a/src/Endatix.Core/Models/Themes/ThemeJsonData.cs
+++ b/src/Endatix.Core/Models/Themes/ThemeJsonData.cs
@@ -40,6 +40,8 @@ public sealed class ThemeJsonData
         }
         catch (JsonException)
         {
+            // System.Text.Json messages name .NET types and property paths; the caller only needs to
+            // know their payload did not parse.
             return Result.Invalid(new ValidationError("Theme JSON is invalid."));
         }
     }

--- a/src/Endatix.Core/UseCases/DataLists/DataListEnsureLocales.cs
+++ b/src/Endatix.Core/UseCases/DataLists/DataListEnsureLocales.cs
@@ -1,6 +1,8 @@
 using Endatix.Core.Common.Translations;
 using Endatix.Core.Entities;
+using Endatix.Core.Exceptions;
 using Endatix.Core.Infrastructure.Result;
+using Microsoft.Extensions.Logging;
 
 namespace Endatix.Core.UseCases.DataLists;
 
@@ -13,10 +15,14 @@ public static class DataListEnsureLocales
     /// Ensures each requested locale is present in <paramref name="dataList"/>'s AvailableLocales.
     /// Already-present locales are no-ops. Invalid codes and catalog capacity errors are returned as validation failures.
     /// </summary>
+    /// <param name="dataList">The catalog to extend.</param>
+    /// <param name="ensureLocales">Locale tokens the import references.</param>
+    /// <param name="logger">Logger for the calling handler. Every rejection is logged before it is returned.</param>
     /// <returns><c>null</c> on success; otherwise validation errors.</returns>
     public static IReadOnlyList<ValidationError>? TryEnsure(
         DataList dataList,
-        IEnumerable<string>? ensureLocales)
+        IEnumerable<string>? ensureLocales,
+        ILogger logger)
     {
         List<ValidationError> errors = [];
 
@@ -48,14 +54,33 @@ public static class DataListEnsureLocales
             }
             catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
             {
-                errors.Add(new ValidationError
-                {
-                    Identifier = $"EnsureLocales.{culture.Value}",
-                    ErrorMessage = "Could not add locale."
-                });
+                errors.Add(ToEnsureLocaleError(dataList.Id, culture, ex, logger));
             }
         }
 
         return errors.Count == 0 ? null : errors;
     }
+
+    /// <summary>
+    /// Turns a rejected <see cref="DataList.AddCulture"/> into a validation error.
+    /// </summary>
+    /// <remarks>
+    /// A domain rule that opted into <see cref="IEndUserSafeError"/> - the culture cap, for one - reaches
+    /// the caller intact rather than being masked into an undiagnosable "Could not add locale.", while
+    /// anything unexpected falls back to author-written text and is logged with the exception.
+    /// </remarks>
+    private static ValidationError ToEnsureLocaleError(
+        long dataListId,
+        CultureCode culture,
+        Exception ex,
+        ILogger logger) =>
+        new()
+        {
+            Identifier = $"EnsureLocales.{culture.Value}",
+            ErrorMessage = SafeError.LogAndResolve(
+                logger,
+                ex,
+                "Could not add locale.",
+                $"adding locale '{culture.Value}' to data list {dataListId}")
+        };
 }

--- a/src/Endatix.Core/UseCases/DataLists/DataListEnsureLocales.cs
+++ b/src/Endatix.Core/UseCases/DataLists/DataListEnsureLocales.cs
@@ -51,7 +51,7 @@ public static class DataListEnsureLocales
                 errors.Add(new ValidationError
                 {
                     Identifier = $"EnsureLocales.{culture.Value}",
-                    ErrorMessage = ex.Message
+                    ErrorMessage = "Could not add locale."
                 });
             }
         }

--- a/src/Endatix.Core/UseCases/DataLists/Locales/AddDataListLocaleHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Locales/AddDataListLocaleHandler.cs
@@ -36,7 +36,7 @@ public sealed class AddDataListLocaleHandler(
             ValidationError error = new()
             {
                 Identifier = nameof(request.Locale),
-                ErrorMessage = ex.Message
+                ErrorMessage = "Invalid locale."
             };
             return Result.Invalid(error);
         }

--- a/src/Endatix.Core/UseCases/DataLists/Locales/RemoveDataListLocaleHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Locales/RemoveDataListLocaleHandler.cs
@@ -36,7 +36,7 @@ public sealed class RemoveDataListLocaleHandler(
             ValidationError error = new()
             {
                 Identifier = nameof(request.Locale),
-                ErrorMessage = ex.Message
+                ErrorMessage = "Invalid locale."
             };
             return Result.Invalid(error);
         }

--- a/src/Endatix.Core/UseCases/DataLists/Locales/SetDataListDefaultLocaleHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Locales/SetDataListDefaultLocaleHandler.cs
@@ -31,12 +31,12 @@ public sealed class SetDataListDefaultLocaleHandler(
         {
             dataList.SetDefaultCulture(CultureCode.Parse(request.DefaultLocale));
         }
-        catch (ArgumentException ex)
+        catch (ArgumentException)
         {
             ValidationError error = new()
             {
                 Identifier = nameof(request.DefaultLocale),
-                ErrorMessage = ex.Message
+                ErrorMessage = "Invalid locale."
             };
             return Result.Invalid(error);
         }

--- a/src/Endatix.Core/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsHandler.cs
@@ -7,6 +7,7 @@ using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;
 using MediatR;
+using Microsoft.Extensions.Logging;
 
 namespace Endatix.Core.UseCases.DataLists.ReplaceItems;
 
@@ -16,7 +17,8 @@ namespace Endatix.Core.UseCases.DataLists.ReplaceItems;
 public sealed class ReplaceDataListItemsHandler(
     IRepository<DataList> repository,
     IMediator mediator,
-    IIdGenerator<long> idGenerator)
+    IIdGenerator<long> idGenerator,
+    ILogger<ReplaceDataListItemsHandler> logger)
     : ICommandHandler<ReplaceDataListItemsCommand, Result<DataListDto>>
 {
     /// <inheritdoc />
@@ -53,7 +55,8 @@ public sealed class ReplaceDataListItemsHandler(
         }
         catch (InvalidOperationException ex)
         {
-            return Result.Error($"Failed to persist data list items: {ex.Message}");
+            logger.LogError(ex, "Failed to persist data list items for data list {DataListId}", dataList.Id);
+            return Result.Error("Failed to persist data list items.");
         }
 
         await mediator.Publish(
@@ -159,7 +162,7 @@ public sealed class ReplaceDataListItemsHandler(
         return new()
         {
             Identifier = identifier,
-            ErrorMessage = ex.Message
+            ErrorMessage = $"Each label value cannot exceed {DataListItem.MAX_LABEL_LENGTH} characters."
         };
     }
 
@@ -183,7 +186,7 @@ public sealed class ReplaceDataListItemsHandler(
         && !string.Equals(paramName, "labels", StringComparison.Ordinal)
         && !string.Equals(paramName, "cultureCode", StringComparison.Ordinal);
 
-    private static Result<DataListDto>? TryReplaceItems(
+    private Result<DataListDto>? TryReplaceItems(
         DataList dataList,
         IReadOnlyList<(IReadOnlyDictionary<string, string> Labels, string Value)> resolvedItems,
         IIdGenerator<long> idGenerator)
@@ -195,18 +198,20 @@ public sealed class ReplaceDataListItemsHandler(
         }
         catch (ArgumentException ex)
         {
+            logger.LogWarning(ex, "Data list items were rejected for data list {DataListId}", dataList.Id);
             return Result.Invalid(new ValidationError
             {
                 Identifier = "Items",
-                ErrorMessage = ex.Message
+                ErrorMessage = "The data list items are invalid."
             });
         }
         catch (InvalidOperationException ex)
         {
+            logger.LogWarning(ex, "Data list items were rejected for data list {DataListId}", dataList.Id);
             return Result.Invalid(new ValidationError
             {
                 Identifier = "Items",
-                ErrorMessage = ex.Message
+                ErrorMessage = "The data list items are invalid."
             });
         }
     }

--- a/src/Endatix.Core/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsHandler.cs
@@ -67,7 +67,7 @@ public sealed class ReplaceDataListItemsHandler(
         return Result.Success(DataListDtoMapper.FromEntity(dataList));
     }
 
-    private static bool TryResolveItems(
+    private bool TryResolveItems(
         DataList dataList,
         IReadOnlyCollection<ReplaceDataListItemInput> items,
         out List<(IReadOnlyDictionary<string, string> Labels, string Value)> resolvedItems,
@@ -90,7 +90,7 @@ public sealed class ReplaceDataListItemsHandler(
         return errors.Count == 0;
     }
 
-    private static void CollectItemErrors(
+    private void CollectItemErrors(
         DataList dataList,
         int index,
         ReplaceDataListItemInput item,
@@ -120,7 +120,7 @@ public sealed class ReplaceDataListItemsHandler(
         }
     }
 
-    private static void CollectLabelMapErrors(
+    private void CollectLabelMapErrors(
         DataList dataList,
         int index,
         IReadOnlyDictionary<string, string> labels,
@@ -151,7 +151,7 @@ public sealed class ReplaceDataListItemsHandler(
         }
         catch (ArgumentException ex)
         {
-            errors.Add(ToLabelValidationError(index, ex));
+            errors.Add(ToLabelValidationError(dataList, index, ex));
         }
     }
 
@@ -159,19 +159,25 @@ public sealed class ReplaceDataListItemsHandler(
     /// Turns a label rejection from <see cref="DataListItem.NormalizeLabels"/> into a validation error.
     /// </summary>
     /// <remarks>
-    /// The reason is read back off the exception through <see cref="SafeError.MessageOr"/> rather than
-    /// re-derived here: <c>NormalizeLabels</c> throws <see cref="DomainValidationException"/>, so its
+    /// The reason is read back off the exception through <see cref="SafeError.LogAndResolve"/> rather
+    /// than re-derived here: <c>NormalizeLabels</c> throws <see cref="DomainValidationException"/>, so its
     /// author-written text is already the text the caller should see, and duplicating the conditions
-    /// would only give the two copies a chance to disagree.
+    /// would only give the two copies a chance to disagree. Going through <c>LogAndResolve</c> keeps the
+    /// diagnostic record for the other case - an <see cref="ArgumentException"/> that did not opt in is a
+    /// defect, and the caller only ever sees the static fallback.
     /// </remarks>
-    private static ValidationError ToLabelValidationError(int index, ArgumentException ex)
+    private ValidationError ToLabelValidationError(DataList dataList, int index, ArgumentException ex)
     {
         var labelsPrefix = $"Items[{index}].Labels";
 
         return new()
         {
             Identifier = ResolveLabelErrorIdentifier(labelsPrefix, ex),
-            ErrorMessage = SafeError.MessageOr(ex, "Labels are not valid for this item.")
+            ErrorMessage = SafeError.LogAndResolve(
+                logger,
+                ex,
+                "Labels are not valid for this item.",
+                $"normalizing labels for item {index} of data list {dataList.Id}")
         };
     }
 

--- a/src/Endatix.Core/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsHandler.cs
@@ -2,6 +2,7 @@ using Endatix.Core.Abstractions;
 using Endatix.Core.Common.Translations;
 using Endatix.Core.Entities;
 using Endatix.Core.Events;
+using Endatix.Core.Exceptions;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
@@ -32,7 +33,7 @@ public sealed class ReplaceDataListItemsHandler(
         }
 
         var ensureErrors =
-            DataListEnsureLocales.TryEnsure(dataList, request.EnsureLocales);
+            DataListEnsureLocales.TryEnsure(dataList, request.EnsureLocales, logger);
         if (ensureErrors is not null)
         {
             return Result.Invalid(ensureErrors);
@@ -154,18 +155,30 @@ public sealed class ReplaceDataListItemsHandler(
         }
     }
 
+    /// <summary>
+    /// Turns a label rejection from <see cref="DataListItem.NormalizeLabels"/> into a validation error.
+    /// </summary>
+    /// <remarks>
+    /// The reason is read back off the exception through <see cref="SafeError.MessageOr"/> rather than
+    /// re-derived here: <c>NormalizeLabels</c> throws <see cref="DomainValidationException"/>, so its
+    /// author-written text is already the text the caller should see, and duplicating the conditions
+    /// would only give the two copies a chance to disagree.
+    /// </remarks>
     private static ValidationError ToLabelValidationError(int index, ArgumentException ex)
     {
         var labelsPrefix = $"Items[{index}].Labels";
-        var identifier = ResolveLabelErrorIdentifier(labelsPrefix, ex);
 
         return new()
         {
-            Identifier = identifier,
-            ErrorMessage = $"Each label value cannot exceed {DataListItem.MAX_LABEL_LENGTH} characters."
+            Identifier = ResolveLabelErrorIdentifier(labelsPrefix, ex),
+            ErrorMessage = SafeError.MessageOr(ex, "Labels are not valid for this item.")
         };
     }
 
+    /// <summary>
+    /// Points the error at the offending culture key when the throw named one; the whole-map throws
+    /// name the <c>labels</c> parameter, which is attributed to the <c>default</c> entry they are about.
+    /// </summary>
     private static string ResolveLabelErrorIdentifier(string labelsPrefix, ArgumentException ex)
     {
         if (IsConcreteLabelKey(ex.ParamName))
@@ -173,7 +186,7 @@ public sealed class ReplaceDataListItemsHandler(
             return $"{labelsPrefix}.{ex.ParamName}";
         }
 
-        if (ex.Message.Contains(SurveyJsTranslationKeys.DefaultKey, StringComparison.OrdinalIgnoreCase))
+        if (string.Equals(ex.ParamName, "labels", StringComparison.Ordinal))
         {
             return $"{labelsPrefix}.{SurveyJsTranslationKeys.DefaultKey}";
         }

--- a/src/Endatix.Core/UseCases/DataLists/Search/SearchDataListItemsHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Search/SearchDataListItemsHandler.cs
@@ -34,12 +34,12 @@ public sealed class SearchDataListItemsHandler(IDataListRepository repository)
         {
             searchPage = await repository.SearchItemsAsync(criteria, cancellationToken).ConfigureAwait(false);
         }
-        catch (ArgumentException ex)
+        catch (ArgumentException)
         {
             ValidationError error = new()
             {
                 Identifier = nameof(request.Locale),
-                ErrorMessage = ex.Message
+                ErrorMessage = "Invalid locale."
             };
             return Result.Invalid(error);
         }

--- a/src/Endatix.Core/UseCases/DataLists/Search/SearchDataListItemsHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Search/SearchDataListItemsHandler.cs
@@ -1,13 +1,17 @@
 using Endatix.Core.Abstractions.Repositories;
+using Endatix.Core.Exceptions;
 using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
+using Microsoft.Extensions.Logging;
 
 namespace Endatix.Core.UseCases.DataLists.Search;
 
 /// <summary>
 /// Handler for searching data list items.
 /// </summary>
-public sealed class SearchDataListItemsHandler(IDataListRepository repository)
+public sealed class SearchDataListItemsHandler(
+    IDataListRepository repository,
+    ILogger<SearchDataListItemsHandler> logger)
     : IQueryHandler<SearchDataListItemsQuery, Result<Paged<DataListItemDto>>>
 {
     /// <inheritdoc />
@@ -34,14 +38,9 @@ public sealed class SearchDataListItemsHandler(IDataListRepository repository)
         {
             searchPage = await repository.SearchItemsAsync(criteria, cancellationToken).ConfigureAwait(false);
         }
-        catch (ArgumentException)
+        catch (ArgumentException ex)
         {
-            ValidationError error = new()
-            {
-                Identifier = nameof(request.Locale),
-                ErrorMessage = "Invalid locale."
-            };
-            return Result.Invalid(error);
+            return Result.Invalid(ToSearchValidationError(request.DataListId, ex));
         }
 
         if (searchPage is null)
@@ -60,4 +59,24 @@ public sealed class SearchDataListItemsHandler(IDataListRepository repository)
 
         return Result.Success(paged);
     }
+
+    /// <summary>
+    /// Turns a rejected search into a validation error on the request field the caller can fix.
+    /// </summary>
+    /// <remarks>
+    /// The only caller-supplied value this search parses is the locale set, so a rejection is attributed
+    /// there. Everything else that could surface as an <see cref="ArgumentException"/> - an EF Core
+    /// translation failure, a bad internal argument - is a defect rather than bad input, and
+    /// <see cref="SafeError.LogAndResolve"/> logs it as one while the caller sees only the fallback.
+    /// </remarks>
+    private ValidationError ToSearchValidationError(long dataListId, ArgumentException ex) =>
+        new()
+        {
+            Identifier = nameof(SearchDataListItemsQuery.Locale),
+            ErrorMessage = SafeError.LogAndResolve(
+                logger,
+                ex,
+                "Invalid locale.",
+                $"searching items on data list {dataListId}")
+        };
 }

--- a/src/Endatix.Core/UseCases/DataLists/Translations/ReplaceDataListTranslationsCsvHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Translations/ReplaceDataListTranslationsCsvHandler.cs
@@ -7,6 +7,7 @@ using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;
 using MediatR;
+using Microsoft.Extensions.Logging;
 
 namespace Endatix.Core.UseCases.DataLists.Translations;
 
@@ -16,7 +17,8 @@ namespace Endatix.Core.UseCases.DataLists.Translations;
 public sealed class ReplaceDataListTranslationsCsvHandler(
     IRepository<DataList> repository,
     IMediator mediator,
-    IIdGenerator<long> idGenerator)
+    IIdGenerator<long> idGenerator,
+    ILogger<ReplaceDataListTranslationsCsvHandler> logger)
     : ICommandHandler<ReplaceDataListTranslationsCsvCommand, Result<DataListDto>>
 {
     /// <inheritdoc />
@@ -45,7 +47,8 @@ public sealed class ReplaceDataListTranslationsCsvHandler(
         }
         catch (FormatException ex)
         {
-            return Invalid("Csv", ex.Message);
+            logger.LogWarning(ex, "Failed to parse data list translations CSV for data list {DataListId}", request.DataListId);
+            return Invalid("Csv", "The translations CSV is invalid.");
         }
 
         if (document.Rows.Count > ReplaceDataListTranslationsCsvCommand.MAX_ROWS)
@@ -69,11 +72,13 @@ public sealed class ReplaceDataListTranslationsCsvHandler(
         }
         catch (ArgumentException ex)
         {
-            return Invalid("Csv", ex.Message);
+            logger.LogWarning(ex, "Data list translations CSV was rejected for data list {DataListId}", request.DataListId);
+            return Invalid("Csv", "The translations CSV is invalid.");
         }
         catch (InvalidOperationException ex)
         {
-            return Invalid("Csv", ex.Message);
+            logger.LogWarning(ex, "Data list translations CSV was rejected for data list {DataListId}", request.DataListId);
+            return Invalid("Csv", "The translations CSV is invalid.");
         }
 
         try
@@ -82,7 +87,8 @@ public sealed class ReplaceDataListTranslationsCsvHandler(
         }
         catch (InvalidOperationException ex)
         {
-            return Result.Error($"Failed to persist data list items: {ex.Message}");
+            logger.LogError(ex, "Failed to persist data list translations for data list {DataListId}", request.DataListId);
+            return Result.Error("Failed to persist data list items.");
         }
 
         await mediator.Publish(

--- a/src/Endatix.Core/UseCases/DataLists/Translations/ReplaceDataListTranslationsCsvHandler.cs
+++ b/src/Endatix.Core/UseCases/DataLists/Translations/ReplaceDataListTranslationsCsvHandler.cs
@@ -34,7 +34,7 @@ public sealed class ReplaceDataListTranslationsCsvHandler(
         }
 
         var ensureErrors =
-            DataListEnsureLocales.TryEnsure(dataList, request.EnsureLocales);
+            DataListEnsureLocales.TryEnsure(dataList, request.EnsureLocales, logger);
         if (ensureErrors is not null)
         {
             return Result.Invalid(ensureErrors);

--- a/src/Endatix.Core/UseCases/Folders/Delete/DeleteFolderHandler.cs
+++ b/src/Endatix.Core/UseCases/Folders/Delete/DeleteFolderHandler.cs
@@ -8,6 +8,7 @@ using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;
 using MediatR;
+using Microsoft.Extensions.Logging;
 
 namespace Endatix.Core.UseCases.Folders.Delete;
 
@@ -21,7 +22,8 @@ public sealed class DeleteFolderHandler(
     IRepository<FormTemplate> formTemplateRepository,
     ITenantContext tenantContext,
     IUnitOfWork unitOfWork,
-    IMediator mediator) : ICommandHandler<DeleteFolderCommand, Result<string>>
+    IMediator mediator,
+    ILogger<DeleteFolderHandler> logger) : ICommandHandler<DeleteFolderCommand, Result<string>>
 {
     /// <inheritdoc/>
     public async Task<Result<string>> Handle(DeleteFolderCommand request, CancellationToken cancellationToken)
@@ -89,7 +91,8 @@ public sealed class DeleteFolderHandler(
         catch (Exception exception)
         {
             await unitOfWork.RollbackTransactionAsync(cancellationToken);
-            return Result.Error($"Error deleting folder: {exception.Message}");
+            logger.LogError(exception, "Failed to delete folder {FolderId}", request.FolderId);
+            return Result.Error("Failed to delete folder.");
         }
     }
 }

--- a/src/Endatix.Core/UseCases/Folders/Delete/DeleteFolderHandler.cs
+++ b/src/Endatix.Core/UseCases/Folders/Delete/DeleteFolderHandler.cs
@@ -90,8 +90,8 @@ public sealed class DeleteFolderHandler(
         }
         catch (Exception exception)
         {
-            await unitOfWork.RollbackTransactionAsync(cancellationToken);
             logger.LogError(exception, "Failed to delete folder {FolderId}", request.FolderId);
+            await unitOfWork.RollbackTransactionAsync(cancellationToken);
             return Result.Error("Failed to delete folder.");
         }
     }

--- a/src/Endatix.Core/UseCases/Forms/List/ListFormsHandler.cs
+++ b/src/Endatix.Core/UseCases/Forms/List/ListFormsHandler.cs
@@ -3,13 +3,16 @@ using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;
 using Endatix.Core.Specifications.Parameters;
+using Microsoft.Extensions.Logging;
 
 namespace Endatix.Core.UseCases.Forms.List;
 
 /// <summary>
 /// Handler for listing forms.
 /// </summary>
-public sealed class ListFormsHandler(IFormsRepository repository)
+public sealed class ListFormsHandler(
+    IFormsRepository repository,
+    ILogger<ListFormsHandler> logger)
     : IQueryHandler<ListFormsQuery, Result<Paged<FormDto>>>
 {
     /// <inheritdoc/>
@@ -54,7 +57,8 @@ public sealed class ListFormsHandler(IFormsRepository repository)
         }
         catch (Exception ex)
         {
-            return Result.Error($"Error listing forms: {ex.Message}");
+            logger.LogError(ex, "Failed to list forms");
+            return Result.Error("Failed to list forms.");
         }
     }
 

--- a/src/Endatix.Core/UseCases/Submissions/Export/SubmissionsExportHandler.cs
+++ b/src/Endatix.Core/UseCases/Submissions/Export/SubmissionsExportHandler.cs
@@ -79,7 +79,7 @@ public sealed class SubmissionsExportHandler(
                     ex.InnerException?.Message ?? "(none)");
             }
 
-            return Result<FileExport>.Error($"Export failed: {ex.Message}");
+            return Result<FileExport>.Error("Export failed.");
         }
     }
 

--- a/src/Endatix.Core/UseCases/Submissions/UpdateStatus/UpdateStatusHandler.cs
+++ b/src/Endatix.Core/UseCases/Submissions/UpdateStatus/UpdateStatusHandler.cs
@@ -2,6 +2,7 @@ using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
+using Microsoft.Extensions.Logging;
 
 namespace Endatix.Core.UseCases.Submissions.UpdateStatus;
 
@@ -9,7 +10,8 @@ namespace Endatix.Core.UseCases.Submissions.UpdateStatus;
 /// Handles updating the status of a submission.
 /// </summary>
 public class UpdateStatusHandler(
-    IRepository<Submission> submissionRepository
+    IRepository<Submission> submissionRepository,
+    ILogger<UpdateStatusHandler> logger
 ) : ICommandHandler<UpdateStatusCommand, Result<SubmissionDto>>
 {
     /// <summary>
@@ -45,12 +47,13 @@ public class UpdateStatusHandler(
         }
         catch (ArgumentException ex)
         {
-            return Result<SubmissionDto>.Invalid(new ValidationError($"Invalid status code provided: {ex.Message}"));
+            logger.LogWarning(ex, "Invalid submission status code {StatusCode}", command.StatusCode);
+            return Result<SubmissionDto>.Invalid(new ValidationError("Invalid status code."));
         }
         catch (InvalidOperationException ex)
         {
-            // not allowed status transition
-            return Result<SubmissionDto>.Invalid(new ValidationError(ex.Message));
+            logger.LogWarning(ex, "Submission status transition rejected for submission {SubmissionId}", command.SubmissionId);
+            return Result<SubmissionDto>.Invalid(new ValidationError("Status transition is not allowed."));
         }
     }
 }

--- a/src/Endatix.Core/UseCases/Submissions/UpdateStatus/UpdateStatusHandler.cs
+++ b/src/Endatix.Core/UseCases/Submissions/UpdateStatus/UpdateStatusHandler.cs
@@ -23,6 +23,7 @@ public class UpdateStatusHandler(
     /// Success result with updated submission DTO if successful.
     /// NotFound if submission doesn't exist or doesn't match form ID.
     /// Invalid if status code is invalid or transition not allowed.
+    /// Persistence failures are not caught here - they surface as a logged, opaque 500.
     /// </returns>
     public async Task<Result<SubmissionDto>> Handle(
         UpdateStatusCommand command,
@@ -40,10 +41,6 @@ public class UpdateStatusHandler(
         {
             var newStatus = SubmissionStatus.FromCode(command.StatusCode);
             submission.UpdateStatus(newStatus);
-
-            await submissionRepository.UpdateAsync(submission, cancellationToken);
-
-            return Result<SubmissionDto>.Success(SubmissionDto.FromSubmission(submission));
         }
         catch (ArgumentException ex)
         {
@@ -55,5 +52,12 @@ public class UpdateStatusHandler(
             logger.LogWarning(ex, "Submission status transition rejected for submission {SubmissionId}", command.SubmissionId);
             return Result<SubmissionDto>.Invalid(new ValidationError("Status transition is not allowed."));
         }
+
+        // Outside the catches above: a persistence failure is not a rejected transition, and mapping
+        // one to a 400 would report an EF Core tracking conflict as caller error. Let it reach
+        // EndatixExceptionHandler as an opaque, logged 500.
+        await submissionRepository.UpdateAsync(submission, cancellationToken);
+
+        return Result<SubmissionDto>.Success(SubmissionDto.FromSubmission(submission));
     }
 }

--- a/src/Endatix.Core/UseCases/Themes/Delete/DeleteThemeHandler.cs
+++ b/src/Endatix.Core/UseCases/Themes/Delete/DeleteThemeHandler.cs
@@ -65,8 +65,8 @@ public class DeleteThemeHandler(
         }
         catch (Exception ex)
         {
-            await unitOfWork.RollbackTransactionAsync(cancellationToken);
             logger.LogError(ex, "Failed to delete theme {ThemeId}", request.ThemeId);
+            await unitOfWork.RollbackTransactionAsync(cancellationToken);
             return Result.Error("Failed to delete theme.");
         }
     }

--- a/src/Endatix.Core/UseCases/Themes/Delete/DeleteThemeHandler.cs
+++ b/src/Endatix.Core/UseCases/Themes/Delete/DeleteThemeHandler.cs
@@ -6,6 +6,7 @@ using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Messaging;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;
+using Microsoft.Extensions.Logging;
 
 namespace Endatix.Core.UseCases.Themes.Delete;
 
@@ -15,7 +16,8 @@ namespace Endatix.Core.UseCases.Themes.Delete;
 public class DeleteThemeHandler(
     IRepository<Theme> themeRepository,
     IRepository<Form> formRepository,
-    IUnitOfWork unitOfWork
+    IUnitOfWork unitOfWork,
+    ILogger<DeleteThemeHandler> logger
 ) : ICommandHandler<DeleteThemeCommand, Result<string>>
 {
     /// <summary>
@@ -64,7 +66,8 @@ public class DeleteThemeHandler(
         catch (Exception ex)
         {
             await unitOfWork.RollbackTransactionAsync(cancellationToken);
-            return Result.Error($"Error deleting theme: {ex.Message}");
+            logger.LogError(ex, "Failed to delete theme {ThemeId}", request.ThemeId);
+            return Result.Error("Failed to delete theme.");
         }
     }
 }

--- a/src/Endatix.Infrastructure/Data/AppUnitOfWork.cs
+++ b/src/Endatix.Infrastructure/Data/AppUnitOfWork.cs
@@ -1,3 +1,5 @@
+using Microsoft.Extensions.Logging;
+
 namespace Endatix.Infrastructure.Data
 {
     /// <summary>
@@ -9,7 +11,9 @@ namespace Endatix.Infrastructure.Data
         /// Initializes a new instance of the <see cref="AppUnitOfWork"/> class.
         /// </summary>
         /// <param name="context">The Entity Framework Core DbContext.</param>
-        public AppUnitOfWork(AppDbContext context) : base(context)
+        /// <param name="logger">Records rollback failures. Optional; DI supplies it.</param>
+        public AppUnitOfWork(AppDbContext context, ILogger<AppUnitOfWork>? logger = null)
+            : base(context, logger)
         {
         }
     }

--- a/src/Endatix.Infrastructure/Data/EfUnitOfWorkBase.cs
+++ b/src/Endatix.Infrastructure/Data/EfUnitOfWorkBase.cs
@@ -1,6 +1,8 @@
 using Endatix.Core.Abstractions.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Endatix.Infrastructure.Data;
 
@@ -13,15 +15,21 @@ public abstract class EfUnitOfWorkBase<TContext> : IUnitOfWork
     where TContext : DbContext
 {
     private readonly TContext _context;
+    private readonly ILogger _logger;
     private IDbContextTransaction? _transaction;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EfUnitOfWorkBase{TContext}"/> class.
     /// </summary>
     /// <param name="context">The Entity Framework Core DbContext.</param>
-    protected EfUnitOfWorkBase(TContext context)
+    /// <param name="logger">
+    /// Records rollback failures, which are never surfaced to the caller. Optional so a test can
+    /// construct a unit of work without wiring logging; DI supplies the real one.
+    /// </param>
+    protected EfUnitOfWorkBase(TContext context, ILogger? logger = null)
     {
         _context = context;
+        _logger = logger ?? NullLogger.Instance;
     }
 
     /// <inheritdoc/>
@@ -53,18 +61,46 @@ public abstract class EfUnitOfWorkBase<TContext> : IUnitOfWork
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Rollback is cleanup, and cleanup runs on the failure path - so it neither throws nor observes
+    /// <paramref name="cancellationToken"/>:
+    /// <list type="bullet">
+    /// <item>No active transaction is the desired end state, not an error. Throwing here turned a
+    /// failed <c>BeginTransactionAsync</c> into "Transaction not started", masking the real cause.</item>
+    /// <item>A rollback failure is not actionable - the transaction is dead either way - and letting it
+    /// propagate out of a <c>catch</c> block replaces the exception the caller was actually handling.</item>
+    /// <item>The token that cancelled the work must not also cancel undoing it, or a cancelled request
+    /// leaves the transaction open until disposal.</item>
+    /// </list>
+    /// </remarks>
     public async Task RollbackTransactionAsync(CancellationToken cancellationToken = default)
     {
-        EnsureTransactionStarted();
+        if (_transaction is null)
+        {
+            return;
+        }
+
+        var transaction = _transaction;
+        _transaction = null;
 
         try
         {
-            await _transaction!.RollbackAsync(cancellationToken);
+            await transaction.RollbackAsync(CancellationToken.None);
+        }
+        catch (Exception rollbackException)
+        {
+            _logger.LogError(rollbackException, "Failed to roll back the transaction");
         }
         finally
         {
-            await _transaction.DisposeAsync();
-            _transaction = null;
+            try
+            {
+                await transaction.DisposeAsync();
+            }
+            catch (Exception disposeException)
+            {
+                _logger.LogError(disposeException, "Failed to dispose the rolled back transaction");
+            }
         }
     }
 
@@ -79,4 +115,4 @@ public abstract class EfUnitOfWorkBase<TContext> : IUnitOfWork
             throw new InvalidOperationException("Transaction not started. Call BeginTransactionAsync first.");
         }
     }
-} 
+}

--- a/src/Endatix.Infrastructure/Exporting/Exporters/Dynamic/CodebookJsonExporter.cs
+++ b/src/Endatix.Infrastructure/Exporting/Exporters/Dynamic/CodebookJsonExporter.cs
@@ -39,7 +39,7 @@ public class CodebookJsonExporter(ILogger<CodebookJsonExporter> logger) : IExpor
             {
                 return fileHeadersResult;
             }
-            
+
             using var stream = writer.AsStream();
             await foreach (var row in records.WithCancellation(cancellationToken))
             {
@@ -58,7 +58,7 @@ public class CodebookJsonExporter(ILogger<CodebookJsonExporter> logger) : IExpor
         catch (Exception ex)
         {
             logger.LogError(ex, "Error exporting Codebook JSON");
-            return Result<FileExport>.Error($"Failed to export Codebook JSON: {ex.Message}");
+            return Result<FileExport>.Error("Failed to export Codebook JSON.");
         }
     }
 
@@ -73,7 +73,7 @@ public class CodebookJsonExporter(ILogger<CodebookJsonExporter> logger) : IExpor
         catch (Exception ex)
         {
             logger.LogError(ex, "Error getting Codebook JSON export headers");
-            return Task.FromResult(Result<FileExport>.Error($"Failed to get export headers: {ex.Message}"));
+            return Task.FromResult(Result<FileExport>.Error("Failed to get export headers."));
         }
     }
 

--- a/src/Endatix.Infrastructure/Exporting/Exporters/Submissions/SubmissionCsvExporter.cs
+++ b/src/Endatix.Infrastructure/Exporting/Exporters/Submissions/SubmissionCsvExporter.cs
@@ -83,7 +83,7 @@ public class SubmissionCsvExporter(
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error exporting submissions to CSV");
-            return Result<FileExport>.Error($"Failed to export submissions: {ex.Message}");
+            return Result<FileExport>.Error("Failed to export submissions.");
         }
     }
 

--- a/src/Endatix.Infrastructure/Exporting/Exporters/Submissions/SubmissionExporterBase.cs
+++ b/src/Endatix.Infrastructure/Exporting/Exporters/Submissions/SubmissionExporterBase.cs
@@ -78,7 +78,7 @@ public abstract class SubmissionExporterBase(
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error getting export headers");
-            return Task.FromResult(Result<FileExport>.Error($"Failed to get export headers: {ex.Message}"));
+            return Task.FromResult(Result<FileExport>.Error("Failed to get export headers."));
         }
     }
 

--- a/src/Endatix.Infrastructure/Exporting/Exporters/Submissions/SubmissionJsonExporter.cs
+++ b/src/Endatix.Infrastructure/Exporting/Exporters/Submissions/SubmissionJsonExporter.cs
@@ -84,7 +84,7 @@ internal sealed partial class SubmissionJsonExporter(
         {
             var formIdForLog = _formId ?? GetFormIdFromOptions(options);
             LogExportError(ex, formIdForLog);
-            return Result<FileExport>.Error($"Failed to export submissions: {ex.Message}");
+            return Result<FileExport>.Error("Failed to export submissions.");
         }
     }
 
@@ -100,7 +100,7 @@ internal sealed partial class SubmissionJsonExporter(
         {
             return null;
         }
-        
+
         return value as long?;
     }
 }

--- a/src/Endatix.Infrastructure/Features/Account/UserPasswordManageService.cs
+++ b/src/Endatix.Infrastructure/Features/Account/UserPasswordManageService.cs
@@ -65,7 +65,7 @@ public class UserPasswordManageService(
         catch (Exception ex)
         {
             logger.LogError(ex, "An unexpected error occurred while resetting the password for user {Email}", SensitiveValue.Email(email));
-            
+
             return Result.Error("Could not reset password. Please try again or contact support.");
         }
 
@@ -117,7 +117,8 @@ public class UserPasswordManageService(
         }
         catch (Exception ex)
         {
-            return Result.Error(ex.Message);
+            logger.LogError(ex, "Failed to change password for user {UserId}", userId);
+            return Result.Error("Failed to change password.");
         }
 
         return Result.Success(appUser.ToUserEntity());

--- a/src/Endatix.Infrastructure/Identity/Authentication/JwtTokenService.cs
+++ b/src/Endatix.Infrastructure/Identity/Authentication/JwtTokenService.cs
@@ -114,7 +114,14 @@ internal sealed class JwtTokenService : IUserTokenService
         var result = await tokenHandler.ValidateTokenAsync(accessToken, validationParameters);
         if (!result.IsValid)
         {
-            return Result.Invalid(new ValidationError(result.Exception?.Message ?? "Invalid access token"));
+            // Do not echo JWT validator diagnostics (issuer/audience/lifetime/key) on this
+            // anonymous-reachable path. Log the exception; clients get a static message.
+            if (result.Exception is not null)
+            {
+                _logger.LogWarning(result.Exception, "Access token validation failed");
+            }
+
+            return Result.Invalid(new ValidationError("Invalid access token"));
         }
 
         var validatedJwtToken = (JwtSecurityToken)result.SecurityToken;

--- a/src/Endatix.Infrastructure/Identity/Authorization/DefaultAuthorizationMapper.cs
+++ b/src/Endatix.Infrastructure/Identity/Authorization/DefaultAuthorizationMapper.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using static Endatix.Infrastructure.Identity.Authorization.IExternalAuthorizationMapper;
 
 namespace Endatix.Infrastructure.Identity.Authorization;
@@ -9,9 +10,11 @@ namespace Endatix.Infrastructure.Identity.Authorization;
 /// </summary>
 /// <param name="roleManager">The role manager to query roles.</param>
 /// <param name="keyNormalizer">The key normalizer for normalizing role names.</param>
+/// <param name="logger">The logger used to record role-mapping failures.</param>
 internal sealed class DefaultAuthorizationMapper(
         RoleManager<AppRole> roleManager,
-        ILookupNormalizer keyNormalizer
+        ILookupNormalizer keyNormalizer,
+        ILogger<DefaultAuthorizationMapper> logger
 ) : IExternalAuthorizationMapper
 {
 
@@ -62,7 +65,9 @@ internal sealed class DefaultAuthorizationMapper(
         }
         catch (Exception ex)
         {
-            return MappingResult.Failure(ex.Message);
+            // Store/EF exception text must not travel back to the caller as an error message.
+            logger.LogError(ex, "Failed to map external roles to application roles and permissions");
+            return MappingResult.Failure("Could not resolve roles and permissions for the external identity.");
         }
     }
 

--- a/src/Endatix.Infrastructure/Identity/IdentityUnitOfWork.cs
+++ b/src/Endatix.Infrastructure/Identity/IdentityUnitOfWork.cs
@@ -1,4 +1,5 @@
 using Endatix.Infrastructure.Data;
+using Microsoft.Extensions.Logging;
 
 namespace Endatix.Infrastructure.Identity;
 
@@ -11,7 +12,9 @@ public class IdentityUnitOfWork : EfUnitOfWorkBase<AppIdentityDbContext>
     /// Initializes a new instance of the <see cref="IdentityUnitOfWork"/> class.
     /// </summary>
     /// <param name="context">The AppIdentityDbContext instance.</param>
-    public IdentityUnitOfWork(AppIdentityDbContext context) : base(context)
+    /// <param name="logger">Records rollback failures. Optional; DI supplies it.</param>
+    public IdentityUnitOfWork(AppIdentityDbContext context, ILogger<IdentityUnitOfWork>? logger = null)
+        : base(context, logger)
     {
     }
 }

--- a/src/Endatix.Infrastructure/ReCaptcha/ReCaptchaHttpClient.cs
+++ b/src/Endatix.Infrastructure/ReCaptcha/ReCaptchaHttpClient.cs
@@ -1,9 +1,10 @@
 using System.Text.Json;
 using Endatix.Core.Infrastructure.Result;
+using Microsoft.Extensions.Logging;
 
 namespace Endatix.Infrastructure.ReCaptcha;
 
-public class ReCaptchaHttpClient(HttpClient client) : IReCaptchaHttpClient
+public class ReCaptchaHttpClient(HttpClient client, ILogger<ReCaptchaHttpClient> logger) : IReCaptchaHttpClient
 {
     public async Task<Result<GoogleReCaptchaResponse>> GetTokenValidationResponseAsync(string token, string secretKey, CancellationToken cancellationToken)
     {
@@ -37,8 +38,9 @@ public class ReCaptchaHttpClient(HttpClient client) : IReCaptchaHttpClient
                     Result.Error("Failed to deserialize Google ReCaptcha response") :
                     Result.Success(result);
                 }
-                catch (Exception)
+                catch (Exception ex)
                 {
+                    logger.LogError(ex, "Failed to deserialize Google ReCaptcha response");
                     return Result.Error("Failed to deserialize Google ReCaptcha response");
                 }
             }
@@ -47,7 +49,8 @@ public class ReCaptchaHttpClient(HttpClient client) : IReCaptchaHttpClient
         }
         catch (Exception ex)
         {
-            return Result.Error($"Http error during token validation: {ex.Message}");
+            logger.LogError(ex, "HTTP error during reCAPTCHA token validation");
+            return Result.Error("Failed to validate reCAPTCHA token");
         }
     }
 }

--- a/src/Endatix.Infrastructure/ReCaptcha/ReCaptchaHttpClient.cs
+++ b/src/Endatix.Infrastructure/ReCaptcha/ReCaptchaHttpClient.cs
@@ -34,9 +34,13 @@ public class ReCaptchaHttpClient(HttpClient client, ILogger<ReCaptchaHttpClient>
                 try
                 {
                     var result = await JsonSerializer.DeserializeAsync<GoogleReCaptchaResponse>(responseContent, cancellationToken: cancellationToken);
-                    return result is null ?
-                    Result.Error("Failed to deserialize Google ReCaptcha response") :
-                    Result.Success(result);
+                    if (result is null)
+                    {
+                        logger.LogError("Google ReCaptcha returned a success status with a null response body");
+                        return Result.Error("Failed to deserialize Google ReCaptcha response");
+                    }
+
+                    return Result.Success(result);
                 }
                 catch (Exception ex)
                 {
@@ -45,12 +49,18 @@ public class ReCaptchaHttpClient(HttpClient client, ILogger<ReCaptchaHttpClient>
                 }
             }
 
-            return Result.Error("Failed to validate reCAPTCHA token");
+            // Distinct from the transport failure below: Google answered, and it refused the request
+            // (bad secret key, malformed form, quota). The status code is diagnostic for us, not for the
+            // caller, so it is logged and kept out of the returned message.
+            logger.LogError(
+                "reCAPTCHA verification returned {StatusCode} for the siteverify request",
+                (int)response.StatusCode);
+            return Result.Error("The reCAPTCHA verification service rejected the request.");
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "HTTP error during reCAPTCHA token validation");
-            return Result.Error("Failed to validate reCAPTCHA token");
+            return Result.Error("Could not reach the reCAPTCHA verification service.");
         }
     }
 }

--- a/src/Endatix.Modules.Reporting/Data/ReportingUnitOfWork.cs
+++ b/src/Endatix.Modules.Reporting/Data/ReportingUnitOfWork.cs
@@ -1,7 +1,10 @@
 using Endatix.Infrastructure.Data;
 using Endatix.Modules.Reporting.Persistence;
+using Microsoft.Extensions.Logging;
 
 namespace Endatix.Modules.Reporting.Data;
 
-internal sealed class ReportingUnitOfWork(ReportingDbContext context)
-    : EfUnitOfWorkBase<ReportingDbContext>(context), IReportingUnitOfWork;
+internal sealed class ReportingUnitOfWork(
+    ReportingDbContext context,
+    ILogger<ReportingUnitOfWork>? logger = null)
+    : EfUnitOfWorkBase<ReportingDbContext>(context, logger), IReportingUnitOfWork;

--- a/src/Endatix.Modules.Reporting/Features/Export/ExportFormatSettingsWriter.cs
+++ b/src/Endatix.Modules.Reporting/Features/Export/ExportFormatSettingsWriter.cs
@@ -62,12 +62,12 @@ internal sealed class ExportFormatSettingsWriter
         {
             ExportFormatSettings.RequireKeySeparator(settings.KeySeparator);
         }
-        catch (ArgumentException ex)
+        catch (ArgumentException)
         {
             errors.Add(new ValidationError
             {
                 Identifier = nameof(ExportFormatSettings.KeySeparator),
-                ErrorMessage = ex.Message,
+                ErrorMessage = "Key separator is invalid.",
             });
         }
 

--- a/tests/Endatix.Api.Tests/Endpoints/Submissions/GetSubmissionFilesTests.cs
+++ b/tests/Endatix.Api.Tests/Endpoints/Submissions/GetSubmissionFilesTests.cs
@@ -5,6 +5,7 @@ using Endatix.Core.UseCases.Submissions.GetFiles;
 using FastEndpoints;
 using MediatR;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Endatix.Api.Endpoints.Submissions;
 
@@ -16,7 +17,10 @@ public class GetSubmissionFilesTests
     public GetSubmissionFilesTests()
     {
         var httpContext = new DefaultHttpContext();
-        _endpoint = Factory.Create<GetSubmissionFiles>(httpContext: httpContext, _mediator);
+        _endpoint = Factory.Create<GetSubmissionFiles>(
+            httpContext: httpContext,
+            _mediator,
+            NullLogger<GetSubmissionFiles>.Instance);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Infrastructure/EndatixExceptionHandlerTests.cs
+++ b/tests/Endatix.Api.Tests/Infrastructure/EndatixExceptionHandlerTests.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Endatix.Api.Infrastructure;
+using Endatix.Core.Exceptions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -43,6 +44,40 @@ public class EndatixExceptionHandlerTests
         root.GetProperty("detail").GetString().Should().NotContain(secretMessage);
         root.GetProperty("instance").GetString().Should().Be("/api/forms");
         root.GetProperty("traceId").GetString().Should().Be("trace-exception");
+    }
+
+    /// <summary>
+    /// Deliberate: the boundary is a safety net, not a status mapper. A domain exception that opted into
+    /// <see cref="IEndUserSafeError"/> still gets an opaque 500 here, because reaching the boundary means
+    /// a handler failed to convert it to a <c>Result</c> - a defect a tidy 4xx would hide.
+    /// </summary>
+    [Fact]
+    public async Task TryHandleAsync_WithSafeDomainError_StillWritesGeneric500()
+    {
+        // Arrange
+        const string domainMessage = "A data list cannot have more than 25 cultures.";
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Path = "/api/data-lists/1/items";
+        httpContext.Response.Body = new MemoryStream();
+        var handler = new EndatixExceptionHandler(NullLogger<EndatixExceptionHandler>.Instance);
+
+        // Act
+        await handler.TryHandleAsync(
+            httpContext,
+            new DomainRuleException(domainMessage),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        httpContext.Response.StatusCode.Should().Be(StatusCodes.Status500InternalServerError);
+
+        httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+        using var document = await JsonDocument.ParseAsync(
+            httpContext.Response.Body,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var detail = document.RootElement.GetProperty("detail").GetString();
+        detail.Should().Be(ResultTitles.INTERNAL_SERVER_ERROR);
+        detail.Should().NotContain(domainMessage);
     }
 
     [Fact]

--- a/tests/Endatix.Api.Tests/Infrastructure/ResultFactoryMustNotInterpolateExceptionMessageTests.cs
+++ b/tests/Endatix.Api.Tests/Infrastructure/ResultFactoryMustNotInterpolateExceptionMessageTests.cs
@@ -13,8 +13,11 @@ namespace Endatix.Api.Tests.Infrastructure;
 /// </remarks>
 public sealed class ResultFactoryMustNotInterpolateExceptionMessageTests
 {
-    private const string ExceptionMessagePattern =
-        @"(?<!Error)Exception\s*\??\s*\.\s*Message|(?<!\w)ex\.Message|(?<!\w)exception\.Message";
+    // `SomethingException.Message`, but not `ErrorException`-style false positives from the
+    // `IEndUserSafeError` types themselves. Identifier-based reads (`ex.Message`, `error.Message`)
+    // are found via the catch clauses that introduce them - see BuildExceptionMessagePattern.
+    private const string ExceptionTypeMessagePattern =
+        @"(?<!Error)Exception\s*\??\s*\.\s*Message";
 
     // Every Result factory whose message ends up in the RFC7807 `detail`. 4xx details are echoed
     // verbatim to the client; only 5xx is scrubbed by EndatixProblemDetails.
@@ -28,16 +31,12 @@ public sealed class ResultFactoryMustNotInterpolateExceptionMessageTests
         @"\.\s*EndUserMessage(?!\s*[{=])",
         RegexOptions.Compiled);
 
-    private static readonly Regex ExceptionMessage = new(
-        ExceptionMessagePattern,
-        RegexOptions.Compiled | RegexOptions.IgnoreCase);
-
-    // Handlers usually build the error indirectly (`ValidationError e = new() { ErrorMessage = ex.Message };`
-    // then `Result.Invalid(e)`), which the factory-call scan above cannot see.
-    private static readonly Regex IndirectExceptionMessage = new(
-        @"(?:ErrorMessage|Detail|Title)\s*=\s*[^;]*?(?:" + ExceptionMessagePattern + @")"
-        + @"|new\s+ValidationError\s*\([^)]*?(?:" + ExceptionMessagePattern + @")",
-        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
+    // `catch (SomeException name)` / `catch (SomeException name) when (...)`. The name it binds is
+    // the only thing that makes `name.Message` a leak, so the scanner learns it per file rather than
+    // guessing at a fixed list of conventional spellings.
+    private static readonly Regex CatchClause = new(
+        @"catch\s*\(\s*[\w.]*Exception(?:\s*<[^>]*>)?\s+(\w+)\s*[)\w]",
+        RegexOptions.Compiled);
 
     [Fact]
     public void OssSrc_ResultFactories_DoNotPassExceptionMessage()
@@ -49,27 +48,10 @@ public sealed class ResultFactoryMustNotInterpolateExceptionMessageTests
         // Act
         foreach (string file in EnumerateSourceFiles(srcRoot))
         {
-            string text = File.ReadAllText(file);
-
-            foreach (Match indirect in IndirectExceptionMessage.Matches(text))
+            string relativePath = Path.GetRelativePath(srcRoot, file);
+            foreach (string leak in FindLeaks(File.ReadAllText(file)))
             {
-                leaks.Add($"{Path.GetRelativePath(srcRoot, file)}: {indirect.Value.ReplaceLineEndings(" ").Trim()}");
-            }
-
-            foreach (Match factory in FactoryCall.Matches(text))
-            {
-                int start = factory.Index;
-                int end = FindMatchingCloseParen(text, factory.Index + factory.Length - 1);
-                if (end < 0)
-                {
-                    continue;
-                }
-
-                string argumentSpan = text[start..end];
-                if (ExceptionMessage.IsMatch(argumentSpan))
-                {
-                    leaks.Add($"{Path.GetRelativePath(srcRoot, file)}: {argumentSpan.ReplaceLineEndings(" ").Trim()}");
-                }
+                leaks.Add($"{relativePath}: {leak}");
             }
         }
 
@@ -78,6 +60,28 @@ public sealed class ResultFactoryMustNotInterpolateExceptionMessageTests
             "Result.Error / Result.Invalid arguments must be author-written; exception text belongs in logs. Leaks:\n{0}",
             string.Join('\n', leaks));
     }
+
+    [Theory]
+    [InlineData("""catch (Exception ex) { return Result.Error(ex.Message); }""")]
+    [InlineData("""catch (Exception error) { return Result.Error(error.Message); }""")]
+    [InlineData("""catch (JsonException e) { return Result.Invalid(new ValidationError(e.Message)); }""")]
+    [InlineData("""catch (Exception ex) when (ex is IOException) { return Result.Error(ex.Message); }""")]
+    [InlineData("""catch (Exception ex) { return Result.Error($"failed (see logs): {ex.Message}"); }""")]
+    [InlineData("""catch (Exception ex) { var e = new ValidationError { ErrorMessage = ex.Message }; }""")]
+    [InlineData("""return Result.Error(exception.Message);""")]
+    [InlineData("""return Result.Error(HttpRequestException.Message);""")]
+    public void Scanner_FlagsExceptionText(string source) =>
+        FindLeaks(source).Should().NotBeEmpty();
+
+    [Theory]
+    [InlineData("""catch (Exception ex) { return Result.Error(SafeError.MessageOr(ex, "Failed.")); }""")]
+    [InlineData("""catch (Exception ex) { logger.LogError(ex, "boom"); return Result.Error("Failed."); }""")]
+    [InlineData("""return Result.Error("Import failed (see the log for details).");""")]
+    [InlineData("""// Historic note: we used to return ex.Message from Result.Error here.""")]
+    [InlineData("""return Result.Invalid(new ValidationError("Use the 'ex.Message' placeholder."));""")]
+    [InlineData("""catch (Exception ex) { logger.LogWarning("{Msg}", ex.Message); }""")]
+    public void Scanner_AllowsSafeText(string source) =>
+        FindLeaks(source).Should().BeEmpty();
 
     /// <summary>
     /// <c>IEndUserSafeError.EndUserMessage</c> is the one message the codebase may return verbatim, so it
@@ -113,6 +117,276 @@ public sealed class ResultFactoryMustNotInterpolateExceptionMessageTests
             + "client-visible exception text. Direct reads:\n{0}",
             string.Join('\n', reads));
     }
+
+    /// <summary>
+    /// Every place in <paramref name="source"/> where caught-exception text reaches a client-visible
+    /// message, either as a direct Result factory argument or through a <c>ValidationError</c> built
+    /// alongside it.
+    /// </summary>
+    private static IEnumerable<string> FindLeaks(string source)
+    {
+        // Scan with literals and comments blanked out: a `)` inside a string would otherwise end the
+        // argument span early and hide a later `.Message`, and `ex.Message` named in prose is not code.
+        string code = BlankOutLiteralsAndComments(source);
+        string exceptionMessagePattern = BuildExceptionMessagePattern(code);
+        Regex exceptionMessage = new(exceptionMessagePattern, RegexOptions.IgnoreCase);
+
+        // Handlers also build the error indirectly (`ValidationError e = new() { ErrorMessage = ex.Message };`
+        // then `Result.Invalid(e)`), which the factory-call scan below cannot see.
+        Regex indirect = new(
+            @"(?:ErrorMessage|Detail|Title)\s*=\s*[^;]*?(?:" + exceptionMessagePattern + @")"
+            + @"|new\s+ValidationError\s*\([^)]*?(?:" + exceptionMessagePattern + @")",
+            RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+        foreach (Match match in indirect.Matches(code))
+        {
+            yield return Excerpt(source, match.Index, match.Length);
+        }
+
+        foreach (Match factory in FactoryCall.Matches(code))
+        {
+            int end = FindMatchingCloseParen(code, factory.Index + factory.Length - 1);
+            if (end < 0)
+            {
+                continue;
+            }
+
+            if (exceptionMessage.IsMatch(code[factory.Index..end]))
+            {
+                yield return Excerpt(source, factory.Index, end - factory.Index);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Matches a read of a caught exception's <c>Message</c>: the identifiers this file's own
+    /// <c>catch</c> clauses bind, plus any <c>*Exception.Message</c> spelled out by type.
+    /// </summary>
+    private static string BuildExceptionMessagePattern(string code)
+    {
+        HashSet<string> identifiers = CatchClause.Matches(code)
+            .Select(match => match.Groups[1].Value)
+            .ToHashSet(StringComparer.Ordinal);
+
+        // Covered without a catch clause in view, so a helper taking an `Exception exception`
+        // parameter is policed the same way a catch block is.
+        identifiers.Add("exception");
+        identifiers.Add("ex");
+
+        return ExceptionTypeMessagePattern
+            + @"|(?<!\w)(?:" + string.Join('|', identifiers.Select(Regex.Escape)) + @")\s*\??\s*\.\s*Message\b";
+    }
+
+    /// <summary>
+    /// Replaces the contents of comments and string/char literals with spaces, keeping every other
+    /// character at its original offset so reported excerpts still line up with the real source.
+    /// Interpolation holes are left intact - <c>$"{ex.Message}"</c> is code, and a leak.
+    /// </summary>
+    private static string BlankOutLiteralsAndComments(string source)
+    {
+        char[] result = source.ToCharArray();
+        int i = 0;
+
+        while (i < source.Length)
+        {
+            if (Matches(source, i, "//"))
+            {
+                while (i < source.Length && source[i] is not ('\n' or '\r'))
+                {
+                    result[i++] = ' ';
+                }
+            }
+            else if (Matches(source, i, "/*"))
+            {
+                while (i < source.Length && !Matches(source, i, "*/"))
+                {
+                    Blank(result, source, i++);
+                }
+
+                i = Math.Min(i + 2, source.Length);
+            }
+            else if (source[i] is '"' or '\'')
+            {
+                i = BlankLiteral(result, source, i);
+            }
+            else
+            {
+                i++;
+            }
+        }
+
+        return new string(result);
+    }
+
+    /// <summary>
+    /// Blanks the literal starting at <paramref name="start"/>; returns the index just past it.
+    /// </summary>
+    private static int BlankLiteral(char[] result, string source, int start)
+    {
+        // `$`/`@` prefixes sit immediately before the quote in any order (`$@"..."`, `@$"..."`).
+        int prefixStart = start;
+        while (prefixStart > 0 && source[prefixStart - 1] is '$' or '@')
+        {
+            prefixStart--;
+        }
+
+        string prefix = source[prefixStart..start];
+        bool interpolated = prefix.Contains('$');
+        char quote = source[start];
+
+        int quoteRun = 0;
+        while (start + quoteRun < source.Length && source[start + quoteRun] == quote)
+        {
+            quoteRun++;
+        }
+
+        // Raw string literal: `"""…"""`, closed by a run of at least as many quotes. No escapes inside.
+        if (quote == '"' && quoteRun >= 3)
+        {
+            return BlankRawLiteral(result, source, start, quoteRun, interpolated);
+        }
+
+        bool verbatim = prefix.Contains('@');
+        int i = start + 1;
+        result[start] = ' ';
+
+        while (i < source.Length)
+        {
+            char c = source[i];
+
+            if (!verbatim && c == '\\' && i + 1 < source.Length)
+            {
+                result[i] = ' ';
+                result[i + 1] = ' ';
+                i += 2;
+            }
+            else if (verbatim && c == quote && i + 1 < source.Length && source[i + 1] == quote)
+            {
+                result[i] = ' ';
+                result[i + 1] = ' ';
+                i += 2;
+            }
+            else if (interpolated && c == '{')
+            {
+                i = SkipInterpolationHole(result, source, i);
+            }
+            else if (c == quote)
+            {
+                result[i] = ' ';
+                return i + 1;
+            }
+            else if (!verbatim && c is '\n' or '\r')
+            {
+                // Unterminated - the compiler will complain long before this scanner does.
+                return i;
+            }
+            else
+            {
+                Blank(result, source, i);
+                i++;
+            }
+        }
+
+        return i;
+    }
+
+    private static int BlankRawLiteral(char[] result, string source, int start, int quoteRun, bool interpolated)
+    {
+        for (int q = 0; q < quoteRun; q++)
+        {
+            result[start + q] = ' ';
+        }
+
+        int i = start + quoteRun;
+        while (i < source.Length)
+        {
+            if (source[i] == '"')
+            {
+                int run = 0;
+                while (i + run < source.Length && source[i + run] == '"')
+                {
+                    run++;
+                }
+
+                if (run >= quoteRun)
+                {
+                    for (int q = 0; q < run; q++)
+                    {
+                        result[i + q] = ' ';
+                    }
+
+                    return i + run;
+                }
+
+                for (int q = 0; q < run; q++)
+                {
+                    result[i + q] = ' ';
+                }
+
+                i += run;
+                continue;
+            }
+
+            if (interpolated && source[i] == '{')
+            {
+                i = SkipInterpolationHole(result, source, i);
+                continue;
+            }
+
+            Blank(result, source, i);
+            i++;
+        }
+
+        return i;
+    }
+
+    /// <summary>
+    /// Leaves an interpolation hole's expression in place (it is code), blanking only its braces.
+    /// <c>{{</c> is an escaped brace, not a hole.
+    /// </summary>
+    private static int SkipInterpolationHole(char[] result, string source, int open)
+    {
+        if (open + 1 < source.Length && source[open + 1] == '{')
+        {
+            result[open] = ' ';
+            result[open + 1] = ' ';
+            return open + 2;
+        }
+
+        result[open] = ' ';
+        int depth = 1;
+        int i = open + 1;
+
+        while (i < source.Length)
+        {
+            if (source[i] == '{')
+            {
+                depth++;
+            }
+            else if (source[i] == '}')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    result[i] = ' ';
+                    return i + 1;
+                }
+            }
+
+            i++;
+        }
+
+        return i;
+    }
+
+    private static bool Matches(string source, int index, string token) =>
+        index + token.Length <= source.Length && string.CompareOrdinal(source, index, token, 0, token.Length) == 0;
+
+    private static void Blank(char[] result, string source, int index) =>
+        result[index] = source[index] is '\n' or '\r' ? source[index] : ' ';
+
+    private static string Excerpt(string source, int start, int length) =>
+        source.Substring(start, Math.Min(length, source.Length - start)).ReplaceLineEndings(" ").Trim();
 
     /// <summary>
     /// Hand-written sources only - build output (obj/bin) is generated and not ours to police.

--- a/tests/Endatix.Api.Tests/Infrastructure/ResultFactoryMustNotInterpolateExceptionMessageTests.cs
+++ b/tests/Endatix.Api.Tests/Infrastructure/ResultFactoryMustNotInterpolateExceptionMessageTests.cs
@@ -1,0 +1,91 @@
+using System.Text.RegularExpressions;
+
+namespace Endatix.Api.Tests.Infrastructure;
+
+/// <summary>
+/// Guards against leaking exception text into RFC7807 <c>detail</c> via Result factories.
+/// </summary>
+public sealed class ResultFactoryMustNotInterpolateExceptionMessageTests
+{
+    private static readonly Regex FactoryCall = new(
+        @"Result(?:<[^>]+>)?\s*\.\s*(Error|Invalid)\s*\(",
+        RegexOptions.Compiled);
+
+    private static readonly Regex ExceptionMessage = new(
+        @"(?<!Error)Exception\s*\??\s*\.\s*Message|(?<!\w)ex\.Message|(?<!\w)exception\.Message",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    [Fact]
+    public void OssSrc_ResultFactories_DoNotPassExceptionMessage()
+    {
+        // Arrange
+        string srcRoot = FindOssSrcRoot();
+        List<string> leaks = [];
+
+        // Act
+        foreach (string file in Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories))
+        {
+            string text = File.ReadAllText(file);
+            foreach (Match factory in FactoryCall.Matches(text))
+            {
+                int start = factory.Index;
+                int end = FindMatchingCloseParen(text, factory.Index + factory.Length - 1);
+                if (end < 0)
+                {
+                    continue;
+                }
+
+                string argumentSpan = text[start..end];
+                if (ExceptionMessage.IsMatch(argumentSpan))
+                {
+                    leaks.Add($"{Path.GetRelativePath(srcRoot, file)}: {argumentSpan.ReplaceLineEndings(" ").Trim()}");
+                }
+            }
+        }
+
+        // Assert
+        leaks.Should().BeEmpty(
+            "Result.Error / Result.Invalid arguments must be author-written; exception text belongs in logs. Leaks:\n{0}",
+            string.Join('\n', leaks));
+    }
+
+    private static string FindOssSrcRoot()
+    {
+        DirectoryInfo? dir = new(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            string candidate = Path.Combine(dir.FullName, "src");
+            if (Directory.Exists(Path.Combine(candidate, "Endatix.Core")))
+            {
+                return candidate;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate oss/src from the test output directory.");
+    }
+
+    private static int FindMatchingCloseParen(string text, int openParenIndex)
+    {
+        int depth = 0;
+        for (int i = openParenIndex; i < text.Length; i++)
+        {
+            char c = text[i];
+            if (c == '(')
+            {
+                depth++;
+            }
+            else if (c == ')')
+            {
+                depth--;
+                if (depth == 0)
+                {
+                    return i + 1;
+                }
+            }
+        }
+
+        return -1;
+    }
+}

--- a/tests/Endatix.Api.Tests/Infrastructure/ResultFactoryMustNotInterpolateExceptionMessageTests.cs
+++ b/tests/Endatix.Api.Tests/Infrastructure/ResultFactoryMustNotInterpolateExceptionMessageTests.cs
@@ -5,15 +5,39 @@ namespace Endatix.Api.Tests.Infrastructure;
 /// <summary>
 /// Guards against leaking exception text into RFC7807 <c>detail</c> via Result factories.
 /// </summary>
+/// <remarks>
+/// The sanctioned way to emit a caught exception's message is <c>SafeError.MessageOr(ex, fallback)</c>,
+/// which only returns text from a type that opted in via <c>IEndUserSafeError</c>. That call is what
+/// tells a reviewer or a scanner the detail is intentional; a bare <c>ex.Message</c> never is.
+/// <see cref="EndUserMessage_IsOnlyReadInsideSafeError"/> keeps that gate from being bypassed.
+/// </remarks>
 public sealed class ResultFactoryMustNotInterpolateExceptionMessageTests
 {
+    private const string ExceptionMessagePattern =
+        @"(?<!Error)Exception\s*\??\s*\.\s*Message|(?<!\w)ex\.Message|(?<!\w)exception\.Message";
+
+    // Every Result factory whose message ends up in the RFC7807 `detail`. 4xx details are echoed
+    // verbatim to the client; only 5xx is scrubbed by EndatixProblemDetails.
     private static readonly Regex FactoryCall = new(
-        @"Result(?:<[^>]+>)?\s*\.\s*(Error|Invalid)\s*\(",
+        @"Result(?:<[^>]+>)?\s*\.\s*(Error|Invalid|NotFound|Conflict|Unauthorized|Forbidden|CriticalError|Unavailable)\s*\(",
+        RegexOptions.Compiled);
+
+    // A dereference of the opt-in message, e.g. `safe.EndUserMessage`. Declaring the property or
+    // implementing the interface is not a read, so definitions are excluded by file name above.
+    private static readonly Regex EndUserMessageRead = new(
+        @"\.\s*EndUserMessage(?!\s*[{=])",
         RegexOptions.Compiled);
 
     private static readonly Regex ExceptionMessage = new(
-        @"(?<!Error)Exception\s*\??\s*\.\s*Message|(?<!\w)ex\.Message|(?<!\w)exception\.Message",
+        ExceptionMessagePattern,
         RegexOptions.Compiled | RegexOptions.IgnoreCase);
+
+    // Handlers usually build the error indirectly (`ValidationError e = new() { ErrorMessage = ex.Message };`
+    // then `Result.Invalid(e)`), which the factory-call scan above cannot see.
+    private static readonly Regex IndirectExceptionMessage = new(
+        @"(?:ErrorMessage|Detail|Title)\s*=\s*[^;]*?(?:" + ExceptionMessagePattern + @")"
+        + @"|new\s+ValidationError\s*\([^)]*?(?:" + ExceptionMessagePattern + @")",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.Singleline);
 
     [Fact]
     public void OssSrc_ResultFactories_DoNotPassExceptionMessage()
@@ -23,9 +47,15 @@ public sealed class ResultFactoryMustNotInterpolateExceptionMessageTests
         List<string> leaks = [];
 
         // Act
-        foreach (string file in Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories))
+        foreach (string file in EnumerateSourceFiles(srcRoot))
         {
             string text = File.ReadAllText(file);
+
+            foreach (Match indirect in IndirectExceptionMessage.Matches(text))
+            {
+                leaks.Add($"{Path.GetRelativePath(srcRoot, file)}: {indirect.Value.ReplaceLineEndings(" ").Trim()}");
+            }
+
             foreach (Match factory in FactoryCall.Matches(text))
             {
                 int start = factory.Index;
@@ -48,6 +78,49 @@ public sealed class ResultFactoryMustNotInterpolateExceptionMessageTests
             "Result.Error / Result.Invalid arguments must be author-written; exception text belongs in logs. Leaks:\n{0}",
             string.Join('\n', leaks));
     }
+
+    /// <summary>
+    /// <c>IEndUserSafeError.EndUserMessage</c> is the one message the codebase may return verbatim, so it
+    /// must be read through the single audited gate rather than dereferenced ad hoc. Keeping every read in
+    /// <c>SafeError</c> means reviewing the opt-in policy is reviewing one file.
+    /// </summary>
+    [Fact]
+    public void EndUserMessage_IsOnlyReadInsideSafeError()
+    {
+        // Arrange
+        string srcRoot = FindOssSrcRoot();
+        List<string> reads = [];
+
+        // Act
+        foreach (string file in EnumerateSourceFiles(srcRoot))
+        {
+            string fileName = Path.GetFileName(file);
+            if (fileName is "SafeError.cs" or "IEndUserSafeError.cs"
+                or "DomainRuleException.cs" or "DomainValidationException.cs")
+            {
+                continue;
+            }
+
+            if (EndUserMessageRead.IsMatch(File.ReadAllText(file)))
+            {
+                reads.Add(Path.GetRelativePath(srcRoot, file));
+            }
+        }
+
+        // Assert
+        reads.Should().BeEmpty(
+            "EndUserMessage must be read via SafeError.MessageOr, which is the audited gate for "
+            + "client-visible exception text. Direct reads:\n{0}",
+            string.Join('\n', reads));
+    }
+
+    /// <summary>
+    /// Hand-written sources only - build output (obj/bin) is generated and not ours to police.
+    /// </summary>
+    private static IEnumerable<string> EnumerateSourceFiles(string srcRoot) =>
+        Directory.EnumerateFiles(srcRoot, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !path.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}", StringComparison.Ordinal)
+                && !path.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}", StringComparison.Ordinal));
 
     private static string FindOssSrcRoot()
     {

--- a/tests/Endatix.Core.Tests/Exceptions/SafeErrorTests.cs
+++ b/tests/Endatix.Core.Tests/Exceptions/SafeErrorTests.cs
@@ -1,0 +1,155 @@
+using Endatix.Core.Exceptions;
+using Microsoft.Extensions.Logging;
+
+namespace Endatix.Core.Tests.Exceptions;
+
+/// <summary>
+/// <see cref="SafeError"/> is the only gate between a caught exception and client-visible text, so its
+/// two branches - opted in, and everything else - are what keep provider detail out of HTTP responses.
+/// </summary>
+public class SafeErrorTests
+{
+    private const string Fallback = "Could not add locale.";
+
+    [Fact]
+    public void MessageOr_WithDomainRuleException_ReturnsTheDomainMessage()
+    {
+        // Arrange
+        DomainRuleException exception = new("A data list cannot have more than 25 cultures.");
+
+        // Act
+        var message = SafeError.MessageOr(exception, Fallback);
+
+        // Assert
+        message.Should().Be("A data list cannot have more than 25 cultures.");
+    }
+
+    [Fact]
+    public void MessageOr_WithDomainValidationException_OmitsTheParameterName()
+    {
+        // Arrange
+        DomainValidationException exception = new(
+            "The synthetic 'default' key cannot be added as a culture.",
+            "cultureCode");
+
+        // Act
+        var message = SafeError.MessageOr(exception, Fallback);
+
+        // Assert
+        message.Should().Be("The synthetic 'default' key cannot be added as a culture.");
+        exception.Message.Should().Contain("cultureCode", "ArgumentException decorates Message, EndUserMessage must not");
+    }
+
+    [Theory]
+    [InlineData("relation \"DataLists\" does not exist")]
+    [InlineData("Host=db;Username=postgres;Password=hunter2")]
+    public void MessageOr_WithProviderStyleException_ReturnsTheFallback(string providerText)
+    {
+        // Arrange
+        InvalidOperationException exception = new(providerText);
+
+        // Act
+        var message = SafeError.MessageOr(exception, Fallback);
+
+        // Assert
+        message.Should().Be(Fallback);
+        message.Should().NotContain(providerText);
+    }
+
+    [Fact]
+    public void MessageOr_WithArgumentException_ReturnsTheFallback()
+    {
+        // Arrange - the same base type a domain-safe rejection uses; only the opt-in distinguishes them.
+        ArgumentException exception = new("Value does not fall within the expected range.", "jsonObjectKey");
+
+        // Act
+        var message = SafeError.MessageOr(exception, Fallback);
+
+        // Assert
+        message.Should().Be(Fallback);
+    }
+
+    [Fact]
+    public void MessageOr_WithNull_ReturnsTheFallback()
+    {
+        // Act
+        var message = SafeError.MessageOr(null, Fallback);
+
+        // Assert
+        message.Should().Be(Fallback);
+    }
+
+    [Fact]
+    public void MessageOr_WhenInnerExceptionCarriesProviderText_DoesNotSurfaceIt()
+    {
+        // Arrange
+        InvalidOperationException inner = new("Npgsql: 28P01 password authentication failed");
+        DomainRuleException exception = new("A data list cannot have more than 25 cultures.", inner);
+
+        // Act
+        var message = SafeError.MessageOr(exception, Fallback);
+
+        // Assert
+        message.Should().Be("A data list cannot have more than 25 cultures.");
+        message.Should().NotContain("Npgsql");
+    }
+
+    /// <summary>
+    /// <see cref="SafeError.LogAndResolve"/> exists so call sites stop re-deciding the severity: a rule
+    /// the caller broke is informational, anything else is an error carrying the full exception.
+    /// </summary>
+    [Fact]
+    public void LogAndResolve_WithSafeError_LogsInformationAndReturnsTheDomainMessage()
+    {
+        // Arrange
+        RecordingLogger logger = new();
+        DomainRuleException exception = new("A data list cannot have more than 25 cultures.");
+
+        // Act
+        var message = SafeError.LogAndResolve(logger, exception, Fallback, "adding locale 'de' to data list 7");
+
+        // Assert
+        message.Should().Be("A data list cannot have more than 25 cultures.");
+        logger.Level.Should().Be(LogLevel.Information);
+        logger.Exception.Should().BeNull("an expected rejection is not an error report");
+    }
+
+    [Fact]
+    public void LogAndResolve_WithUnexpectedException_LogsErrorWithTheExceptionAndReturnsTheFallback()
+    {
+        // Arrange
+        RecordingLogger logger = new();
+        InvalidOperationException exception = new("Npgsql: 28P01 password authentication failed");
+
+        // Act
+        var message = SafeError.LogAndResolve(logger, exception, Fallback, "adding locale 'de' to data list 7");
+
+        // Assert
+        message.Should().Be(Fallback);
+        message.Should().NotContain("Npgsql");
+        logger.Level.Should().Be(LogLevel.Error);
+        logger.Exception.Should().BeSameAs(exception, "the diagnostic must survive somewhere");
+    }
+
+    private sealed class RecordingLogger : ILogger
+    {
+        public LogLevel? Level { get; private set; }
+
+        public Exception? Exception { get; private set; }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            Level = logLevel;
+            Exception = exception;
+        }
+    }
+}

--- a/tests/Endatix.Core.Tests/Models/Themes/ThemeJsonDataTests.cs
+++ b/tests/Endatix.Core.Tests/Models/Themes/ThemeJsonDataTests.cs
@@ -1,0 +1,49 @@
+using Endatix.Core.Infrastructure.Result;
+using Endatix.Core.Models.Themes;
+
+namespace Endatix.Core.Tests.Models.Themes;
+
+public class ThemeJsonDataTests
+{
+    [Theory]
+    [InlineData("{\n  \"themeName\": \"dark\",\n  \"cssVariables\": ,\n}")]
+    [InlineData("invalid-theme-data")]
+    public void Create_WithUnparsableJson_ReturnsTheStaticMessage(string json)
+    {
+        // Act
+        var result = ThemeJsonData.Create(json);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().ContainSingle()
+            .Which.ErrorMessage.Should().Be("Theme JSON is invalid.");
+    }
+
+    /// <summary>
+    /// <see cref="System.Text.Json.JsonException.Message"/> names .NET types and property paths, so the
+    /// caller is told only that their payload did not parse.
+    /// </summary>
+    [Fact]
+    public void Create_WithTypeMismatch_DoesNotLeakSerializerDetail()
+    {
+        // Act
+        var result = ThemeJsonData.Create("{\"themeName\": 12345}");
+
+        // Assert
+        var message = result.ValidationErrors.Should().ContainSingle().Which.ErrorMessage;
+        message.Should().Be("Theme JSON is invalid.");
+        message.Should().NotContainAny("ThemeData", "System.", "Path:", "JsonException");
+    }
+
+    [Fact]
+    public void Create_WithEmptyJson_ReturnsInvalid()
+    {
+        // Act
+        var result = ThemeJsonData.Create(string.Empty);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Invalid);
+        result.ValidationErrors.Should().ContainSingle()
+            .Which.ErrorMessage.Should().Be("Theme data cannot be empty");
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/DataListEnsureLocalesTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/DataListEnsureLocalesTests.cs
@@ -1,0 +1,91 @@
+using Endatix.Core.Entities;
+using Endatix.Core.Exceptions;
+using Endatix.Core.UseCases.DataLists;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Endatix.Core.Tests.UseCases.DataLists;
+
+public class DataListEnsureLocalesTests
+{
+    private static DataList CreateDataList() =>
+        new(SampleData.TENANT_ID, "Cities", "Test list", "cities");
+
+    [Fact]
+    public void TryEnsure_WithValidLocales_ReturnsNull()
+    {
+        // Arrange
+        var dataList = CreateDataList();
+
+        // Act
+        var errors = DataListEnsureLocales.TryEnsure(dataList, ["es", "fr"], NullLogger.Instance);
+
+        // Assert
+        errors.Should().BeNull();
+        dataList.AvailableLocales.Should().Contain(["es", "fr"]);
+    }
+
+    /// <summary>
+    /// The catalog cap is a domain rule the caller can act on. Masking it as "Could not add locale."
+    /// left the failure undiagnosable, so it must arrive intact via <see cref="IEndUserSafeError"/>.
+    /// </summary>
+    [Fact]
+    public void TryEnsure_WhenCatalogCapExceeded_SurfacesTheDomainRule()
+    {
+        // Arrange
+        var dataList = CreateDataList();
+        var locales = BuildLocalesBeyondCap(dataList.MaxAvailableCultures);
+
+        // Act
+        var errors = DataListEnsureLocales.TryEnsure(dataList, locales, NullLogger.Instance);
+
+        // Assert
+        errors.Should().NotBeNull();
+        errors!.Should().Contain(e =>
+            e.ErrorMessage == $"A data list cannot have more than {dataList.MaxAvailableCultures} cultures.");
+        errors.Should().NotContain(e => e.ErrorMessage == "Could not add locale.");
+    }
+
+    [Fact]
+    public void TryEnsure_WithMalformedCultureCode_ReportsTheToken()
+    {
+        // Arrange
+        var dataList = CreateDataList();
+
+        // Act
+        var errors = DataListEnsureLocales.TryEnsure(dataList, ["not a locale"], NullLogger.Instance);
+
+        // Assert
+        errors.Should().ContainSingle()
+            .Which.ErrorMessage.Should().Be("'not a locale' is not a valid culture code.");
+    }
+
+    [Fact]
+    public void TryEnsure_WithSyntheticDefaultKey_IsRejected()
+    {
+        // Arrange
+        var dataList = CreateDataList();
+
+        // Act
+        var errors = DataListEnsureLocales.TryEnsure(dataList, ["default"], NullLogger.Instance);
+
+        // Assert
+        errors.Should().ContainSingle()
+            .Which.Identifier.Should().Be("EnsureLocales.default");
+    }
+
+    /// <summary>
+    /// Enough distinct, well-formed culture codes to push the catalog past its cap.
+    /// </summary>
+    private static string[] BuildLocalesBeyondCap(int cap)
+    {
+        string[] pool =
+        [
+            "es", "fr", "de", "it", "pt", "nl", "sv", "da", "fi", "no",
+            "pl", "cs", "sk", "hu", "ro", "bg", "el", "tr", "ru", "uk",
+            "ja", "ko", "zh", "ar", "he", "hi", "th", "vi", "id", "ms",
+            "et", "lv", "lt", "sl", "hr", "sr", "ca", "eu", "gl", "is"
+        ];
+
+        return [.. pool.Take(cap + 1)];
+    }
+}

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsHandlerTests.cs
@@ -334,7 +334,11 @@ public class ReplaceDataListItemsHandlerTests
             TestContext.Current.CancellationToken);
 
         result.Status.Should().Be(ResultStatus.Invalid);
-        result.ValidationErrors.Should().Contain(e => e.Identifier == "Items[0].Labels.default");
+        result.ValidationErrors.Should().Contain(e =>
+            e.Identifier == "Items[0].Labels.default"
+            && e.ErrorMessage == "Labels must include a non-empty 'default' entry.");
+        result.ValidationErrors.Should().NotContain(e =>
+            e.ErrorMessage.Contains(DataListItem.MAX_LABEL_LENGTH.ToString()));
     }
 
     [Fact]

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsHandlerTests.cs
@@ -1,12 +1,13 @@
 using Endatix.Core.Abstractions;
 using Endatix.Core.Common.Translations;
 using Endatix.Core.Entities;
+using Endatix.Core.Exceptions;
 using Endatix.Core.Events;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;
 using Endatix.Core.UseCases.DataLists.ReplaceItems;
-using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
 using MediatR;
 
 namespace Endatix.Core.Tests.UseCases.DataLists.ReplaceItems;
@@ -17,6 +18,7 @@ public class ReplaceDataListItemsHandlerTests
     private readonly IMediator _mediator;
     private readonly IIdGenerator<long> _idGenerator;
     private readonly ReplaceDataListItemsHandler _sut;
+    private readonly RecordingLogger _logger = new();
     private long _nextId = 100;
 
     public ReplaceDataListItemsHandlerTests()
@@ -29,7 +31,7 @@ public class ReplaceDataListItemsHandlerTests
             _repository,
             _mediator,
             _idGenerator,
-            NullLogger<ReplaceDataListItemsHandler>.Instance);
+            _logger);
     }
 
     private static ReplaceDataListItemInput Item(string label, string value) =>
@@ -383,5 +385,55 @@ public class ReplaceDataListItemsHandlerTests
         result.ValidationErrors.Should().Contain(e => e.Identifier == "Items[0].Labels");
         result.ValidationErrors.Should().Contain(e => e.Identifier == "Items[0].Value");
         result.ValidationErrors.Should().Contain(e => e.Identifier == "Items[1].Labels.fr");
+    }
+
+    /// <summary>
+    /// A label rejection reaches the caller through <see cref="SafeError.LogAndResolve"/> rather than
+    /// <c>MessageOr</c>, so closing the leak did not also close the log. Every throw in
+    /// <c>NormalizeLabels</c> is a <c>DomainValidationException</c> today, so this asserts the opted-in
+    /// half; the other half - an <see cref="ArgumentException"/> that never opted in is logged at
+    /// <see cref="LogLevel.Error"/> with the exception, the caller seeing only the static fallback - is
+    /// covered by <c>SafeErrorTests.LogAndResolve_WithUnexpectedException_LogsErrorWithTheExceptionAndReturnsTheFallback</c>.
+    /// </summary>
+    [Fact]
+    public async Task Handle_LabelRejected_LogsTheRejection()
+    {
+        DataList dataList = new(SampleData.TENANT_ID, "Cities") { Id = 1 };
+        dataList.AddCulture(CultureCode.Parse("es"));
+        _repository.SingleOrDefaultAsync(Arg.Any<DataListsSpecifications.ByIdWithItemsSpec>(), Arg.Any<CancellationToken>())
+            .Returns(dataList);
+
+        var result = await _sut.Handle(
+            new ReplaceDataListItemsCommand(1, [
+                new(
+                    Value: "NYC",
+                    Labels: new Dictionary<string, string> { ["es"] = "Nueva York" })
+            ]),
+            TestContext.Current.CancellationToken);
+
+        result.Status.Should().Be(ResultStatus.Invalid);
+        _logger.Entries.Should().Contain(entry =>
+            entry.Level == LogLevel.Information
+            && entry.Message.Contains("normalizing labels for item 0 of data list 1"));
+    }
+
+    /// <summary>
+    /// Captures what was logged so a test can assert the record exists, not just its absence.
+    /// </summary>
+    private sealed class RecordingLogger : ILogger<ReplaceDataListItemsHandler>
+    {
+        public List<(LogLevel Level, string Message, Exception? Exception)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            Entries.Add((logLevel, formatter(state, exception), exception));
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/ReplaceItems/ReplaceDataListItemsHandlerTests.cs
@@ -6,6 +6,7 @@ using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;
 using Endatix.Core.UseCases.DataLists.ReplaceItems;
+using Microsoft.Extensions.Logging.Abstractions;
 using MediatR;
 
 namespace Endatix.Core.Tests.UseCases.DataLists.ReplaceItems;
@@ -24,7 +25,11 @@ public class ReplaceDataListItemsHandlerTests
         _mediator = Substitute.For<IMediator>();
         _idGenerator = Substitute.For<IIdGenerator<long>>();
         _idGenerator.CreateId().Returns(_ => Interlocked.Increment(ref _nextId));
-        _sut = new ReplaceDataListItemsHandler(_repository, _mediator, _idGenerator);
+        _sut = new ReplaceDataListItemsHandler(
+            _repository,
+            _mediator,
+            _idGenerator,
+            NullLogger<ReplaceDataListItemsHandler>.Instance);
     }
 
     private static ReplaceDataListItemInput Item(string label, string value) =>
@@ -266,9 +271,7 @@ public class ReplaceDataListItemsHandlerTests
             TestContext.Current.CancellationToken);
 
         result.Status.Should().Be(ResultStatus.Invalid);
-        result.ValidationErrors.Should().Contain(e =>
-            e.Identifier == "Items"
-            && e.ErrorMessage.Contains(DataList.MAX_ITEMS.ToString()));
+        result.ValidationErrors.Should().Contain(e => e.Identifier == "Items");
         await _repository.DidNotReceive().UpdateAsync(Arg.Any<DataList>(), Arg.Any<CancellationToken>());
     }
 

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/Search/SearchDataListItemsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/Search/SearchDataListItemsHandlerTests.cs
@@ -3,6 +3,9 @@ using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.UseCases.DataLists.Search;
 using Endatix.Core.Common.Translations;
+using Endatix.Core.Exceptions;
+using NSubstitute.ExceptionExtensions;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Endatix.Core.Tests.UseCases.DataLists.Search;
 
@@ -14,7 +17,7 @@ public class SearchDataListItemsHandlerTests
     public SearchDataListItemsHandlerTests()
     {
         _repository = Substitute.For<IDataListRepository>();
-        _sut = new SearchDataListItemsHandler(_repository);
+        _sut = new SearchDataListItemsHandler(_repository, NullLogger<SearchDataListItemsHandler>.Instance);
     }
 
     private static DataListSearchItemResult Item(
@@ -289,5 +292,49 @@ public class SearchDataListItemsHandlerTests
 
         act.Should().Throw<ArgumentException>()
             .Which.ParamName.Should().Be("cultureCode");
+    }
+
+    /// <summary>
+    /// BCL and EF Core argument text can name columns, expressions and providers, so it must never reach
+    /// the response - only author-written text does.
+    /// </summary>
+    [Fact]
+    public async Task Handle_WhenSearchRejectsAnArgument_DoesNotEchoTheExceptionMessage()
+    {
+        // Arrange
+        const string internalDetail = "The LINQ expression 'DbSet<DataListItem>.Where(...)' could not be translated";
+        _repository.SearchItemsAsync(Arg.Any<DataListSearchCriteria>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ArgumentException(internalDetail, "cultureCode"));
+
+        // Act
+        var result = await _sut.Handle(new SearchDataListItemsQuery(1, "App", 0, 10), CancellationToken.None);
+
+        // Assert
+        var error = result.ValidationErrors.Should().ContainSingle().Which;
+        error.ErrorMessage.Should().NotContain("LINQ");
+        error.Identifier.Should().Be(nameof(SearchDataListItemsQuery.Locale));
+        error.ErrorMessage.Should().Be("Invalid locale.");
+    }
+
+    /// <summary>
+    /// A domain rule that opted into <see cref="IEndUserSafeError"/> is surfaced intact.
+    /// </summary>
+    [Fact]
+    public async Task Handle_WhenSearchRejectsWithASafeDomainError_SurfacesTheDomainMessage()
+    {
+        // Arrange
+        _repository.SearchItemsAsync(Arg.Any<DataListSearchCriteria>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new DomainValidationException(
+                "'zz-ZZ' is not in the data list AvailableLocales catalog.",
+                "cultureCode"));
+
+        // Act
+        var result = await _sut.Handle(new SearchDataListItemsQuery(1, "App", 0, 10), CancellationToken.None);
+
+        // Assert
+        var error = result.ValidationErrors.Should().ContainSingle().Which;
+        error.Identifier.Should().Be(nameof(SearchDataListItemsQuery.Locale));
+        error.ErrorMessage.Should().Be("'zz-ZZ' is not in the data list AvailableLocales catalog.");
+        error.ErrorMessage.Should().NotContain("cultureCode");
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/DataLists/Translations/ReplaceDataListTranslationsCsvHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/DataLists/Translations/ReplaceDataListTranslationsCsvHandlerTests.cs
@@ -6,6 +6,7 @@ using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;
 using Endatix.Core.UseCases.DataLists.Translations;
+using Microsoft.Extensions.Logging.Abstractions;
 using MediatR;
 
 namespace Endatix.Core.Tests.UseCases.DataLists.Translations;
@@ -24,7 +25,11 @@ public class ReplaceDataListTranslationsCsvHandlerTests
         _mediator = Substitute.For<IMediator>();
         _idGenerator = Substitute.For<IIdGenerator<long>>();
         _idGenerator.CreateId().Returns(_ => Interlocked.Increment(ref _nextId));
-        _sut = new ReplaceDataListTranslationsCsvHandler(_repository, _mediator, _idGenerator);
+        _sut = new ReplaceDataListTranslationsCsvHandler(
+            _repository,
+            _mediator,
+            _idGenerator,
+            NullLogger<ReplaceDataListTranslationsCsvHandler>.Instance);
     }
 
     private DataList GivenDataList(params string[] locales)

--- a/tests/Endatix.Core.Tests/UseCases/Folders/Delete/DeleteFolderHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Folders/Delete/DeleteFolderHandlerTests.cs
@@ -6,6 +6,7 @@ using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;
 using Endatix.Core.UseCases.Folders.Delete;
+using Microsoft.Extensions.Logging.Abstractions;
 using MediatR;
 using NSubstitute.ExceptionExtensions;
 
@@ -35,7 +36,8 @@ public class DeleteFolderHandlerTests
             _formTemplateRepository,
             _tenantContext,
             _unitOfWork,
-            _mediator);
+            _mediator,
+            NullLogger<DeleteFolderHandler>.Instance);
     }
 
     [Fact]
@@ -305,7 +307,7 @@ public class DeleteFolderHandlerTests
         var result = await _handler.Handle(request, CancellationToken.None);
 
         result.Status.Should().Be(ResultStatus.Error);
-        result.Errors.Should().Contain(e => e.Contains("Error deleting folder"));
+        result.Errors.Should().Contain(e => e == "Failed to delete folder.");
         await _unitOfWork.Received(1).RollbackTransactionAsync(Arg.Any<CancellationToken>());
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/Forms/List/ListFormsHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Forms/List/ListFormsHandlerTests.cs
@@ -2,6 +2,7 @@ using Endatix.Core.Abstractions.Repositories;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;
 using Endatix.Core.UseCases.Forms;
+using Microsoft.Extensions.Logging.Abstractions;
 using Endatix.Core.UseCases.Forms.List;
 
 namespace Endatix.Core.Tests.UseCases.Forms.List;
@@ -14,7 +15,7 @@ public class ListFormsHandlerTests
     public ListFormsHandlerTests()
     {
         _repository = Substitute.For<IFormsRepository>();
-        _handler = new ListFormsHandler(_repository);
+        _handler = new ListFormsHandler(_repository, NullLogger<ListFormsHandler>.Instance);
     }
 
     [Fact]

--- a/tests/Endatix.Core.Tests/UseCases/Submissions/UpdateStatus/UpdateStatusHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Submissions/UpdateStatus/UpdateStatusHandlerTests.cs
@@ -1,6 +1,8 @@
 using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.UseCases.Submissions.UpdateStatus;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute.ExceptionExtensions;
 
 namespace Endatix.Core.Tests.UseCases.Submissions.UpdateStatus;
@@ -13,7 +15,7 @@ public class UpdateStatusHandlerTests
     public UpdateStatusHandlerTests()
     {
         _submissionRepository = Substitute.For<IRepository<Submission>>();
-        _handler = new UpdateStatusHandler(_submissionRepository);
+        _handler = new UpdateStatusHandler(_submissionRepository, NullLogger<UpdateStatusHandler>.Instance);
     }
 
     [Fact]
@@ -67,14 +69,14 @@ public class UpdateStatusHandlerTests
 
         _submissionRepository.GetByIdAsync(command.SubmissionId, Arg.Any<CancellationToken>())
             .Returns(submission);
-    
+
         // Act
         var result = await _handler.Handle(command, CancellationToken.None);
 
         // Assert
         result.Should().NotBeNull();
         result.IsSuccess.Should().BeFalse();
-        result.ValidationErrors.Should().ContainSingle(e => e.ErrorMessage.Contains("Invalid status code provided"));
+        result.ValidationErrors.Should().ContainSingle(e => e.ErrorMessage == "Invalid status code.");
         await _submissionRepository.DidNotReceive()
             .UpdateAsync(Arg.Any<Submission>(), Arg.Any<CancellationToken>());
     }

--- a/tests/Endatix.Core.Tests/UseCases/Themes/Create/CreateThemeHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Themes/Create/CreateThemeHandlerTests.cs
@@ -122,6 +122,6 @@ public class CreateThemeHandlerTests
         result.Should().NotBeNull();
         result.Status.Should().Be(ResultStatus.Invalid);
         result.IsInvalid().Should().BeTrue();
-        result.ValidationErrors.Should().Contain(e => e.ErrorMessage.StartsWith("Theme JSON is invalid"));
+        result.ValidationErrors.Should().Contain(e => e.ErrorMessage == "Theme JSON is invalid.");
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/Themes/Create/CreateThemeHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Themes/Create/CreateThemeHandlerTests.cs
@@ -31,12 +31,12 @@ public class CreateThemeHandlerTests
         // Arrange
         var themeData = new ThemeData { ThemeName = "Test Theme" };
         var request = new CreateThemeCommand("Test Theme", "Test Description", JsonSerializer.Serialize(themeData));
-        
+
         _themesRepository.FirstOrDefaultAsync(
             Arg.Any<ThemeSpecifications.ByName>(),
             Arg.Any<CancellationToken>())
             .Returns((Theme?)null);
-        
+
         _tenantContext.TenantId.Returns(SampleData.TENANT_ID);
 
         // Act
@@ -48,14 +48,14 @@ public class CreateThemeHandlerTests
         result.Value.Should().NotBeNull();
         result.Value.Name.Should().Be(request.Name);
         result.Value.Description.Should().Be(request.Description);
-        
+
         // Verify JSON data contains the theme name
         var jsonData = JsonSerializer.Deserialize<ThemeData>(result.Value.JsonData);
         jsonData.Should().NotBeNull();
         jsonData!.ThemeName.Should().Be(request.Name);
 
         await _themesRepository.Received(1).AddAsync(
-            Arg.Is<Theme>(t => 
+            Arg.Is<Theme>(t =>
                 t.Name == request.Name &&
                 t.Description == request.Description
             ),
@@ -86,7 +86,7 @@ public class CreateThemeHandlerTests
         // Arrange
         var request = new CreateThemeCommand("Existing Theme", "Test Description");
         var existingTheme = new Theme(SampleData.TENANT_ID, "Existing Theme") { Id = 1 };
-        
+
         _tenantContext.TenantId.Returns(SampleData.TENANT_ID);
         _themesRepository.FirstOrDefaultAsync(
             Arg.Any<ThemeSpecifications.ByName>(),
@@ -108,7 +108,7 @@ public class CreateThemeHandlerTests
     {
         // Arrange
         var request = new CreateThemeCommand("Test Theme", "Test Description", "invalid-json-data");
-        
+
         _tenantContext.TenantId.Returns(SampleData.TENANT_ID);
         _themesRepository.FirstOrDefaultAsync(
             Arg.Any<ThemeSpecifications.ByName>(),
@@ -122,6 +122,6 @@ public class CreateThemeHandlerTests
         result.Should().NotBeNull();
         result.Status.Should().Be(ResultStatus.Invalid);
         result.IsInvalid().Should().BeTrue();
-        result.ValidationErrors.Should().Contain(e => e.ErrorMessage.Contains("Invalid JSON"));
+        result.ValidationErrors.Should().Contain(e => e.ErrorMessage == "Theme JSON is invalid.");
     }
-} 
+}

--- a/tests/Endatix.Core.Tests/UseCases/Themes/Create/CreateThemeHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Themes/Create/CreateThemeHandlerTests.cs
@@ -122,6 +122,6 @@ public class CreateThemeHandlerTests
         result.Should().NotBeNull();
         result.Status.Should().Be(ResultStatus.Invalid);
         result.IsInvalid().Should().BeTrue();
-        result.ValidationErrors.Should().Contain(e => e.ErrorMessage == "Theme JSON is invalid.");
+        result.ValidationErrors.Should().Contain(e => e.ErrorMessage.StartsWith("Theme JSON is invalid"));
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/Themes/Delete/DeleteThemeHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Themes/Delete/DeleteThemeHandlerTests.cs
@@ -4,7 +4,7 @@ using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;
-using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Logging;
 using Endatix.Core.UseCases.Themes.Delete;
 using NSubstitute.ExceptionExtensions;
 
@@ -16,6 +16,7 @@ public class DeleteThemeHandlerTests
     private readonly IRepository<Form> _formsRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly DeleteThemeHandler _handler;
+    private readonly RecordingLogger _logger = new();
 
     public DeleteThemeHandlerTests()
     {
@@ -26,7 +27,7 @@ public class DeleteThemeHandlerTests
             _themesRepository,
             _formsRepository,
             _unitOfWork,
-            NullLogger<DeleteThemeHandler>.Instance);
+            _logger);
     }
 
     [Fact]
@@ -144,5 +145,61 @@ public class DeleteThemeHandlerTests
         result.Should().NotBeNull();
         result.Status.Should().Be(ResultStatus.Error);
         result.Errors.Should().Contain(e => e == "Failed to delete theme.");
+    }
+
+    /// <summary>
+    /// The original cause is the only thing worth diagnosing, so it must be logged before the rollback
+    /// that follows it. Rollback itself can no longer destroy it - <c>IUnitOfWork.RollbackTransactionAsync</c>
+    /// is contractually non-throwing, covered by <c>AppUnitOfWorkTests</c> - but the ordering keeps the
+    /// record independent of that guarantee.
+    /// </summary>
+    [Fact]
+    public async Task Handle_WhenDeletionFails_LogsTheCauseBeforeRollingBack()
+    {
+        // Arrange
+        var theme = new Theme(SampleData.TENANT_ID, "Test Theme") { Id = 1 };
+        var request = new DeleteThemeCommand(1);
+        var cause = new Exception("Database error");
+
+        _themesRepository.GetByIdAsync(request.ThemeId, Arg.Any<CancellationToken>())
+                     .Returns(theme);
+
+        _formsRepository.ListAsync(
+            Arg.Any<FormSpecifications.ByThemeId>(),
+            Arg.Any<CancellationToken>())
+            .Returns(new List<Form>());
+
+        _themesRepository.DeleteAsync(Arg.Any<Theme>(), Arg.Any<CancellationToken>())
+                     .ThrowsAsync(cause);
+
+        // Act
+        var result = await _handler.Handle(request, CancellationToken.None);
+
+        // Assert
+        result.Status.Should().Be(ResultStatus.Error);
+        result.Errors.Should().Contain(e => e == "Failed to delete theme.");
+        _logger.Entries.Should().ContainSingle(entry =>
+            entry.Level == LogLevel.Error && entry.Exception == cause);
+        await _unitOfWork.Received(1).RollbackTransactionAsync(Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Captures what was logged so a test can assert the record exists, not just its absence.
+    /// </summary>
+    private sealed class RecordingLogger : ILogger<DeleteThemeHandler>
+    {
+        public List<(LogLevel Level, string Message, Exception? Exception)> Entries { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            Entries.Add((logLevel, formatter(state, exception), exception));
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/Themes/Delete/DeleteThemeHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Themes/Delete/DeleteThemeHandlerTests.cs
@@ -4,6 +4,7 @@ using Endatix.Core.Entities;
 using Endatix.Core.Infrastructure.Domain;
 using Endatix.Core.Infrastructure.Result;
 using Endatix.Core.Specifications;
+using Microsoft.Extensions.Logging.Abstractions;
 using Endatix.Core.UseCases.Themes.Delete;
 using NSubstitute.ExceptionExtensions;
 
@@ -21,7 +22,11 @@ public class DeleteThemeHandlerTests
         _themesRepository = Substitute.For<IRepository<Theme>>();
         _formsRepository = Substitute.For<IRepository<Form>>();
         _unitOfWork = Substitute.For<IUnitOfWork>();
-        _handler = new DeleteThemeHandler(_themesRepository, _formsRepository, _unitOfWork);
+        _handler = new DeleteThemeHandler(
+            _themesRepository,
+            _formsRepository,
+            _unitOfWork,
+            NullLogger<DeleteThemeHandler>.Instance);
     }
 
     [Fact]
@@ -138,6 +143,6 @@ public class DeleteThemeHandlerTests
         // Assert
         result.Should().NotBeNull();
         result.Status.Should().Be(ResultStatus.Error);
-        result.Errors.Should().Contain(e => e.Contains("Error deleting theme"));
+        result.Errors.Should().Contain(e => e == "Failed to delete theme.");
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/Themes/PartialUpdate/PartialUpdateThemeHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Themes/PartialUpdate/PartialUpdateThemeHandlerTests.cs
@@ -282,6 +282,6 @@ public class PartialUpdateThemeHandlerTests
         // Assert
         result.Should().NotBeNull();
         result.Status.Should().Be(ResultStatus.Invalid);
-        result.ValidationErrors.Should().Contain(e => e.ErrorMessage.StartsWith("Theme JSON is invalid"));
+        result.ValidationErrors.Should().Contain(e => e.ErrorMessage == "Theme JSON is invalid.");
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/Themes/PartialUpdate/PartialUpdateThemeHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Themes/PartialUpdate/PartialUpdateThemeHandlerTests.cs
@@ -282,6 +282,6 @@ public class PartialUpdateThemeHandlerTests
         // Assert
         result.Should().NotBeNull();
         result.Status.Should().Be(ResultStatus.Invalid);
-        result.ValidationErrors.Should().Contain(e => e.ErrorMessage == "Theme JSON is invalid.");
+        result.ValidationErrors.Should().Contain(e => e.ErrorMessage.StartsWith("Theme JSON is invalid"));
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/Themes/PartialUpdate/PartialUpdateThemeHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Themes/PartialUpdate/PartialUpdateThemeHandlerTests.cs
@@ -282,6 +282,6 @@ public class PartialUpdateThemeHandlerTests
         // Assert
         result.Should().NotBeNull();
         result.Status.Should().Be(ResultStatus.Invalid);
-        result.ValidationErrors.Should().Contain(e => e.ErrorMessage.Contains("Invalid JSON"));
+        result.ValidationErrors.Should().Contain(e => e.ErrorMessage == "Theme JSON is invalid.");
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/Themes/Update/UpdateThemeHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Themes/Update/UpdateThemeHandlerTests.cs
@@ -198,6 +198,6 @@ public class UpdateThemeHandlerTests
         // Assert
         result.Should().NotBeNull();
         result.Status.Should().Be(ResultStatus.Invalid);
-        result.ValidationErrors.Should().Contain(e => e.ErrorMessage == "Theme JSON is invalid.");
+        result.ValidationErrors.Should().Contain(e => e.ErrorMessage.StartsWith("Theme JSON is invalid"));
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/Themes/Update/UpdateThemeHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Themes/Update/UpdateThemeHandlerTests.cs
@@ -198,6 +198,6 @@ public class UpdateThemeHandlerTests
         // Assert
         result.Should().NotBeNull();
         result.Status.Should().Be(ResultStatus.Invalid);
-        result.ValidationErrors.Should().Contain(e => e.ErrorMessage.StartsWith("Theme JSON is invalid"));
+        result.ValidationErrors.Should().Contain(e => e.ErrorMessage == "Theme JSON is invalid.");
     }
 }

--- a/tests/Endatix.Core.Tests/UseCases/Themes/Update/UpdateThemeHandlerTests.cs
+++ b/tests/Endatix.Core.Tests/UseCases/Themes/Update/UpdateThemeHandlerTests.cs
@@ -43,15 +43,16 @@ public class UpdateThemeHandlerTests
         // Arrange
         var themeId = 1;
         var originalTheme = new Theme(SampleData.TENANT_ID, "Original Name", "Original Description") { Id = themeId };
-        
-        var themeData = new ThemeData { 
+
+        var themeData = new ThemeData
+        {
             ThemeName = "Updated Theme",
             ColorPalette = "dark",
             CssVariables = new Dictionary<string, string> { ["--primary-color"] = "#000000" }
         };
         var themeDataJson = JsonSerializer.Serialize(themeData);
         var request = new UpdateThemeCommand(themeId, "Updated Theme", "Updated Description", themeDataJson);
-        
+
         _themesRepository.GetByIdAsync(request.ThemeId, Arg.Any<CancellationToken>())
                      .Returns(originalTheme);
 
@@ -64,7 +65,7 @@ public class UpdateThemeHandlerTests
         result.Value.Should().NotBeNull();
         result.Value.Name.Should().Be(request.Name);
         result.Value.Description.Should().Be(request.Description);
-        
+
         // Verify JSON data was updated
         var jsonData = JsonSerializer.Deserialize<ThemeData>(result.Value.JsonData);
         jsonData.Should().NotBeNull();
@@ -73,7 +74,7 @@ public class UpdateThemeHandlerTests
         jsonData!.CssVariables.Should().ContainKey("--primary-color");
 
         await _themesRepository.Received(1).UpdateAsync(
-            Arg.Is<Theme>(t => 
+            Arg.Is<Theme>(t =>
                 t.Id == themeId &&
                 t.Name == request.Name &&
                 t.Description == request.Description
@@ -88,17 +89,17 @@ public class UpdateThemeHandlerTests
         // Arrange
         var themeId = 1;
         var originalTheme = new Theme(
-            tenantId: SampleData.TENANT_ID, 
-            name: "Original Name", 
-            description: "Original Description", 
+            tenantId: SampleData.TENANT_ID,
+            name: "Original Name",
+            description: "Original Description",
             jsonData: "{\"themeName\":\"Original Name\",\"colorPalette\":\"light\"}"
-        ) 
-        { 
-            Id = themeId 
+        )
+        {
+            Id = themeId
         };
-        
+
         var request = new UpdateThemeCommand(themeId, "Updated Theme", "Updated Description", null);
-        
+
         _themesRepository.GetByIdAsync(request.ThemeId, Arg.Any<CancellationToken>())
                      .Returns(originalTheme);
 
@@ -111,7 +112,7 @@ public class UpdateThemeHandlerTests
         result.Value.Should().NotBeNull();
         result.Value.Name.Should().Be(request.Name);
         result.Value.Description.Should().Be(request.Description);
-        
+
         // Verify name in JSON was updated but other properties remained
         var jsonData = JsonSerializer.Deserialize<ThemeData>(result.Value.JsonData);
         jsonData.Should().NotBeNull();
@@ -127,15 +128,15 @@ public class UpdateThemeHandlerTests
         var themeDataPayload = "{\"themeName\":\"Updated Theme\",\"colorPalette\":\"dark\"}";
         var originalTheme = new Theme(SampleData.TENANT_ID, "Original Name", "Original Description") { Id = themeId };
         var request = new UpdateThemeCommand(
-            themeId: themeId, 
-            name: "Updated Theme", 
+            themeId: themeId,
+            name: "Updated Theme",
             description: "Updated Description",
             themeData: themeDataPayload
         );
-        
+
         _themesRepository.GetByIdAsync(request.ThemeId, Arg.Any<CancellationToken>())
                      .Returns(originalTheme);
-        
+
         _themesRepository.UpdateAsync(Arg.Any<Theme>(), Arg.Any<CancellationToken>())
                      .ThrowsAsync(new Exception("Database error"));
 
@@ -145,7 +146,7 @@ public class UpdateThemeHandlerTests
         // Assert
         await act.Should().ThrowAsync<Exception>();
     }
-    
+
     [Fact]
     public async Task Handle_DuplicateThemeName_ReturnsErrorResult()
     {
@@ -154,15 +155,15 @@ public class UpdateThemeHandlerTests
         var existingThemeId = 2;
         var themeName = "Duplicate Theme Name";
         var emptyThemeData = string.Empty;
-        
+
         var originalTheme = new Theme(SampleData.TENANT_ID, "Original Name", "Original Description") { Id = themeId };
         var existingTheme = new Theme(SampleData.TENANT_ID, themeName, "Another Description") { Id = existingThemeId };
-        
+
         var request = new UpdateThemeCommand(themeId, themeName, "Updated Description", emptyThemeData);
-        
+
         _themesRepository.GetByIdAsync(request.ThemeId, Arg.Any<CancellationToken>())
                      .Returns(originalTheme);
-                     
+
         _themesRepository.FirstOrDefaultAsync(Arg.Any<ISpecification<Theme>>(), Arg.Any<CancellationToken>())
                      .Returns(existingTheme);
 
@@ -173,7 +174,7 @@ public class UpdateThemeHandlerTests
         result.Should().NotBeNull();
         result.Status.Should().Be(ResultStatus.Error);
         result.Errors.Should().Contain($"Another theme with the name '{themeName}' already exists");
-        
+
         // Verify the theme was not updated
         await _themesRepository.DidNotReceive().UpdateAsync(Arg.Any<Theme>(), Arg.Any<CancellationToken>());
     }
@@ -189,14 +190,14 @@ public class UpdateThemeHandlerTests
         var request = new UpdateThemeCommand(themeId, "Updated Theme", "Updated Description", invalidThemeData);
 
         _themesRepository.GetByIdAsync(request.ThemeId, Arg.Any<CancellationToken>())
-                     .Returns(originalTheme);   
+                     .Returns(originalTheme);
 
         // Act
         var result = await _handler.Handle(request, CancellationToken.None);
 
         // Assert
-        result.Should().NotBeNull();    
+        result.Should().NotBeNull();
         result.Status.Should().Be(ResultStatus.Invalid);
-        result.ValidationErrors.Should().Contain(e => e.ErrorMessage.Contains("Invalid JSON"));
+        result.ValidationErrors.Should().Contain(e => e.ErrorMessage == "Theme JSON is invalid.");
     }
-} 
+}

--- a/tests/Endatix.Infrastructure.Tests/Data/AppUnitOfWorkTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Data/AppUnitOfWorkTests.cs
@@ -100,15 +100,19 @@ public class AppUnitOfWorkTests
         await _dbTransaction.Received(1).DisposeAsync();
     }
 
+    /// <summary>
+    /// No active transaction is the state rollback exists to reach, so asking for it again is a no-op.
+    /// Throwing here meant a failed <c>BeginTransactionAsync</c> came back as "Transaction not started"
+    /// from the caller's catch block, hiding the connection failure that actually caused it.
+    /// </summary>
     [Fact]
-    public async Task RollbackTransactionAsync_WhenTransactionNotStarted_ShouldThrowInvalidOperationException()
+    public async Task RollbackTransactionAsync_WhenTransactionNotStarted_ShouldDoNothing()
     {
         // Act
         var act = () => _sut.RollbackTransactionAsync();
 
         // Assert
-        await act.Should().ThrowAsync<InvalidOperationException>()
-            .WithMessage("Transaction not started. Call BeginTransactionAsync first.");
+        await act.Should().NotThrowAsync();
     }
 
     [Fact]
@@ -127,22 +131,89 @@ public class AppUnitOfWorkTests
         await _dbTransaction.Received(1).DisposeAsync();
     }
 
+    /// <summary>
+    /// Callers roll back from a catch block. A rollback failure escaping there would replace the
+    /// exception being handled - the only one worth diagnosing - so it is logged and swallowed.
+    /// </summary>
     [Fact]
-    public async Task RollbackTransactionAsync_WhenRollbackFails_ShouldStillDisposeTransaction()
+    public async Task RollbackTransactionAsync_WhenRollbackFails_ShouldSwallowAndStillDisposeTransaction()
     {
         // Arrange
         var cancellationToken = CancellationToken.None;
         _appDbContext.Database.BeginTransactionAsync(cancellationToken).Returns(_dbTransaction);
         await _sut.BeginTransactionAsync(cancellationToken);
 
-        _dbTransaction.RollbackAsync(cancellationToken)
+        _dbTransaction.RollbackAsync(Arg.Any<CancellationToken>())
             .Throws(new DbUpdateException("Rollback failed"));
 
         // Act
         var act = () => _sut.RollbackTransactionAsync(cancellationToken);
 
         // Assert
-        await act.Should().ThrowAsync<DbUpdateException>();
+        await act.Should().NotThrowAsync();
+        await _dbTransaction.Received(1).DisposeAsync();
+    }
+
+    /// <summary>
+    /// Disposal is the second way rollback can fail, and it must not escape either.
+    /// </summary>
+    [Fact]
+    public async Task RollbackTransactionAsync_WhenDisposeFails_ShouldSwallow()
+    {
+        // Arrange
+        var cancellationToken = CancellationToken.None;
+        _appDbContext.Database.BeginTransactionAsync(cancellationToken).Returns(_dbTransaction);
+        await _sut.BeginTransactionAsync(cancellationToken);
+
+        _dbTransaction.DisposeAsync()
+            .Throws(new DbUpdateException("Dispose failed"));
+
+        // Act
+        var act = () => _sut.RollbackTransactionAsync(cancellationToken);
+
+        // Assert
+        await act.Should().NotThrowAsync();
+    }
+
+    /// <summary>
+    /// The token that cancelled the work must not also cancel undoing it, or a cancelled request
+    /// leaves the transaction open until the context is disposed.
+    /// </summary>
+    [Fact]
+    public async Task RollbackTransactionAsync_WhenTokenAlreadyCancelled_ShouldStillRollBack()
+    {
+        // Arrange
+        _appDbContext.Database.BeginTransactionAsync(Arg.Any<CancellationToken>()).Returns(_dbTransaction);
+        await _sut.BeginTransactionAsync(CancellationToken.None);
+
+        using CancellationTokenSource cts = new();
+        await cts.CancelAsync();
+
+        // Act
+        await _sut.RollbackTransactionAsync(cts.Token);
+
+        // Assert
+        await _dbTransaction.Received(1).RollbackAsync(CancellationToken.None);
+        await _dbTransaction.Received(1).DisposeAsync();
+    }
+
+    /// <summary>
+    /// A rolled back transaction is finished, so a second rollback must not touch it again.
+    /// </summary>
+    [Fact]
+    public async Task RollbackTransactionAsync_CalledTwice_ShouldRollBackOnce()
+    {
+        // Arrange
+        var cancellationToken = CancellationToken.None;
+        _appDbContext.Database.BeginTransactionAsync(cancellationToken).Returns(_dbTransaction);
+        await _sut.BeginTransactionAsync(cancellationToken);
+
+        // Act
+        await _sut.RollbackTransactionAsync(cancellationToken);
+        await _sut.RollbackTransactionAsync(cancellationToken);
+
+        // Assert
+        await _dbTransaction.Received(1).RollbackAsync(Arg.Any<CancellationToken>());
         await _dbTransaction.Received(1).DisposeAsync();
     }
 }

--- a/tests/Endatix.Infrastructure.Tests/Features/Account/UserPasswordManageServiceTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/Account/UserPasswordManageServiceTests.cs
@@ -347,7 +347,7 @@ public class UserPasswordManageServiceTests
         result.Errors.Should().Contain("Could not reset password. Please try again or contact support.");
 
         await _userManager.Received(1).ResetPasswordAsync(user, Arg.Any<string>(), newPassword);
-        
+
         _logger.Received().Log(
             LogLevel.Error,
             Arg.Any<EventId>(),
@@ -491,7 +491,7 @@ public class UserPasswordManageServiceTests
         // Assert
         result.Status.Should().Be(ResultStatus.Error);
         result.Errors.Should().HaveCount(1);
-        result.Errors.First().Should().Be("An unexpected error occurred while changing the password");
+        result.Errors.First().Should().Be("Failed to change password.");
     }
 
     [Fact]

--- a/tests/Endatix.Infrastructure.Tests/Features/ReCaptcha/ReCaptchaHttpClientTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/ReCaptcha/ReCaptchaHttpClientTests.cs
@@ -1,19 +1,25 @@
 using System.Net;
 using Endatix.Infrastructure.ReCaptcha;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Endatix.Infrastructure.Tests.Features.ReCaptcha;
 
 public class ReCaptchaHttpClientTests
 {
+    private static ReCaptchaHttpClient CreateClient(HttpMessageHandler? handler = null)
+        => new(
+            handler is null ? new HttpClient() : new HttpClient(handler),
+            NullLogger<ReCaptchaHttpClient>.Instance);
+
     [Fact]
     public async Task ReturnsError_WhenTokenIsMissing()
     {
         // Arrange
-        var client = new ReCaptchaHttpClient(new HttpClient());
-        
+        var client = CreateClient();
+
         // Act
         var result = await client.GetTokenValidationResponseAsync(null!, "secret", CancellationToken.None);
-        
+
         // Assert
         Assert.False(result.IsSuccess);
         Assert.Contains("Token is required", result.Errors.FirstOrDefault());
@@ -23,11 +29,11 @@ public class ReCaptchaHttpClientTests
     public async Task ReturnsError_WhenSecretIsMissing()
     {
         // Arrange
-        var client = new ReCaptchaHttpClient(new HttpClient());
-        
+        var client = CreateClient();
+
         // Act
         var result = await client.GetTokenValidationResponseAsync("token", null!, CancellationToken.None);
-        
+
         // Assert
         Assert.False(result.IsSuccess);
         Assert.Contains("Secret key is required", result.Errors);
@@ -38,14 +44,14 @@ public class ReCaptchaHttpClientTests
     {
         // Arrange
         var handler = new ThrowingHandler();
-        var client = new ReCaptchaHttpClient(new HttpClient(handler));
-        
+        var client = CreateClient(handler);
+
         // Act
         var result = await client.GetTokenValidationResponseAsync("token", "secret", CancellationToken.None);
-        
+
         // Assert
         Assert.False(result.IsSuccess);
-        Assert.Contains("Http error during token validation", result.Errors.FirstOrDefault());
+        Assert.Contains("Failed to validate reCAPTCHA token", result.Errors.FirstOrDefault());
     }
 
     [Fact]
@@ -53,11 +59,11 @@ public class ReCaptchaHttpClientTests
     {
         // Arrange
         var handler = new StatusCodeHandler(HttpStatusCode.BadRequest, "{}");
-        var client = new ReCaptchaHttpClient(new HttpClient(handler));
-        
+        var client = CreateClient(handler);
+
         // Act
         var result = await client.GetTokenValidationResponseAsync("token", "secret", CancellationToken.None);
-        
+
         // Assert
         Assert.False(result.IsSuccess);
         Assert.Contains("Failed to validate reCAPTCHA token", result.Errors.FirstOrDefault());
@@ -68,11 +74,11 @@ public class ReCaptchaHttpClientTests
     {
         // Arrange
         var handler = new StatusCodeHandler(HttpStatusCode.OK, "not a json");
-        var client = new ReCaptchaHttpClient(new HttpClient(handler));
-        
+        var client = CreateClient(handler);
+
         // Act
         var result = await client.GetTokenValidationResponseAsync("token", "secret", CancellationToken.None);
-        
+
         // Assert
         Assert.False(result.IsSuccess);
         Assert.Contains("Failed to deserialize Google ReCaptcha response", result.Errors.FirstOrDefault());
@@ -89,11 +95,11 @@ public class ReCaptchaHttpClientTests
             "\"score\":0.9," +
             "\"action\":\"form_submit\"}";
         var handler = new StatusCodeHandler(HttpStatusCode.OK, json);
-        var client = new ReCaptchaHttpClient(new HttpClient(handler));
-        
+        var client = CreateClient(handler);
+
         // Act
         var result = await client.GetTokenValidationResponseAsync("token", "secret", CancellationToken.None);
-        
+
         // Assert
         Assert.True(result.IsSuccess);
         Assert.NotNull(result.Value);
@@ -122,4 +128,4 @@ public class ReCaptchaHttpClientTests
                 Content = new StringContent(_content)
             });
     }
-} 
+}

--- a/tests/Endatix.Infrastructure.Tests/Features/ReCaptcha/ReCaptchaHttpClientTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Features/ReCaptcha/ReCaptchaHttpClientTests.cs
@@ -51,7 +51,7 @@ public class ReCaptchaHttpClientTests
 
         // Assert
         Assert.False(result.IsSuccess);
-        Assert.Contains("Failed to validate reCAPTCHA token", result.Errors.FirstOrDefault());
+        Assert.Contains("Could not reach the reCAPTCHA verification service.", result.Errors.FirstOrDefault());
     }
 
     [Fact]
@@ -66,7 +66,28 @@ public class ReCaptchaHttpClientTests
 
         // Assert
         Assert.False(result.IsSuccess);
-        Assert.Contains("Failed to validate reCAPTCHA token", result.Errors.FirstOrDefault());
+        Assert.Contains("The reCAPTCHA verification service rejected the request.", result.Errors.FirstOrDefault());
+    }
+
+    /// <summary>
+    /// A transport failure and a refusal by Google are different operational problems - one is our egress,
+    /// the other our secret key or quota - so they must not collapse into one indistinguishable string.
+    /// </summary>
+    [Fact]
+    public async Task ReturnsError_DistinguishesTransportFailureFromServiceRejection()
+    {
+        // Arrange
+        var throwingClient = CreateClient(new ThrowingHandler());
+        var rejectingClient = CreateClient(new StatusCodeHandler(HttpStatusCode.BadRequest, "{}"));
+
+        // Act
+        var transportResult = await throwingClient.GetTokenValidationResponseAsync("token", "secret", CancellationToken.None);
+        var rejectionResult = await rejectingClient.GetTokenValidationResponseAsync("token", "secret", CancellationToken.None);
+
+        // Assert
+        Assert.False(transportResult.IsSuccess);
+        Assert.False(rejectionResult.IsSuccess);
+        Assert.NotEqual(transportResult.Errors.FirstOrDefault(), rejectionResult.Errors.FirstOrDefault());
     }
 
     [Fact]

--- a/tests/Endatix.Infrastructure.Tests/Identity/Authentication/JwtTokenServiceTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Identity/Authentication/JwtTokenServiceTests.cs
@@ -214,7 +214,8 @@ public class JwtTokenServiceTests
         // Assert
         result.IsSuccess.Should().BeFalse();
         result.ValidationErrors.Should().NotBeNull();
-        result.ValidationErrors.First().ErrorMessage.Should().Contain("JWT must have three segments");
+        result.ValidationErrors.First().ErrorMessage.Should().Be("Invalid access token");
+        result.ValidationErrors.Should().NotContain(e => e.ErrorMessage.Contains("JWT must have three segments"));
     }
 
     [Fact]

--- a/tests/Endatix.Infrastructure.Tests/Identity/Authorization/DefaultAuthorizationMapperTests.cs
+++ b/tests/Endatix.Infrastructure.Tests/Identity/Authorization/DefaultAuthorizationMapperTests.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore.Query;
 using Endatix.Infrastructure.Identity;
 using Endatix.Infrastructure.Identity.Authorization;
 using Endatix.Core.Entities.Identity;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Endatix.Infrastructure.Tests.Identity.Authorization;
 
@@ -28,7 +29,10 @@ public sealed class DefaultAuthorizationMapperTests
 
         _roleManager.Roles.Returns(_roles.AsQueryable());
 
-        _mapper = new DefaultAuthorizationMapper(_roleManager, _keyNormalizer);
+        _mapper = new DefaultAuthorizationMapper(
+            _roleManager,
+            _keyNormalizer,
+            NullLogger<DefaultAuthorizationMapper>.Instance);
     }
 
     #region Empty Input Tests


### PR DESCRIPTION
# fix(e1002): stop leaking exception text through Result error details

## Description
With this PR `Result` becomes the only vocabulary for expected failures; ToProblem is the only status mapper. Entities throw to enforce invariants, the handler catches and converts, and EndatixExceptionHandler stays a safety net - a Domain*Exception reaching it means a handler failed to convert, so it gets an opaque 500 and the defect surfaces rather than being papered over with a tidy 4xx.
Handlers were interpolating ex.Message into Result.Error / Result.Invalid. ToProblem maps those into RFC7807 detail, and 4xx detail is echoed to the client verbatim — so EF Core, Npgsql, JsonException and BCL guard text (connection strings, SQL fragments, file paths, schema names) was reachable from the API. The >= 500 suppression in EndatixProblemDetails covered the 500s; the 400s were live.

- This closes the leaks and adds the pattern that keeps them closed.
- Infra:
     - IEndUserSafeError — opt-in marker: this message was authored for the caller.
     - DomainValidationException / DomainRuleException — carry the message from the throw site. Derive from ArgumentException / InvalidOperationException, so existing catch sites and tests were unaffected.
     - SafeError.MessageOr / LogAndResolve — the single gate that reads it back; LogAndResolve also fixes the severity (Information for an opted-in rejection, Error with the full exception otherwise).

Default-deny, demonstrated by existing code: JsonExtractor wraps ex.Message into an InvalidOperationException, and NotFoundException / DuplicateSubmissionException predate this — none opt in, so all three are masked with no edit.

Call sites
Leaks fixed in DefaultAuthorizationMapper, ReCaptchaHttpClient, ThemeJsonData, SearchDataListItemsHandler, DataListEnsureLocales, ReplaceDataListItemsHandler. Three hand-rolled message resolvers replaced by one SafeError call each — net −47 lines of logic in src/.

- remove all PII and sensitive exception info from being returned to the client.
- update tests

## Related Issues
- closes #1002 

## Type of Change
Check all that apply.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Dependency update
- [x] Refactoring (non-breaking change which improves code quality)
- [x] Security hardening

## Checklist
- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective or that my feature works
- New and existing tests pass locally with my changes
- Any dependent changes have been merged and published in downstream modules

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Screenshots
If applicable, add screenshots to help explain your changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Replaced technical exception details in API responses with clear, user-safe error messages.
  * Improved handling of invalid exports, themes, locales, submissions, authentication tokens, and external service requests.
  * Preserved meaningful domain validation messages while preventing sensitive implementation details from being exposed.
  * Added consistent error logging to support troubleshooting without revealing internal details to end users.

* **Tests**
  * Expanded coverage to verify sanitized errors, safe domain messages, logging behavior, and invalid input handling.

* **Documentation**
  * Added guidance for safe exception handling, logging, and generic server-error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->