### PR TITLE
fix(e862): require a real tenant on every background job

### DIFF
--- a/src/Endatix.Modules.Jobs/Domain/BackgroundJob.cs
+++ b/src/Endatix.Modules.Jobs/Domain/BackgroundJob.cs
@@ -46,8 +46,11 @@ public class BackgroundJob : BaseEntity, IAggregateRoot, ITenantOwned
     {
         Guard.Against.NullOrWhiteSpace(jobType);
         Guard.Against.NullOrWhiteSpace(payloadJson);
-        // 0 == AuthConstants.DEFAULT_TENANT_ID (app-level work) is valid; only negatives are not.
-        Guard.Against.Negative(tenantId);
+        // Every job belongs to a tenant. Zero is the value the tenant context reports when there is
+        // no ambient tenant at all, so a row carrying it belongs to nobody rather than to everybody
+        // — and the tenant filter would hide it from every tenant while showing it to every
+        // background service. Platform-wide work needs its own design, not this sentinel.
+        Guard.Against.NegativeOrZero(tenantId);
 
         JobType = jobType;
         PayloadJson = payloadJson;

--- a/src/Endatix.Modules.Jobs/Persistence/Config/PostgreSql/BackgroundJobConfigurationPostgreSql.cs
+++ b/src/Endatix.Modules.Jobs/Persistence/Config/PostgreSql/BackgroundJobConfigurationPostgreSql.cs
@@ -27,6 +27,15 @@ internal sealed class BackgroundJobConfigurationPostgreSql : IEntityTypeConfigur
         builder.Property(job => job.ResultJson)
             .HasColumnType("jsonb");
 
+        var tenantId = $"\"{nameof(BackgroundJob.TenantId)}\"";
+
+        // The entity refuses a job without a tenant, but the entity is not the only way a row can
+        // arrive: a migration, a seeder or a hand-written statement all bypass it. A row with tenant
+        // zero would be hidden from every tenant and visible to every background service, so the
+        // rule belongs to the data as well as the code.
+        builder.ToTable(table => table.HasCheckConstraint(
+            "CK_BackgroundJobs_TenantId", $"{tenantId} > 0"));
+
         var status = $"\"{nameof(BackgroundJob.Status)}\"";
 
         // Serves the sweeper's "which jobs are due?" scan — the hottest query here, run on every

--- a/src/Endatix.Modules.Jobs/Persistence/Migrations/PostgreSql/20260908144106_RequireRealTenantOnBackgroundJobs.Designer.cs
+++ b/src/Endatix.Modules.Jobs/Persistence/Migrations/PostgreSql/20260908144106_RequireRealTenantOnBackgroundJobs.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Endatix.Modules.Jobs.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Endatix.Modules.Jobs.Persistence.Migrations.PostgreSql
 {
     [DbContext(typeof(JobsPostgreSqlDbContext))]
-    partial class JobsPostgreSqlDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260908144106_RequireRealTenantOnBackgroundJobs")]
+    partial class RequireRealTenantOnBackgroundJobs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Endatix.Modules.Jobs/Persistence/Migrations/PostgreSql/20260908144106_RequireRealTenantOnBackgroundJobs.cs
+++ b/src/Endatix.Modules.Jobs/Persistence/Migrations/PostgreSql/20260908144106_RequireRealTenantOnBackgroundJobs.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Endatix.Modules.Jobs.Persistence.Migrations.PostgreSql
+{
+    /// <inheritdoc />
+    public partial class RequireRealTenantOnBackgroundJobs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddCheckConstraint(
+                name: "CK_BackgroundJobs_TenantId",
+                schema: "jobs",
+                table: "BackgroundJobs",
+                sql: "\"TenantId\" > 0");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "CK_BackgroundJobs_TenantId",
+                schema: "jobs",
+                table: "BackgroundJobs");
+        }
+    }
+}

--- a/tests/Endatix.Modules.Jobs.Tests/Domain/BackgroundJobTests.cs
+++ b/tests/Endatix.Modules.Jobs.Tests/Domain/BackgroundJobTests.cs
@@ -61,14 +61,15 @@ public class BackgroundJobTests
     }
 
     [Fact]
-    public void Constructor_DefaultTenantId_IsAllowed()
+    public void Constructor_TenantIdZero_Throws()
     {
         // Arrange
-        // Act — tenant 0 is the app-level tenant, valid for cross-tenant system work.
-        var job = new BackgroundJob("SubmissionExport", "{}", tenantId: 0, nextAttemptAt: Now);
+        // Act
+        var act = () => new BackgroundJob("SubmissionExport", "{}", tenantId: 0, nextAttemptAt: Now);
 
-        // Assert
-        job.TenantId.Should().Be(0);
+        // Assert — zero is what the tenant context reports when no tenant is ambient, so a job
+        // carrying it would be hidden from every tenant and visible to every background service.
+        act.Should().Throw<ArgumentException>();
     }
 
     [Fact]


### PR DESCRIPTION
## Description of changes

`BackgroundJob` accepted `tenantId: 0`, on a comment of mine in J1 claiming it marked "app-level work, valid for cross-tenant system work". That asserted a design the e862 plan does not contain — the plan's tenant-zero discussion is about the *reader's* context being zero off-request, never about a job row owning zero.

Zero is what the tenant context reports when **no tenant is ambient**. Under the shared filter `currentTenantId == 0 || e.TenantId == currentTenantId`, a row carrying it is:

- **invisible to every tenant** — `7 == 0` false, `0 == 7` false, so `GET jobs/{jobId}` 404s for every real caller, permanently
- **visible to every background service** — which reads with context zero

A job nobody can poll and every worker will run. Belonging to nobody rather than to everybody.

## Enforced in two places, because the entity is not the only way a row arrives

**Constructor guard** — `Guard.Against.NegativeOrZero`. `BackgroundJobQueue.CreateJob` is the only production caller, so this covers every enqueue path: API request, outbox handler, hosted service alike.

**Check constraint** — `CHECK ("TenantId" > 0)`, in a reversible migration. The constructor is bypassed by migrations, seeders, EF materialization of existing rows, and hand-written SQL. Verified against PostgreSQL:

```
ERROR:  new row for relation "BackgroundJobs" violates check constraint "CK_BackgroundJobs_TenantId"
```

…while a real tenant id inserts normally.

## This does not close off platform-wide work

Running something across all tenants is a legitimate need, and it stays open — it simply wants its own design rather than an overloaded sentinel. Two things it needs, neither of which exists yet:

- an execution context for the runner, so a tenant-less job has defined semantics instead of inheriting the wide-open ambient filter the handler contract (§2.4 Phase B) warns against
- a platform-admin read path, since such a job is unreadable through the tenant-scoped endpoint

Both are owed the day a platform job type appears, whichever way this column behaves today. Keeping zero would have made *"belongs to the platform"* and *"nobody set a tenant"* indistinguishable in the data.

It is also worth asking whether such work should be one tenant-less job at all: **N per-tenant jobs** give per-tenant retry, failure isolation and visibility, which is already how webhook fan-out is planned — one job per endpoint, not one per event.

## Type of Change

- [x] SaaS specific Bug fix

## Checklist

36 tests pass; the test that asserted zero was valid now asserts it throws. `ef migrations has-pending-model-changes` reports no drift. Constraint behaviour verified against a live PostgreSQL.

Refs #862

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119JYZK8PGaghZKW4ESoNYK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Background jobs now require a valid, non-zero tenant association.
  * Invalid tenant IDs are rejected consistently during job creation and database persistence.

* **Tests**
  * Added coverage confirming that background jobs with a zero tenant ID are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->