### PR TITLE
fix(#1015): ExportFormat Id collision when seeding default export formats for a new tenant

### DIFF
--- a/src/Endatix.Infrastructure/Data/DbContextModelBuilderExtensions.cs
+++ b/src/Endatix.Infrastructure/Data/DbContextModelBuilderExtensions.cs
@@ -78,6 +78,47 @@ public static class DbContextModelBuilderExtensions
     }
 
     /// <summary>
+    /// Configures Snowflake Id generation for every <see cref="BaseEntity"/> in the model, so an Id is
+    /// assigned when the entity starts being tracked rather than at SaveChanges time.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="BaseEntity.Id"/> is <c>DatabaseGeneratedOption.None</c>, so the default value of 0 is a
+    /// real key value rather than an EF temporary one. Without an Add-time generator, adding more than
+    /// one new entity before saving puts several rows with Id 0 into the identity map and the change
+    /// tracker rejects the second as a duplicate key.
+    /// </para>
+    /// <para>
+    /// EF caches one model per context type, so the <paramref name="valueGeneratorFactory"/> passed by
+    /// the first context built in a process is captured for the lifetime of that model. Pass the
+    /// DI-registered singleton rather than constructing one per context, or every later context will
+    /// silently generate ids from the first one's generator.
+    /// </para>
+    /// </remarks>
+    /// <param name="builder">The model builder to configure.</param>
+    /// <param name="valueGeneratorFactory">Factory producing the Snowflake-backed value generator.</param>
+    public static void ConfigureEntityIdValueGenerators(
+        this ModelBuilder builder,
+        EfCoreValueGeneratorFactory valueGeneratorFactory)
+    {
+        Guard.Against.Null(builder, nameof(builder));
+        Guard.Against.Null(valueGeneratorFactory, nameof(valueGeneratorFactory));
+
+        var entityTypes = builder.Model.GetEntityTypes()
+            .Where(entityType =>
+                !entityType.IsOwned() &&
+                typeof(BaseEntity).IsAssignableFrom(entityType.ClrType));
+
+        foreach (var entityType in entityTypes)
+        {
+            builder.Entity(entityType.ClrType)
+                .Property<long>(nameof(BaseEntity.Id))
+                .HasValueGenerator((property, _) => valueGeneratorFactory.Create<long>(property))
+                .ValueGeneratedNever();
+        }
+    }
+
+    /// <summary>
     /// Applies entity type configurations from the specified assembly, filtered by DbContext type using generic attributes.
     /// This allows isolating configurations for different DbContexts that share the same assembly.
     /// </summary>

--- a/src/Endatix.Modules.Reporting/Data/ExportFormatRepository.cs
+++ b/src/Endatix.Modules.Reporting/Data/ExportFormatRepository.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Endatix.Core.Abstractions;
 using Endatix.Modules.Reporting.Contracts.Export;
 using Endatix.Modules.Reporting.Domain;
 using Endatix.Modules.Reporting.Features.Export;
@@ -14,7 +15,8 @@ internal sealed class ExportFormatRepository(
     ReportingDbContext dbContext,
     IReportingUnitOfWork unitOfWork,
     ExportFormatSettingsParser settingsParser,
-    IExportCapabilityRegistry capabilityRegistry) : IExportFormatRepository
+    IExportCapabilityRegistry capabilityRegistry,
+    IIdGenerator<long> idGenerator) : IExportFormatRepository
 {
     private static readonly string _defaultSubmissionsSettingsJson = JsonSerializer.Serialize(new
     {
@@ -220,7 +222,18 @@ internal sealed class ExportFormatRepository(
             "Default form definition codebook export");
         codebookFormat.UpdateSettingsJson(_defaultCodebookSettingsJson);
 
-        await dbContext.ExportFormats.AddRangeAsync([csvFormat, jsonFormat, codebookFormat], cancellationToken);
+        ExportFormat[] defaultFormats = [csvFormat, jsonFormat, codebookFormat];
+
+        // Ids must be assigned before the rows are tracked. BaseEntity.Id is DatabaseGeneratedOption.None,
+        // so the default 0 is a real key value rather than an EF temporary one, and the change tracker
+        // rejects the second row of the batch as a duplicate key. The SaveChanges-time stamping in
+        // ReportingDbContext.ProcessEntities only covers rows added one at a time.
+        foreach (var format in defaultFormats)
+        {
+            format.Id = idGenerator.CreateId();
+        }
+
+        await dbContext.ExportFormats.AddRangeAsync(defaultFormats, cancellationToken);
         await unitOfWork.SaveChangesAsync(cancellationToken);
 
         var hasDefaultMapping = await dbContext.SurveyTypeExportMappings

--- a/src/Endatix.Modules.Reporting/Data/ExportFormatRepository.cs
+++ b/src/Endatix.Modules.Reporting/Data/ExportFormatRepository.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using Endatix.Core.Abstractions;
 using Endatix.Modules.Reporting.Contracts.Export;
 using Endatix.Modules.Reporting.Domain;
 using Endatix.Modules.Reporting.Features.Export;
@@ -15,9 +14,10 @@ internal sealed class ExportFormatRepository(
     ReportingDbContext dbContext,
     IReportingUnitOfWork unitOfWork,
     ExportFormatSettingsParser settingsParser,
-    IExportCapabilityRegistry capabilityRegistry,
-    IIdGenerator<long> idGenerator) : IExportFormatRepository
+    IExportCapabilityRegistry capabilityRegistry) : IExportFormatRepository
 {
+    private const string CsvFormatName = "CSV";
+
     private static readonly string _defaultSubmissionsSettingsJson = JsonSerializer.Serialize(new
     {
         aliasProfile = "native",
@@ -184,20 +184,136 @@ internal sealed class ExportFormatRepository(
                 cancellationToken);
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Every read here uses <c>IgnoreQueryFilters</c> with explicit <c>TenantId</c> and
+    /// <c>IsDeleted</c> predicates, the same shape <c>FlattenedSubmissionRepository</c> uses. This
+    /// method runs at tenant provisioning, where the ambient tenant is not the tenant being seeded;
+    /// under the tenant filter each guard would read "TenantId == ambient AND TenantId == target",
+    /// never match, and re-seed a tenant that already has its defaults.
+    /// </remarks>
     public async Task SeedDefaultsAsync(long tenantId, CancellationToken cancellationToken)
     {
-        var hasFormats = await dbContext.ExportFormats
-            .AsNoTracking()
-            .AnyAsync(format => format.TenantId == tenantId, cancellationToken);
+        await unitOfWork.BeginTransactionAsync(cancellationToken);
 
-        if (hasFormats)
+        try
         {
-            return;
+            var seeded = await SeedDefaultsCoreAsync(tenantId, cancellationToken);
+            await unitOfWork.CommitTransactionAsync(cancellationToken);
+
+            if (!seeded)
+            {
+                return;
+            }
+        }
+        catch (DbUpdateException)
+        {
+            // Two provisioning flows can reach the guards before either writes. The loser hits the
+            // filtered unique index on (TenantId, Name) or on the tenant default mapping. Both wanted
+            // the same end state, so if the winner produced it this is success, not a 500.
+            await unitOfWork.RollbackTransactionAsync(cancellationToken);
+            dbContext.ChangeTracker.Clear();
+
+            if (await IsFullySeededAsync(tenantId, cancellationToken))
+            {
+                return;
+            }
+
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Creates whatever part of the tenant default set is missing. Returns false when nothing was
+    /// written, so the caller can skip work on the common already-seeded path.
+    /// </summary>
+    private async Task<bool> SeedDefaultsCoreAsync(long tenantId, CancellationToken cancellationToken)
+    {
+        var liveFormats = await dbContext.ExportFormats
+            .IgnoreQueryFilters()
+            .Where(format => format.TenantId == tenantId && !format.IsDeleted)
+            .ToListAsync(cancellationToken);
+
+        var wrote = false;
+
+        if (liveFormats.Count == 0)
+        {
+            liveFormats = BuildDefaultFormats(tenantId);
+            await dbContext.ExportFormats.AddRangeAsync(liveFormats, cancellationToken);
+            wrote = true;
         }
 
+        // The mapping must point at a format that still exists. GetTenantDefaultAsync resolves it via
+        // Include, which the soft-delete filter nulls out, so a mapping left pointing at a deleted
+        // format reports "no default" forever. Repoint it instead of skipping on mapping-exists.
+        var targetFormat =
+            liveFormats.FirstOrDefault(format => format.Name == CsvFormatName) ?? liveFormats[0];
+
+        var defaultMapping = await dbContext.SurveyTypeExportMappings
+            .IgnoreQueryFilters()
+            .Where(mapping =>
+                mapping.TenantId == tenantId &&
+                mapping.IsDefault &&
+                mapping.SurveyTypeId == null &&
+                !mapping.IsDeleted)
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (defaultMapping is null)
+        {
+            SurveyTypeExportMapping mapping = new(
+                tenantId,
+                targetFormat.Id,
+                surveyTypeId: null,
+                isDefault: true);
+
+            await dbContext.SurveyTypeExportMappings.AddAsync(mapping, cancellationToken);
+            wrote = true;
+        }
+        else if (!liveFormats.Exists(format => format.Id == defaultMapping.ExportFormatId))
+        {
+            defaultMapping.UpdateExportFormat(targetFormat.Id);
+            wrote = true;
+        }
+
+        if (wrote)
+        {
+            // One SaveChanges for formats and mapping together: the previous two-phase write could
+            // commit the formats and then fail, leaving a tenant whose formats exist — so the guard
+            // returns early — but whose default mapping never gets created on any retry.
+            await unitOfWork.SaveChangesAsync(cancellationToken);
+        }
+
+        return wrote;
+    }
+
+    private async Task<bool> IsFullySeededAsync(long tenantId, CancellationToken cancellationToken)
+    {
+        var hasFormats = await dbContext.ExportFormats
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .AnyAsync(format => format.TenantId == tenantId && !format.IsDeleted, cancellationToken);
+
+        if (!hasFormats)
+        {
+            return false;
+        }
+
+        return await dbContext.SurveyTypeExportMappings
+            .IgnoreQueryFilters()
+            .AsNoTracking()
+            .AnyAsync(
+                mapping =>
+                    mapping.TenantId == tenantId &&
+                    mapping.IsDefault &&
+                    mapping.SurveyTypeId == null &&
+                    !mapping.IsDeleted,
+                cancellationToken);
+    }
+
+    private List<ExportFormat> BuildDefaultFormats(long tenantId)
+    {
         ExportFormat csvFormat = new(
             tenantId,
-            "CSV",
+            CsvFormatName,
             ExportTarget.Submissions,
             ExportDeliveryFormat.Csv,
             ExportProfile.Native,
@@ -222,40 +338,7 @@ internal sealed class ExportFormatRepository(
             "Default form definition codebook export");
         codebookFormat.UpdateSettingsJson(_defaultCodebookSettingsJson);
 
-        ExportFormat[] defaultFormats = [csvFormat, jsonFormat, codebookFormat];
-
-        // Ids must be assigned before the rows are tracked. BaseEntity.Id is DatabaseGeneratedOption.None,
-        // so the default 0 is a real key value rather than an EF temporary one, and the change tracker
-        // rejects the second row of the batch as a duplicate key. The SaveChanges-time stamping in
-        // ReportingDbContext.ProcessEntities only covers rows added one at a time.
-        foreach (var format in defaultFormats)
-        {
-            format.Id = idGenerator.CreateId();
-        }
-
-        await dbContext.ExportFormats.AddRangeAsync(defaultFormats, cancellationToken);
-        await unitOfWork.SaveChangesAsync(cancellationToken);
-
-        var hasDefaultMapping = await dbContext.SurveyTypeExportMappings
-            .AsNoTracking()
-            .AnyAsync(
-                mapping =>
-                    mapping.TenantId == tenantId &&
-                    mapping.IsDefault &&
-                    mapping.SurveyTypeId == null,
-                cancellationToken);
-
-        if (!hasDefaultMapping)
-        {
-            SurveyTypeExportMapping defaultMapping = new(
-                tenantId,
-                csvFormat.Id,
-                surveyTypeId: null,
-                isDefault: true);
-
-            await dbContext.SurveyTypeExportMappings.AddAsync(defaultMapping, cancellationToken);
-            await unitOfWork.SaveChangesAsync(cancellationToken);
-        }
+        return [csvFormat, jsonFormat, codebookFormat];
     }
 
     private ExportFormatDto MapDto(ExportFormat exportFormat)

--- a/src/Endatix.Modules.Reporting/Domain/SurveyTypeExportMapping.cs
+++ b/src/Endatix.Modules.Reporting/Domain/SurveyTypeExportMapping.cs
@@ -46,6 +46,17 @@ public sealed class SurveyTypeExportMapping : BaseEntity, ITenantOwned, IAggrega
 
     public ExportFormat ExportFormat { get; private set; } = null!;
 
+    /// <summary>
+    /// Repoints this mapping at another export format. Used when the format it referenced has been
+    /// soft deleted, which would otherwise make the tenant default unresolvable.
+    /// </summary>
+    public void UpdateExportFormat(long exportFormatId)
+    {
+        Guard.Against.NegativeOrZero(exportFormatId);
+
+        ExportFormatId = exportFormatId;
+    }
+
     public void MarkAsDefault() => IsDefault = true;
 
     public void ClearDefault() => IsDefault = false;

--- a/src/Endatix.Modules.Reporting/Persistence/ReportingDbContext.cs
+++ b/src/Endatix.Modules.Reporting/Persistence/ReportingDbContext.cs
@@ -14,15 +14,18 @@ public class ReportingDbContext : DbContext, ITenantDbContext
 {
     private readonly IIdGenerator<long> _idGenerator;
     private readonly ITenantContext _tenantContext;
+    private readonly EfCoreValueGeneratorFactory _valueGeneratorFactory;
 
     public ReportingDbContext(
         DbContextOptions<ReportingDbContext> options,
         IIdGenerator<long> idGenerator,
-        ITenantContext tenantContext)
+        ITenantContext tenantContext,
+        EfCoreValueGeneratorFactory valueGeneratorFactory)
         : base(options)
     {
         _idGenerator = idGenerator;
         _tenantContext = tenantContext;
+        _valueGeneratorFactory = valueGeneratorFactory;
     }
 
     public DbSet<FormSchema> FormSchemas => Set<FormSchema>();
@@ -41,6 +44,12 @@ public class ReportingDbContext : DbContext, ITenantDbContext
         modelBuilder.HasDefaultSchema(ReportingPersistence.Schema);
 
         modelBuilder.ApplyEndatixQueryFilters(this);
+
+        // Ids are assigned by the value generator when an entity is tracked, not by ProcessEntities at
+        // SaveChanges. Fan-out depends on it: AddRange of N new rows would otherwise put N entities with
+        // Id 0 into the identity map and throw before SaveChanges ran. ProcessEntities keeps its Id
+        // branch as a no-op fallback for rows whose key some other path already set.
+        modelBuilder.ConfigureEntityIdValueGenerators(_valueGeneratorFactory);
         modelBuilder.ApplyConfigurationsFor<ReportingDbContext>(typeof(ReportingDbContext).Assembly);
         ApplyProviderSpecificConfigurations(modelBuilder);
 

--- a/src/Endatix.Modules.Reporting/Persistence/ReportingDbContextFactory.cs
+++ b/src/Endatix.Modules.Reporting/Persistence/ReportingDbContextFactory.cs
@@ -18,6 +18,7 @@ public sealed class ReportingDbContextFactory : IDesignTimeDbContextFactory<Repo
         return new ReportingDbContext(
             optionsBuilder.Options,
             DesignTimeDbContextDependencies.IdGenerator,
-            DesignTimeDbContextDependencies.TenantContext);
+            DesignTimeDbContextDependencies.TenantContext,
+            new EfCoreValueGeneratorFactory(DesignTimeDbContextDependencies.IdGenerator));
     }
 }

--- a/tests/Endatix.IntegrationTests/Infrastructure/ExportFormatRepositorySeedIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/ExportFormatRepositorySeedIntegrationTests.cs
@@ -1,0 +1,153 @@
+using Endatix.Core.Abstractions;
+using Endatix.IntegrationTests.Shared;
+using Endatix.Modules.Reporting.Data;
+using Endatix.Modules.Reporting.Domain;
+using Endatix.Modules.Reporting.Features.Export;
+using Endatix.Modules.Reporting.Features.Export.Capabilities;
+using Endatix.Modules.Reporting.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Endatix.IntegrationTests;
+
+/// <summary>
+/// PostgreSQL integration coverage for <see cref="ExportFormatRepository.SeedDefaultsAsync"/>, which adds
+/// several rows in one batch and therefore needs its Ids assigned before the change tracker sees them.
+/// </summary>
+[Collection(nameof(DbIntegrationTestCollection))]
+[Trait("Category", "Infrastructure")]
+[Trait("Priority", "P1")]
+[Trait("DbSpecific", "PostgreSql")]
+public sealed class ExportFormatRepositorySeedIntegrationTests
+{
+    private const long TenantId = 47;
+
+    private readonly DbIntegrationFixture _fixture;
+    private readonly IncrementingIdGenerator _idGenerator = new();
+
+    public ExportFormatRepositorySeedIntegrationTests(DbIntegrationFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task SeedDefaultsAsync_TenantWithoutFormats_CreatesDefaultsWithDistinctIds()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        await PrepareSchemaAsync(cancellationToken);
+
+        await using ReportingDbContext context = CreateReportingDbContext();
+        ExportFormatRepository repository = CreateRepository(context);
+
+        // Act
+        await repository.SeedDefaultsAsync(TenantId, cancellationToken);
+
+        // Assert
+        List<ExportFormat> formats = await ReadFormatsAsync(cancellationToken);
+
+        formats.Should().HaveCount(3);
+        formats.Select(format => format.Name).Should().BeEquivalentTo("CSV", "JSON", "Codebook");
+        formats.Select(format => format.Id).Should().OnlyHaveUniqueItems();
+        formats.Select(format => format.Id).Should().AllSatisfy(id => id.Should().BePositive());
+    }
+
+    [Fact]
+    public async Task SeedDefaultsAsync_TenantWithoutFormats_CreatesDefaultMappingToCsvFormat()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        await PrepareSchemaAsync(cancellationToken);
+
+        await using ReportingDbContext context = CreateReportingDbContext();
+        ExportFormatRepository repository = CreateRepository(context);
+
+        // Act
+        await repository.SeedDefaultsAsync(TenantId, cancellationToken);
+
+        // Assert
+        await using ReportingDbContext readContext = CreateReportingDbContext();
+        long csvFormatId = await readContext.ExportFormats
+            .AsNoTracking()
+            .Where(format => format.TenantId == TenantId && format.Name == "CSV")
+            .Select(format => format.Id)
+            .SingleAsync(cancellationToken);
+
+        List<SurveyTypeExportMapping> mappings = await readContext.SurveyTypeExportMappings
+            .AsNoTracking()
+            .Where(mapping => mapping.TenantId == TenantId)
+            .ToListAsync(cancellationToken);
+
+        mappings.Should().ContainSingle();
+        mappings[0].IsDefault.Should().BeTrue();
+        mappings[0].SurveyTypeId.Should().BeNull();
+        mappings[0].ExportFormatId.Should().Be(csvFormatId);
+    }
+
+    [Fact]
+    public async Task SeedDefaultsAsync_TenantAlreadySeeded_LeavesExistingFormatsUnchanged()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        await PrepareSchemaAsync(cancellationToken);
+
+        await using (ReportingDbContext firstContext = CreateReportingDbContext())
+        {
+            await CreateRepository(firstContext).SeedDefaultsAsync(TenantId, cancellationToken);
+        }
+
+        List<long> idsAfterFirstSeed = (await ReadFormatsAsync(cancellationToken))
+            .Select(format => format.Id)
+            .OrderBy(id => id)
+            .ToList();
+
+        // Act
+        await using (ReportingDbContext secondContext = CreateReportingDbContext())
+        {
+            await CreateRepository(secondContext).SeedDefaultsAsync(TenantId, cancellationToken);
+        }
+
+        // Assert
+        List<long> idsAfterSecondSeed = (await ReadFormatsAsync(cancellationToken))
+            .Select(format => format.Id)
+            .OrderBy(id => id)
+            .ToList();
+
+        idsAfterSecondSeed.Should().Equal(idsAfterFirstSeed);
+    }
+
+    private async Task PrepareSchemaAsync(CancellationToken cancellationToken)
+    {
+        await _fixture.Checkpoint.ResetAsync(_fixture.ConnectionString, _fixture.Provider, cancellationToken);
+        await ReportingTestSchema.EnsureMigratedAsync(_fixture.ConnectionString, _fixture.Provider, cancellationToken);
+    }
+
+    private async Task<List<ExportFormat>> ReadFormatsAsync(CancellationToken cancellationToken)
+    {
+        await using ReportingDbContext context = CreateReportingDbContext();
+
+        return await context.ExportFormats
+            .AsNoTracking()
+            .Where(format => format.TenantId == TenantId)
+            .ToListAsync(cancellationToken);
+    }
+
+    private ReportingDbContext CreateReportingDbContext()
+    {
+        ITenantContext tenantContext = Substitute.For<ITenantContext>();
+        tenantContext.TenantId.Returns(TenantId);
+
+        DbContextOptionsBuilder<ReportingDbContext> optionsBuilder =
+            ReportingTestSchema.ConfigureOptionsBuilder(_fixture.ConnectionString);
+
+        return new ReportingDbContext(optionsBuilder.Options, _idGenerator, tenantContext);
+    }
+
+    private ExportFormatRepository CreateRepository(ReportingDbContext context) =>
+        new(
+            context,
+            new ReportingUnitOfWork(context),
+            new ExportFormatSettingsParser(NullLogger<ExportFormatSettingsParser>.Instance),
+            new ExportCapabilityRegistry(),
+            _idGenerator);
+}

--- a/tests/Endatix.IntegrationTests/Infrastructure/ExportFormatRepositorySeedIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/ExportFormatRepositorySeedIntegrationTests.cs
@@ -1,5 +1,8 @@
+using System.Text.Json;
 using Endatix.Core.Abstractions;
+using Endatix.Infrastructure.Data;
 using Endatix.IntegrationTests.Shared;
+using Endatix.Modules.Reporting.Contracts.Export;
 using Endatix.Modules.Reporting.Data;
 using Endatix.Modules.Reporting.Domain;
 using Endatix.Modules.Reporting.Features.Export;
@@ -11,8 +14,9 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Endatix.IntegrationTests;
 
 /// <summary>
-/// PostgreSQL integration coverage for <see cref="ExportFormatRepository.SeedDefaultsAsync"/>, which adds
-/// several rows in one batch and therefore needs its Ids assigned before the change tracker sees them.
+/// PostgreSQL integration coverage for <see cref="ExportFormatRepository.SeedDefaultsAsync"/>: the
+/// multi-row insert, its idempotence guards across tenant scopes, and repair of a default mapping
+/// left pointing at a soft-deleted format.
 /// </summary>
 [Collection(nameof(DbIntegrationTestCollection))]
 [Trait("Category", "Infrastructure")]
@@ -21,6 +25,7 @@ namespace Endatix.IntegrationTests;
 public sealed class ExportFormatRepositorySeedIntegrationTests
 {
     private const long TenantId = 47;
+    private const long OtherTenantId = 48;
 
     private readonly DbIntegrationFixture _fixture;
     private readonly IncrementingIdGenerator _idGenerator = new();
@@ -37,11 +42,8 @@ public sealed class ExportFormatRepositorySeedIntegrationTests
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         await PrepareSchemaAsync(cancellationToken);
 
-        await using ReportingDbContext context = CreateReportingDbContext();
-        ExportFormatRepository repository = CreateRepository(context);
-
         // Act
-        await repository.SeedDefaultsAsync(TenantId, cancellationToken);
+        await SeedAsync(TenantId, ambientTenantId: TenantId, cancellationToken);
 
         // Assert
         List<ExportFormat> formats = await ReadFormatsAsync(cancellationToken);
@@ -53,30 +55,50 @@ public sealed class ExportFormatRepositorySeedIntegrationTests
     }
 
     [Fact]
+    public async Task SeedDefaultsAsync_TenantWithoutFormats_CreatesFormatsWithTheirExportSettings()
+    {
+        // Arrange
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        await PrepareSchemaAsync(cancellationToken);
+
+        // Act
+        await SeedAsync(TenantId, ambientTenantId: TenantId, cancellationToken);
+
+        // Assert
+        List<ExportFormat> formats = await ReadFormatsAsync(cancellationToken);
+
+        ExportFormat csv = formats.Single(format => format.Name == "CSV");
+        csv.ExportTarget.Should().Be(ExportTarget.Submissions);
+        csv.DeliveryFormat.Should().Be(ExportDeliveryFormat.Csv);
+        csv.Profile.Should().Be(ExportProfile.Native);
+        // Parsed, not string-matched: the column is jsonb and the server renormalises the text.
+        ReadSetting(csv.SettingsJson, "aliasProfile").Should().Be("native");
+        ReadSetting(csv.SettingsJson, "keySeparator").Should().Be("__");
+
+        ExportFormat json = formats.Single(format => format.Name == "JSON");
+        json.ExportTarget.Should().Be(ExportTarget.Submissions);
+        json.DeliveryFormat.Should().Be(ExportDeliveryFormat.Json);
+
+        ExportFormat codebook = formats.Single(format => format.Name == "Codebook");
+        codebook.ExportTarget.Should().Be(ExportTarget.Codebook);
+        codebook.DeliveryFormat.Should().Be(ExportDeliveryFormat.Json);
+        ReadSetting(codebook.SettingsJson, "aliasProfile").Should().Be("native");
+    }
+
+    [Fact]
     public async Task SeedDefaultsAsync_TenantWithoutFormats_CreatesDefaultMappingToCsvFormat()
     {
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         await PrepareSchemaAsync(cancellationToken);
 
-        await using ReportingDbContext context = CreateReportingDbContext();
-        ExportFormatRepository repository = CreateRepository(context);
-
         // Act
-        await repository.SeedDefaultsAsync(TenantId, cancellationToken);
+        await SeedAsync(TenantId, ambientTenantId: TenantId, cancellationToken);
 
         // Assert
-        await using ReportingDbContext readContext = CreateReportingDbContext();
-        long csvFormatId = await readContext.ExportFormats
-            .AsNoTracking()
-            .Where(format => format.TenantId == TenantId && format.Name == "CSV")
-            .Select(format => format.Id)
-            .SingleAsync(cancellationToken);
-
-        List<SurveyTypeExportMapping> mappings = await readContext.SurveyTypeExportMappings
-            .AsNoTracking()
-            .Where(mapping => mapping.TenantId == TenantId)
-            .ToListAsync(cancellationToken);
+        long csvFormatId = (await ReadFormatsAsync(cancellationToken))
+            .Single(format => format.Name == "CSV").Id;
+        List<SurveyTypeExportMapping> mappings = await ReadMappingsAsync(cancellationToken);
 
         mappings.Should().ContainSingle();
         mappings[0].IsDefault.Should().BeTrue();
@@ -85,35 +107,146 @@ public sealed class ExportFormatRepositorySeedIntegrationTests
     }
 
     [Fact]
-    public async Task SeedDefaultsAsync_TenantAlreadySeeded_LeavesExistingFormatsUnchanged()
+    public async Task SeedDefaultsAsync_CalledTwice_LeavesFormatsAndMappingUnchanged()
     {
         // Arrange
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;
         await PrepareSchemaAsync(cancellationToken);
+        await SeedAsync(TenantId, ambientTenantId: TenantId, cancellationToken);
 
-        await using (ReportingDbContext firstContext = CreateReportingDbContext())
-        {
-            await CreateRepository(firstContext).SeedDefaultsAsync(TenantId, cancellationToken);
-        }
-
-        List<long> idsAfterFirstSeed = (await ReadFormatsAsync(cancellationToken))
-            .Select(format => format.Id)
+        List<long> formatIdsBefore = await ReadFormatIdsAsync(cancellationToken);
+        List<long> mappingIdsBefore = (await ReadMappingsAsync(cancellationToken))
+            .Select(mapping => mapping.Id)
             .OrderBy(id => id)
             .ToList();
 
         // Act
-        await using (ReportingDbContext secondContext = CreateReportingDbContext())
-        {
-            await CreateRepository(secondContext).SeedDefaultsAsync(TenantId, cancellationToken);
-        }
+        await SeedAsync(TenantId, ambientTenantId: TenantId, cancellationToken);
 
         // Assert
-        List<long> idsAfterSecondSeed = (await ReadFormatsAsync(cancellationToken))
-            .Select(format => format.Id)
+        (await ReadFormatIdsAsync(cancellationToken)).Should().Equal(formatIdsBefore);
+        (await ReadMappingsAsync(cancellationToken))
+            .Select(mapping => mapping.Id)
             .OrderBy(id => id)
-            .ToList();
+            .Should().Equal(mappingIdsBefore);
+    }
 
-        idsAfterSecondSeed.Should().Equal(idsAfterFirstSeed);
+    [Fact]
+    public async Task SeedDefaultsAsync_AmbientTenantIsAnotherTenant_DoesNotDuplicateOnSecondCall()
+    {
+        // Arrange — provisioning seeds tenant A while the request scope belongs to tenant B. Under the
+        // tenant query filter the idempotence guards read TenantId == B AND TenantId == A, match
+        // nothing, and try to seed a second full set. The duplicate rows never land — the unique index
+        // on (TenantId, Name) is filtered on IsDeleted, not scoped to a tenant — so what the guards
+        // actually prevent is a wasted insert that fails with 23505 and, before this changed, surfaced
+        // as an unhandled DbUpdateException.
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        await PrepareSchemaAsync(cancellationToken);
+
+        await SeedAsync(TenantId, ambientTenantId: OtherTenantId, cancellationToken);
+
+        // Act
+        await SeedAsync(TenantId, ambientTenantId: OtherTenantId, cancellationToken);
+
+        // Assert
+        List<ExportFormat> formats = await ReadFormatsAsync(cancellationToken);
+        formats.Should().HaveCount(3);
+        formats.Select(format => format.Name).Should().OnlyHaveUniqueItems();
+        (await ReadMappingsAsync(cancellationToken)).Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task SeedDefaultsAsync_FormatsSoftDeleted_RepointsDefaultMappingAtNewCsvFormat()
+    {
+        // Arrange — the mapping survives a soft delete of the format it references. Left alone it
+        // resolves through an Include that the soft-delete filter nulls out, so the tenant reads as
+        // having no default export format at all.
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        await PrepareSchemaAsync(cancellationToken);
+        await SeedAsync(TenantId, ambientTenantId: TenantId, cancellationToken);
+
+        await SoftDeleteAllFormatsAsync(cancellationToken);
+
+        // Act
+        await SeedAsync(TenantId, ambientTenantId: TenantId, cancellationToken);
+
+        // Assert
+        List<ExportFormat> formats = await ReadFormatsAsync(cancellationToken);
+        formats.Should().HaveCount(3, "the soft-deleted set is replaced, not resurrected");
+
+        long csvFormatId = formats.Single(format => format.Name == "CSV").Id;
+        List<SurveyTypeExportMapping> mappings = await ReadMappingsAsync(cancellationToken);
+
+        mappings.Should().ContainSingle();
+        mappings[0].ExportFormatId.Should().Be(csvFormatId);
+
+        await using ReportingDbContext context = CreateReportingDbContext(TenantId);
+        ExportFormatRecord? tenantDefault = await CreateRepository(context)
+            .GetTenantDefaultAsync(TenantId, cancellationToken);
+
+        tenantDefault.Should().NotBeNull();
+        tenantDefault!.Id.Should().Be(csvFormatId);
+    }
+
+    [Fact]
+    public async Task SeedDefaultsAsync_DefaultMappingMissing_CreatesItWithoutRecreatingFormats()
+    {
+        // Arrange — the state a crash between the old two-phase writes would leave behind: formats
+        // committed, mapping never written. The formats-exist guard used to make it unrepairable.
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        await PrepareSchemaAsync(cancellationToken);
+        await SeedAsync(TenantId, ambientTenantId: TenantId, cancellationToken);
+
+        await DeleteAllMappingsAsync(cancellationToken);
+        List<long> formatIdsBefore = await ReadFormatIdsAsync(cancellationToken);
+
+        // Act
+        await SeedAsync(TenantId, ambientTenantId: TenantId, cancellationToken);
+
+        // Assert
+        (await ReadFormatIdsAsync(cancellationToken)).Should().Equal(formatIdsBefore);
+        (await ReadMappingsAsync(cancellationToken)).Should().ContainSingle();
+    }
+
+    private static string? ReadSetting(string? settingsJson, string propertyName)
+    {
+        using JsonDocument document = JsonDocument.Parse(settingsJson!);
+
+        return document.RootElement.TryGetProperty(propertyName, out JsonElement value)
+            ? value.GetString()
+            : null;
+    }
+
+    private async Task SeedAsync(long tenantId, long ambientTenantId, CancellationToken cancellationToken)
+    {
+        await using ReportingDbContext context = CreateReportingDbContext(ambientTenantId);
+        await CreateRepository(context).SeedDefaultsAsync(tenantId, cancellationToken);
+    }
+
+    private async Task SoftDeleteAllFormatsAsync(CancellationToken cancellationToken)
+    {
+        await using ReportingDbContext context = CreateReportingDbContext(TenantId);
+
+        List<ExportFormat> formats = await context.ExportFormats
+            .Where(format => format.TenantId == TenantId)
+            .ToListAsync(cancellationToken);
+
+        foreach (ExportFormat format in formats)
+        {
+            format.Delete();
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    private async Task DeleteAllMappingsAsync(CancellationToken cancellationToken)
+    {
+        await using ReportingDbContext context = CreateReportingDbContext(TenantId);
+
+        await context.SurveyTypeExportMappings
+            .IgnoreQueryFilters()
+            .Where(mapping => mapping.TenantId == TenantId)
+            .ExecuteDeleteAsync(cancellationToken);
     }
 
     private async Task PrepareSchemaAsync(CancellationToken cancellationToken)
@@ -122,9 +255,15 @@ public sealed class ExportFormatRepositorySeedIntegrationTests
         await ReportingTestSchema.EnsureMigratedAsync(_fixture.ConnectionString, _fixture.Provider, cancellationToken);
     }
 
+    private async Task<List<long>> ReadFormatIdsAsync(CancellationToken cancellationToken) =>
+        (await ReadFormatsAsync(cancellationToken))
+            .Select(format => format.Id)
+            .OrderBy(id => id)
+            .ToList();
+
     private async Task<List<ExportFormat>> ReadFormatsAsync(CancellationToken cancellationToken)
     {
-        await using ReportingDbContext context = CreateReportingDbContext();
+        await using ReportingDbContext context = CreateReportingDbContext(TenantId);
 
         return await context.ExportFormats
             .AsNoTracking()
@@ -132,22 +271,35 @@ public sealed class ExportFormatRepositorySeedIntegrationTests
             .ToListAsync(cancellationToken);
     }
 
-    private ReportingDbContext CreateReportingDbContext()
+    private async Task<List<SurveyTypeExportMapping>> ReadMappingsAsync(CancellationToken cancellationToken)
+    {
+        await using ReportingDbContext context = CreateReportingDbContext(TenantId);
+
+        return await context.SurveyTypeExportMappings
+            .AsNoTracking()
+            .Where(mapping => mapping.TenantId == TenantId)
+            .ToListAsync(cancellationToken);
+    }
+
+    private ReportingDbContext CreateReportingDbContext(long ambientTenantId)
     {
         ITenantContext tenantContext = Substitute.For<ITenantContext>();
-        tenantContext.TenantId.Returns(TenantId);
+        tenantContext.TenantId.Returns(ambientTenantId);
 
         DbContextOptionsBuilder<ReportingDbContext> optionsBuilder =
             ReportingTestSchema.ConfigureOptionsBuilder(_fixture.ConnectionString);
 
-        return new ReportingDbContext(optionsBuilder.Options, _idGenerator, tenantContext);
+        return new ReportingDbContext(
+            optionsBuilder.Options,
+            _idGenerator,
+            tenantContext,
+            new EfCoreValueGeneratorFactory(_idGenerator));
     }
 
-    private ExportFormatRepository CreateRepository(ReportingDbContext context) =>
+    private static ExportFormatRepository CreateRepository(ReportingDbContext context) =>
         new(
             context,
             new ReportingUnitOfWork(context),
             new ExportFormatSettingsParser(NullLogger<ExportFormatSettingsParser>.Instance),
-            new ExportCapabilityRegistry(),
-            _idGenerator);
+            new ExportCapabilityRegistry());
 }

--- a/tests/Endatix.IntegrationTests/Infrastructure/FlattenedSubmissionRepositoryTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/FlattenedSubmissionRepositoryTests.cs
@@ -5,6 +5,7 @@ using Endatix.Modules.Reporting.Data;
 using Endatix.Modules.Reporting.Domain;
 using Endatix.Modules.Reporting.Persistence;
 using Microsoft.EntityFrameworkCore;
+using Endatix.Infrastructure.Data;
 
 namespace Endatix.IntegrationTests;
 
@@ -251,7 +252,13 @@ public sealed class FlattenedSubmissionRepositoryTests
         DbContextOptionsBuilder<ReportingDbContext> optionsBuilder =
             ReportingTestSchema.ConfigureOptionsBuilder(_fixture.ConnectionString);
 
-        return new ReportingDbContext(optionsBuilder.Options, new IncrementingIdGenerator(), tenantContext);
+        IncrementingIdGenerator idGenerator = new();
+
+        return new ReportingDbContext(
+            optionsBuilder.Options,
+            idGenerator,
+            tenantContext,
+            new EfCoreValueGeneratorFactory(idGenerator));
     }
 
     private static FlattenedSubmissionRepository CreateRepository(ReportingDbContext dbContext)

--- a/tests/Endatix.IntegrationTests/Infrastructure/FormSchemaProcessorReplaceMergeIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/FormSchemaProcessorReplaceMergeIntegrationTests.cs
@@ -339,7 +339,13 @@ public sealed class FormSchemaProcessorReplaceMergeIntegrationTests
         DbContextOptionsBuilder<ReportingDbContext> optionsBuilder =
             ReportingTestSchema.ConfigureOptionsBuilder(_fixture.ConnectionString);
 
-        return new ReportingDbContext(optionsBuilder.Options, new IncrementingIdGenerator(), tenantContext);
+        IncrementingIdGenerator idGenerator = new();
+
+        return new ReportingDbContext(
+            optionsBuilder.Options,
+            idGenerator,
+            tenantContext,
+            new EfCoreValueGeneratorFactory(idGenerator));
     }
 
     private sealed record SeededForm(long FormId, long FormDefinitionId);

--- a/tests/Endatix.IntegrationTests/Infrastructure/FormSchemaProviderIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/FormSchemaProviderIntegrationTests.cs
@@ -112,7 +112,13 @@ public sealed class FormSchemaProviderIntegrationTests
         DbContextOptionsBuilder<ReportingDbContext> optionsBuilder =
             ReportingTestSchema.ConfigureOptionsBuilder(_fixture.ConnectionString);
 
-        return new ReportingDbContext(optionsBuilder.Options, new IncrementingIdGenerator(), tenantContext);
+        IncrementingIdGenerator idGenerator = new();
+
+        return new ReportingDbContext(
+            optionsBuilder.Options,
+            idGenerator,
+            tenantContext,
+            new EfCoreValueGeneratorFactory(idGenerator));
     }
 
     private AppDbContext CreateAppDbContext()

--- a/tests/Endatix.IntegrationTests/Infrastructure/FormSchemaRepositoryTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/FormSchemaRepositoryTests.cs
@@ -10,6 +10,7 @@ using Endatix.Modules.Reporting.Features.FormSchema.FormSchema;
 using Endatix.Modules.Reporting.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using Endatix.Infrastructure.Data;
 
 namespace Endatix.IntegrationTests;
 
@@ -135,7 +136,13 @@ public sealed class FormSchemaRepositoryTests
         DbContextOptionsBuilder<ReportingDbContext> optionsBuilder =
             ReportingTestSchema.ConfigureOptionsBuilder(_fixture.ConnectionString);
 
-        return new ReportingDbContext(optionsBuilder.Options, new IncrementingIdGenerator(), tenantContext);
+        IncrementingIdGenerator idGenerator = new();
+
+        return new ReportingDbContext(
+            optionsBuilder.Options,
+            idGenerator,
+            tenantContext,
+            new EfCoreValueGeneratorFactory(idGenerator));
     }
 
     private static FormSchemaRepository CreateRepository(ReportingDbContext dbContext)

--- a/tests/Endatix.IntegrationTests/Infrastructure/ReportingExportRepositoryIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/ReportingExportRepositoryIntegrationTests.cs
@@ -576,7 +576,13 @@ public sealed class ReportingExportRepositoryIntegrationTests
         DbContextOptionsBuilder<ReportingDbContext> optionsBuilder =
             ReportingTestSchema.ConfigureOptionsBuilder(_fixture.ConnectionString);
 
-        return new ReportingDbContext(optionsBuilder.Options, new IncrementingIdGenerator(), tenantContext);
+        IncrementingIdGenerator idGenerator = new();
+
+        return new ReportingDbContext(
+            optionsBuilder.Options,
+            idGenerator,
+            tenantContext,
+            new EfCoreValueGeneratorFactory(idGenerator));
     }
 
     private static ReportingExportRepository CreateRepository(

--- a/tests/Endatix.IntegrationTests/Infrastructure/ReportingQueryFilterTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/ReportingQueryFilterTests.cs
@@ -4,6 +4,7 @@ using Endatix.Modules.Reporting.Contracts.Export;
 using Endatix.Modules.Reporting.Domain;
 using Endatix.Modules.Reporting.Persistence;
 using Microsoft.EntityFrameworkCore;
+using Endatix.Infrastructure.Data;
 
 namespace Endatix.IntegrationTests;
 
@@ -102,6 +103,6 @@ public sealed class ReportingQueryFilterTests
             DbContextOptions<ReportingDbContext> options,
             IIdGenerator<long> idGenerator,
             ITenantContext tenantContext)
-            : base(options, idGenerator, tenantContext) { }
+            : base(options, idGenerator, tenantContext, new EfCoreValueGeneratorFactory(idGenerator)) { }
     }
 }

--- a/tests/Endatix.IntegrationTests/Infrastructure/ReportingTestSchema.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/ReportingTestSchema.cs
@@ -20,10 +20,13 @@ internal static class ReportingTestSchema
 
         var optionsBuilder = ConfigureOptionsBuilder(connectionString);
 
+        SequentialIdGenerator idGenerator = new();
+
         await using ReportingDbContext context = new(
             optionsBuilder.Options,
-            new NoOpIdGenerator(),
-            new BypassTenantContext());
+            idGenerator,
+            new BypassTenantContext(),
+            new EfCoreValueGeneratorFactory(idGenerator));
 
         // Reporting integration tests reset data via Respawn but keep schema objects.
         // Drop the module schema so updated migrations (e.g. FormSchemas rename) apply cleanly.
@@ -60,9 +63,20 @@ internal static class ReportingTestSchema
             })
             .Build();
 
-    private sealed class NoOpIdGenerator : IIdGenerator<long>
+    /// <summary>
+    /// Ids for the context that migrates the schema. Must be real values, not 0.
+    /// </summary>
+    /// <remarks>
+    /// EF caches one model per context type, and the value generator configured in
+    /// <c>ReportingDbContext.OnModelCreating</c> closes over the factory of whichever context built
+    /// that model first — in this assembly, this one. A generator returning 0 here would hand every
+    /// later test an Id of 0 and resurrect the duplicate-key failure this seeding path was fixed for.
+    /// </remarks>
+    private sealed class SequentialIdGenerator : IIdGenerator<long>
     {
-        public long CreateId() => 0;
+        private long _current = 900_000;
+
+        public long CreateId() => Interlocked.Increment(ref _current);
     }
 
     private sealed class BypassTenantContext : ITenantContext

--- a/tests/Endatix.IntegrationTests/Infrastructure/SubmissionBackfillProcessorIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/SubmissionBackfillProcessorIntegrationTests.cs
@@ -14,6 +14,7 @@ using Endatix.Modules.Reporting.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using Endatix.Infrastructure.Data;
 
 namespace Endatix.IntegrationTests;
 
@@ -256,7 +257,13 @@ public sealed class SubmissionBackfillProcessorIntegrationTests
         DbContextOptionsBuilder<ReportingDbContext> optionsBuilder =
             ReportingTestSchema.ConfigureOptionsBuilder(_fixture.ConnectionString);
 
-        return new ReportingDbContext(optionsBuilder.Options, new IncrementingIdGenerator(), tenantContext);
+        IncrementingIdGenerator idGenerator = new();
+
+        return new ReportingDbContext(
+            optionsBuilder.Options,
+            idGenerator,
+            tenantContext,
+            new EfCoreValueGeneratorFactory(idGenerator));
     }
 
     private static FlattenedSubmissionRepository CreateRepository(ReportingDbContext dbContext)

--- a/tests/Endatix.IntegrationTests/Infrastructure/SyncFormDeletionOutboxHandlerIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/SyncFormDeletionOutboxHandlerIntegrationTests.cs
@@ -11,6 +11,7 @@ using Endatix.Outbox.Engine;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Text.Json;
+using Endatix.Infrastructure.Data;
 
 namespace Endatix.IntegrationTests;
 
@@ -138,7 +139,13 @@ public sealed class SyncFormDeletionOutboxHandlerIntegrationTests
         DbContextOptionsBuilder<ReportingDbContext> optionsBuilder =
             ReportingTestSchema.ConfigureOptionsBuilder(_fixture.ConnectionString);
 
-        return new ReportingDbContext(optionsBuilder.Options, new IncrementingIdGenerator(), tenantContext);
+        IncrementingIdGenerator idGenerator = new();
+
+        return new ReportingDbContext(
+            optionsBuilder.Options,
+            idGenerator,
+            tenantContext,
+            new EfCoreValueGeneratorFactory(idGenerator));
     }
 
     private static IOutboxMessage CreateMessage()

--- a/tests/Endatix.IntegrationTests/Infrastructure/SyncSubmissionDeletionOutboxHandlerIntegrationTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/SyncSubmissionDeletionOutboxHandlerIntegrationTests.cs
@@ -10,6 +10,7 @@ using Endatix.Modules.Reporting.Features.Outbox;
 using Endatix.Modules.Reporting.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
+using Endatix.Infrastructure.Data;
 
 namespace Endatix.IntegrationTests;
 
@@ -149,7 +150,13 @@ public sealed class SyncSubmissionDeletionOutboxHandlerIntegrationTests
         DbContextOptionsBuilder<ReportingDbContext> optionsBuilder =
             ReportingTestSchema.ConfigureOptionsBuilder(_fixture.ConnectionString);
 
-        return new ReportingDbContext(optionsBuilder.Options, new IncrementingIdGenerator(), tenantContext);
+        IncrementingIdGenerator idGenerator = new();
+
+        return new ReportingDbContext(
+            optionsBuilder.Options,
+            idGenerator,
+            tenantContext,
+            new EfCoreValueGeneratorFactory(idGenerator));
     }
 
     private static FlattenedSubmissionRepository CreateRepository(ReportingDbContext dbContext)

--- a/tests/Endatix.Modules.Reporting.Tests/Persistence/ReportingDbContextTests.cs
+++ b/tests/Endatix.Modules.Reporting.Tests/Persistence/ReportingDbContextTests.cs
@@ -1,5 +1,6 @@
 using Endatix.Core.Abstractions;
 using Endatix.Infrastructure.Data;
+using Endatix.Modules.Reporting.Contracts.Export;
 using Endatix.Modules.Reporting.Domain;
 using Endatix.Modules.Reporting.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -90,16 +91,79 @@ public class ReportingDbContextTests
         indexFilters.Should().HaveCount(2);
     }
 
+    [Theory]
+    [InlineData("Npgsql.EntityFrameworkCore.PostgreSQL")]
+    [InlineData("Microsoft.EntityFrameworkCore.SqlServer")]
+    public void Add_MultipleNewEntities_AssignsDistinctIdsBeforeTracking(string providerName)
+    {
+        // Arrange — the duplicate-key failure this guards is provider independent: BaseEntity.Id is
+        // DatabaseGeneratedOption.None on both, so an unset Id of 0 is a real key on both. Runs at the
+        // model level, so it needs no database and covers the SQL Server leg the integration tests skip.
+        var optionsBuilder = new DbContextOptionsBuilder<ReportingDbContext>();
+        ConfigureProvider(optionsBuilder, providerName);
+
+        using var context = CreateContext(optionsBuilder.Options);
+
+        const long tenantId = 1L;
+        ExportFormat[] formats =
+        [
+            new(tenantId, "CSV", ExportTarget.Submissions, ExportDeliveryFormat.Csv),
+            new(tenantId, "JSON", ExportTarget.Submissions, ExportDeliveryFormat.Json),
+            new(tenantId, "Codebook", ExportTarget.Codebook, ExportDeliveryFormat.Json)
+        ];
+
+        formats.Select(format => format.Id).Should().AllSatisfy(id => id.Should().Be(0));
+
+        // Act
+        context.ExportFormats.AddRange(formats);
+
+        // Assert
+        var ids = formats.Select(format => format.Id).ToList();
+        ids.Should().OnlyHaveUniqueItems();
+        ids.Should().AllSatisfy(id => id.Should().BePositive());
+    }
+
+    private static void ConfigureProvider(
+        DbContextOptionsBuilder<ReportingDbContext> optionsBuilder,
+        string providerName)
+    {
+        if (providerName.Contains("SqlServer", StringComparison.Ordinal))
+        {
+            optionsBuilder.UseSqlServer("Server=(localdb)\\mssqllocaldb;Database=ReportingTests;Trusted_Connection=True");
+            ModuleDbContextExtensions.ConfigureProviderScopedMigrations(
+                optionsBuilder,
+                ReportingPersistence.SqlServerMigrationsNamespace);
+        }
+        else
+        {
+            optionsBuilder.UseNpgsql("Host=localhost;Database=reporting_tests;Username=postgres;Password=postgres");
+            ModuleDbContextExtensions.ConfigureProviderScopedMigrations(
+                optionsBuilder,
+                ReportingPersistence.PostgreSqlMigrationsNamespace);
+        }
+    }
+
     private static ReportingDbContext CreateContext(
         DbContextOptions<ReportingDbContext> options,
         ITenantContext? tenantContext = null)
     {
-        var idGenerator = Substitute.For<IIdGenerator<long>>();
-        idGenerator.CreateId().Returns(1001, 1002);
+        // A real incrementing generator, not a substitute returning a fixed pair: EF caches one model
+        // per context type, so the generator handed to the first context built in this assembly is the
+        // one every later context generates ids from. A generator that repeats a value would make
+        // multi-row Add fail with a duplicate key.
+        SequentialIdGenerator idGenerator = new();
 
         return new ReportingDbContext(
             options,
             idGenerator,
-            tenantContext ?? Substitute.For<ITenantContext>());
+            tenantContext ?? Substitute.For<ITenantContext>(),
+            new EfCoreValueGeneratorFactory(idGenerator));
+    }
+
+    private sealed class SequentialIdGenerator : IIdGenerator<long>
+    {
+        private long _current = 1000;
+
+        public long CreateId() => Interlocked.Increment(ref _current);
     }
 }


### PR DESCRIPTION
## Description

`ExportFormatRepository.SeedDefaultsAsync` threw before writing anything. It handed three `ExportFormat` rows to `AddRangeAsync` while their Ids were still `0`, and since `BaseEntity.Id` is `DatabaseGeneratedOption.None`, `0` is a real key value rather than an EF temporary one — so the change tracker rejected the second row:

> The instance of entity type 'ExportFormat' cannot be tracked because another instance with the same key value for {'Id'} is already being tracked.

Ids were stamped only by `ReportingDbContext.ProcessEntities`, which runs from `SaveChanges` — after tracking, so it never got the chance.

### Ids are now assigned when an entity is tracked

`ReportingDbContext` takes the DI-registered `EfCoreValueGeneratorFactory` and wires a value generator for every `BaseEntity` in its model, through a shared `ConfigureEntityIdValueGenerators` extension. This is the pattern `AppDbContext`, `AppIdentityDbContext` and `JobsDbContextBase` (#959) already use. Every multi-row `Add` in the module is covered, not just this call site, and the module is left with one Id mechanism instead of two.

**Injecting the factory rather than constructing one per context is load-bearing.** EF caches one model per context type, so the factory belonging to the first context built in a process is captured for that model's lifetime. Two test doubles returned unusable Ids and would have silently defeated the generator for every later context in the assembly — `ReportingTestSchema`'s generator returned `0`, and `ReportingDbContextTests` substituted a fixed pair. Both now increment, with the reason recorded where they are defined.

### Seeding correctness

Four further problems, all reachable through the tenant-provisioning path this method exists for:

| Problem | Fix |
|---|---|
| The idempotence guards ran under the tenant query filter, so seeding tenant A from tenant B's scope read `TenantId == B AND TenantId == A` and matched nothing | `IgnoreQueryFilters` with explicit `TenantId`/`IsDeleted` predicates — the shape `FlattenedSubmissionRepository` already uses |
| Formats and mapping committed in two `SaveChanges` with no transaction; a crash between them left the mapping uncreatable on any retry, because the formats-exist guard then returned early | One transaction, one save |
| A concurrent provisioning race threw an opaque 500 | The loser re-checks and returns quietly when the winner produced the state it wanted |
| The mapping guard skipped whenever a mapping existed, so once the formats were soft deleted it kept pointing at a deleted one — and `GetTenantDefaultAsync` resolves it through an `Include` that the soft-delete filter nulls out, so the tenant read as having no default forever | The mapping is repointed at a live format; adds `SurveyTypeExportMapping.UpdateExportFormat` |

On the first row: the duplicate rows could never actually land, because the unique index on `(TenantId, Name)` is filtered on `IsDeleted` and is not tenant-scoped. What the defeated guards produced was a wasted insert failing with `23505`, surfacing as an unhandled `DbUpdateException`.

### Deliberately out of scope

- `AppDbContext` and `JobsDbContextBase` still carry private copies of the same wiring. Deduplicating onto the shared extension is worth doing once #959 lands, rather than conflicting with it now.
- The default formats are defined twice — once in the `InitialReporting` migration SQL, once as constants here — and already disagree on `locale`. Pre-existing and orthogonal.
- `ReportingDbContext` keeps its `ProcessEntities` Id branch as a no-op fallback. #959 restructures that method, so leaving it alone keeps the conflict surface small.

## Related Issues

Fixes #1015. Related to #899 (the *migration* seed path for the same table) and #959, which introduces the value-generator pattern this follows and touches the same `ReportingDbContext` methods.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
- I have added tests that prove my fix is effective
- New and existing tests pass locally with my changes

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Testing

Seven PostgreSQL integration tests: the multi-row insert, per-format settings, idempotence, the cross-tenant scope, soft-delete repair, and a missing mapping. Plus a model-level fan-out test over **both** providers, which needs no database and covers the SQL Server leg the integration tests skip.

Each was checked to fail without the code it guards:

- Remove the generator wiring → all 7 integration tests and both provider legs fail.
- Remove the guards and the race handling → the cross-tenant test fails with `23505 duplicate key value violates unique constraint "IX_ExportFormats_TenantId_Name"`.

Suites: `Endatix.IntegrationTests` 108 passed / 1 skipped · `Endatix.Modules.Reporting.Tests` 396 passed / 1 skipped · `Endatix.Infrastructure.Tests` 1183 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
