### PR TITLE
fix(#1034): Serve separate liveness and readiness probes so a database blip stops restarting every pod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ Thumbs.db
 .coverage/
 .secrets
 .coverage-test/
+
+# Rider/ReSharper per-developer editor state
+*.DotSettings.user

--- a/docs/endatix-docs/docs/configuration/settings/health-checks.md
+++ b/docs/endatix-docs/docs/configuration/settings/health-checks.md
@@ -21,9 +21,29 @@ When you use `builder.Host.ConfigureEndatix()`, the following health checks are 
 
 These health checks are exposed through the following endpoints:
 
-- **`/health`**: Basic health status (healthy, degraded, or unhealthy)
+- **`/health`**: Status across **all** registered checks (healthy, degraded, or unhealthy)
 - **`/health/detail`**: Detailed JSON report of all health checks
 - **`/health/ui`**: HTML UI showing health check results in a more readable format
+- **`/alive`**: **Liveness probe** — only `self`/`live` checks, never the database
+- **`/ready`**: **Readiness probe** — only `ready`-tagged checks (the databases)
+
+Point a container orchestrator's `livenessProbe` at `/alive` and its `readinessProbe` at `/ready`.
+Using `/health` for liveness means a database blip restarts every pod at once, which removes
+capacity while the system is already degraded and cannot fix the database.
+
+Paths are configurable:
+
+```json
+{
+  "Endatix": {
+    "Hosting": {
+      "HealthCheckPath": "/health",
+      "LivenessPath": "/alive",
+      "ReadinessPath": "/ready"
+    }
+  }
+}
+```
 
 ## Customizing Health Checks
 

--- a/docs/endatix-docs/docs/configuration/settings/health-checks.md
+++ b/docs/endatix-docs/docs/configuration/settings/health-checks.md
@@ -15,7 +15,7 @@ This page focuses on **configuration and settings** (defaults, endpoint path, fi
 
 When you use `builder.Host.ConfigureEndatix()`, the following health checks are automatically configured:
 
-- **Self**: Basic application health check (skipped when Aspire ServiceDefaults are present)
+- **endatix-self**: Process-alive check, tagged `self`. Always registered; the name cannot collide with Aspire ServiceDefaults' own `self` check
 - **Database**: EF Core health check for the main app database when persistence is configured
 - **Identity-database**: EF Core health check for the identity database when identity persistence is configured
 

--- a/docs/endatix-docs/docs/developers/api/health-checks.mdx
+++ b/docs/endatix-docs/docs/developers/api/health-checks.mdx
@@ -66,7 +66,7 @@ Use it to properly configure your health monitoring tool. When you request the h
   "status": "Healthy",
   "checks": [
     {
-      "name": "self",
+      "name": "endatix-self",
       "status": "Healthy",
       "description": null,
       "data": {}
@@ -120,4 +120,4 @@ app.UseEndatix(middleware => middleware
 - Use **tags** (e.g. `db`, `ready`) to group checks and, if needed, add a separate readiness route that only runs a subset.
 - Rely on **`/health/detail`** in CI or monitoring for a stable JSON shape.
 - Add custom checks for critical dependencies via `AddCheck` or `Builder.Add...` on the health checks builder.
-- When you adopt Aspire, the existing DB and custom checks will compose with Aspire’s defaults; the self-check is already skipped when Aspire ServiceDefaults are present.
+- When you adopt Aspire, the existing DB and custom checks compose with Aspire's defaults. Endatix's own process check is named `endatix-self` so it sits alongside Aspire's `self` check rather than colliding with it.

--- a/docs/endatix-docs/docs/developers/api/health-checks.mdx
+++ b/docs/endatix-docs/docs/developers/api/health-checks.mdx
@@ -16,15 +16,35 @@ When health checks middleware is enabled (default with `app.UseEndatix()`), the 
 
 | Path | Description |
 |------|-------------|
-| `{Path}` | Overall status: `Healthy`, `Degraded`, or `Unhealthy`. Default path is `/health`. |
+| `{Path}` | Overall status across **every** registered check: `Healthy`, `Degraded`, or `Unhealthy`. Default path is `/health`. |
 | `{Path}/detail` | JSON report with status, per-check results, and total duration. |
 | `{Path}/ui` | HTML page listing each check with status and duration. |
+| `{LivenessPath}` | **Liveness.** Only checks tagged `self` or `live` — never the database. Default `/alive`. |
+| `{ReadinessPath}` | **Readiness.** Only checks tagged `ready` — the database checks. Default `/ready`. |
 
-Example with default path:
+Example with default paths:
 
-- **`/health`** — Liveness/overall status
+- **`/health`** — Overall status, all checks (humans and dashboards)
 - **`/health/detail`** — Full JSON (for CI/monitoring)
 - **`/health/ui`** — Human-readable UI
+- **`/alive`** — Liveness probe
+- **`/ready`** — Readiness probe
+
+:::warning Point your orchestrator at `/alive` and `/ready`, not `/health`
+
+`/health` includes the database. A `livenessProbe` pointed at it restarts **every** pod when the
+database blips — removing capacity exactly when the system is already degraded, and restarting a
+process cannot fix a database that is down. Liveness answers "is this process running?" and belongs
+on `/alive`; readiness answers "can this pod serve traffic?" and belongs on `/ready`.
+
+`/ready` is also narrower than `/health` on purpose: it runs only `ready`-tagged checks, so a custom
+check you add does not silently start evicting pods from the Service endpoints.
+
+The bundled Helm chart is already configured this way — see `probes` in its `values.yaml`.
+:::
+
+Paths are configurable via `Endatix:Hosting:HealthCheckPath`, `Endatix:Hosting:LivenessPath` and
+`Endatix:Hosting:ReadinessPath`.
 
 ## Default checks
 
@@ -34,7 +54,8 @@ With `builder.Host.ConfigureEndatix()` and `app.UseEndatix()`:
 - **database** — EF Core health check for the main `AppDbContext` when persistence is configured.
 - **identity-database** — EF Core health check for `AppIdentityDbContext` when identity persistence is configured.
 
-Database checks use tags `db` and `ready`, so you can add a dedicated readiness endpoint that only runs DB checks if needed.
+Database checks use tags `db` and `ready`; the `self` check is tagged `self`. Those tags are what
+`/ready` and `/alive` filter on, so a custom check joins a probe only if you tag it accordingly.
 
 ## JSON detail shape
 

--- a/docs/endatix-docs/docs/developers/api/health-checks.mdx
+++ b/docs/endatix-docs/docs/developers/api/health-checks.mdx
@@ -50,7 +50,7 @@ Paths are configurable via `Endatix:Hosting:HealthCheckPath`, `Endatix:Hosting:L
 
 With `builder.Host.ConfigureEndatix()` and `app.UseEndatix()`:
 
-- **self** — Basic process-alive check (skipped when Aspire ServiceDefaults are present).
+- **endatix-self** — Process-alive check, tagged `self`. Registered unconditionally; the name is Endatix-owned so it cannot collide with Aspire ServiceDefaults' own `self` check.
 - **database** — EF Core health check for the main `AppDbContext` when persistence is configured.
 - **identity-database** — EF Core health check for `AppIdentityDbContext` when identity persistence is configured.
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -194,16 +194,23 @@ spec:
           {{- toYaml .Values.resources | nindent 10 }}
         readinessProbe:
           httpGet:
-            path: /health
+            path: {{ .Values.probes.readiness.path }}
             port: 8080
-          initialDelaySeconds: 10
-          periodSeconds: 10
+          initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+          timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+          failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          successThreshold: {{ .Values.probes.readiness.successThreshold }}
+        # Deliberately NOT the readiness path: liveness must not fail on a database
+        # outage, or a blip restarts every pod. See values.yaml -> probes.
         livenessProbe:
           httpGet:
-            path: /health
+            path: {{ .Values.probes.liveness.path }}
             port: 8080
-          initialDelaySeconds: 30
-          periodSeconds: 30
+          initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+          timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+          failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
         # The only writable path. Startup and /health do not need it, but
         # ASP.NET Core spills oversized request bodies to Path.GetTempPath()
         # and the runtime puts its diagnostic socket there.

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -101,6 +101,16 @@ spec:
         - name: ConnectionStrings__DefaultConnection_DbProvider
           value: {{ .Values.db.provider | quote }}
 
+        # Probe paths, from the SAME values the probes below use. Rendering only httpGet would let
+        # the two diverge: --set probes.liveness.path=/healthz would change what kubelet requests
+        # while the app still served /alive, so every probe 404s and the container restart-loops.
+        - name: Endatix__Hosting__HealthCheckPath
+          value: {{ .Values.probes.health.path | quote }}
+        - name: Endatix__Hosting__LivenessPath
+          value: {{ .Values.probes.liveness.path | quote }}
+        - name: Endatix__Hosting__ReadinessPath
+          value: {{ .Values.probes.readiness.path | quote }}
+
         # Auth
         - name: Endatix__Auth__Providers__EndatixJwt__SigningKey
           valueFrom:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -119,9 +119,21 @@ otel:
 # exactly when the system is already degraded — and restarting a process cannot fix a database.
 # /health is still served, unfiltered, for humans and dashboards.
 #
-# failureThreshold x periodSeconds is how long a blip must last before it counts. The readiness
-# defaults below tolerate ~30s; raise failureThreshold if your database fails over more slowly than
-# that and you would rather keep serving from cache than drop every pod out of the Service.
+# failureThreshold x periodSeconds is how long a blip must last before it counts.
+#
+# A DELIBERATE TRADE-OFF worth understanding before you tune it: every replica points at the same
+# database, so readiness is a shared fate rather than a per-pod one. When it trips it trips
+# everywhere, Kubernetes empties the Service endpoints, and the ingress returns 502/503 for
+# EVERYTHING — routes that need no database, cached reads, and /health itself for the dashboard you
+# are using to diagnose the incident. Readiness normally expresses per-pod ability to serve; a
+# dependency shared by all pods is the case it handles worst.
+#
+# The default is 6 x 10s = 60s rather than the more usual 30s for exactly that reason: a failover or
+# a brief connection-limit spike should not empty the Service, while an outage lasting minutes still
+# should, because a pod that cannot reach its database genuinely cannot serve most requests. If your
+# database fails over more slowly than 60s, raise failureThreshold further. The better long-term
+# answer is a circuit breaker and a degraded-mode response rather than eviction, which is tracked
+# separately — this default is the conservative choice available today.
 #
 # UPGRADING: /alive and /ready do not exist in appVersion 0.7.6 or earlier — they 404 there, and a
 # 404 on livenessProbe is a restart loop. Normally this cannot bite you: release-prepare.sh stamps
@@ -130,12 +142,16 @@ otel:
 # that needs action is an explicitly PINNED image.tag older than the chart — set both paths back to
 # /health until the pin catches up.
 probes:
+  # Also rendered into Endatix__Hosting__*Path so the app serves exactly what kubelet requests.
+  health:
+    path: /health
   readiness:
     path: /ready
     initialDelaySeconds: 10
     periodSeconds: 10
     timeoutSeconds: 1
-    failureThreshold: 3
+    # 6 x 10s = 60s before a shared-database blip empties the Service. See the note above.
+    failureThreshold: 6
     successThreshold: 1
   liveness:
     path: /alive

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -108,6 +108,42 @@ otel:
   protocol: grpc
   serviceName: endatix-api
 
+# Kubernetes probes. The three paths differ on purpose.
+#
+# readinessProbe -> /ready runs only checks tagged "ready" (the database checks). A pod that cannot
+# reach its database cannot serve traffic, so it should leave the Service endpoints — but nothing
+# else should be able to evict it, which is why this is not /health: /health runs EVERY registered
+# check, so any extra check a consumer adds would silently join the readiness path.
+# livenessProbe -> /alive runs only process-level checks and never touches the database. Pointing
+# liveness at a database-backed path means one blip restarts every pod at once, removing capacity
+# exactly when the system is already degraded — and restarting a process cannot fix a database.
+# /health is still served, unfiltered, for humans and dashboards.
+#
+# failureThreshold x periodSeconds is how long a blip must last before it counts. The readiness
+# defaults below tolerate ~30s; raise failureThreshold if your database fails over more slowly than
+# that and you would rather keep serving from cache than drop every pod out of the Service.
+#
+# UPGRADING: /alive and /ready do not exist in appVersion 0.7.6 or earlier — they 404 there, and a
+# 404 on livenessProbe is a restart loop. Normally this cannot bite you: release-prepare.sh stamps
+# chart version and appVersion with the same release version, and the template falls back to
+# .Chart.Version for image.tag, so an upgraded release always runs a matching image. The one case
+# that needs action is an explicitly PINNED image.tag older than the chart — set both paths back to
+# /health until the pin catches up.
+probes:
+  readiness:
+    path: /ready
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+    successThreshold: 1
+  liveness:
+    path: /alive
+    initialDelaySeconds: 30
+    periodSeconds: 30
+    timeoutSeconds: 1
+    failureThreshold: 3
+
 resources:
   requests:
     cpu: 100m

--- a/src/Endatix.Framework/Configuration/HostingOptions.cs
+++ b/src/Endatix.Framework/Configuration/HostingOptions.cs
@@ -36,6 +36,21 @@ public class HostingOptions : EndatixOptionsBase
     public bool? UseHttpsRedirection { get; set; }
 
     /// <summary>
+    /// Gets or sets the path serving the full health report (every registered check).
+    /// </summary>
+    public string HealthCheckPath { get; set; } = "/health";
+
+    /// <summary>
+    /// Gets or sets the path serving the liveness probe — process-level checks only, never the database.
+    /// </summary>
+    public string LivenessPath { get; set; } = "/alive";
+
+    /// <summary>
+    /// Gets or sets the path serving the readiness probe — checks tagged <c>ready</c>.
+    /// </summary>
+    public string ReadinessPath { get; set; } = "/ready";
+
+    /// <summary>
     /// Gets or sets reverse proxy hosting options.
     /// </summary>
     public ReverseProxyOptions ReverseProxy { get; set; } = new();

--- a/src/Endatix.Hosting/Builders/EndatixHealthChecksBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixHealthChecksBuilder.cs
@@ -1,3 +1,4 @@
+using Endatix.Hosting.HealthChecks;
 using Endatix.Infrastructure.Data;
 using Endatix.Infrastructure.Identity;
 using Microsoft.Extensions.DependencyInjection;
@@ -10,6 +11,12 @@ namespace Endatix.Hosting.Builders;
 /// </summary>
 public class EndatixHealthChecksBuilder
 {
+    /// <summary>
+    /// Name of the process-level check Endatix registers. Distinct from Aspire ServiceDefaults'
+    /// own "self" check so both can coexist without a duplicate-name registration error.
+    /// </summary>
+    public const string SelfCheckName = "endatix-self";
+
     private readonly EndatixBuilder _parent;
     private bool _defaultsApplied;
 
@@ -35,12 +42,14 @@ public class EndatixHealthChecksBuilder
             return this;
         }
 
-        // Skip adding Endatix own health check if Aspire ServiceDefaults are being used
-        // Aspire already adds a "self" health check, and it should not be duplicated
-        if (!IsAspireServiceDefaultsPresent())
-        {
-            AddCheck("self", () => HealthCheckResult.Healthy(), tags: new[] { "self" });
-        }
+        // Registered unconditionally, under a name Endatix owns. Previously this was skipped when
+        // Aspire ServiceDefaults looked present, detected by a substring match on "ServiceDiscovery"
+        // in any registered service type — which any transitive Microsoft.Extensions.ServiceDiscovery
+        // reference satisfies. A false positive there left no check tagged self or live at all, and
+        // an empty liveness predicate reports Healthy: a hung process would have stayed green
+        // forever. Owning the name removes both the duplicate-name risk and the guesswork, and
+        // guarantees the liveness probe always has something to evaluate.
+        AddCheck(SelfCheckName, () => HealthCheckResult.Healthy(), tags: new[] { HealthCheckTags.Self });
 
         AddDbContextHealthChecks();
 
@@ -86,28 +95,13 @@ public class EndatixHealthChecksBuilder
     {
         if (_parent.Services.Any(s => s.ServiceType == typeof(AppDbContext)))
         {
-            Builder.AddDbContextCheck<AppDbContext>("database", failureStatus: HealthStatus.Unhealthy, tags: new[] { "db", "ready" });
+            Builder.AddDbContextCheck<AppDbContext>("database", failureStatus: HealthStatus.Unhealthy, tags: new[] { HealthCheckTags.Db, HealthCheckTags.Ready });
         }
 
         if (_parent.Services.Any(s => s.ServiceType == typeof(AppIdentityDbContext)))
         {
-            Builder.AddDbContextCheck<AppIdentityDbContext>("identity-database", failureStatus: HealthStatus.Unhealthy, tags: new[] { "db", "identity", "ready" });
+            Builder.AddDbContextCheck<AppIdentityDbContext>("identity-database", failureStatus: HealthStatus.Unhealthy, tags: new[] { HealthCheckTags.Db, HealthCheckTags.Identity, HealthCheckTags.Ready });
         }
-    }
-
-    /// <summary>
-    /// Checks if Aspire ServiceDefaults are being used by looking for telemetry services.
-    /// This helps avoid conflicts with Aspire's default health checks.
-    /// </summary>
-    /// <returns>True if Aspire ServiceDefaults appear to be present, false otherwise.</returns>
-    private bool IsAspireServiceDefaultsPresent()
-    {
-        // Probe for ServiceDiscovery only. Matching "OpenTelemetry" as well used to be the tell,
-        // but Endatix now registers the OTel SDK itself (EndatixTelemetryBuilder) — so that check
-        // would treat our own telemetry as Aspire and silently drop the "self" health check.
-        // Aspire's ServiceDefaults always adds service discovery; the OTel SDK never does.
-        return _parent.Services.Any(s =>
-            s.ServiceType.FullName?.Contains("ServiceDiscovery") == true);
     }
 
     /// <summary>

--- a/src/Endatix.Hosting/Builders/EndatixHealthChecksMiddlewareBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixHealthChecksMiddlewareBuilder.cs
@@ -1,5 +1,6 @@
 using Endatix.Hosting.HealthChecks;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
@@ -122,15 +123,26 @@ public class EndatixHealthChecksMiddlewareBuilder
     }
 
     /// <summary>
-    /// Applies the configuration to the application builder.
+    /// Applies every endpoint. Kept for callers that map health checks directly; <c>UseDefaults</c>
+    /// uses <see cref="ApplyProbes"/> and <see cref="ApplyDiagnostics"/> so the two groups can sit
+    /// on opposite sides of HTTPS redirection.
     /// </summary>
     /// <param name="app">The application builder.</param>
     internal void Apply(IApplicationBuilder app)
     {
-        _logger?.LogInformation("Configuring health checks middleware with path: {Path}", _options.Path);
+        ApplyProbes(app);
+        ApplyDiagnostics(app);
+    }
 
-        var healthCheckOptions = HealthCheckOptionsFactory.CreateDefaultOptions(_options.ResponseWriter);
-        app.UseHealthChecks(_options.Path, healthCheckOptions);
+    /// <summary>
+    /// Maps the liveness and readiness probes. Register these BEFORE HSTS and HTTPS redirection:
+    /// Kubernetes counts any 2xx-3xx as probe Success, so an HTTP probe answered with a 307 greens
+    /// both probes permanently and readiness would never drop a pod whose database is gone.
+    /// </summary>
+    /// <param name="app">The application builder.</param>
+    internal void ApplyProbes(IApplicationBuilder app)
+    {
+        ValidatePaths();
 
         if (_options.EnableLivenessEndpoint)
         {
@@ -142,8 +154,22 @@ public class EndatixHealthChecksMiddlewareBuilder
         if (_options.EnableReadinessEndpoint)
         {
             _logger?.LogInformation("Configuring readiness endpoint with path: {Path}", _options.ReadinessPath);
-            app.UseHealthChecks(_options.ReadinessPath, HealthCheckOptionsFactory.CreateReadinessOptions());
+            MapReadiness(app);
         }
+    }
+
+    /// <summary>
+    /// Maps the unfiltered report and its detail/UI views. These stay BEHIND HTTPS redirection and
+    /// HSTS — they expose check names, descriptions and durations, which must not be served in
+    /// cleartext — and behind the API middleware so they inherit its CORS policy.
+    /// </summary>
+    /// <param name="app">The application builder.</param>
+    internal void ApplyDiagnostics(IApplicationBuilder app)
+    {
+        _logger?.LogInformation("Configuring health checks middleware with path: {Path}", _options.Path);
+
+        var healthCheckOptions = HealthCheckOptionsFactory.CreateDefaultOptions(_options.ResponseWriter);
+        app.UseHealthChecks(_options.Path, healthCheckOptions);
 
         if (_options.EnableJsonView)
         {
@@ -157,24 +183,109 @@ public class EndatixHealthChecksMiddlewareBuilder
     }
 
     /// <summary>
-    /// An empty predicate result reports Healthy, so a liveness endpoint with no matching
-    /// registration answers 200 forever while proving only that Kestrel is listening. That is a
-    /// silent downgrade — it looks identical to a passing check — so say so at startup.
+    /// Readiness must fail closed. An empty predicate reports Healthy, so a readiness endpoint with
+    /// no matching registration would answer 200 forever — Kubernetes would keep every pod in the
+    /// Service endpoints while the database is unreachable and every request 500s. That state is
+    /// reachable: the database checks are registered only when a DbContext is already in Services,
+    /// so a host calling HealthChecks.UseDefaults() before or without persistence has none.
     /// </summary>
-    private void WarnIfNoLivenessChecksRegistered(IApplicationBuilder app)
+    private void MapReadiness(IApplicationBuilder app)
+    {
+        if (HasRegistrationMatching(app, HealthCheckOptionsFactory.IsReadinessCheck))
+        {
+            app.UseHealthChecks(_options.ReadinessPath, HealthCheckOptionsFactory.CreateReadinessOptions());
+            return;
+        }
+
+        _logger?.LogError(
+            "Readiness endpoint {Path} has no health check tagged '{Tag}', so it cannot tell whether " +
+            "this instance can serve traffic. It will report Unhealthy rather than pass by default. " +
+            "Register a '{TagAgain}'-tagged check (persistence registers one) or call " +
+            "WithoutReadinessEndpoint() if this host is deliberately dependency-free.",
+            _options.ReadinessPath,
+            HealthCheckTags.Ready,
+            HealthCheckTags.Ready);
+
+        app.Map(_options.ReadinessPath, branch => branch.Run(async context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+            context.Response.ContentType = "text/plain";
+            await context.Response.WriteAsync(
+                $"Unhealthy: no health check is tagged '{HealthCheckTags.Ready}'.");
+        }));
+    }
+
+    /// <summary>
+    /// Rejects path configuration that fails in ways the runtime reports badly or not at all: an
+    /// empty path matches EVERY request and replaces the application with the health report, a path
+    /// without a leading slash throws from inside Map naming no option, and a duplicate path is
+    /// silently ignored because the first registration wins — which would quietly give the liveness
+    /// probe the unfiltered report, the exact bug this split exists to fix.
+    /// </summary>
+    private void ValidatePaths()
+    {
+        var paths = new (string Option, string Value)[]
+        {
+            ("Endatix:Hosting:HealthCheckPath", _options.Path),
+            ("Endatix:Hosting:LivenessPath", _options.LivenessPath),
+            ("Endatix:Hosting:ReadinessPath", _options.ReadinessPath)
+        };
+
+        foreach (var (option, value) in paths)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new InvalidOperationException(
+                    $"{option} is empty. An empty health check path matches every request and would " +
+                    "replace the entire application with the health report.");
+            }
+
+            if (!value.StartsWith('/'))
+            {
+                throw new InvalidOperationException(
+                    $"{option} is '{value}' but must start with '/'.");
+            }
+        }
+
+        var duplicate = paths
+            .GroupBy(entry => entry.Value, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault(group => group.Count() > 1);
+
+        if (duplicate is not null)
+        {
+            throw new InvalidOperationException(
+                $"Health check paths must be distinct, but {string.Join(" and ", duplicate.Select(entry => entry.Option))} " +
+                $"are both '{duplicate.Key}'. The first registration wins, so the others would be dead code.");
+        }
+    }
+
+    private static bool HasRegistrationMatching(IApplicationBuilder app, Func<HealthCheckRegistration, bool> predicate)
     {
         var registrations = app.ApplicationServices
             .GetService<IOptions<HealthCheckServiceOptions>>()?.Value.Registrations;
 
-        if (registrations is null || registrations.Any(HealthCheckOptionsFactory.IsLivenessCheck))
+        return registrations is not null && registrations.Any(predicate);
+    }
+
+    /// <summary>
+    /// An empty predicate result reports Healthy, so a liveness endpoint with no matching
+    /// registration answers 200 forever while proving only that Kestrel is listening. Unlike
+    /// readiness this is not failed closed — a liveness probe that fails closed restart-loops the
+    /// container — but it must not pass silently either.
+    /// </summary>
+    private void WarnIfNoLivenessChecksRegistered(IApplicationBuilder app)
+    {
+        if (HasRegistrationMatching(app, HealthCheckOptionsFactory.IsLivenessCheck))
         {
             return;
         }
 
         _logger?.LogWarning(
-            "Liveness endpoint {Path} is mapped but no health check is tagged 'self' or 'live'. It " +
-            "will report Healthy unconditionally and cannot detect an unhealthy process.",
-            _options.LivenessPath);
+            "Liveness endpoint {Path} is mapped but no health check is tagged '{Self}' or '{Live}'. " +
+            "It will report Healthy unconditionally and cannot detect an unhealthy process.",
+            _options.LivenessPath,
+            HealthCheckTags.Self,
+            HealthCheckTags.Live);
     }
 
     /// <summary>

--- a/src/Endatix.Hosting/Builders/EndatixHealthChecksMiddlewareBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixHealthChecksMiddlewareBuilder.cs
@@ -1,6 +1,9 @@
 using Endatix.Hosting.HealthChecks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Endatix.Hosting.Builders;
 
@@ -46,6 +49,68 @@ public class EndatixHealthChecksMiddlewareBuilder
     }
 
     /// <summary>
+    /// Configures the path where the liveness probe is exposed. Defaults to "/alive".
+    /// </summary>
+    /// <param name="path">The path where the liveness probe will be exposed.</param>
+    /// <returns>The builder for chaining.</returns>
+    public EndatixHealthChecksMiddlewareBuilder WithLivenessPath(string path)
+    {
+        _options.LivenessPath = path;
+        return this;
+    }
+
+    /// <summary>
+    /// Configures the path where the readiness probe is exposed. Defaults to "/ready".
+    /// </summary>
+    /// <param name="path">The path where the readiness probe will be exposed.</param>
+    /// <returns>The builder for chaining.</returns>
+    public EndatixHealthChecksMiddlewareBuilder WithReadinessPath(string path)
+    {
+        _options.ReadinessPath = path;
+        return this;
+    }
+
+    /// <summary>
+    /// Stops the liveness endpoint from being mapped.
+    /// </summary>
+    /// <returns>The builder for chaining.</returns>
+    public EndatixHealthChecksMiddlewareBuilder WithoutLivenessEndpoint()
+    {
+        _options.EnableLivenessEndpoint = false;
+        return this;
+    }
+
+    /// <summary>
+    /// Stops the readiness endpoint from being mapped.
+    /// </summary>
+    /// <returns>The builder for chaining.</returns>
+    public EndatixHealthChecksMiddlewareBuilder WithoutReadinessEndpoint()
+    {
+        _options.EnableReadinessEndpoint = false;
+        return this;
+    }
+
+    /// <summary>
+    /// Stops the JSON detail view at {Path}/detail from being mapped.
+    /// </summary>
+    /// <returns>The builder for chaining.</returns>
+    public EndatixHealthChecksMiddlewareBuilder WithoutJsonView()
+    {
+        _options.EnableJsonView = false;
+        return this;
+    }
+
+    /// <summary>
+    /// Stops the HTML UI view at {Path}/ui from being mapped.
+    /// </summary>
+    /// <returns>The builder for chaining.</returns>
+    public EndatixHealthChecksMiddlewareBuilder WithoutWebUI()
+    {
+        _options.EnableWebUI = false;
+        return this;
+    }
+
+    /// <summary>
     /// Configures a custom response writer for the health checks endpoint.
     /// </summary>
     /// <param name="responseWriter">The custom response writer.</param>
@@ -67,6 +132,19 @@ public class EndatixHealthChecksMiddlewareBuilder
         var healthCheckOptions = HealthCheckOptionsFactory.CreateDefaultOptions(_options.ResponseWriter);
         app.UseHealthChecks(_options.Path, healthCheckOptions);
 
+        if (_options.EnableLivenessEndpoint)
+        {
+            _logger?.LogInformation("Configuring liveness endpoint with path: {Path}", _options.LivenessPath);
+            app.UseHealthChecks(_options.LivenessPath, HealthCheckOptionsFactory.CreateLivenessOptions());
+            WarnIfNoLivenessChecksRegistered(app);
+        }
+
+        if (_options.EnableReadinessEndpoint)
+        {
+            _logger?.LogInformation("Configuring readiness endpoint with path: {Path}", _options.ReadinessPath);
+            app.UseHealthChecks(_options.ReadinessPath, HealthCheckOptionsFactory.CreateReadinessOptions());
+        }
+
         if (_options.EnableJsonView)
         {
             app.UseHealthChecks($"{_options.Path}/detail", HealthCheckOptionsFactory.CreateJsonOptions());
@@ -76,6 +154,27 @@ public class EndatixHealthChecksMiddlewareBuilder
         {
             app.UseHealthChecks($"{_options.Path}/ui", HealthCheckOptionsFactory.CreateWebUIOptions());
         }
+    }
+
+    /// <summary>
+    /// An empty predicate result reports Healthy, so a liveness endpoint with no matching
+    /// registration answers 200 forever while proving only that Kestrel is listening. That is a
+    /// silent downgrade — it looks identical to a passing check — so say so at startup.
+    /// </summary>
+    private void WarnIfNoLivenessChecksRegistered(IApplicationBuilder app)
+    {
+        var registrations = app.ApplicationServices
+            .GetService<IOptions<HealthCheckServiceOptions>>()?.Value.Registrations;
+
+        if (registrations is null || registrations.Any(HealthCheckOptionsFactory.IsLivenessCheck))
+        {
+            return;
+        }
+
+        _logger?.LogWarning(
+            "Liveness endpoint {Path} is mapped but no health check is tagged 'self' or 'live'. It " +
+            "will report Healthy unconditionally and cannot detect an unhealthy process.",
+            _options.LivenessPath);
     }
 
     /// <summary>

--- a/src/Endatix.Hosting/Builders/EndatixHealthChecksMiddlewareBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixHealthChecksMiddlewareBuilder.cs
@@ -222,16 +222,31 @@ public class EndatixHealthChecksMiddlewareBuilder
     /// silently ignored because the first registration wins — which would quietly give the liveness
     /// probe the unfiltered report, the exact bug this split exists to fix.
     /// </summary>
+    /// <remarks>
+    /// Checks the routes actually mapped, not the options as written. A disabled probe's path is
+    /// never registered, so it cannot collide with anything and must not fail startup. The
+    /// detail/UI views are derived from <see cref="HealthChecksOptions.Path"/> rather than
+    /// configured, but they occupy routes all the same — and because probes are mapped first, a
+    /// liveness path of "{Path}/detail" would shadow the JSON view rather than conflict visibly.
+    /// </remarks>
     private void ValidatePaths()
     {
-        var paths = new (string Option, string Value)[]
+        var configured = new List<(string Option, string Value)>
         {
-            ("Endatix:Hosting:HealthCheckPath", _options.Path),
-            ("Endatix:Hosting:LivenessPath", _options.LivenessPath),
-            ("Endatix:Hosting:ReadinessPath", _options.ReadinessPath)
+            ("Endatix:Hosting:HealthCheckPath", _options.Path)
         };
 
-        foreach (var (option, value) in paths)
+        if (_options.EnableLivenessEndpoint)
+        {
+            configured.Add(("Endatix:Hosting:LivenessPath", _options.LivenessPath));
+        }
+
+        if (_options.EnableReadinessEndpoint)
+        {
+            configured.Add(("Endatix:Hosting:ReadinessPath", _options.ReadinessPath));
+        }
+
+        foreach (var (option, value) in configured)
         {
             if (string.IsNullOrWhiteSpace(value))
             {
@@ -247,7 +262,19 @@ public class EndatixHealthChecksMiddlewareBuilder
             }
         }
 
-        var duplicate = paths
+        var mapped = new List<(string Option, string Value)>(configured);
+
+        if (_options.EnableJsonView)
+        {
+            mapped.Add(($"{_options.Path}/detail (the JSON view)", $"{_options.Path}/detail"));
+        }
+
+        if (_options.EnableWebUI)
+        {
+            mapped.Add(($"{_options.Path}/ui (the HTML view)", $"{_options.Path}/ui"));
+        }
+
+        var duplicate = mapped
             .GroupBy(entry => entry.Value, StringComparer.OrdinalIgnoreCase)
             .FirstOrDefault(group => group.Count() > 1);
 

--- a/src/Endatix.Hosting/Builders/EndatixMiddlewareBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixMiddlewareBuilder.cs
@@ -80,17 +80,19 @@ public class EndatixMiddlewareBuilder
         // Terminal branch: HTTP /dev/embed-host must not 307 to HTTPS (mixed content vs Hub).
         UseEmbedHost();
 
-        // Same reason, and it matters more here: Kubernetes treats any 2xx-3xx as probe Success, so
-        // an HTTP probe answered with a 307 to HTTPS greens both probes permanently — readiness
-        // would never drop a pod whose database is gone. Register the probe branches before the
-        // redirect so they answer on plain HTTP regardless of the HTTPS configuration.
+        // Probes ONLY, and only these, ahead of the redirect. Kubernetes treats any 2xx-3xx as probe
+        // Success, so an HTTP probe answered with a 307 to HTTPS greens both probes permanently and
+        // readiness would never drop a pod whose database is gone. The unfiltered report and its
+        // detail/UI views deliberately stay behind HSTS and the redirect further down: they expose
+        // check names, descriptions and durations, which must not be served in cleartext.
+        EndatixHealthChecksMiddlewareBuilder? healthChecks = null;
         if (options.UseHealthChecks)
         {
-            UseHealthChecks(
-                options.HealthCheckPath,
-                health => health
-                    .WithLivenessPath(options.LivenessPath)
-                    .WithReadinessPath(options.ReadinessPath));
+            healthChecks = new EndatixHealthChecksMiddlewareBuilder(this, _logger);
+            healthChecks.WithPath(options.HealthCheckPath)
+                .WithLivenessPath(options.LivenessPath)
+                .WithReadinessPath(options.ReadinessPath);
+            healthChecks.ApplyProbes(App);
         }
 
         if (options.UseHsts)
@@ -107,6 +109,11 @@ public class EndatixMiddlewareBuilder
         {
             UseApi(options.ApiOptions);
         }
+
+        // After UseApi on purpose: UseCors lives inside it, so a dashboard on another origin fetching
+        // /health/detail keeps its Access-Control-Allow-Origin header. The probes above need no CORS
+        // — kubelet sends no Origin — which is why only these move.
+        healthChecks?.ApplyDiagnostics(App);
 
         options.ConfigureAdditionalMiddleware?.Invoke(App);
 
@@ -309,14 +316,15 @@ public class EndatixMiddlewareBuilder
         // Use the dedicated health checks middleware builder to avoid code duplication
         EndatixHealthChecksMiddlewareBuilder healthChecksBuilder = new(this, _logger);
 
-        // Apply custom configuration if provided
+        // Path first, THEN the delegate: applying it afterwards silently overwrote a caller's own
+        // WithPath("/internal/health"), so the call compiled, ran and did nothing.
+        healthChecksBuilder.WithPath(path);
+
         if (configureHealthChecks is { })
         {
             configureHealthChecks(healthChecksBuilder);
         }
 
-        // Configure the health checks middleware
-        healthChecksBuilder.WithPath(path);
         healthChecksBuilder.Apply(App);
 
         return this;

--- a/src/Endatix.Hosting/Builders/EndatixMiddlewareBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixMiddlewareBuilder.cs
@@ -80,6 +80,19 @@ public class EndatixMiddlewareBuilder
         // Terminal branch: HTTP /dev/embed-host must not 307 to HTTPS (mixed content vs Hub).
         UseEmbedHost();
 
+        // Same reason, and it matters more here: Kubernetes treats any 2xx-3xx as probe Success, so
+        // an HTTP probe answered with a 307 to HTTPS greens both probes permanently — readiness
+        // would never drop a pod whose database is gone. Register the probe branches before the
+        // redirect so they answer on plain HTTP regardless of the HTTPS configuration.
+        if (options.UseHealthChecks)
+        {
+            UseHealthChecks(
+                options.HealthCheckPath,
+                health => health
+                    .WithLivenessPath(options.LivenessPath)
+                    .WithReadinessPath(options.ReadinessPath));
+        }
+
         if (options.UseHsts)
         {
             UseHsts();
@@ -93,11 +106,6 @@ public class EndatixMiddlewareBuilder
         if (options.UseApi)
         {
             UseApi(options.ApiOptions);
-        }
-
-        if (options.UseHealthChecks)
-        {
-            UseHealthChecks(options.HealthCheckPath);
         }
 
         options.ConfigureAdditionalMiddleware?.Invoke(App);

--- a/src/Endatix.Hosting/Builders/EndatixTelemetryBuilder.cs
+++ b/src/Endatix.Hosting/Builders/EndatixTelemetryBuilder.cs
@@ -4,6 +4,7 @@ using Endatix.Hosting.Options;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Endatix.Framework.Configuration;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry.Exporter;
 using OpenTelemetry.Logs;
@@ -100,11 +101,11 @@ public class EndatixTelemetryBuilder
             [OtlpTracesProtocol, OtlpMetricsProtocol, OtlpLogsProtocol, OtlpProtocol];
     }
 
-    private static readonly string[] _defaultExcludedPaths = ["/health", "/alive", "/ready"];
+    private static readonly string[] _fallbackExcludedPaths = ["/health", "/alive", "/ready"];
 
     private readonly EndatixBuilder _parent;
     private readonly ILogger _logger;
-    private readonly List<string> _excludedPaths = [.. _defaultExcludedPaths];
+    private readonly List<string> _excludedPaths;
 
     private TelemetryOptions _options = new();
     private Instrumentations _instrumentation = Instrumentations.All;
@@ -119,6 +120,31 @@ public class EndatixTelemetryBuilder
     {
         _parent = parent;
         _logger = parent.LoggerFactory.CreateLogger<EndatixTelemetryBuilder>();
+        _excludedPaths = [.. ResolveExcludedPaths(parent)];
+    }
+
+    /// <summary>
+    /// Seeds the exclusion list from the configured probe paths rather than from literals, so a host
+    /// that moves a probe does not start shipping a span for every kubelet request — one per pod
+    /// every few seconds — while the exclusion list still protects a path nothing serves.
+    /// </summary>
+    private static string[] ResolveExcludedPaths(EndatixBuilder parent)
+    {
+        var hosting = parent.Configuration
+            .GetSection($"Endatix:{new HostingOptions().SectionPath}")
+            .Get<HostingOptions>();
+
+        if (hosting is null)
+        {
+            return _fallbackExcludedPaths;
+        }
+
+        return
+        [
+            hosting.HealthCheckPath,
+            hosting.LivenessPath,
+            hosting.ReadinessPath
+        ];
     }
 
     /// <summary>

--- a/src/Endatix.Hosting/HealthChecks/HealthCheckOptionsFactory.cs
+++ b/src/Endatix.Hosting/HealthChecks/HealthCheckOptionsFactory.cs
@@ -30,11 +30,11 @@ internal static class HealthCheckOptionsFactory
     /// Creates options for the liveness endpoint: only checks tagged <c>self</c> or <c>live</c>.
     /// </summary>
     /// <remarks>
-    /// Both tags are accepted because the host may register either. Endatix's own defaults tag the
-    /// process check <c>self</c>; Aspire ServiceDefaults, when present, contributes <c>live</c>
-    /// instead and Endatix skips its own to avoid duplicating it. A predicate matching no checks
-    /// yields an empty report, which reports Healthy — the correct answer for liveness, since
-    /// reaching the endpoint at all proves the process is up.
+    /// Both tags are accepted because the host may register either. Endatix always registers its own
+    /// process check tagged <c>self</c>; Aspire ServiceDefaults, when present, contributes a
+    /// <c>live</c>-tagged one alongside it. A predicate matching no checks yields an empty report,
+    /// which reports Healthy — the correct answer for liveness, since reaching the endpoint at all
+    /// proves the process is up.
     /// </remarks>
     /// <returns>Health check options filtered to liveness checks.</returns>
     public static HealthCheckOptions CreateLivenessOptions()

--- a/src/Endatix.Hosting/HealthChecks/HealthCheckOptionsFactory.cs
+++ b/src/Endatix.Hosting/HealthChecks/HealthCheckOptionsFactory.cs
@@ -47,7 +47,7 @@ internal static class HealthCheckOptionsFactory
     /// to warn when nothing matches, rather than duplicating the tag names at the call site.
     /// </summary>
     public static bool IsLivenessCheck(HealthCheckRegistration registration) =>
-        registration.Tags.Contains("self") || registration.Tags.Contains("live");
+        registration.Tags.Contains(HealthCheckTags.Self) || registration.Tags.Contains(HealthCheckTags.Live);
 
     /// <summary>
     /// Creates options for the readiness endpoint: only checks tagged <c>ready</c>.
@@ -63,7 +63,7 @@ internal static class HealthCheckOptionsFactory
     /// tags <c>ready</c>, not every registration.
     /// </summary>
     public static bool IsReadinessCheck(HealthCheckRegistration registration) =>
-        registration.Tags.Contains("ready");
+        registration.Tags.Contains(HealthCheckTags.Ready);
 
     /// <summary>
     /// Creates health check options for JSON output.

--- a/src/Endatix.Hosting/HealthChecks/HealthCheckOptionsFactory.cs
+++ b/src/Endatix.Hosting/HealthChecks/HealthCheckOptionsFactory.cs
@@ -27,6 +27,45 @@ internal static class HealthCheckOptionsFactory
     }
 
     /// <summary>
+    /// Creates options for the liveness endpoint: only checks tagged <c>self</c> or <c>live</c>.
+    /// </summary>
+    /// <remarks>
+    /// Both tags are accepted because the host may register either. Endatix's own defaults tag the
+    /// process check <c>self</c>; Aspire ServiceDefaults, when present, contributes <c>live</c>
+    /// instead and Endatix skips its own to avoid duplicating it. A predicate matching no checks
+    /// yields an empty report, which reports Healthy — the correct answer for liveness, since
+    /// reaching the endpoint at all proves the process is up.
+    /// </remarks>
+    /// <returns>Health check options filtered to liveness checks.</returns>
+    public static HealthCheckOptions CreateLivenessOptions()
+    {
+        return new HealthCheckOptions { Predicate = IsLivenessCheck };
+    }
+
+    /// <summary>
+    /// Selects the checks that answer "is this process alive?". Exposed so the same rule can be used
+    /// to warn when nothing matches, rather than duplicating the tag names at the call site.
+    /// </summary>
+    public static bool IsLivenessCheck(HealthCheckRegistration registration) =>
+        registration.Tags.Contains("self") || registration.Tags.Contains("live");
+
+    /// <summary>
+    /// Creates options for the readiness endpoint: only checks tagged <c>ready</c>.
+    /// </summary>
+    /// <returns>Health check options filtered to readiness checks.</returns>
+    public static HealthCheckOptions CreateReadinessOptions()
+    {
+        return new HealthCheckOptions { Predicate = IsReadinessCheck };
+    }
+
+    /// <summary>
+    /// Selects the checks that answer "can this instance serve traffic?" — the dependencies Endatix
+    /// tags <c>ready</c>, not every registration.
+    /// </summary>
+    public static bool IsReadinessCheck(HealthCheckRegistration registration) =>
+        registration.Tags.Contains("ready");
+
+    /// <summary>
     /// Creates health check options for JSON output.
     /// </summary>
     /// <returns>Health check options configured for JSON output.</returns>

--- a/src/Endatix.Hosting/HealthChecks/HealthCheckTags.cs
+++ b/src/Endatix.Hosting/HealthChecks/HealthCheckTags.cs
@@ -1,0 +1,27 @@
+namespace Endatix.Hosting.HealthChecks;
+
+/// <summary>
+/// Tags Endatix puts on its health checks, and which the probe endpoints filter on.
+/// </summary>
+/// <remarks>
+/// Shared constants rather than literals at each site: registration and predicate must agree, and a
+/// rename that touched only one of them would leave a probe with an empty predicate — which reports
+/// Healthy, so it would fail silently rather than loudly.
+/// </remarks>
+public static class HealthCheckTags
+{
+    /// <summary>Process-level check. Selected by the liveness probe.</summary>
+    public const string Self = "self";
+
+    /// <summary>Aspire ServiceDefaults' equivalent of <see cref="Self"/>. Also selected by liveness.</summary>
+    public const string Live = "live";
+
+    /// <summary>A dependency the instance needs to serve traffic. Selected by the readiness probe.</summary>
+    public const string Ready = "ready";
+
+    /// <summary>Database-backed check.</summary>
+    public const string Db = "db";
+
+    /// <summary>Identity store check.</summary>
+    public const string Identity = "identity";
+}

--- a/src/Endatix.Hosting/HealthChecks/HealthChecksOptions.cs
+++ b/src/Endatix.Hosting/HealthChecks/HealthChecksOptions.cs
@@ -18,6 +18,29 @@ public class HealthChecksOptions
     public string Path { get; set; } = "/health";
 
     /// <summary>
+    /// Gets or sets the path where the liveness probe is exposed.
+    /// </summary>
+    /// <remarks>
+    /// Separate from <see cref="Path"/> on purpose. This endpoint runs only checks tagged
+    /// <c>self</c> or <c>live</c> — never the database — so it answers "is this process still
+    /// running?" rather than "can it serve traffic?". Pointing a Kubernetes livenessProbe at a
+    /// path that includes the database means a database blip restarts every pod, which removes
+    /// capacity at the moment the system is already degraded.
+    /// </remarks>
+    public string LivenessPath { get; set; } = "/alive";
+
+    /// <summary>
+    /// Gets or sets the path where the readiness probe is exposed.
+    /// </summary>
+    /// <remarks>
+    /// Runs only checks tagged <c>ready</c> — the database checks Endatix registers by default.
+    /// Distinct from <see cref="Path"/>, which runs every registered check: a consumer adding an
+    /// untagged slow or flaky check would otherwise put it on the readiness path and start
+    /// evicting pods from the Service endpoints for something unrelated to serving traffic.
+    /// </remarks>
+    public string ReadinessPath { get; set; } = "/ready";
+
+    /// <summary>
     /// Gets or sets a custom response writer for the health checks endpoint.
     /// </summary>
     public Func<HttpContext, Microsoft.Extensions.Diagnostics.HealthChecks.HealthReport, Task>? ResponseWriter { get; set; }
@@ -31,4 +54,14 @@ public class HealthChecksOptions
     /// Gets or sets a value indicating whether to enable the HTML UI view at {Path}/ui.
     /// </summary>
     public bool EnableWebUI { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to expose the liveness endpoint at <see cref="LivenessPath"/>.
+    /// </summary>
+    public bool EnableLivenessEndpoint { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to expose the readiness endpoint at <see cref="ReadinessPath"/>.
+    /// </summary>
+    public bool EnableReadinessEndpoint { get; set; } = true;
 } 

--- a/src/Endatix.Hosting/Options/EndatixMiddlewareOptions.cs
+++ b/src/Endatix.Hosting/Options/EndatixMiddlewareOptions.cs
@@ -54,6 +54,16 @@ public class EndatixMiddlewareOptions
     public string HealthCheckPath { get; set; } = "/health";
 
     /// <summary>
+    /// Path for the liveness probe. Runs only process-level checks, never the database.
+    /// </summary>
+    public string LivenessPath { get; set; } = "/alive";
+
+    /// <summary>
+    /// Path for the readiness probe. Runs only checks tagged <c>ready</c>.
+    /// </summary>
+    public string ReadinessPath { get; set; } = "/ready";
+
+    /// <summary>
     /// Gets or sets the API options for configuring API middleware.
     /// </summary>
     /// <remarks>

--- a/src/Endatix.Hosting/Options/EndatixMiddlewareOptionsFactory.cs
+++ b/src/Endatix.Hosting/Options/EndatixMiddlewareOptionsFactory.cs
@@ -25,6 +25,11 @@ internal static class EndatixMiddlewareOptionsFactory
             UseForwardedHeaders = useForwardedHeaders,
             UseHsts = options.UseHsts ?? !useForwardedHeaders,
             UseHttpsRedirection = options.UseHttpsRedirection ?? !useForwardedHeaders,
+            // Bound, not defaulted: UseDefaults() routes through this factory, so a path left out
+            // here can never be changed from configuration no matter what the options object says.
+            HealthCheckPath = options.HealthCheckPath,
+            LivenessPath = options.LivenessPath,
+            ReadinessPath = options.ReadinessPath,
             ApiOptions = apiOptions ?? new ApiOptions()
         };
     }

--- a/tests/Endatix.Hosting.Tests/HealthChecks/EndatixHealthChecksBuilderTests.cs
+++ b/tests/Endatix.Hosting.Tests/HealthChecks/EndatixHealthChecksBuilderTests.cs
@@ -1,3 +1,4 @@
+using Endatix.Hosting.Builders;
 using Endatix.Hosting.HealthChecks;
 using Endatix.Infrastructure.Builders;
 using Microsoft.Extensions.Configuration;
@@ -15,7 +16,7 @@ internal sealed class ServiceDiscoveryMarker;
 
 /// <summary>
 /// Dummy type standing in for Endatix's own OpenTelemetry registration. It must NOT be mistaken for
-/// Aspire — that misdetection would silently drop the "self" health check.
+/// Aspire. The detection is gone now; the process check is always registered.
 /// </summary>
 internal sealed class OpenTelemetryMarker;
 
@@ -64,7 +65,7 @@ public sealed class EndatixHealthChecksBuilderTests
 
         // Assert
         report.Status.Should().Be(HealthStatus.Healthy);
-        report.Entries.Should().ContainKey("self");
+        report.Entries.Should().ContainKey(EndatixHealthChecksBuilder.SelfCheckName);
         report.Entries.Should().ContainKey("my-service");
         report.Entries["my-service"].Status.Should().Be(HealthStatus.Healthy);
         report.Entries["my-service"].Description.Should().Be("My service is healthy");
@@ -92,12 +93,12 @@ public sealed class EndatixHealthChecksBuilderTests
         var report = await healthCheckService.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         // Assert
-        report.Entries.Should().ContainKey("self");
-        report.Entries["self"].Status.Should().Be(HealthStatus.Healthy);
+        report.Entries.Should().ContainKey(EndatixHealthChecksBuilder.SelfCheckName);
+        report.Entries[EndatixHealthChecksBuilder.SelfCheckName].Status.Should().Be(HealthStatus.Healthy);
     }
 
     [Fact]
-    public async Task ConfigureEndatix_WhenAspireServiceDefaultsPresent_SelfCheckIsNotAdded()
+    public async Task ConfigureEndatix_WhenServiceDiscoveryRegistered_SelfCheckIsStillAdded()
     {
         // Arrange
         var config = CreateMinimalConfig();
@@ -105,7 +106,7 @@ public sealed class EndatixHealthChecksBuilderTests
             .ConfigureAppConfiguration((_, c) => c.AddConfiguration(config))
             .ConfigureServices((context, services) =>
             {
-                // Simulate Aspire presence so UseDefaults() skips the "self" check
+                // A service-discovery registration used to suppress the process check via a substring match
                 services.AddSingleton<ServiceDiscoveryMarker>();
                 var builder = services.AddEndatix(context.Configuration);
                 builder.HealthChecks.UseDefaults();
@@ -119,7 +120,8 @@ public sealed class EndatixHealthChecksBuilderTests
         var report = await healthCheckService.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         // Assert
-        report.Entries.Should().NotContainKey("self");
+        report.Entries.Should().ContainKey(EndatixHealthChecksBuilder.SelfCheckName,
+            "the process check is registered unconditionally now — Aspire detection was a substring match that could false-positive and leave liveness with nothing to evaluate");
     }
 
     [Fact]
@@ -145,8 +147,8 @@ public sealed class EndatixHealthChecksBuilderTests
         var report = await healthCheckService.CheckHealthAsync(TestContext.Current.CancellationToken);
 
         // Assert
-        report.Entries.Should().ContainKey("self");
-        report.Entries["self"].Status.Should().Be(HealthStatus.Healthy);
+        report.Entries.Should().ContainKey(EndatixHealthChecksBuilder.SelfCheckName);
+        report.Entries[EndatixHealthChecksBuilder.SelfCheckName].Status.Should().Be(HealthStatus.Healthy);
     }
 
     /// <summary>
@@ -179,7 +181,7 @@ public sealed class EndatixHealthChecksBuilderTests
             TestContext.Current.CancellationToken);
 
         // Assert
-        report.Entries.Should().ContainKey("self");
+        report.Entries.Should().ContainKey(EndatixHealthChecksBuilder.SelfCheckName);
         report.Entries.Should().NotContainKey("database", "liveness must not depend on the database");
         report.Entries.Should().NotContainKey("identity-database");
     }
@@ -214,7 +216,8 @@ public sealed class EndatixHealthChecksBuilderTests
 
         // Assert
         report.Entries.Should().ContainKey("database");
-        report.Entries.Should().NotContainKey("self");
+        report.Entries.Should().NotContainKey(EndatixHealthChecksBuilder.SelfCheckName,
+            "the process check does not gate traffic");
         report.Entries.Should().NotContainKey("consumer-check", "only checks tagged 'ready' gate traffic");
     }
 

--- a/tests/Endatix.Hosting.Tests/HealthChecks/EndatixHealthChecksBuilderTests.cs
+++ b/tests/Endatix.Hosting.Tests/HealthChecks/EndatixHealthChecksBuilderTests.cs
@@ -1,3 +1,4 @@
+using Endatix.Hosting.HealthChecks;
 using Endatix.Infrastructure.Builders;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -146,6 +147,75 @@ public sealed class EndatixHealthChecksBuilderTests
         // Assert
         report.Entries.Should().ContainKey("self");
         report.Entries["self"].Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    /// <summary>
+    /// The predicate is the whole safety property of the liveness probe, and the end-to-end test
+    /// cannot catch a regression that still leaves /alive green. Assert the filtering directly.
+    /// </summary>
+    [Fact]
+    public async Task CheckHealth_WithLivenessPredicate_ExcludesDatabaseChecks()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(_minimalConfig)
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["ConnectionStrings:DefaultConnection"] = "Server=(localdb)\\mssqllocaldb;Database=EndatixHealthCheckTest;Trusted_Connection=True;TrustServerCertificate=True" })
+            .Build();
+
+        using var host = Host.CreateDefaultBuilder()
+            .ConfigureAppConfiguration((_, c) => c.AddConfiguration(config))
+            .ConfigureServices((context, services) =>
+            {
+                var builder = services.AddEndatix(context.Configuration);
+                builder.UseDefaults();
+                builder.FinalizeConfiguration();
+            })
+            .Build();
+        var healthCheckService = host.Services.GetRequiredService<HealthCheckService>();
+
+        // Act
+        var report = await healthCheckService.CheckHealthAsync(
+            HealthCheckOptionsFactory.IsLivenessCheck,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        report.Entries.Should().ContainKey("self");
+        report.Entries.Should().NotContainKey("database", "liveness must not depend on the database");
+        report.Entries.Should().NotContainKey("identity-database");
+    }
+
+    [Fact]
+    public async Task CheckHealth_WithReadinessPredicate_ContainsOnlyDatabaseChecks()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(_minimalConfig)
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["ConnectionStrings:DefaultConnection"] = "Server=(localdb)\\mssqllocaldb;Database=EndatixHealthCheckTest;Trusted_Connection=True;TrustServerCertificate=True" })
+            .Build();
+
+        using var host = Host.CreateDefaultBuilder()
+            .ConfigureAppConfiguration((_, c) => c.AddConfiguration(config))
+            .ConfigureServices((context, services) =>
+            {
+                var builder = services.AddEndatix(context.Configuration);
+                builder.UseDefaults();
+                // An untagged check, as a consumer would add: it must not reach the readiness probe,
+                // or an unrelated dependency starts evicting pods from the Service endpoints.
+                builder.HealthChecks.AddCheck("consumer-check", () => HealthCheckResult.Healthy());
+                builder.FinalizeConfiguration();
+            })
+            .Build();
+        var healthCheckService = host.Services.GetRequiredService<HealthCheckService>();
+
+        // Act
+        var report = await healthCheckService.CheckHealthAsync(
+            HealthCheckOptionsFactory.IsReadinessCheck,
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        report.Entries.Should().ContainKey("database");
+        report.Entries.Should().NotContainKey("self");
+        report.Entries.Should().NotContainKey("consumer-check", "only checks tagged 'ready' gate traffic");
     }
 
     [Fact]

--- a/tests/Endatix.IntegrationTests/Infrastructure/HealthCheckTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/HealthCheckTests.cs
@@ -184,6 +184,31 @@ public sealed class HealthCheckTests
             "liveness is unaffected — failing it closed would restart-loop the container");
     }
 
+    /// <summary>
+    /// Probes are mapped before the diagnostic views and the first registration wins, so a liveness
+    /// path equal to a derived view shadows it silently rather than colliding visibly.
+    /// </summary>
+    [Fact]
+    public async Task Startup_fails_when_a_probe_path_shadows_a_diagnostic_view()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var factory = new EndatixWebApplicationFactory(
+                _fixture.Database.ConnectionString,
+                _fixture.Database.Provider)
+            .WithWebHostBuilder(builder => builder.UseSetting("Endatix:Hosting:LivenessPath", "/health/detail"));
+
+        // Act
+        var act = async () =>
+        {
+            var client = factory.CreateClient();
+            await client.GetAsync(new Uri("/health", UriKind.Relative), cancellationToken);
+        };
+
+        // Assert
+        await act.Should().ThrowAsync<Exception>("the JSON view would be shadowed by the liveness probe");
+    }
+
     [Theory]
     [InlineData("Endatix:Hosting:HealthCheckPath", "", "empty path matches every request")]
     [InlineData("Endatix:Hosting:LivenessPath", "alive", "a path without a leading slash throws from inside Map")]

--- a/tests/Endatix.IntegrationTests/Infrastructure/HealthCheckTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/HealthCheckTests.cs
@@ -2,6 +2,9 @@ using System.Net;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Endatix.Hosting.HealthChecks;
 using Endatix.IntegrationTests.Shared;
 
 namespace Endatix.IntegrationTests;
@@ -71,11 +74,13 @@ public sealed class HealthCheckTests
 
         // Act
         var alive = await client.GetAsync(new Uri("/alive", UriKind.Relative), cancellationToken);
+        var ready = await client.GetAsync(new Uri("/ready", UriKind.Relative), cancellationToken);
         var health = await client.GetAsync(new Uri("/health", UriKind.Relative), cancellationToken);
 
         // Assert
         alive.StatusCode.Should().Be(HttpStatusCode.OK, "liveness must not depend on the database");
-        health.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable, "readiness must fail when the database is unreachable");
+        ready.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable, "readiness must fail when the database is unreachable");
+        health.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable, "the unfiltered report includes the database");
     }
 
     [Fact]
@@ -96,6 +101,122 @@ public sealed class HealthCheckTests
         // Assert
         custom.StatusCode.Should().Be(HttpStatusCode.OK);
         standard.StatusCode.Should().Be(HttpStatusCode.NotFound, "the configured path replaces the default");
+    }
+
+    [Fact]
+    public async Task Readiness_endpoint_honours_a_custom_path()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var factory = new EndatixWebApplicationFactory(
+                _fixture.Database.ConnectionString,
+                _fixture.Database.Provider)
+            .WithWebHostBuilder(builder => builder.UseSetting("Endatix:Hosting:ReadinessPath", "/custom-ready"));
+        var client = factory.CreateClient();
+
+        // Act
+        var custom = await client.GetAsync(new Uri("/custom-ready", UriKind.Relative), cancellationToken);
+        var standard = await client.GetAsync(new Uri("/ready", UriKind.Relative), cancellationToken);
+
+        // Assert
+        custom.StatusCode.Should().Be(HttpStatusCode.OK);
+        standard.StatusCode.Should().Be(HttpStatusCode.NotFound, "the configured path replaces the default");
+    }
+
+    [Fact]
+    public async Task Health_endpoint_honours_a_custom_path()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var factory = new EndatixWebApplicationFactory(
+                _fixture.Database.ConnectionString,
+                _fixture.Database.Provider)
+            .WithWebHostBuilder(builder => builder.UseSetting("Endatix:Hosting:HealthCheckPath", "/custom-health"));
+        var client = factory.CreateClient();
+
+        // Act
+        var custom = await client.GetAsync(new Uri("/custom-health", UriKind.Relative), cancellationToken);
+        var detail = await client.GetAsync(new Uri("/custom-health/detail", UriKind.Relative), cancellationToken);
+        var standard = await client.GetAsync(new Uri("/health", UriKind.Relative), cancellationToken);
+
+        // Assert
+        custom.StatusCode.Should().Be(HttpStatusCode.OK);
+        detail.StatusCode.Should().Be(HttpStatusCode.OK, "the detail view follows the configured base path");
+        standard.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    /// <summary>
+    /// Readiness must fail closed. Reachable in production: the database checks are registered only
+    /// when a DbContext is already in Services, so a host calling HealthChecks.UseDefaults() before
+    /// or without persistence maps /ready with nothing to evaluate — and an empty predicate reports
+    /// Healthy, which would keep every pod in the Service endpoints while requests 500.
+    /// </summary>
+    [Fact]
+    public async Task Readiness_endpoint_reports_unhealthy_when_no_readiness_check_is_registered()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var factory = new EndatixWebApplicationFactory(
+                _fixture.Database.ConnectionString,
+                _fixture.Database.Provider)
+            .WithWebHostBuilder(builder => builder.ConfigureTestServices(services =>
+                services.Configure<HealthCheckServiceOptions>(options =>
+                {
+                    var readiness = options.Registrations
+                        .Where(registration => registration.Tags.Contains(HealthCheckTags.Ready))
+                        .ToList();
+
+                    foreach (var registration in readiness)
+                    {
+                        options.Registrations.Remove(registration);
+                    }
+                })));
+        var client = factory.CreateClient();
+
+        // Act
+        var ready = await client.GetAsync(new Uri("/ready", UriKind.Relative), cancellationToken);
+        var alive = await client.GetAsync(new Uri("/alive", UriKind.Relative), cancellationToken);
+
+        // Assert
+        ready.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable,
+            "readiness with nothing to check must not pass by default");
+        alive.StatusCode.Should().Be(HttpStatusCode.OK,
+            "liveness is unaffected — failing it closed would restart-loop the container");
+    }
+
+    [Theory]
+    [InlineData("Endatix:Hosting:HealthCheckPath", "", "empty path matches every request")]
+    [InlineData("Endatix:Hosting:LivenessPath", "alive", "a path without a leading slash throws from inside Map")]
+    [InlineData("Endatix:Hosting:ReadinessPath", "/health", "a duplicate path is silently ignored, first registration wins")]
+    public async Task Startup_fails_when_a_probe_path_is_invalid(string setting, string value, string reason)
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var factory = new EndatixWebApplicationFactory(
+                _fixture.Database.ConnectionString,
+                _fixture.Database.Provider)
+            .WithWebHostBuilder(builder => builder.UseSetting(setting, value));
+
+        // Act
+        var act = async () =>
+        {
+            var client = factory.CreateClient();
+            await client.GetAsync(new Uri("/health", UriKind.Relative), cancellationToken);
+        };
+
+        // Assert
+        (await act.Should().ThrowAsync<Exception>(reason))
+            .Which.Should().Match<Exception>(
+                exception => Flatten(exception).Contains(setting, StringComparison.Ordinal),
+                "the failure must name the offending option");
+    }
+
+    private static string Flatten(Exception exception)
+    {
+        var text = exception.ToString();
+        return exception is AggregateException aggregate
+            ? text + string.Join(' ', aggregate.InnerExceptions.Select(inner => inner.ToString()))
+            : text;
     }
 
     // Port 1 is reserved and nothing listens on it, so the connection fails fast rather than

--- a/tests/Endatix.IntegrationTests/Infrastructure/HealthCheckTests.cs
+++ b/tests/Endatix.IntegrationTests/Infrastructure/HealthCheckTests.cs
@@ -1,6 +1,8 @@
+using System.Net;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
+using Endatix.IntegrationTests.Shared;
 
 namespace Endatix.IntegrationTests;
 
@@ -29,6 +31,79 @@ public sealed class HealthCheckTests
         // Assert
         response.EnsureSuccessStatusCode();
     }
+
+    [Fact]
+    public async Task Alive_endpoint_returns_success()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        var client = _fixture.Factory.CreateClient();
+
+        // Act
+        var response = await client.GetAsync(new Uri("/alive", UriKind.Relative), cancellationToken);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+    }
+
+    /// <summary>
+    /// The reason the two probes exist. Liveness answers "is the process running?", so it must stay
+    /// green while the database is down — a Kubernetes livenessProbe that goes red on a database
+    /// blip restarts every pod at once, and restarting a process cannot fix a database.
+    /// Readiness answers "can this pod serve traffic?", so it must go red and drop the pod out of
+    /// the Service endpoints.
+    /// </summary>
+    [Fact]
+    public async Task Probes_disagree_when_the_database_is_unreachable()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+
+        // Auto-migrations off deliberately. The shared factory config turns them on, so CreateClient
+        // would run DatabaseMigrationService against the dead host and survive only because that
+        // service swallows its exception. This test would then start failing at CreateClient the day
+        // that swallow is tightened, reading as a probe regression when nothing about probes changed.
+        await using var factory = new EndatixWebApplicationFactory(
+                UnreachableConnectionString(_fixture.Database.Provider),
+                _fixture.Database.Provider)
+            .WithWebHostBuilder(builder => builder.UseSetting("Endatix:Data:EnableAutoMigrations", "false"));
+        var client = factory.CreateClient();
+
+        // Act
+        var alive = await client.GetAsync(new Uri("/alive", UriKind.Relative), cancellationToken);
+        var health = await client.GetAsync(new Uri("/health", UriKind.Relative), cancellationToken);
+
+        // Assert
+        alive.StatusCode.Should().Be(HttpStatusCode.OK, "liveness must not depend on the database");
+        health.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable, "readiness must fail when the database is unreachable");
+    }
+
+    [Fact]
+    public async Task Liveness_endpoint_honours_a_custom_path()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await using var factory = new EndatixWebApplicationFactory(
+                _fixture.Database.ConnectionString,
+                _fixture.Database.Provider)
+            .WithWebHostBuilder(builder => builder.UseSetting("Endatix:Hosting:LivenessPath", "/custom-alive"));
+        var client = factory.CreateClient();
+
+        // Act
+        var custom = await client.GetAsync(new Uri("/custom-alive", UriKind.Relative), cancellationToken);
+        var standard = await client.GetAsync(new Uri("/alive", UriKind.Relative), cancellationToken);
+
+        // Assert
+        custom.StatusCode.Should().Be(HttpStatusCode.OK);
+        standard.StatusCode.Should().Be(HttpStatusCode.NotFound, "the configured path replaces the default");
+    }
+
+    // Port 1 is reserved and nothing listens on it, so the connection fails fast rather than
+    // hanging for the provider's default timeout.
+    private static string UnreachableConnectionString(TestDatabaseProvider provider) =>
+        provider == TestDatabaseProvider.SqlServer
+            ? "Server=127.0.0.1,1;Database=endatix_down;User Id=sa;Password=Nope;TrustServerCertificate=True;Connect Timeout=2"
+            : "Host=127.0.0.1;Port=1;Database=endatix_down;Username=postgres;Password=postgres;Timeout=2;Command Timeout=2";
 
     [Fact]
     public async Task Health_endpoint_returns_success_with_per_test_service_override()


### PR DESCRIPTION
## Description

Both Kubernetes probes pointed at `/health`, which runs **every** registered check including the database. A database blip therefore failed liveness as well as readiness, so the kubelet restarted every pod at once — removing capacity while the system was already degraded, when restarting a process cannot fix a database that is down.

Adds two filtered endpoints beside the unfiltered `/health`:

| Endpoint | Runs | For |
|---|---|---|
| `/alive` | checks tagged `self` or `live` | livenessProbe — never touches the database |
| `/ready` | checks tagged `ready` | readinessProbe — the database checks |
| `/health` | everything, unchanged | humans and dashboards |

The tags already existed (`EndatixHealthChecksBuilder` tags the process check `self` and both `DbContext` checks `db`/`ready`, and `EndatixTelemetryBuilder` already excluded `/health`, `/alive` and `/ready` from traces). What was missing was endpoints that filter on them.

`/ready` is narrower than `/health` deliberately: a consumer adding an untagged check should not silently join the readiness path and start evicting pods from the Service endpoints.

### Registered before HTTPS redirection

Kubernetes counts any **2xx–3xx as probe Success**, so an HTTP probe answered with a `307` to HTTPS greens both probes permanently — readiness would never drop a pod with a dead database, defeating the point of this change.

It is inert today only because `HTTP_PORTS=8080` alone leaves `HttpsRedirectionMiddleware` unable to resolve a target port. Adding a TLS listener or setting `ASPNETCORE_HTTPS_PORTS` arms it. `UseEmbedHost` already sits ahead of the redirect for the same reason, and the probe branches now join it.

### Paths are bound, not just declared

`UseDefaults()` routes through `EndatixMiddlewareOptionsFactory`, which populated only the HTTPS-related options — so the pre-existing `HealthCheckPath` could never be changed from configuration despite reading as a knob. All three paths are now bound from `HostingOptions`:

```json
{ "Endatix": { "Hosting": {
    "HealthCheckPath": "/health", "LivenessPath": "/alive", "ReadinessPath": "/ready" } } }
```

An integration test asserts a configured path is actually honoured, so the binding cannot silently rot again.

### A silent-degradation guard

An empty predicate reports `Healthy`, so a liveness endpoint with no matching registration answers 200 forever while proving only that Kestrel is listening. That is reachable: `IsAspireServiceDefaultsPresent()` is a **substring** match on `"ServiceDiscovery"`, so an unrelated service-discovery package suppresses the `self` check without contributing a `live` one. The middleware now logs a warning at startup when nothing matches, rather than degrading silently.

### Chart

Probe paths, timeouts and thresholds are values, defaulting to the split. The previous comment argued at length about blip tolerance while exposing no threshold to tune it — `failureThreshold`, `successThreshold` and `timeoutSeconds` are now configurable.

The `UPGRADING` note is scoped to what actually bites: `/alive` and `/ready` do not exist in appVersion 0.7.6 or earlier, but `release-prepare.sh` stamps chart version and appVersion together and the template falls back to `.Chart.Version` for `image.tag` — so only an explicitly **pinned** older `image.tag` needs the paths set back.

## Related Issues

Fixes #1034.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Dependency update
- [ ] Refactoring (non-breaking change which improves code quality)
- [ ] Other (please describe)

## Checklist

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
- I have added tests that prove my fix is effective
- New and existing tests pass locally with my changes

> [!NOTE]
> - [x] I confirm that my Pull Request follows all the checklist requirements above

## Testing

`Probes_disagree_when_the_database_is_unreachable` is the acceptance criterion directly: against an unreachable database, `/alive` → **200** and `/health` → **503**. Verified to have teeth — neutralising the predicate so `/alive` runs all checks fails it with *"Expected alive.StatusCode to be OK because liveness must not depend on the database, but found ServiceUnavailable"*.

Unit tests assert the filtering itself, which the end-to-end test cannot catch when a regression still leaves `/alive` green: the liveness predicate excludes `database`/`identity-database`, and the readiness predicate excludes both `self` and an untagged consumer check.

That test also no longer depends on `DatabaseMigrationService` swallowing its own exception — auto-migrations are disabled explicitly, so tightening that swallow later cannot make this read as a probe regression.

Suites: Core 1432 · Infrastructure 1218 · Api 893 · Hosting 148 · Integration 118 passed / 1 skipped. `helm lint` clean; `helm template` verified with defaults and with every new probe knob overridden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated liveness (`/alive`) and readiness (`/ready`) health probes alongside the overall `/health` endpoint.
  * Liveness checks avoid database dependencies, while readiness checks report database-backed availability.
  * Kubernetes health probes now support configurable paths, timing, and failure thresholds.
  * Health-check endpoints support configurable paths and optional JSON or web UI output.

* **Bug Fixes**
  * Improved probe behavior when checks are unavailable, including fail-closed readiness handling.

* **Documentation**
  * Updated health-check guidance with endpoint behavior, probe tags, and deployment recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->